### PR TITLE
Partial checksums

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -446,6 +446,12 @@ gboolean ostree_repo_list_objects (OstreeRepo                  *self,
                                    GCancellable                *cancellable,
                                    GError                     **error);
 
+gboolean ostree_repo_list_commit_objects_starting_with ( OstreeRepo                  *self,
+                                                         const char                  *start,
+                                                         GHashTable                 **out_commits,
+                                                         GCancellable                *cancellable,
+                                                         GError                     **error);
+
 gboolean ostree_repo_list_static_delta_names (OstreeRepo                  *self,
                                               GPtrArray                  **out_deltas,
                                               GCancellable                *cancellable,

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -34,6 +34,15 @@ $OSTREE rev-parse 'test2^'
 $OSTREE rev-parse 'test2^^' 2>/dev/null && (echo 1>&2 "rev-parse test2^^ unexpectedly succeeded!"; exit 1)
 echo "ok rev-parse"
 
+checksum=$($OSTREE rev-parse test2)
+partial=${checksum:0:6} 
+echo "partial:" $partial
+echo "corresponds to:" $checksum
+$OSTREE rev-parse test2 > checksum
+$OSTREE rev-parse $partial > partial-results
+assert_file_has_content checksum $(cat partial-results)
+echo "ok shortened checksum"
+
 (cd repo && ostree rev-parse test2)
 echo "ok repo-in-cwd"
 


### PR DESCRIPTION
Allows OSTree commands to accept a unique truncated checksum as input instead of needing to type the full checksum or refspec.
