### PR TITLE
packaging: Make the ostree rpm own and create /etc/ostree/remotes.d/

### DIFF
--- a/packaging/ostree.spec.in
+++ b/packaging/ostree.spec.in
@@ -84,6 +84,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/girepository-1.0/OSTree-1.0.typelib
 %{_mandir}/man1/*.gz
 %{_prefix}/lib/systemd/system-preset/91-ostree.preset
+%dir %{_sysconfdir}/ostree/remotes.d
 
 %files devel
 %{_libdir}/lib*.so


### PR DESCRIPTION
We need the rpm to create this directory in order to avoid errors like the ones below:

-bash-4.2# ostree remote add --set=gpg-verify=false dustyserver http://192.168.122.124:8000/  
error: Error opening file '/etc/ostree/remotes.d/dustyserver.conf': No such file or directory
