### PR TITLE
libostree: fix a gobject-introspection warning

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -268,7 +268,7 @@ gboolean      ostree_repo_query_object_storage_size (OstreeRepo           *self,
 gboolean      ostree_repo_import_object_from (OstreeRepo           *self,
                                               OstreeRepo           *source,
                                               OstreeObjectType      objtype,
-                                              const char           *sha256, 
+                                              const char           *checksum,
                                               GCancellable         *cancellable,
                                               GError              **error);
 


### PR DESCRIPTION
src/libostree/ostree-repo.c:1759: Warning: OSTree:
  ostree_repo_import_object_from: unknown parameter 'checksum' in
  documentation comment, should be 'sha256'

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
