### PR TITLE
checkout: permit checkout of a single file

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -45,6 +45,7 @@ testfiles = test-basic \
 	test-admin-deploy-uboot \
 	test-admin-instutil-set-kargs \
 	test-admin-upgrade-not-backwards \
+	test-repo-checkout-subpath 	\
 	test-setuid \
 	test-delta \
 	test-xattrs \

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -587,6 +587,16 @@ checkout_tree_at (OstreeRepo                        *self,
         }
     }
 
+  if (g_file_info_get_file_type (source_info) != G_FILE_TYPE_DIRECTORY)
+    {
+      ret = checkout_one_file_at (self, (GFile *) source,
+                                  source_info,
+                                  destination_dfd, destination,
+                                  g_file_info_get_name (source_info),
+                                  mode, TRUE,
+                                  cancellable, error);
+      goto out;
+    }
   dir_enum = g_file_enumerate_children ((GFile*)source,
                                         OSTREE_GIO_FAST_QUERYINFO, 
                                         G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,

--- a/tests/test-repo-checkout-subpath.sh
+++ b/tests/test-repo-checkout-subpath.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright (C) 2011,2013 Colin Walters <walters@verbum.org>
+# Copyright (C) 2014 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+setup_test_repository "bare"
+echo "ok setup"
+
+echo '1..2'
+
+repopath=${test_tmpdir}/ostree-srv/gnomerepo
+
+ostree --repo=repo checkout -U --subpath=/ test2 checkedout
+
+ostree --repo=repo checkout -U --subpath=/firstfile test2 checkedout2


### PR DESCRIPTION
fixes a coredump when using a command like:

$ ostree --repo=repo checkout -U --subpath=/usr/lib/passwd \
  fedora-atomic/rawhide/x86_64/docker-host usrlib-new

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
