### PR TITLE
tests: fix intermittent failure for test-sysroot

### DIFF
--- a/tests/test-sysroot.js
+++ b/tests/test-sysroot.js
@@ -41,7 +41,6 @@ function libtestExec(shellCode) {
 						  GSystem.SubprocessStreamDisposition.INHERIT,
 						  GSystem.SubprocessStreamDisposition.INHERIT,
 						  null);
-    proc.init(null);
     proc.wait_sync_check(null);
 }
 


### PR DESCRIPTION
libtestExec doesn't run twice the same process now.

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
