### PR TITLE
Add verbose option to manual

### DIFF
--- a/doc/ostree.xml
+++ b/doc/ostree.xml
@@ -117,6 +117,14 @@ Boston, MA 02111-1307, USA.
                     repository.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>-v, --verbose</option></term>
+
+                <listitem><para>
+                    Produce debug level output.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 


### PR DESCRIPTION
Because ostree has a verbose option.
