### PR TITLE
Change error message with g_key_file_get_string

### DIFF
--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -116,9 +116,14 @@ ostree_builtin_config (int argc, char **argv, GCancellable *cancellable, GError 
         goto out;
 
       readonly_config = ostree_repo_get_config (repo);
-      value = g_key_file_get_string (readonly_config, section, key, error);
+      value = g_key_file_get_string (readonly_config, section, key, NULL);
       if (value == NULL)
-        goto out;
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "%s not found in '%s'",
+                   key, section);
+          goto out;
+        }
 
       g_print ("%s\n", value);
     }

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -155,9 +155,14 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
     {
       gs_free char *url = NULL;
 
-      url = g_key_file_get_string (config, key, "url", error);
+      url = g_key_file_get_string (config, key, "url", NULL);
       if (url == NULL)
-        goto out;
+	{
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "url not found in '%s'",
+                   key);
+          goto out;
+        }
 
       g_print ("%s\n", url);
     }


### PR DESCRIPTION
Current error message(G_KEY_FILE_ERROR_GROUP_NOT_FOUND) is

```
[root@localhost ostree]# ostree remote show-url bar
error: Key file does not have group 'remote "bar"'
```

This should be clear. And this patch will change the message as below

```
[root@localhost ostree]# ./ostree remote show-url bar
error: url not found in 'remote "bar"'
[root@localhost ostree]# ./ostree config get 'remote "bar"'.url
error: url not found in 'remote "bar"'
```
