### PR TITLE
Remove space in the remote tag

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1214,11 +1214,11 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   pull_data->remote_name = g_strdup (remote_name);
   config = ostree_repo_get_config (self);
 
-  remote_key = g_strdup_printf ("remote \"%s\"", pull_data->remote_name);
+  remote_key = g_strdup_printf ("remote_\"%s\"", pull_data->remote_name);
   if (!g_key_file_has_group (config, remote_key))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "No remote '%s' found in " SYSCONFDIR "/ostree/remotes.d",
+                   "No remote_'%s' found in " SYSCONFDIR "/ostree/remotes.d",
                    remote_key);
       goto out;
     }
@@ -1453,7 +1453,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       if (!(branches_iter && *branches_iter))
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "No configured branches for remote %s", pull_data->remote_name);
+                       "No configured branches for remote_%s", pull_data->remote_name);
           goto out;
         }
       for (;branches_iter && *branches_iter; branches_iter++)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -420,7 +420,7 @@ ostree_repo_remote_add (OstreeRepo     *self,
       goto out;
     }
 
-  section = g_strdup_printf ("remote \"%s\"", name);
+  section = g_strdup_printf ("remote_\"%s\"", name);
 
   is_system = ostree_repo_is_system (self);
   if (is_system)
@@ -505,7 +505,7 @@ ostree_repo_remote_delete (OstreeRepo     *self,
       goto out;
     }
 
-  section = g_strdup_printf ("remote \"%s\"", name);
+  section = g_strdup_printf ("remote_\"%s\"", name);
 
   /* Note we prefer deleting from the config if it exists there */
   if (g_key_file_has_group (self->config, section))

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -93,7 +93,7 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
 
   op = argv[1];
   remote_name = argv[2];
-  key = g_strdup_printf ("remote \"%s\"", remote_name);
+  key = g_strdup_printf ("remote_\"%s\"", remote_name);
 
   config = ostree_repo_copy_config (repo);
 


### PR DESCRIPTION
Please don't insert space into the remote tag like [remote "NAME"]. 
Because g_key_file_has_group() doesn't support space and os-tree has a bug [here](https://github.com/GNOME/ostree/blob/master/src/libostree/ostree-repo.c#L511-L514).
