### PR TITLE
Chnage style for NULL check

### DIFF
--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -117,15 +117,15 @@ ostree_builtin_config (int argc, char **argv, GCancellable *cancellable, GError 
 
       readonly_config = ostree_repo_get_config (repo);
       value = g_key_file_get_string (readonly_config, section, key, NULL);
-      if (value == NULL)
+      if (!value)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "%s not found in '%s'",
                    key, section);
           goto out;
         }
-
-      g_print ("%s\n", value);
+      else
+        g_print ("%s\n", value);
     }
   else
     {

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -156,15 +156,15 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
       gs_free char *url = NULL;
 
       url = g_key_file_get_string (config, key, "url", NULL);
-      if (url == NULL)
+      if (!url)
 	{
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "url not found in '%s'",
                    key);
           goto out;
         }
-
-      g_print ("%s\n", url);
+      else
+        g_print ("%s\n", url);
     }
   else if (!strcmp (op, "delete"))
     {


### PR DESCRIPTION
> if (!g_key_file_has_section (config, key))
> {
> set_error ("No remote '%s' found", remotename);
> goto out;
> }

Sorry, if I misunderstand. But the returned value from g_key_file_get_string is used later. So I think this style is the best?
