### PR TITLE
repo: Add symbolic refspec 'BOOT'

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -73,6 +73,10 @@ struct OstreeRepo {
   gboolean generate_sizes;
 
   OstreeRepo *parent_repo;
+
+  /* For instances created by ostree_repo_new_default()
+   * or ostree_sysroot_get_repo() */
+  OstreeSysroot *sysroot;
 };
 
 gboolean

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -24,6 +24,7 @@
 #include "libgsystem.h"
 
 #include "ostree-sysroot-private.h"
+#include "ostree-repo-private.h"
 #include "ostree-bootloader-uboot.h"
 #include "ostree-bootloader-syslinux.h"
 #include "ostree-bootloader-grub2.h"
@@ -836,6 +837,9 @@ ostree_sysroot_get_repo (OstreeSysroot         *self,
   ret_repo = ostree_repo_new (repo_path);
   if (!ostree_repo_open (ret_repo, cancellable, error))
     goto out;
+
+  /* Stash a sysroot reference so the "BOOT" alias works. */
+  ret_repo->sysroot = g_object_ref (self);
     
   ret = TRUE;
   ot_transfer_out_value (out_repo, &ret_repo);


### PR DESCRIPTION
ostree_repo_resolve_rev() now recognizes 'BOOT' as a symbolic reference
to the checksum of the currently booted deployment.

Somewhat analogous to the symbolic reference 'HEAD' in git.

This seems to work, but I had to do some slightly sneaky things to avoid disrupting the API.  Not sure how you feel about it.

Simple example:

```
# atomic status
  TIMESTAMP (UTC)         ID             OSNAME               REFSPEC······································
* 2014-12-05 18:25:49     1ff9126862     rhel-atomic-host     local:rhel-atomic-host/7/x86_64/standard·····
  2014-12-05 17:00:37     ba5330508a     rhel-atomic-host     local:rhel-atomic-host/7/x86_64/standard·····

# atomic db diff 1ff9126862^ 1ff9126862
ostree diff commit old: 1ff9126862^ (ba5330508af4a116eb13abd51e17a13fa01eb13a01cd62e354918f92b5e34800)
ostree diff commit new: 1ff9126862 (1ff912686206eb7799ea4ffea4abf656367ba84c38e40fe0d89224b5d4c9eec8)
Upgraded:
 ostree-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64
 ostree-debuginfo-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64
 ostree-grub2-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64

# atomic db diff BOOT^ BOOT
ostree diff commit old: BOOT^ (ba5330508af4a116eb13abd51e17a13fa01eb13a01cd62e354918f92b5e34800)
ostree diff commit new: BOOT (1ff912686206eb7799ea4ffea4abf656367ba84c38e40fe0d89224b5d4c9eec8)
Upgraded:
 ostree-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64
 ostree-debuginfo-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64
 ostree-grub2-2014.12.7.g98cde4b-1.fc22.test.20141205.2.x86_64
```
