### PR TITLE
pull: allow pulling delta update from different refs

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1694,6 +1694,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   char **refs_to_fetch = NULL;
   GSource *update_timeout = NULL;
   gboolean disable_static_deltas = FALSE;
+  const char *force_from = NULL;
 
   if (options)
     {
@@ -1706,6 +1707,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       (void) g_variant_lookup (options, "override-remote-name", "s", &pull_data->remote_name);
       (void) g_variant_lookup (options, "depth", "i", &pull_data->maxdepth);
       (void) g_variant_lookup (options, "disable-static-deltas", "b", &disable_static_deltas);
+      (void) g_variant_lookup (options, "force-from", "&s", &force_from);
     }
 
   g_return_val_if_fail (pull_data->maxdepth >= -1, FALSE);
@@ -2098,7 +2100,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
     {
       g_autofree char *from_revision = NULL;
-      const char *ref = key;
+      const char *ref = force_from ? force_from : key;
       const char *to_revision = value;
       GVariant *delta_superblock = NULL;
 

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -33,6 +33,7 @@ static gboolean opt_commit_only;
 static gboolean opt_disable_static_deltas;
 static char* opt_subpath;
 static int opt_depth = 0;
+static char* opt_force_from;
  
  static GOptionEntry options[] = {
    { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
@@ -41,6 +42,7 @@ static int opt_depth = 0;
    { "mirror", 0, 0, G_OPTION_ARG_NONE, &opt_mirror, "Write refs suitable for a mirror", NULL },
    { "subpath", 0, 0, G_OPTION_ARG_STRING, &opt_subpath, "Only pull the provided subpath", NULL },
    { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
+   { "force-from", 0, 0, G_OPTION_ARG_STRING, &opt_force_from, "Force using a ref or commit as the base for pulling data", NULL},
    { NULL }
  };
 
@@ -147,9 +149,15 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
     g_variant_builder_add (&builder, "{s@v}", "disable-static-deltas",
                            g_variant_new_variant (g_variant_new_boolean (opt_disable_static_deltas)));
 
+    if (opt_force_from)
+       g_variant_builder_add (&builder, "{s@v}", "force-from",
+                             g_variant_new_variant (g_variant_new_string (opt_force_from)));
+
     if (!ostree_repo_pull_with_options (repo, remote, g_variant_builder_end (&builder),
                                         progress, cancellable, error))
       goto out;
+    
+
   }
 
   if (progress)


### PR DESCRIPTION
Added the option --force-from= to ostree pull where a delta does not
need to be applied between commits from different refs.

The implementation is probably not good, I made it for personal need,
but I'm sure the idea can be better evaluated.

Some background for this request at:
https://mail.gnome.org/archives/ostree-list/2015-June/msg00012.html
