### PR TITLE
sysroot: Support /boot on / for syslinux and uboot

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -70,6 +70,7 @@ dist_test_scripts = \
 	tests/test-gpg-signed-commit.sh \
 	tests/test-admin-upgrade-unconfigured.sh \
 	tests/test-admin-deploy-syslinux.sh \
+	tests/test-admin-deploy-syslinux-bootonslash.sh \
 	tests/test-admin-deploy-2.sh \
 	tests/test-admin-deploy-karg.sh \
 	tests/test-admin-deploy-switch.sh \

--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -284,6 +284,7 @@ grub2_child_setup (gpointer user_data)
 static gboolean
 _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
                                        int                    bootversion,
+                                       gboolean               have_boot_partition,
                                        GCancellable          *cancellable,
                                        GError               **error)
 {

--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -64,14 +64,16 @@ _ostree_bootloader_uboot_get_name (OstreeBootloader *bootloader)
 
 static gboolean
 create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
-                                        int                    bootversion,
-                                        GPtrArray             *new_lines,
-                                        GCancellable          *cancellable,
-                                        GError               **error)
+                                        int                        bootversion,
+                                        gboolean                   have_boot_partition,
+                                        GPtrArray                 *new_lines,
+                                        GCancellable              *cancellable,
+                                        GError                   **error)
 {
   g_autoptr(GPtrArray) boot_loader_configs = NULL;
   OstreeBootconfigParser *config;
   const char *val;
+  const char *filename_prefix = have_boot_partition ? "" : "/boot";
 
   if (!_ostree_sysroot_read_boot_loader_configs (self->sysroot, bootversion, &boot_loader_configs,
                                                  cancellable, error))
@@ -87,11 +89,11 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
                    "No \"linux\" key in bootloader config");
       return FALSE;
     }
-  g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image=%s", val));
+  g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image=%s%s", filename_prefix, val));
 
   val = ostree_bootconfig_parser_get (config, "initrd");
   if (val)
-    g_ptr_array_add (new_lines, g_strdup_printf ("ramdisk_image=%s", val));
+    g_ptr_array_add (new_lines, g_strdup_printf ("ramdisk_image=%s%s", filename_prefix, val));
 
   val = ostree_bootconfig_parser_get (config, "options");
   if (val)
@@ -140,9 +142,10 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
 
 static gboolean
 _ostree_bootloader_uboot_write_config (OstreeBootloader          *bootloader,
-                                  int                    bootversion,
-                                  GCancellable          *cancellable,
-                                  GError               **error)
+                                       int                        bootversion,
+                                       gboolean                   have_boot_partition,
+                                       GCancellable              *cancellable,
+                                       GError                   **error)
 {
   OstreeBootloaderUboot *self = OSTREE_BOOTLOADER_UBOOT (bootloader);
   g_autoptr(GFile) new_config_path = NULL;
@@ -161,7 +164,9 @@ _ostree_bootloader_uboot_write_config (OstreeBootloader          *bootloader,
 
   new_lines = g_ptr_array_new_with_free_func (g_free);
 
-  if (!create_config_from_boot_loader_entries (self, bootversion, new_lines,
+  if (!create_config_from_boot_loader_entries (self, bootversion,
+                                               have_boot_partition,
+                                               new_lines,
                                                cancellable, error))
     return FALSE;
 

--- a/src/libostree/ostree-bootloader.c
+++ b/src/libostree/ostree-bootloader.c
@@ -54,14 +54,16 @@ _ostree_bootloader_get_name (OstreeBootloader  *self)
 
 gboolean
 _ostree_bootloader_write_config (OstreeBootloader  *self,
-                            int            bootversion,
-                            GCancellable  *cancellable,
-                            GError       **error)
+                                 int            bootversion,
+                                 gboolean have_boot_partition,
+                                 GCancellable  *cancellable,
+                                 GError       **error)
 {
   g_return_val_if_fail (OSTREE_IS_BOOTLOADER (self), FALSE);
 
   return OSTREE_BOOTLOADER_GET_IFACE (self)->write_config (self, bootversion, 
-                                                       cancellable, error);
+                                                           have_boot_partition,
+                                                           cancellable, error);
 }
 
 gboolean

--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -44,6 +44,7 @@ struct _OstreeBootloaderInterface
   const char *         (* get_name)               (OstreeBootloader  *self);
   gboolean             (* write_config)           (OstreeBootloader  *self,
                                                    int            bootversion,
+                                                   gboolean       have_boot_partition,
                                                    GCancellable  *cancellable,
                                                    GError       **error);
   gboolean             (* is_atomic)              (OstreeBootloader  *self);
@@ -60,6 +61,7 @@ const char *_ostree_bootloader_get_name (OstreeBootloader  *self);
 
 gboolean _ostree_bootloader_write_config (OstreeBootloader  *self,
                                           int            bootversion,
+                                          gboolean       have_boot_partition,
                                           GCancellable  *cancellable,
                                           GError       **error);
 

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -30,7 +30,9 @@ G_BEGIN_DECLS
 typedef enum {
 
   /* Don't flag deployments as immutable. */
-  OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS = 1 << 0
+  OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS = 1 << 0,
+  /* If set, assume /boot is on / */
+  OSTREE_SYSROOT_DEBUG_BOOT_IS_NOT_MOUNT = 1 << 1
 
 } OstreeSysrootDebugFlags;
 

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -160,9 +160,10 @@ ostree_sysroot_init (OstreeSysroot *self)
 {
   const GDebugKey keys[] = {
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },
+    { "boot-is-not-mount", OSTREE_SYSROOT_DEBUG_BOOT_IS_NOT_MOUNT }
   };
 
-  self->debug_flags = g_parse_debug_string (g_getenv("OSTREE_SYSROOT_DEBUG"),
+  self->debug_flags = g_parse_debug_string (g_getenv ("OSTREE_SYSROOT_DEBUG"),
                                             keys, G_N_ELEMENTS (keys));
 
   self->sysroot_fd = -1;

--- a/tests/test-admin-deploy-syslinux-bootonslash.sh
+++ b/tests/test-admin-deploy-syslinux-bootonslash.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive-z2" "syslinux"
+
+echo "1..2"
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+# Override the default and say that /boot is not a partition
+env OSTREE_SYSROOT_DEBUG=${OSTREE_SYSROOT_DEBUG},boot-is-not-mount \
+  ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "KERNEL /boot/ostree/testos.*vmlinuz"
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "INITRD /boot/ostree/testos.*initramfs"
+
+echo "ok bootonslash"
+
+${CMD_PREFIX} ostree admin undeploy 0
+
+# Legacy default of /boot is a partition
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "KERNEL /ostree/testos.*vmlinuz"
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "INITRD /ostree/testos.*initramfs"
+
+echo "ok bootpartition"


### PR DESCRIPTION
People making smaller operating systems, particularly things like
cloud images, don't need to have /boot as a separate partition.

Build on the code that recently landed to detect whether /boot
is a mountpoint at runtime (for read-only purposes) here in order
to influence bootloader config generation.

Basically if /boot is not a partition, prepend `/boot` to generated
syslinux/uboot config.

NOTE: _not_ tested in a real world scenario for either syslinux or
uboot, but I did extend the test suite to cover this.

https://bugzilla.gnome.org/show_bug.cgi?id=751666
