### PR TITLE
tests: Add a test-abi

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -23,7 +23,11 @@ include $(top_srcdir)/buildutil/glib-tap.mk
 # include the builddir in $PATH so we find our just-built ostree
 # binary.
 TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
+	SRCDIR=$$(cd $(top_srcdir) && pwd) \
+	BUILDDIR=$$(cd $(top_builddir) && pwd) \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH}
+
+uninstalled_test_scripts = tests/test-abi.sh
 
 test_scripts = \
 	tests/test-basic.sh \

--- a/tests/test-abi.sh
+++ b/tests/test-abi.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+echo '1..1'
+
+grep ' ostree_[A-Za-z0-9_]*;' ${SRCDIR}/src/libostree/libostree.sym | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
+eu-readelf -a ${BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9_.]*,\1,' |sort -u > found-symbols.txt
+diff -u expected-symbols.txt found-symbols.txt
+
+echo 'ok'


### PR DESCRIPTION
This would have caught a potential ABI regression in
https://bugzilla.gnome.org/show_bug.cgi?id=764056
(If we ran this test while building `--without-libarchive`)