### PR TITLE
[merged] OstreeSePolicy: add ostree_sepolicy_get_csum()

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -331,4 +331,5 @@ global:
 LIBOSTREE_2016.5 {
 global:
         ostree_repo_import_object_from_with_trust;
+        ostree_sepolicy_get_csum;
 } LIBOSTREE_2016.4;

--- a/src/libostree/ostree-sepolicy.h
+++ b/src/libostree/ostree-sepolicy.h
@@ -45,6 +45,9 @@ _OSTREE_PUBLIC
 const char *ostree_sepolicy_get_name (OstreeSePolicy *self);
 
 _OSTREE_PUBLIC
+const char *ostree_sepolicy_get_csum (OstreeSePolicy *self);
+
+_OSTREE_PUBLIC
 gboolean ostree_sepolicy_get_label (OstreeSePolicy    *self,
                                     const char       *relpath,
                                     guint32           unix_mode,

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -140,17 +140,17 @@ ot_gio_checksum_stream (GInputStream   *in,
 }
 
 char *
-ot_checksum_file (GFile          *file,
-                  GChecksumType   checksum_type,
-                  GCancellable   *cancellable,
-                  GError        **error)
+ot_checksum_file_at (int             dfd,
+                     const char     *path,
+                     GChecksumType   checksum_type,
+                     GCancellable   *cancellable,
+                     GError        **error)
 {
   GChecksum *checksum = NULL;
   char *ret = NULL;
   g_autoptr(GInputStream) in = NULL;
 
-  in = (GInputStream*)g_file_read (file, cancellable, error);
-  if (!in)
+  if (!ot_openat_read_stream (dfd, path, TRUE, &in, cancellable, error))
     goto out;
 
   checksum = g_checksum_new (checksum_type);

--- a/src/libotutil/ot-checksum-utils.h
+++ b/src/libotutil/ot-checksum-utils.h
@@ -53,10 +53,11 @@ gboolean ot_gio_checksum_stream (GInputStream   *in,
                                  GCancellable   *cancellable,
                                  GError        **error);
 
-char * ot_checksum_file (GFile          *file,
-                         GChecksumType   checksum_type,
-                         GCancellable   *cancellable,
-                         GError        **error);
+char * ot_checksum_file_at (int             dfd,
+                            const char     *path,
+                            GChecksumType   checksum_type,
+                            GCancellable   *cancellable,
+                            GError        **error);
 
 void ot_gio_checksum_stream_async (GInputStream         *in,
                                    int                   io_priority,


### PR DESCRIPTION
This can be used as a fingerprint to determine whether two
OstreeSePolicy objects are equivalent.

Also add documentation for ostree_sepolicy_get_name().