### PR TITLE
Add a stub .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# We're just using a "stubbed out" Travis right now so we can
+# use Homu <https://github.com/barosl/homu> to auto-squash
+# etc.
+#
+# In the future we'll hook up better tests.
+language: c
+dist: trusty
+addons:
+    apt:
+    packages:
+      - automake
+      - autotools-dev
+script:
+  - env NOCONFIGURE=1 ./autogen.sh
+
+notifications:
+  # This is Colin's personal Homu instance.  We will
+  # also work on productizing this in Project Atomic.
+  webhooks: http://escher.verbum.org:54856/travis
+  email: false
+
+branches:
+  only:
+    - auto
+


### PR DESCRIPTION
This is at the moment just so that we can use Homu.  In the future I'd
like to make travis just one of multiple PR testers we use.