### PR TITLE
[merged] commit: Support generating commits with no parent, or a custom one

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..50"
+echo "1..52"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -95,6 +95,23 @@ cd checkout-test2-4
 assert_file_has_content yet/another/tree/green 'leaf'
 assert_file_has_content four '4'
 echo "ok cwd contents"
+
+cd ${test_tmpdir}
+$OSTREE commit -b test2-no-parent -s '' $test_tmpdir/checkout-test2-4
+assert_streq $($OSTREE log test2-no-parent |grep '^commit' | wc -l) "1"
+$OSTREE commit -b test2-no-parent -s '' --parent=none $test_tmpdir/checkout-test2-4
+assert_streq $($OSTREE log test2-no-parent |grep '^commit' | wc -l) "1"
+echo "ok commit no parent"
+
+cd ${test_tmpdir}
+$OSTREE commit -b test2-custom-parent -s '' $test_tmpdir/checkout-test2-4
+$OSTREE commit -b test2-custom-parent -s '' $test_tmpdir/checkout-test2-4
+$OSTREE commit -b test2-custom-parent -s '' $test_tmpdir/checkout-test2-4
+assert_streq $($OSTREE log test2-custom-parent |grep '^commit' | wc -l) "3"
+prevparent=$($OSTREE rev-parse test2-custom-parent^)
+$OSTREE commit -b test2-custom-parent -s '' --parent=${prevparent} $test_tmpdir/checkout-test2-4
+assert_streq $($OSTREE log test2-custom-parent |grep '^commit' | wc -l) "3"
+echo "ok commit custom parent"
 
 cd ${test_tmpdir}
 $OSTREE diff test2^ test2 > diff-test2


### PR DESCRIPTION
When I'm doing local development builds, it's quite common for me not
to want to accumulate history.  There are also use cases for this on
build servers as well.

In particular, using this, one could write a build system that didn't
necessarily need to have access to (a copy of) the OSTree repository.
Instead, the build system would determine the last commit ID on the
branch, and pass that to a worker node, then sync the generated
content back.

The API supported generating custom commits that don't necessarily
reference the previous commit on the same branch, let's just expose
this in the command line for convenience.

I plan to also support this rpm-ostree.