### PR TITLE
[merged] packaging: fix bashism in dist-snapshot target

### DIFF
--- a/packaging/Makefile.dist-packaging
+++ b/packaging/Makefile.dist-packaging
@@ -22,7 +22,7 @@ dist-snapshot:
 	  tar -A -f $${TARFILE_TMP} submodule.tar; \
 	  rm submodule.tar; \
 	done; \
-	mv $(PKG_VER).tar{.tmp,}; \
+	mv $(PKG_VER).tar.tmp $(PKG_VER).tar; \
 	rm -f $(PKG_VER).tar.xz; \
 	xz $(PKG_VER).tar 
 


### PR DESCRIPTION
On Debian and its derivatives, /bin/sh is a lightweight POSIX shell
(currently dash) which does not support the bash {foo,bar} syntax.