### PR TITLE
[merged] Fix various build-time test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ _build
 /test-remote-add.test
 /test-setuid.test
 /test-xattrs.test
+/tests/libreaddir-rand.so
 test-varint
 test*.test
 *.trs

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,12 @@ ABOUT-NLS
 _build
 
 /build-aux/test-driver
+/buildutil/gtk-doc.m4
+/buildutil/libtool.m4
+/buildutil/ltoptions.m4
+/buildutil/ltsugar.m4
+/buildutil/ltversion.m4
+/buildutil/lt~obsolete.m4
 
 /doc/ostree-decl.txt
 /doc/ostree-overrides.txt
@@ -51,12 +57,20 @@ _build
 /doc/xml
 /doc/ostree.1
 
+/man/*.1
+/man/*.5
+
 /ostree
 /ostree-prepare-root
 /ostree-remount
 /OSTree-1.0.gir
 
+/rofiles-fuse
+
 /src/libostree/ostree-1.pc
+/src/libostree/ostree-enumtypes.c
+/src/libostree/ostree-enumtypes.h
+/src/ostree/parse-datetime.c
 
 /test-admin-deploy-1.test
 /test-admin-deploy-2.test
@@ -71,6 +85,10 @@ _build
 /test-setuid.test
 /test-xattrs.test
 /tests/libreaddir-rand.so
+/tests/test-basic-c
+/tests/test-libarchive-import
+/tests/test-lzma
+/tests/test-sysroot-c
 test-varint
 test*.test
 *.trs

--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -49,3 +49,6 @@ GITIGNOREFILES =
 # This is a special facility to chain together hooks easily
 INSTALL_DATA_HOOKS =
 install-data-hook: $(INSTALL_DATA_HOOKS)
+
+ALL_LOCAL_RULES =
+all-local: $(ALL_LOCAL_RULES)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -216,6 +216,10 @@ EXTRA_DIST += \
 	tests/gpg-verify-data/trustdb.gpg \
 	tests/gpg-verify-data/gpg.conf
 
+tests-libreaddir-rand-so-symlink:
+	ln -fns ../.libs/libreaddir-rand.so tests
+ALL_LOCAL_RULES += tests-libreaddir-rand-so-symlink
+
 # Unfortunately the glib test data APIs don't actually handle
 # non-recursive Automake, so we change our code to canonically look
 # for tests/ which is just a symlink when installed.

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -131,6 +131,9 @@ libreaddir_rand_la_SOURCES = tests/readdir-rand.c
 libreaddir_rand_la_CFLAGS = $(OT_INTERNAL_GIO_UNIX_CFLAGS)
 libreaddir_rand_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS)
 libreaddir_rand_la_LDFLAGS = -avoid-version
+if !ENABLE_INSTALLED_TESTS
+libreaddir_rand_la_LDFLAGS += -rpath $(abs_builddir)
+endif
 
 test_programs = tests/test-varint tests/test-ot-unix-utils tests/test-bsdiff tests/test-mutable-tree \
 	tests/test-keyfile-utils tests/test-ot-opt-utils tests/test-ot-tool-util \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -25,7 +25,10 @@ include $(top_srcdir)/buildutil/glib-tap.mk
 TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	SRCDIR=$$(cd $(top_srcdir) && pwd) \
 	BUILDDIR=$$(cd $(top_builddir) && pwd) \
-	PATH=$$(cd $(top_builddir) && pwd):$${PATH}
+	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd) \
+	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd) \
+	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
+	$(NULL)
 
 uninstalled_test_scripts = tests/test-abi.sh
 

--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -13,7 +13,7 @@ touch ${tempdir}/.testtmp
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
 	echo "Skipping cleanup of ${tempdir}"
-    else if test -f ${tempdir}/.test; then
+    else if test -f ${tempdir}/.testtmp; then
 	rm "${tempdir}" -rf
     fi
     fi

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (C) 2011,2014 Colin Walters <walters@verbum.org>
 #
 # This library is free software; you can redistribute it and/or

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -114,7 +114,7 @@ assert_streq $($OSTREE log test2-custom-parent |grep '^commit' | wc -l) "3"
 echo "ok commit custom parent"
 
 cd ${test_tmpdir}
-orphaned_rev=$($OSTREE commit --orphan -s '' $test_tmpdir/checkout-test2-4)
+orphaned_rev=$($OSTREE commit --orphan -s "$(date)" $test_tmpdir/checkout-test2-4)
 $OSTREE ls ${orphaned_rev} >/dev/null
 $OSTREE prune --refs-only
 if $OSTREE ls ${orphaned_rev} 2>err.txt; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -324,3 +324,11 @@ os_repository_new_commit ()
     ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" -b testos/buildmaster/x86_64-runtime -s "Build"
     cd ${test_tmpdir}
 }
+
+skip_without_user_xattrs () {
+    touch test-xattrs
+    if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+        echo "1..0 # SKIP this test requires xattr support"
+        exit 0
+    fi
+}

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -332,3 +332,20 @@ skip_without_user_xattrs () {
         exit 0
     fi
 }
+
+skip_without_fuse () {
+    if ! fusermount --version >/dev/null 2>&1; then
+        echo "1..0 # SKIP no fusermount"
+        exit 0
+    fi
+
+    if ! [ -w /dev/fuse ]; then
+        echo "1..0 # SKIP no write access to /dev/fuse"
+        exit 0
+    fi
+
+    if ! [ -e /etc/mtab ]; then
+        echo "1..0 # SKIP no /etc/mtab"
+        exit 0
+    fi
+}

--- a/tests/test-admin-locking.sh
+++ b/tests/test-admin-locking.sh
@@ -25,8 +25,8 @@ set -euo pipefail
 setup_os_repository "archive-z2" "syslinux"
 
 # If parallel is not installed, skip the test
-if ! parallel --help >/dev/null 2>&1; then
-    echo "1..0 # SKIP no /usr/bin/parallel"
+if ! parallel --gnu /bin/true </dev/null >/dev/null 2>&1; then
+    echo "1..0 # SKIP GNU parallel not available"
     exit 0
 fi    
 
@@ -42,7 +42,7 @@ echo "rev=${rev}"
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
 assert_has_dir sysroot/boot/ostree/testos-${bootcsum}
 
-parallel_cmd=parallel
+parallel_cmd="parallel --gnu"
 if parallel --help | grep -q -e --no-notice; then
     parallel_cmd="${parallel_cmd} --no-notice"
 fi

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -21,11 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "1..0 # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
+skip_without_user_xattrs
 
 echo "1..1"
 

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -19,9 +19,15 @@
 
 set -euo pipefail
 
-echo "1..1"
-
 . $(dirname $0)/libtest.sh
+
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "1..0 # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
+echo "1..1"
 
 setup_test_repository "bare-user"
 echo "ok setup"

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -132,5 +132,6 @@ if ${CMD_PREFIX} ostree --repo=repo show main | grep -o 'Found [[:digit:]] signa
 fi
 
 rm -rf repo gnomerepo-files
+gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
 
 echo "ok"

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -156,6 +156,13 @@ ${CMD_PREFIX} ostree --repo=repo2 ls ${newrev} >/dev/null
 
 echo 'ok pull delta'
 
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "ok apply offline # SKIP bare-user repository requires xattr support"
+    echo "ok apply offline inline # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
 rm repo2 -rf
 mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=bare-user
 mkdir deltadir

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_user_xattrs
+
 bindatafiles="bash true ostree"
 morebindatafiles="false ls"
 
@@ -155,13 +157,6 @@ ${CMD_PREFIX} ostree --repo=repo2 fsck
 ${CMD_PREFIX} ostree --repo=repo2 ls ${newrev} >/dev/null
 
 echo 'ok pull delta'
-
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "ok apply offline # SKIP bare-user repository requires xattr support"
-    echo "ok apply offline inline # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
 
 rm repo2 -rf
 mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=bare-user

--- a/tests/test-demo-buildsystem.sh
+++ b/tests/test-demo-buildsystem.sh
@@ -19,13 +19,9 @@
 
 set -euo pipefail
 
-if ! fusermount --version >/dev/null 2>&1; then
-    echo "1..0 # SKIP no fusermount"
-    exit 0
-fi
-
 . $(dirname $0)/libtest.sh
 
+skip_without_fuse
 skip_without_user_xattrs
 
 echo "1..1"

--- a/tests/test-demo-buildsystem.sh
+++ b/tests/test-demo-buildsystem.sh
@@ -26,11 +26,7 @@ fi
 
 . $(dirname $0)/libtest.sh
 
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "1..0 # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
+skip_without_user_xattrs
 
 echo "1..1"
 

--- a/tests/test-demo-buildsystem.sh
+++ b/tests/test-demo-buildsystem.sh
@@ -26,6 +26,12 @@ fi
 
 . $(dirname $0)/libtest.sh
 
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "1..0 # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
 echo "1..1"
 
 # Run "triggers" like ldconfig, gtk-update-icon-cache, etc.

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -78,4 +78,6 @@ if ${OSTREE} show test2 | grep -o 'Found [[:digit:]] signature'; then
   assert_not_reached
 fi
 
+gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+
 echo "ok"

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -21,11 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "1..0 # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
+skip_without_user_xattrs
 
 echo "1..1"
 

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -19,9 +19,15 @@
 
 set -euo pipefail
 
-echo "1..1"
-
 . $(dirname $0)/libtest.sh
+
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "1..0 # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
+echo "1..1"
 
 setup_test_repository "archive-z2"
 echo "ok setup"

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -127,6 +127,12 @@ assert_file_has_content deltascount "^1$"
 
 echo "ok prune"
 
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "ok prune with partial repo # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
 rm repo -rf
 ostree --repo=repo init --mode=bare-user
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_user_xattrs
+
 setup_fake_remote_repo1 "archive-z2"
 
 echo '1..2'
@@ -126,12 +128,6 @@ ${CMD_PREFIX} ostree --repo=repo static-delta list | wc -l > deltascount
 assert_file_has_content deltascount "^1$"
 
 echo "ok prune"
-
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "ok prune with partial repo # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
 
 rm repo -rf
 ostree --repo=repo init --mode=bare-user

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -121,3 +121,5 @@ echo "ok pull mirror with invalid summary sig and no verification"
 # assert_file_has_content deltas.txt "${origmain}-${newmain}"
 
 # echo "ok pull mirror with signed summary covering static deltas"
+
+gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -133,3 +133,5 @@ assert_file_has_content summary.txt "Good signature from \"Ostree Tester <test@t
 grep static-deltas summary.txt > static-deltas.txt
 assert_file_has_content static-deltas.txt \
   $(${OSTREE} --repo=repo rev-parse origin:main)
+
+gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye

--- a/tests/test-pull-untrusted.sh
+++ b/tests/test-pull-untrusted.sh
@@ -39,6 +39,12 @@ echo "ok pull-local --untrusted didn't hardlink"
 
 # Corrupt repo
 for i in ${test_tmpdir}/repo/objects/*/*.file; do
+
+    # make sure it's not a symlink
+    if [ -L $i ]; then
+        continue
+    fi
+
     echo "corrupting $i"
     echo "broke" >> $i
     break;

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -143,4 +143,5 @@ if ${OSTREE} pull R2:main >/dev/null 2>&1; then
 fi
 ${OSTREE} pull R3:main >/dev/null
 
+gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
 echo "ok"

--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -25,6 +25,13 @@ if ! fusermount --version >/dev/null 2>&1; then
 fi
 
 . $(dirname $0)/libtest.sh
+
+touch test-xattrs
+if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    echo "1..0 # SKIP bare-user repository requires xattr support"
+    exit 0
+fi
+
 setup_test_repository "bare-user"
 
 echo "1..5"

--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -19,13 +19,9 @@
 
 set -euo pipefail
 
-if ! fusermount --version >/dev/null 2>&1; then
-    echo "1..0 # SKIP no fusermount"
-    exit 0
-fi
-
 . $(dirname $0)/libtest.sh
 
+skip_without_fuse
 skip_without_user_xattrs
 
 setup_test_repository "bare-user"

--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -26,11 +26,7 @@ fi
 
 . $(dirname $0)/libtest.sh
 
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "1..0 # SKIP bare-user repository requires xattr support"
-    exit 0
-fi
+skip_without_user_xattrs
 
 setup_test_repository "bare-user"
 

--- a/tests/test-xattrs.sh
+++ b/tests/test-xattrs.sh
@@ -21,7 +21,8 @@ set -euo pipefail
 
 touch test-xattrs
 if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    exit 77
+    echo "1..0 # SKIP: cannot run setfattr"
+    exit 0
 fi
 
 echo "1..2"


### PR DESCRIPTION
This branch makes the build-time tests for 2016.4 work in an autobuilder environment (Debian sbuild), and does most of the necessary cleanup for the build chroot to be deleted.

One remaining issue is that one test leaks several gpg-agent processes matching `gpg-agent --homedir /var/tmp/tap-test.*/repo/tmp/ostree-gpg-*` (where the first `*` is the same for all the processes). For the moment I haven't identified which one, so I'm working around that in the packaging for now.

I'm still getting two failures in git master that I didn't see in 2016.4, which are not fixed here:

* `tests/test-pull-untrusted.sh`: fails with `corrupted untrusted pull unexpectedly failed!` (test appears to be new since 2016.4)
* `tests/test-basic.sh`: fails at `assert_not_reached 'Found orphaned commit'` (regression since 2016.4)