### PR TITLE
[merged] tests: Make failing to kill the GPG agent non-fatal

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -349,3 +349,7 @@ skip_without_fuse () {
         exit 0
     fi
 }
+
+libtest_cleanup_gpg () {
+    gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye || true
+}

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -132,6 +132,6 @@ if ${CMD_PREFIX} ostree --repo=repo show main | grep -o 'Found [[:digit:]] signa
 fi
 
 rm -rf repo gnomerepo-files
-gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+libtest_cleanup_gpg
 
 echo "ok"

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -78,6 +78,6 @@ if ${OSTREE} show test2 | grep -o 'Found [[:digit:]] signature'; then
   assert_not_reached
 fi
 
-gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+libtest_cleanup_gpg
 
 echo "ok"

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -122,4 +122,4 @@ echo "ok pull mirror with invalid summary sig and no verification"
 
 # echo "ok pull mirror with signed summary covering static deltas"
 
-gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+libtest_cleanup_gpg

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -134,4 +134,4 @@ grep static-deltas summary.txt > static-deltas.txt
 assert_file_has_content static-deltas.txt \
   $(${OSTREE} --repo=repo rev-parse origin:main)
 
-gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+libtest_cleanup_gpg

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -143,5 +143,5 @@ if ${OSTREE} pull R2:main >/dev/null 2>&1; then
 fi
 ${OSTREE} pull R3:main >/dev/null
 
-gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye
+libtest_cleanup_gpg
 echo "ok"


### PR DESCRIPTION
It's not working for me in `make check` on a RHEL 7 Workstation,
apparently because no GPG agent is spawned.  I'm guessing this has
something to do with the GPG version?

The downside of this is we will be less likely to notice if GPG
changes again and we start leaking agents like we're in The Matrix
Reloaded.  But the real solution to that is containers anyways.