### PR TITLE
[merged] More test fixes

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -23,8 +23,6 @@ include $(top_srcdir)/buildutil/glib-tap.mk
 # include the builddir in $PATH so we find our just-built ostree
 # binary.
 TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
-	SRCDIR=$$(cd $(top_srcdir) && pwd) \
-	BUILDDIR=$$(cd $(top_builddir) && pwd) \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd) \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd) \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -41,8 +41,12 @@ test_tmpdir=$(pwd)
 if ! test -f .testtmp; then
     files=$(ls)
     if test -n "${files}"; then
+	ls -l
 	assert_not_reached "test tmpdir=${test_tmpdir} is not empty; run this test via \`make check TESTS=\`, not directly"
     fi
+    # Remember that this is an acceptable test $(pwd), for the benefit of
+    # C and JS tests which may source this file again
+    touch .testtmp
 fi
 
 export G_DEBUG=fatal-warnings

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -17,7 +17,17 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-SRCDIR=$(dirname $0)
+if [ -n "${G_TEST_SRCDIR:-}" ]; then
+  test_srcdir="${G_TEST_SRCDIR}/tests"
+else
+  test_srcdir=$(dirname $0)
+fi
+
+if [ -n "${G_TEST_BUILDDIR:-}" ]; then
+  test_builddir="${G_TEST_BUILDDIR}/tests"
+else
+  test_builddir=$(dirname $0)
+fi
 
 assert_not_reached () {
     echo $@ 1>&2; exit 1
@@ -54,7 +64,7 @@ export TEST_GPG_KEYID_3="DF444D67"
 # homedir in order to create lockfiles.  Work around
 # this by copying locally.
 echo "Copying gpghome to ${test_tmpdir}"
-cp -a ${SRCDIR}/gpghome ${test_tmpdir}
+cp -a "${test_srcdir}/gpghome" ${test_tmpdir}
 export TEST_GPG_KEYHOME=${test_tmpdir}/gpghome
 export OSTREE_GPG_HOME=${test_tmpdir}/gpghome/trusted
 
@@ -63,9 +73,9 @@ if test -n "${OT_TESTS_DEBUG:-}"; then
 fi
 
 if test -n "${OT_TESTS_VALGRIND:-}"; then
-    CMD_PREFIX="env G_SLICE=always-malloc valgrind -q --leak-check=full --num-callers=30 --suppressions=${SRCDIR}/ostree-valgrind.supp"
+    CMD_PREFIX="env G_SLICE=always-malloc valgrind -q --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/ostree-valgrind.supp"
 else
-    CMD_PREFIX="env LD_PRELOAD=${SRCDIR}/libreaddir-rand.so"
+    CMD_PREFIX="env LD_PRELOAD=${test_builddir}/libreaddir-rand.so"
 fi
 
 assert_streq () {

--- a/tests/test-abi.sh
+++ b/tests/test-abi.sh
@@ -21,8 +21,8 @@ set -euo pipefail
 
 echo '1..1'
 
-grep ' ostree_[A-Za-z0-9_]*;' ${SRCDIR}/src/libostree/libostree.sym | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
-eu-readelf -a ${BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9_.]*,\1,' |sort -u > found-symbols.txt
+grep ' ostree_[A-Za-z0-9_]*;' ${G_TEST_SRCDIR}/src/libostree/libostree.sym | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
+eu-readelf -a ${G_TEST_BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9_.]*,\1,' |sort -u > found-symbols.txt
 diff -u expected-symbols.txt found-symbols.txt
 
 echo 'ok'

--- a/tests/test-archivez.sh
+++ b/tests/test-archivez.sh
@@ -25,7 +25,7 @@ echo '1..11'
 
 setup_test_repository "archive-z2"
 
-. ${SRCDIR}/archive-test.sh
+. ${test_srcdir}/archive-test.sh
 
 cd ${test_tmpdir}
 mkdir repo2

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -130,9 +130,9 @@ assert_streq "${totalsize_orig}" "${totalsize_swapped}"
 
 echo 'ok generate + show endian swapped'
 
-tar xf ${SRCDIR}/pre-endian-deltas-repo-big.tar.xz
+tar xf ${test_srcdir}/pre-endian-deltas-repo-big.tar.xz
 mv pre-endian-deltas-repo{,-big}
-tar xf ${SRCDIR}/pre-endian-deltas-repo-little.tar.xz
+tar xf ${test_srcdir}/pre-endian-deltas-repo-little.tar.xz
 mv pre-endian-deltas-repo{,-little}
 legacy_origrev=$(${CMD_PREFIX} ostree --repo=pre-endian-deltas-repo-big rev-parse main^)
 legacy_newrev=$(${CMD_PREFIX} ostree --repo=pre-endian-deltas-repo-big rev-parse main)

--- a/tests/test-pull-archive-z.sh
+++ b/tests/test-pull-archive-z.sh
@@ -23,4 +23,4 @@ set -euo pipefail
 
 setup_fake_remote_repo1 "archive-z2"
 
-. ${SRCDIR}/pull-test.sh
+. ${test_srcdir}/pull-test.sh

--- a/tests/test-xattrs.sh
+++ b/tests/test-xattrs.sh
@@ -19,15 +19,11 @@
 
 set -euo pipefail
 
-touch test-xattrs
-if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-    echo "1..0 # SKIP: cannot run setfattr"
-    exit 0
-fi
+. $(dirname $0)/libtest.sh
+
+skip_without_user_xattrs
 
 echo "1..2"
-
-. $(dirname $0)/libtest.sh
 
 setup_test_repository "archive-z2"
 


### PR DESCRIPTION
Having fixed the build-time tests in #232, now it's the installed-tests' turn :-)

With these changes (minus the one for `test-abi` because that didn't exist in the 2016.4 release), the installed-tests pass on a Debian VM again.