### PR TITLE
[merged] Inherit options and remotes from parent repo

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -40,6 +40,7 @@ test_scripts = \
 	tests/test-export.sh \
 	tests/test-help.sh \
 	tests/test-libarchive.sh \
+	tests/test-parent.sh \
 	tests/test-pull-archive-z.sh \
 	tests/test-pull-commit-only.sh \
 	tests/test-pull-corruption.sh \

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -321,6 +321,9 @@ global:
         ostree_sysroot_deployment_unlock;
         ostree_deployment_get_unlocked;
         ostree_deployment_unlocked_state_to_string;
+        ostree_repo_get_remote_option;
+        ostree_repo_get_remote_list_option;
+        ostree_repo_get_remote_boolean_option;
 } LIBOSTREE_2016.3;
 
 /*                         NOTE NOTE NOTE

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -195,13 +195,6 @@ _ostree_repo_commit_modifier_apply (OstreeRepo               *self,
 gboolean
 _ostree_repo_remote_name_is_file (const char *remote_name);
 
-gboolean
-_ostree_repo_get_remote_option_inherit (OstreeRepo  *self,
-                                        const char  *remote_name,
-                                        const char  *option_name,
-                                        char       **out_value,
-                                        GError     **error);
-
 #ifdef HAVE_LIBSOUP
 OstreeFetcher *
 _ostree_repo_remote_new_fetcher (OstreeRepo  *self,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -196,29 +196,6 @@ gboolean
 _ostree_repo_remote_name_is_file (const char *remote_name);
 
 gboolean
-_ostree_repo_get_remote_option (OstreeRepo  *self,
-                                const char  *remote_name,
-                                const char  *option_name,
-                                const char  *default_value,
-                                char       **out_value,
-                                GError     **error);
-
-gboolean
-_ostree_repo_get_remote_list_option (OstreeRepo   *self,
-                                     const char   *remote_name,
-                                     const char   *option_name,
-                                     char       ***out_value,
-                                     GError      **error);
-
-gboolean
-_ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
-                                        const char  *remote_name,
-                                        const char  *option_name,
-                                        gboolean     default_value,
-                                        gboolean    *out_value,
-                                        GError     **error);
-
-gboolean
 _ostree_repo_get_remote_option_inherit (OstreeRepo  *self,
                                         const char  *remote_name,
                                         const char  *option_name,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1993,9 +1993,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   requested_refs_to_fetch = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   commits_to_fetch = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
-  if (!_ostree_repo_get_remote_option (self,
-                                       remote_name_or_baseurl, "metalink",
-                                       NULL, &metalink_url_str, error))
+  if (!ostree_repo_get_remote_option (self,
+                                      remote_name_or_baseurl, "metalink",
+                                      NULL, &metalink_url_str, error))
     goto out;
 
   if (!metalink_url_str)
@@ -2049,9 +2049,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                                      summary_bytes, FALSE);
     }
 
-  if (!_ostree_repo_get_remote_list_option (self,
-                                            remote_name_or_baseurl, "branches",
-                                            &configured_branches, error))
+  if (!ostree_repo_get_remote_list_option (self,
+                                           remote_name_or_baseurl, "branches",
+                                           &configured_branches, error))
     goto out;
 
   if (strcmp (soup_uri_get_scheme (pull_data->base_uri), "file") == 0)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -257,13 +257,18 @@ _ostree_repo_remote_name_is_file (const char *remote_name)
   return g_str_has_prefix (remote_name, "file://");
 }
 
+/**
+ * ostree_repo_get_remote_option:
+ * @self:
+ *
+ */
 gboolean
-_ostree_repo_get_remote_option (OstreeRepo  *self,
-                                const char  *remote_name,
-                                const char  *option_name,
-                                const char  *default_value,
-                                char       **out_value,
-                                GError     **error)
+ostree_repo_get_remote_option (OstreeRepo  *self,
+                               const char  *remote_name,
+                               const char  *option_name,
+                               const char  *default_value,
+                               char       **out_value,
+                               GError     **error)
 {
   local_cleanup_remote OstreeRemote *remote = NULL;
   gboolean ret = FALSE;
@@ -289,12 +294,17 @@ _ostree_repo_get_remote_option (OstreeRepo  *self,
   return ret;
 }
 
+/**
+ * ostree_repo_get_remote_list_option:
+ * @self:
+ *
+ */
 gboolean
-_ostree_repo_get_remote_list_option (OstreeRepo   *self,
-                                     const char   *remote_name,
-                                     const char   *option_name,
-                                     char       ***out_value,
-                                     GError      **error)
+ostree_repo_get_remote_list_option (OstreeRepo   *self,
+                                    const char   *remote_name,
+                                    const char   *option_name,
+                                    char       ***out_value,
+                                    GError      **error)
 {
   local_cleanup_remote OstreeRemote *remote = NULL;
   gboolean ret = FALSE;
@@ -331,13 +341,18 @@ _ostree_repo_get_remote_list_option (OstreeRepo   *self,
   return ret;
 }
 
+/**
+ * ostree_repo_get_remote_boolean_option:
+ * @self:
+ *
+ */
 gboolean
-_ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
-                                        const char  *remote_name,
-                                        const char  *option_name,
-                                        gboolean     default_value,
-                                        gboolean    *out_value,
-                                        GError     **error)
+ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
+                                       const char  *remote_name,
+                                       const char  *option_name,
+                                       gboolean     default_value,
+                                       gboolean    *out_value,
+                                       GError     **error)
 {
   local_cleanup_remote OstreeRemote *remote = NULL;
   gboolean ret = FALSE;
@@ -374,9 +389,9 @@ _ostree_repo_get_remote_option_inherit (OstreeRepo  *self,
   g_autofree char *value = NULL;
   gboolean ret = FALSE;
 
-  if (!_ostree_repo_get_remote_option (self,
-                                       remote_name, option_name,
-                                       NULL, &value, error))
+  if (!ostree_repo_get_remote_option (self,
+                                      remote_name, option_name,
+                                      NULL, &value, error))
     goto out;
 
   if (value == NULL && parent != NULL)
@@ -412,9 +427,9 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
   g_return_val_if_fail (OSTREE_IS_REPO (self), NULL);
   g_return_val_if_fail (remote_name != NULL, NULL);
 
-  if (!_ostree_repo_get_remote_boolean_option (self, remote_name,
-                                               "tls-permissive", FALSE,
-                                               &tls_permissive, error))
+  if (!ostree_repo_get_remote_boolean_option (self, remote_name,
+                                              "tls-permissive", FALSE,
+                                              &tls_permissive, error))
     goto out;
 
   if (tls_permissive)
@@ -426,13 +441,13 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
     g_autofree char *tls_client_cert_path = NULL;
     g_autofree char *tls_client_key_path = NULL;
 
-    if (!_ostree_repo_get_remote_option (self, remote_name,
-                                         "tls-client-cert-path", NULL,
-                                         &tls_client_cert_path, error))
+    if (!ostree_repo_get_remote_option (self, remote_name,
+                                        "tls-client-cert-path", NULL,
+                                        &tls_client_cert_path, error))
       goto out;
-    if (!_ostree_repo_get_remote_option (self, remote_name,
-                                         "tls-client-key-path", NULL,
-                                         &tls_client_key_path, error))
+    if (!ostree_repo_get_remote_option (self, remote_name,
+                                        "tls-client-key-path", NULL,
+                                        &tls_client_key_path, error))
       goto out;
 
     if ((tls_client_cert_path != NULL) != (tls_client_key_path != NULL))
@@ -462,9 +477,9 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
   {
     g_autofree char *tls_ca_path = NULL;
 
-    if (!_ostree_repo_get_remote_option (self, remote_name,
-                                         "tls-ca-path", NULL,
-                                         &tls_ca_path, error))
+    if (!ostree_repo_get_remote_option (self, remote_name,
+                                        "tls-ca-path", NULL,
+                                        &tls_ca_path, error))
       goto out;
 
     if (tls_ca_path != NULL)
@@ -482,9 +497,9 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
   {
     g_autofree char *http_proxy = NULL;
 
-    if (!_ostree_repo_get_remote_option (self, remote_name,
-                                         "proxy", NULL,
-                                         &http_proxy, error))
+    if (!ostree_repo_get_remote_option (self, remote_name,
+                                        "proxy", NULL,
+                                        &http_proxy, error))
       goto out;
 
     if (http_proxy != NULL)
@@ -1343,8 +1358,8 @@ ostree_repo_remote_get_gpg_verify (OstreeRepo  *self,
       return TRUE;
     }
 
- return _ostree_repo_get_remote_boolean_option (self, name, "gpg-verify",
-                                                TRUE, out_gpg_verify, error);
+ return ostree_repo_get_remote_boolean_option (self, name, "gpg-verify",
+                                               TRUE, out_gpg_verify, error);
 }
 
 /**
@@ -1366,8 +1381,8 @@ ostree_repo_remote_get_gpg_verify_summary (OstreeRepo  *self,
                                            gboolean    *out_gpg_verify_summary,
                                            GError     **error)
 {
-  return _ostree_repo_get_remote_boolean_option (self, name, "gpg-verify-summary",
-                                                 FALSE, out_gpg_verify_summary, error);
+  return ostree_repo_get_remote_boolean_option (self, name, "gpg-verify-summary",
+                                                FALSE, out_gpg_verify_summary, error);
 }
 
 /**
@@ -1889,8 +1904,8 @@ ostree_repo_remote_fetch_summary (OstreeRepo    *self,
   g_return_val_if_fail (OSTREE_REPO (self), FALSE);
   g_return_val_if_fail (name != NULL, FALSE);
 
-  if (!_ostree_repo_get_remote_option (self, name, "metalink", NULL,
-                                       &metalink_url_string, error))
+  if (!ostree_repo_get_remote_option (self, name, "metalink", NULL,
+                                      &metalink_url_string, error))
     goto out;
 
   if (!repo_remote_fetch_summary (self,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -280,8 +280,19 @@ _ostree_repo_remote_name_is_file (const char *remote_name)
 
 /**
  * ostree_repo_get_remote_option:
- * @self:
+ * @self: A OstreeRepo
+ * @remote_name: Name
+ * @option_name: Option
+ * @default_value: (allow-none): Value returned if @option_name is not present
+ * @out_value: (out): Return location for value
+ * @error: Error
  *
+ * OSTree remotes are represented by keyfile groups, formatted like:
+ * `[remote "remotename"]`. This function returns a value named @option_name
+ * underneath that group, or @default_value if the remote exists but not the
+ * option name.
+ *
+ * Returns: %TRUE on success, otherwise %FALSE with @error set
  */
 gboolean
 ostree_repo_get_remote_option (OstreeRepo  *self,
@@ -341,8 +352,20 @@ ostree_repo_get_remote_option (OstreeRepo  *self,
 
 /**
  * ostree_repo_get_remote_list_option:
- * @self:
+ * @self: A OstreeRepo
+ * @remote_name: Name
+ * @option_name: Option
+ * @out_value: (out) (array zero-terminated=1): location to store the list
+ *            of strings. The list should be freed with
+ *            g_strfreev().
+ * @error: Error
  *
+ * OSTree remotes are represented by keyfile groups, formatted like:
+ * `[remote "remotename"]`. This function returns a value named @option_name
+ * underneath that group, and returns it as an zero terminated array of strings.
+ * If the option is not set, @out_value will be set to %NULL.
+ *
+ * Returns: %TRUE on success, otherwise %FALSE with @error set
  */
 gboolean
 ostree_repo_get_remote_list_option (OstreeRepo   *self,
@@ -399,8 +422,19 @@ ostree_repo_get_remote_list_option (OstreeRepo   *self,
 
 /**
  * ostree_repo_get_remote_boolean_option:
- * @self:
+ * @self: A OstreeRepo
+ * @remote_name: Name
+ * @option_name: Option
+ * @default_value: (allow-none): Value returned if @option_name is not present
+ * @out_value: (out) : location to store the result.
+ * @error: Error
  *
+ * OSTree remotes are represented by keyfile groups, formatted like:
+ * `[remote "remotename"]`. This function returns a value named @option_name
+ * underneath that group, and returns it as a boolean.
+ * If the option is not set, @out_value will be set to @default_value.
+ *
+ * Returns: %TRUE on success, otherwise %FALSE with @error set
  */
 gboolean
 ostree_repo_get_remote_boolean_option (OstreeRepo  *self,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -148,6 +148,29 @@ gboolean      ostree_repo_remote_get_gpg_verify_summary (OstreeRepo  *self,
                                                          GError     **error);
 
 _OSTREE_PUBLIC
+gboolean      ostree_repo_get_remote_option (OstreeRepo  *self,
+                                             const char  *remote_name,
+                                             const char  *option_name,
+                                             const char  *default_value,
+                                             char       **out_value,
+                                             GError     **error);
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_get_remote_list_option (OstreeRepo   *self,
+                                                  const char   *remote_name,
+                                                  const char   *option_name,
+                                                  char       ***out_value,
+                                                  GError      **error);
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
+                                                     const char  *remote_name,
+                                                     const char  *option_name,
+                                                     gboolean     default_value,
+                                                     gboolean    *out_value,
+                                                     GError     **error);
+
+_OSTREE_PUBLIC
 gboolean      ostree_repo_remote_gpg_import (OstreeRepo         *self,
                                              const char         *name,
                                              GInputStream       *source_stream,

--- a/tests/test-parent.sh
+++ b/tests/test-parent.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo '1..2'
+
+setup_test_repository "archive-z2"
+
+export OSTREE_GPG_SIGN="${OSTREE} gpg-sign --gpg-homedir=${TEST_GPG_KEYHOME}"
+
+cd ${test_tmpdir}
+
+# Create a repo
+mkdir repo2
+${CMD_PREFIX} ostree --repo=repo2 init
+${CMD_PREFIX} ostree --repo=repo2 remote add --gpg-import=${test_tmpdir}/gpghome/trusted/pubring.gpg --set=gpg-verify=true aremote file://$(pwd)/repo test2
+
+# Create a repo with repo2 as parent
+${CMD_PREFIX} ostree init --repo=repo3 --mode=bare-user
+${CMD_PREFIX} ostree config --repo=repo3 set core.parent `pwd`/repo2
+
+# Ensure the unsigned pull fails so we know we imported the gpg config correctly
+if ${CMD_PREFIX} ostree --repo=repo3 pull aremote; then
+    assert_not_reached "GPG verification unexpectedly succeeded"
+fi
+echo "ok unsigned pull w/parent"
+
+# Make a signed commit
+${OSTREE} commit -b test2 -s "A GPG signed commit" -m "Signed commit body" --gpg-sign=${TEST_GPG_KEYID_1} --gpg-homedir=${TEST_GPG_KEYHOME} --tree=dir=files
+
+# Make sure we pick up the remote url and gpg config from the parent
+echo "ok signed pull w/parent"

--- a/tests/test-parent.sh
+++ b/tests/test-parent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+# Copyright (C) 2016 Alexander Larsson <alexl@redhat.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,6 @@ export OSTREE_GPG_SIGN="${OSTREE} gpg-sign --gpg-homedir=${TEST_GPG_KEYHOME}"
 cd ${test_tmpdir}
 
 # Create a repo
-mkdir repo2
 ${CMD_PREFIX} ostree --repo=repo2 init
 ${CMD_PREFIX} ostree --repo=repo2 remote add --gpg-import=${test_tmpdir}/gpghome/trusted/pubring.gpg --set=gpg-verify=true aremote file://$(pwd)/repo test2
 
@@ -44,8 +43,8 @@ if ${CMD_PREFIX} ostree --repo=repo3 pull aremote; then
 fi
 echo "ok unsigned pull w/parent"
 
-# Make a signed commit
+# Make a signed commit and ensure we can now pull
 ${OSTREE} commit -b test2 -s "A GPG signed commit" -m "Signed commit body" --gpg-sign=${TEST_GPG_KEYID_1} --gpg-homedir=${TEST_GPG_KEYHOME} --tree=dir=files
+${CMD_PREFIX} ostree --repo=repo3 pull aremote
 
-# Make sure we pick up the remote url and gpg config from the parent
 echo "ok signed pull w/parent"


### PR DESCRIPTION
This makes parent repos much more useful. In particular I'd like to use this to make a user repo inherited from a system repo, pull from a http remote and then do a local pull into the system remote (via a privileged helper).