### PR TITLE
[merged] build: Make tests/libreaddir-rand.so rule use AM_V_GEN

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -222,9 +222,9 @@ EXTRA_DIST += \
 	tests/gpg-verify-data/trustdb.gpg \
 	tests/gpg-verify-data/gpg.conf
 
-tests-libreaddir-rand-so-symlink:
-	ln -fns ../.libs/libreaddir-rand.so tests
-ALL_LOCAL_RULES += tests-libreaddir-rand-so-symlink
+tests/libreaddir-rand.so: Makefile
+	$(AM_V_GEN) ln -fns ../.libs/libreaddir-rand.so tests
+ALL_LOCAL_RULES += tests/libreaddir-rand.so
 
 # Unfortunately the glib test data APIs don't actually handle
 # non-recursive Automake, so we change our code to canonically look


### PR DESCRIPTION
So non-verbose builds don't have a verbose rule smack in the middle.