### PR TITLE
WIP offline support

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -319,6 +319,14 @@ gboolean
 _ostree_repo_update_mtime (OstreeRepo        *self,
                            GError           **error);
 
+gboolean
+_ostree_repo_load_cache_summary (OstreeRepo        *self,
+                                 const char        *remote,
+                                 GBytes            **summary,
+                                 GBytes            **summary_sig,
+                                 GCancellable      *cancellable,
+                                 GError           **error);
+
 /* Load the summary from the cache if the provided .sig file is the same as the
    cached version.  */
 gboolean

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -164,6 +164,26 @@ gboolean      ostree_repo_remote_fetch_summary (OstreeRepo    *self,
                                                 GCancellable  *cancellable,
                                                 GError       **error);
 
+/**
+ * OstreeRepoRemoteFetchSummaryFlags:
+ * @OSTREE_REPO_REMOTE_FETCH_SUMMARY_NONE: No flags.
+ * @OSTREE_REPO_REMOTE_FETCH_SUMMARY_FALLBACK_TO_CACHE: Use cached data on network failure.
+ */
+typedef enum {
+  OSTREE_REPO_REMOTE_FETCH_SUMMARY_NONE = 0,
+  OSTREE_REPO_REMOTE_FETCH_SUMMARY_FALLBACK_TO_CACHE = 1<<0,
+} OstreeRepoRemoteFetchSummaryFlags;
+
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_remote_fetch_summary_ext (OstreeRepo    *self,
+                                                    const char    *name,
+                                                    OstreeRepoRemoteFetchSummaryFlags flags,
+                                                    GBytes       **out_summary,
+                                                    GBytes       **out_signatures,
+                                                    GCancellable  *cancellable,
+                                                    GError       **error);
+
 _OSTREE_PUBLIC
 OstreeRepo * ostree_repo_get_parent (OstreeRepo  *self);
 
@@ -364,6 +384,25 @@ gboolean ostree_repo_remote_list_refs (OstreeRepo       *self,
                                        GHashTable      **out_all_refs,
                                        GCancellable     *cancellable,
                                        GError          **error);
+
+
+/**
+ * OstreeRepoRemoteListRefsFlags:
+ * @OSTREE_REPO_REMOTE_LIST_REFS_NONE: No flags.
+ * @OSTREE_REPO_REMOTE_LIST_REFS_FALLBACK_TO_CACHE: Use cached data on network failure.
+ */
+typedef enum {
+  OSTREE_REPO_REMOTE_LIST_REFS_NONE = 0,
+  OSTREE_REPO_REMOTE_LIST_REFS_FALLBACK_TO_CACHE = 1<<0,
+} OstreeRepoRemoteListRefsFlags;
+
+_OSTREE_PUBLIC
+gboolean ostree_repo_remote_list_refs_ext (OstreeRepo       *self,
+                                           const char       *remote_name,
+                                           OstreeRepoRemoteListRefsFlags flags,
+                                           GHashTable      **out_all_refs,
+                                           GCancellable     *cancellable,
+                                           GError          **error);
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_variant (OstreeRepo  *self,


### PR DESCRIPTION
This patch adds a fallback-to-cache flags for the fetch_summary() (and list_remote_refs()) that lets the client specify that on network error, the local cache should be used to report data.

This is pretty important for xdg-app, as we want the gnome-software UI to work to some degree even when offline. 

Note, I've not actually tested this code, its more of a strawman for how to handle offline support in general. In particular, this only handles the completely offline case too. 

Another interesting feature we may want is to keep using the local cache for some small time without even checking the signature. For instance, if gnome-software causes a series of calls during the regular check for updates there is no need to update the cache for each call. For that we could use a ALWAYS_USE_CACHE and then do an initial call without that to prime the cache.

A completely different approach would be to put all these caches in xdg-app. 

Opinions?
