### PR TITLE
[merged] build: Move grub2-15_ostree back to pkglibexecdir

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -41,10 +41,10 @@ endif
 
 if !BUILDOPT_BUILTIN_GRUB2_MKCONFIG
 # We're using the system grub2-mkconfig generator
-libexec_SCRIPTS = src/boot/grub2/grub2-15_ostree
+pkglibexec_SCRIPTS += src/boot/grub2/grub2-15_ostree
 install-grub2-config-hook:
 	mkdir -p $(DESTDIR)$(grub2configdir)
-	ln -sf $(libexecdir)/grub2-15_ostree $(DESTDIR)$(grub2configdir)/15_ostree
+	ln -sf $(pkglibexecdir)/grub2-15_ostree $(DESTDIR)$(grub2configdir)/15_ostree
 grub2configdir = $(sysconfdir)/grub.d
 INSTALL_DATA_HOOKS += install-grub2-config-hook
 else


### PR DESCRIPTION
It's not quite namespaced enough to have
`/usr/libexec/grub2-15_ostree`, and the Fedora spec file expects
things in `/usr/libexec/ostree`.  Changing the spec file would be
annoying as we'd need conditionals.