### PR TITLE
[merged] Add support for separate cache-dir

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -335,4 +335,5 @@ global:
         ostree_repo_get_remote_option;
         ostree_repo_get_remote_list_option;
         ostree_repo_get_remote_boolean_option;
+        ostree_repo_set_cache_dir;
 } LIBOSTREE_2016.4;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -33,7 +33,8 @@ G_BEGIN_DECLS
 
 #define _OSTREE_OBJECT_SIZES_ENTRY_SIGNATURE "ay"
 
-#define _OSTREE_SUMMARY_CACHE_PATH "tmp/cache/summaries"
+#define _OSTREE_SUMMARY_CACHE_DIR "summaries"
+#define _OSTREE_CACHE_DIR "cache"
 
 /**
  * OstreeRepo:
@@ -52,6 +53,7 @@ struct OstreeRepo {
   int    repo_dir_fd;
   GFile *tmp_dir;
   int    tmp_dir_fd;
+  int    cache_dir_fd;
   GFile *objects_dir;
   GFile *state_dir;
   int objects_dir_fd;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -54,6 +54,7 @@ struct OstreeRepo {
   GFile *tmp_dir;
   int    tmp_dir_fd;
   int    cache_dir_fd;
+  char  *cache_dir;
   GFile *objects_dir;
   GFile *state_dir;
   int objects_dir_fd;

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -125,7 +125,10 @@ _ostree_repo_prune_tmp (OstreeRepo *self,
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
   glnx_fd_close int fd = -1;
 
-  fd = glnx_opendirat_with_errno (self->repo_dir_fd, _OSTREE_SUMMARY_CACHE_PATH, FALSE);
+  if (self->cache_dir_fd == -1)
+    return TRUE;
+
+  fd = glnx_opendirat_with_errno (self->cache_dir_fd, _OSTREE_SUMMARY_CACHE_DIR, FALSE);
   if (fd < 0)
     {
       if (errno == ENOENT)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2574,6 +2574,34 @@ ostree_repo_set_disable_fsync (OstreeRepo    *self,
 }
 
 /**
+ * ostree_repo_set_cache_dir:
+ * @self: An #OstreeRepo
+ * @cache_dir: Path of location to store caches for remotes
+ *
+ * Set a custom location for the cache directory used for e.g.
+ * per-remote summary caches. Setting this manually is useful when
+ * doing operations on a system repo as a user because you don't have
+ * write permissions in the repo, where the cache is normally stored.
+ */
+gboolean
+ostree_repo_set_cache_dir (OstreeRepo    *self,
+                           const char    *cache_dir,
+                           GCancellable   *cancellable,
+                           GError        **error)
+{
+  int fd;
+
+  if (!glnx_opendirat (-1, cache_dir, TRUE, &fd, error))
+    return FALSE;
+
+  if (self->cache_dir_fd != -1)
+    close (self->cache_dir_fd);
+  self->cache_dir_fd = fd;
+
+  return TRUE;
+}
+
+/**
  * ostree_repo_get_disable_fsync:
  * @self: An #OstreeRepo
  *

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2576,7 +2576,8 @@ ostree_repo_set_disable_fsync (OstreeRepo    *self,
 /**
  * ostree_repo_set_cache_dir:
  * @self: An #OstreeRepo
- * @cache_dir: Path of location to store caches for remotes
+ * @dfd: directory fd
+ * @path: subpath in @dfd
  *
  * Set a custom location for the cache directory used for e.g.
  * per-remote summary caches. Setting this manually is useful when
@@ -2585,13 +2586,14 @@ ostree_repo_set_disable_fsync (OstreeRepo    *self,
  */
 gboolean
 ostree_repo_set_cache_dir (OstreeRepo    *self,
-                           const char    *cache_dir,
-                           GCancellable   *cancellable,
+                           int            dfd,
+                           const char    *path,
+                           GCancellable  *cancellable,
                            GError        **error)
 {
   int fd;
 
-  if (!glnx_opendirat (-1, cache_dir, TRUE, &fd, error))
+  if (!glnx_opendirat (dfd, path, TRUE, &fd, error))
     return FALSE;
 
   if (self->cache_dir_fd != -1)

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -65,7 +65,8 @@ void          ostree_repo_set_disable_fsync (OstreeRepo    *self,
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_set_cache_dir (OstreeRepo    *self,
-                                         const char    *cache_dir,
+                                         int            dfd,
+                                         const char    *path,
                                          GCancellable   *cancellable,
                                          GError        **error);
 

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -64,6 +64,12 @@ void          ostree_repo_set_disable_fsync (OstreeRepo    *self,
                                              gboolean       disable_fsync);
 
 _OSTREE_PUBLIC
+gboolean      ostree_repo_set_cache_dir (OstreeRepo    *self,
+                                         const char    *cache_dir,
+                                         GCancellable   *cancellable,
+                                         GError        **error);
+
+_OSTREE_PUBLIC
 gboolean      ostree_repo_get_disable_fsync (OstreeRepo    *self);
 
 _OSTREE_PUBLIC

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -35,10 +35,12 @@ static gboolean opt_disable_static_deltas;
 static gboolean opt_require_static_deltas;
 static gboolean opt_untrusted;
 static char* opt_subpath;
+static char* opt_cache_dir;
 static int opt_depth = 0;
  
 static GOptionEntry options[] = {
    { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
+   { "cache-dir", 0, 0, G_OPTION_ARG_STRING, &opt_cache_dir, "Use custom cache dir", NULL },
    { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
    { "disable-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_disable_static_deltas, "Do not use static deltas", NULL },
    { "require-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_require_static_deltas, "Require static deltas", NULL },
@@ -129,6 +131,12 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
   if (opt_disable_fsync)
     ostree_repo_set_disable_fsync (repo, TRUE);
+
+  if (opt_cache_dir)
+    {
+      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+        goto out;
+    }
 
   if (opt_mirror)
     pullflags |= OSTREE_REPO_PULL_FLAGS_MIRROR;

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -134,7 +134,7 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
   if (opt_cache_dir)
     {
-      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+      if (!ostree_repo_set_cache_dir (repo, AT_FDCWD, opt_cache_dir, cancellable, error))
         goto out;
     }
 

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -54,7 +54,7 @@ ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError
 
   if (opt_cache_dir)
     {
-      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+      if (!ostree_repo_set_cache_dir (repo, AT_FDCWD, opt_cache_dir, cancellable, error))
         goto out;
     }
 

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -25,7 +25,10 @@
 #include "ot-main.h"
 #include "ot-remote-builtins.h"
 
+static char* opt_cache_dir;
+
 static GOptionEntry option_entries[] = {
+  { "cache-dir", 0, 0, G_OPTION_ARG_STRING, &opt_cache_dir, "Use custom cache dir", NULL },
 };
 
 gboolean
@@ -47,6 +50,12 @@ ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError
     {
       ot_util_usage_error (context, "NAME must be specified", error);
       goto out;
+    }
+
+  if (opt_cache_dir)
+    {
+      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+        goto out;
     }
 
   remote_name = argv[1];

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -28,7 +28,10 @@
 
 static gboolean opt_raw;
 
+static char* opt_cache_dir;
+
 static GOptionEntry option_entries[] = {
+  { "cache-dir", 0, 0, G_OPTION_ARG_STRING, &opt_cache_dir, "Use custom cache dir", NULL },
   { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "Show raw variant data", NULL },
   { NULL }
 };
@@ -58,6 +61,12 @@ ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GEr
     }
 
   remote_name = argv[1];
+
+  if (opt_cache_dir)
+    {
+      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+        goto out;
+    }
 
   if (opt_raw)
     flags |= OSTREE_DUMP_RAW;

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -64,7 +64,7 @@ ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (opt_cache_dir)
     {
-      if (!ostree_repo_set_cache_dir (repo, opt_cache_dir, cancellable, error))
+      if (!ostree_repo_set_cache_dir (repo, AT_FDCWD, opt_cache_dir, cancellable, error))
         goto out;
     }
 

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..6"
+echo "1..7"
 
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
@@ -91,6 +91,21 @@ assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig
 echo "ok prune summary cache"
 
+cd ${test_tmpdir}
+repo_reinit
+mkdir cachedir
+${OSTREE} --repo=repo pull --cache-dir=cachedir origin main
+assert_not_has_file repo/tmp/cache/summaries/origin
+assert_not_has_file repo/tmp/cache/summaries/origin.sig
+assert_has_file cachedir/summaries/origin
+assert_has_file cachedir/summaries/origin.sig
+
+rm cachedir/summaries/origin
+${OSTREE} --repo=repo pull --cache-dir=cachedir origin main
+assert_not_has_file repo/tmp/cache/summaries/origin
+assert_has_file cachedir/summaries/origin
+
+echo "ok pull with signed summary and cachedir"
 
 cd ${test_tmpdir}
 repo_reinit


### PR DESCRIPTION
This lets you specify a cache dir outside of the repo, which is useful for repeated operations on a system repository that you don't have write rights to. For instance, the system xdg-app repo.