### PR TITLE
[merged] Fix the symbol versions for ostree_repo_get_remote_*option

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -321,9 +321,6 @@ global:
         ostree_sysroot_deployment_unlock;
         ostree_deployment_get_unlocked;
         ostree_deployment_unlocked_state_to_string;
-        ostree_repo_get_remote_option;
-        ostree_repo_get_remote_list_option;
-        ostree_repo_get_remote_boolean_option;
 } LIBOSTREE_2016.3;
 
 /*                         NOTE NOTE NOTE
@@ -335,4 +332,7 @@ LIBOSTREE_2016.5 {
 global:
         ostree_repo_import_object_from_with_trust;
         ostree_sepolicy_get_csum;
+        ostree_repo_get_remote_option;
+        ostree_repo_get_remote_list_option;
+        ostree_repo_get_remote_boolean_option;
 } LIBOSTREE_2016.4;


### PR DESCRIPTION
These were accidentally added to 2016.4 instead of 2016.5