### PR TITLE
[merged] ostree-repo-pull: always initialize flags_i

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1908,7 +1908,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   if (options)
     {
-      int flags_i;
+      int flags_i = OSTREE_REPO_PULL_FLAGS_NONE;
       (void) g_variant_lookup (options, "refs", "^a&s", &refs_to_fetch);
       (void) g_variant_lookup (options, "flags", "i", &flags_i);
       /* Reduce risk of issues if enum happens to be 64 bit for some reason */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3999,11 +3999,17 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
  * Like ostree_repo_pull(), but supports an extensible set of flags.
  * The following are currently defined:
  *
- *   * subdir (s): Pull just this subdirectory
+ *   * refs (as): Array of string refs
  *   * flags (i): An instance of #OstreeRepoPullFlags
- *   * refs: (as): Array of string refs
- *   * depth: (i): How far in the history to traverse; default is 0, -1 means infinite
- *   * override-commit-ids: (as): Array of specific commit IDs to fetch for refs
+ *   * subdir (s): Pull just this subdirectory
+ *   * override-remote-name (s): If local, add this remote to refspec
+ *   * gpg-verify (b): GPG verify commits
+ *   * gpg-verify-summary (b): GPG verify summary
+ *   * depth (i): How far in the history to traverse; default is 0, -1 means infinite
+ *   * disable-static-deltas (b): Do not use static deltas
+ *   * require-static-deltas (b): Require static deltas
+ *   * override-commit-ids (as): Array of specific commit IDs to fetch for refs
+ *   * dry-run (b): Only print information on what will be downloaded (requires static deltas)
  */
 gboolean
 ostree_repo_pull_with_options (OstreeRepo             *self,


### PR DESCRIPTION
Otherwise we get undefined behaviour if the client didn't explicitly set
any flags.

Also, add documentation for all the other options supported by
`ostree_repo_pull_with_options()`.