### PR TITLE
[merged] refs: Add g_prefix_error around opendir for easier debugging

### DIFF
--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -749,7 +749,10 @@ _ostree_repo_write_ref (OstreeRepo    *self,
     {
       if (!glnx_opendirat (self->repo_dir_fd, "refs/heads", TRUE,
                            &dfd, error))
-        goto out;
+        {
+          g_prefix_error (error, "Opening %s: ", "refs/heads");
+          goto out;
+        }
     }
   else
     {
@@ -757,7 +760,10 @@ _ostree_repo_write_ref (OstreeRepo    *self,
 
       if (!glnx_opendirat (self->repo_dir_fd, "refs/remotes", TRUE,
                            &refs_remotes_dfd, error))
-        goto out;
+        {
+          g_prefix_error (error, "Opening %s: ", "refs/remotes");
+          goto out;
+        }
 
       if (rev != NULL)
         {
@@ -767,7 +773,10 @@ _ostree_repo_write_ref (OstreeRepo    *self,
         }
 
       if (!glnx_opendirat (refs_remotes_dfd, remote, TRUE, &dfd, error))
-        goto out;
+        {
+          g_prefix_error (error, "Opening remotes/ dir %s: ", remote);
+          goto out;
+        }
     }
 
   if (rev == NULL)


### PR DESCRIPTION
Addresses:
  https://github.com/projectatomic/rpm-ostree/issues/264

We should consider moving this down into `glnx_opendirat`, but for now
a quick fix.