### PR TITLE
[merged] commit: Fix crash if dfd_iter is NULL

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2525,7 +2525,7 @@ write_directory_content_to_mtree_internal (OstreeRepo                  *self,
             }
 
           if (!get_modified_xattrs (self, modifier,
-                                    child_relpath, child_info, child, dfd_iter->fd, name,
+                                    child_relpath, child_info, child, dfd_iter != NULL ? dfd_iter->fd : -1, name,
                                     &xattrs,
                                     cancellable, error))
             goto out;


### PR DESCRIPTION
in write_directory_content_to_mtree_internal dfd_iter can be NULL,
for instance if commiting from --tree=ref=FOO. Don't blindly de-ref
it to avoid crashing.