### PR TITLE
OstreeRepo: add extensions directory

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2172,6 +2172,13 @@ ostree_repo_create (OstreeRepo     *self,
   if (!g_file_make_directory (self->tmp_dir, cancellable, error))
     goto out;
 
+  {
+    g_autoptr(GFile) extensions_dir =
+      g_file_resolve_relative_path (self->repodir, "extensions");
+    if (!g_file_make_directory (extensions_dir, cancellable, error))
+      goto out;
+  }
+
   g_clear_object (&child);
   child = g_file_get_child (self->repodir, "refs");
   if (!g_file_make_directory (child, cancellable, error))


### PR DESCRIPTION
It's very useful for third-party applications to have someplace to store
their data guaranteed to be on the same device as the repo (thus
ensuring hardlinks) while still being shielded away from any of OSTree's
timely garbage collections.

We create a new "extensions/" subdirectory where apps can include
whatever they wish in "extensions/myapp/". This subdirectory is
completely unmanaged by ostree.

NB: I didn't bother making it a member of the OstreeRepo proper since we
don't really use it for anything else yet.