### PR TITLE
[merged] libtest: show files' contents when assertions about them fail

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -100,13 +100,17 @@ assert_has_dir () {
 
 assert_not_has_file () {
     if test -f "$1"; then
-	echo 1>&2 "File '$1' exists"; exit 1
+        sed -e 's/^/# /' < "$1" >&2
+        echo 1>&2 "File '$1' exists"
+        exit 1
     fi
 }
 
 assert_not_file_has_content () {
     if grep -q -e "$2" "$1"; then
-	echo 1>&2 "File '$1' incorrectly matches regexp '$2'"; exit 1
+        sed -e 's/^/# /' < "$1" >&2
+        echo 1>&2 "File '$1' incorrectly matches regexp '$2'"
+        exit 1
     fi
 }
 
@@ -118,13 +122,17 @@ assert_not_has_dir () {
 
 assert_file_has_content () {
     if ! grep -q -e "$2" "$1"; then
-	echo 1>&2 "File '$1' doesn't match regexp '$2'"; exit 1
+        sed -e 's/^/# /' < "$1" >&2
+        echo 1>&2 "File '$1' doesn't match regexp '$2'"
+        exit 1
     fi
 }
 
 assert_file_empty() {
     if test -s "$1"; then
-	echo 1>&2 "File '$1' is not empty"; exit 1
+        sed -e 's/^/# /' < "$1" >&2
+        echo 1>&2 "File '$1' is not empty"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
I've seen an intermittent test failure in an autobuilder (sbuild)
environment where logs from failed builds cannot be retrieved,
but I can no longer reproduce it. Put the contents of the offending
file in the test's failing output so that if the failure comes back,
it can be debugged.

Signed-off-by: Simon McVittie <smcv@debian.org>

---

FWIW, the test failure was that `ostree --repo=repo pull origin main` aborted during `test-pull-resume.sh`. As I said, I can't reproduce it any more; it might have been a bug in something that has subsequently been upgraded in Debian unstable.