### PR TITLE
[merged] Add --prefix and --subpath argument to ostree export

### DIFF
--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -483,7 +483,7 @@ file_to_archive_entry_common (GFile         *root,
   if (opts->path_prefix && opts->path_prefix[0])
     {
       g_autofree char *old_pathstr = pathstr;
-      pathstr = g_build_filename (opts->path_prefix, old_pathstr, NULL);
+      pathstr = g_strconcat (opts->path_prefix, old_pathstr, NULL);
     }
 
   if (pathstr == NULL || !pathstr[0])

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -480,6 +480,12 @@ file_to_archive_entry_common (GFile         *root,
   g_autoptr(GVariant) xattrs = NULL;
   time_t ts = (time_t) opts->timestamp_secs;
 
+  if (opts->path_prefix && opts->path_prefix[0])
+    {
+      g_autofree char *old_pathstr = pathstr;
+      pathstr = g_build_filename (opts->path_prefix, old_pathstr, NULL);
+    }
+
   if (pathstr == NULL || !pathstr[0])
     {
       g_free (pathstr);

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -480,7 +480,7 @@ file_to_archive_entry_common (GFile         *root,
   g_autoptr(GVariant) xattrs = NULL;
   time_t ts = (time_t) opts->timestamp_secs;
 
-  if (pathstr && !pathstr[0])
+  if (pathstr == NULL || !pathstr[0])
     {
       g_free (pathstr);
       pathstr = g_strdup (".");

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -610,7 +610,10 @@ typedef struct {
   guint64 timestamp_secs;
 
   guint unused_uint[8];
-  gpointer unused_ptrs[8];
+
+  char *path_prefix;
+
+  gpointer unused_ptrs[7];
 } OstreeRepoExportArchiveOptions;
 
 _OSTREE_PUBLIC

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -33,11 +33,13 @@
 
 static char *opt_output_path;
 static char *opt_subpath;
+static char *opt_prefix;
 static gboolean opt_no_xattrs;
 
 static GOptionEntry options[] = {
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Skip output of extended attributes", NULL },
   { "subpath", 0, 0, G_OPTION_ARG_STRING, &opt_subpath, "Checkout sub-directory PATH", "PATH" },
+  { "prefix", 0, 0, G_OPTION_ARG_STRING, &opt_prefix, "Add PATH as prefix to archive pathnames", "PATH" },
   { "output", 'o', 0, G_OPTION_ARG_STRING, &opt_output_path, "Output to PATH ", "PATH" },
   { NULL }
 };
@@ -131,6 +133,8 @@ ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError 
     subtree = g_file_resolve_relative_path (root, opt_subpath);
   else
     subtree = g_object_ref (root);
+
+  opts.path_prefix = opt_prefix;
 
   if (!ostree_repo_export_tree_to_archive (repo, &opts, (OstreeRepoFile*)subtree, a,
                                            cancellable, error))

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -32,10 +32,12 @@
 #endif
 
 static char *opt_output_path;
+static char *opt_subpath;
 static gboolean opt_no_xattrs;
 
 static GOptionEntry options[] = {
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Skip output of extended attributes", NULL },
+  { "subpath", 0, 0, G_OPTION_ARG_STRING, &opt_subpath, "Checkout sub-directory PATH", "PATH" },
   { "output", 'o', 0, G_OPTION_ARG_STRING, &opt_output_path, "Output to PATH ", "PATH" },
   { NULL }
 };
@@ -60,6 +62,7 @@ ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError 
   gboolean ret = FALSE;
   const char *rev;
   g_autoptr(GFile) root = NULL;
+  g_autoptr(GFile) subtree = NULL;
   g_autofree char *commit = NULL;
   g_autoptr(GVariant) commit_data = NULL;
   struct archive *a;
@@ -124,7 +127,12 @@ ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError 
 
   opts.timestamp_secs = ostree_commit_get_timestamp (commit_data);
 
-  if (!ostree_repo_export_tree_to_archive (repo, &opts, (OstreeRepoFile*)root, a,
+  if (opt_subpath)
+    subtree = g_file_resolve_relative_path (root, opt_subpath);
+  else
+    subtree = g_object_ref (root);
+
+  if (!ostree_repo_export_tree_to_archive (repo, &opts, (OstreeRepoFile*)subtree, a,
                                            cancellable, error))
     goto out;
 

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 setup_test_repository "archive-z2"
 
-echo '1..3'
+echo '1..4'
 
 $OSTREE checkout test2 test2-co
 $OSTREE commit --no-xattrs -b test2-noxattrs -s "test2 without xattrs" --tree=dir=test2-co
@@ -46,6 +46,15 @@ ${CMD_PREFIX} ostree --repo=repo diff --no-xattrs ./t2 ./t/baz > diff.txt
 assert_file_empty diff.txt
 
 echo 'ok export --subpath gnutar diff (no xattrs)'
+
+cd ${test_tmpdir}
+${OSTREE} 'export' test2-noxattrs --prefix=the-prefix -o test2-prefix.tar
+mkdir t3
+(cd t3 && tar xf ../test2-prefix.tar)
+${CMD_PREFIX} ostree --repo=repo diff --no-xattrs test2-noxattrs ./t3/the-prefix > diff.txt
+assert_file_empty diff.txt
+
+echo 'ok export --prefix gnutar diff (no xattrs)'
 
 rm test2.tar test2-subpath.tar diff.txt t t2 -rf
 

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 setup_test_repository "archive-z2"
 
-echo '1..4'
+echo '1..5'
 
 $OSTREE checkout test2 test2-co
 $OSTREE commit --no-xattrs -b test2-noxattrs -s "test2 without xattrs" --tree=dir=test2-co
@@ -56,7 +56,17 @@ assert_file_empty diff.txt
 
 echo 'ok export --prefix gnutar diff (no xattrs)'
 
-rm test2.tar test2-subpath.tar diff.txt t t2 -rf
+cd ${test_tmpdir}
+${OSTREE} 'export' test2-noxattrs --subpath=baz --prefix=the-prefix/ -o test2-prefix-subpath.tar
+mkdir t4
+(cd t4 && tar xf ../test2-prefix-subpath.tar)
+${CMD_PREFIX} ostree --repo=repo diff --no-xattrs ./t4/the-prefix ./t/baz > diff.txt
+${CMD_PREFIX} ostree --repo=repo diff --no-xattrs test2-noxattrs ./t3/the-prefix > diff.txt
+assert_file_empty diff.txt
+
+echo 'ok export --prefix --subpath gnutar diff (no xattrs)'
+
+rm test2.tar test2-subpath.tar diff.txt t t2 t3 t4 -rf
 
 cd ${test_tmpdir}
 ${OSTREE} 'export' test2 -o test2.tar

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -48,7 +48,7 @@ assert_file_empty diff.txt
 echo 'ok export --subpath gnutar diff (no xattrs)'
 
 cd ${test_tmpdir}
-${OSTREE} 'export' test2-noxattrs --prefix=the-prefix -o test2-prefix.tar
+${OSTREE} 'export' test2-noxattrs --prefix=the-prefix/ -o test2-prefix.tar
 mkdir t3
 (cd t3 && tar xf ../test2-prefix.tar)
 ${CMD_PREFIX} ostree --repo=repo diff --no-xattrs test2-noxattrs ./t3/the-prefix > diff.txt

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 setup_test_repository "archive-z2"
 
-echo '1..2'
+echo '1..3'
 
 $OSTREE checkout test2 test2-co
 $OSTREE commit --no-xattrs -b test2-noxattrs -s "test2 without xattrs" --tree=dir=test2-co
@@ -35,9 +35,19 @@ mkdir t
 (cd t && tar xf ../test2.tar)
 ${CMD_PREFIX} ostree --repo=repo diff --no-xattrs test2-noxattrs ./t > diff.txt
 assert_file_empty diff.txt
-rm test2.tar diff.txt t -rf
 
 echo 'ok export gnutar diff (no xattrs)'
+
+cd ${test_tmpdir}
+${OSTREE} 'export' test2-noxattrs --subpath=baz -o test2-subpath.tar
+mkdir t2
+(cd t2 && tar xf ../test2-subpath.tar)
+${CMD_PREFIX} ostree --repo=repo diff --no-xattrs ./t2 ./t/baz > diff.txt
+assert_file_empty diff.txt
+
+echo 'ok export --subpath gnutar diff (no xattrs)'
+
+rm test2.tar test2-subpath.tar diff.txt t t2 -rf
 
 cd ${test_tmpdir}
 ${OSTREE} 'export' test2 -o test2.tar


### PR DESCRIPTION
--prefix is already  supported in the CLI, and I need --prefix to do some prefix rewriting when exporting xdg-apps as OCI archives (i.e. convert files to usr).