### PR TITLE
[merged] libtest: Skip FUSE if CAP_SYS_ADMIN not in bounding set

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -370,6 +370,11 @@ skip_without_fuse () {
         exit 0
     fi
 
+    if ! capsh --print | grep -q 'Bounding set.*[^a-z]cap_sys_admin'; then
+	echo "1..0 # SKIP No cap_sys_admin in bounding set, can't use FUSE"
+        exit 0
+    fi
+
     if ! [ -w /dev/fuse ]; then
         echo "1..0 # SKIP no write access to /dev/fuse"
         exit 0


### PR DESCRIPTION
I'm not sure if something changed or there was a race condition , or
if extraterrestrials intervened to make the tests pass before, but
in the Docker container `/dev/fuse` does exist and since we appear
to be running as uid 0 it'll be writable.

We previously discussed that another requirement for FUSE (and most
setuid binaries) is having `CAP_SYS_ADMIN`, so let's check for that in
the bounding set too.