### PR TITLE
[merged] repo: Allow loading files staged in the transaction

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3066,6 +3066,13 @@ ostree_repo_load_file (OstreeRepo         *self,
                                     error))
         goto out;
 
+      if (fd < 0 && self->commit_stagedir_fd != -1)
+        {
+          if (!ot_openat_ignore_enoent (self->commit_stagedir_fd, loose_path_buf, &fd,
+                                        error))
+            goto out;
+        }
+
       if (fd != -1)
         {
           tmp_stream = g_unix_input_stream_new (fd, TRUE);


### PR DESCRIPTION
Currently we can load metadata from the stage dir, but not file
data, which makes no sense.