### PR TITLE
[merged] Add URL override for fetching objects

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -51,6 +51,7 @@ test_scripts = \
 	tests/test-pull-summary-sigs.sh \
 	tests/test-pull-resume.sh \
 	tests/test-pull-untrusted.sh \
+	tests/test-pull-override-url.sh \
 	tests/test-local-pull.sh \
 	tests/test-local-pull-depth.sh \
 	tests/test-gpg-signed-commit.sh \

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1909,6 +1909,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   gboolean require_static_deltas = FALSE;
   gboolean opt_gpg_verify = FALSE;
   gboolean opt_gpg_verify_summary = FALSE;
+  const char *url_override = NULL;
 
   if (options)
     {
@@ -1926,6 +1927,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       (void) g_variant_lookup (options, "require-static-deltas", "b", &require_static_deltas);
       (void) g_variant_lookup (options, "override-commit-ids", "^a&s", &override_commit_ids);
       (void) g_variant_lookup (options, "dry-run", "b", &pull_data->dry_run);
+      (void) g_variant_lookup (options, "override-url", "&s", &url_override);
     }
 
   g_return_val_if_fail (pull_data->maxdepth >= -1, FALSE);
@@ -2021,7 +2023,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     {
       g_autofree char *baseurl = NULL;
 
-      if (!ostree_repo_remote_get_url (self, remote_name_or_baseurl, &baseurl, error))
+      if (url_override != NULL)
+        baseurl = g_strdup (url_override);
+      else if (!ostree_repo_remote_get_url (self, remote_name_or_baseurl, &baseurl, error))
         goto out;
 
       pull_data->base_uri = soup_uri_new (baseurl);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4097,6 +4097,7 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
  *   * require-static-deltas (b): Require static deltas
  *   * override-commit-ids (as): Array of specific commit IDs to fetch for refs
  *   * dry-run (b): Only print information on what will be downloaded (requires static deltas)
+ *   * override-url (s): Fetch objects from this URL if remote specifies no metalink in options
  */
 gboolean
 ostree_repo_pull_with_options (OstreeRepo             *self,

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -37,7 +37,8 @@ static gboolean opt_untrusted;
 static char* opt_subpath;
 static char* opt_cache_dir;
 static int opt_depth = 0;
- 
+static char* opt_url;
+
 static GOptionEntry options[] = {
    { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
    { "cache-dir", 0, 0, G_OPTION_ARG_STRING, &opt_cache_dir, "Use custom cache dir", NULL },
@@ -49,6 +50,7 @@ static GOptionEntry options[] = {
    { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Do not trust (local) sources", NULL },
    { "dry-run", 0, 0, G_OPTION_ARG_NONE, &opt_dry_run, "Only print information on what will be downloaded (requires static deltas)", NULL },
    { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
+   { "url", 0, 0, G_OPTION_ARG_STRING, &opt_url, "Pull objects from this URL instead of the one from the remote config", NULL },
    { NULL }
  };
 
@@ -228,6 +230,9 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
     GVariantBuilder builder;
     g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
 
+    if (opt_url)
+      g_variant_builder_add (&builder, "{s@v}", "override-url",
+                             g_variant_new_variant (g_variant_new_string (opt_url)));
     if (opt_subpath)
       g_variant_builder_add (&builder, "{s@v}", "subdir",
                              g_variant_new_variant (g_variant_new_string (opt_subpath)));

--- a/src/ostree/ot-builtin-trivial-httpd.c
+++ b/src/ostree/ot-builtin-trivial-httpd.c
@@ -389,8 +389,15 @@ ostree_builtin_trivial_httpd (int argc, char **argv, GCancellable *cancellable, 
     {
       GOutputStream *stream = NULL;
 
-      if (g_strcmp0(opt_log, "-") == 0)
-        stream = G_OUTPUT_STREAM (g_unix_output_stream_new (STDOUT_FILENO, FALSE));
+      if (g_strcmp0 (opt_log, "-") == 0)
+        {
+          if (opt_daemonize)
+            {
+              ot_util_usage_error (context, "Cannot use --log-file=- and --daemonize at the same time", error);
+              goto out;
+            }
+          stream = G_OUTPUT_STREAM (g_unix_output_stream_new (STDOUT_FILENO, FALSE));
+        }
       else
         {
           g_autoptr(GFile) log_file;

--- a/src/ostree/ot-builtin-trivial-httpd.c
+++ b/src/ostree/ot-builtin-trivial-httpd.c
@@ -22,6 +22,8 @@
 
 #include <libsoup/soup.h>
 
+#include <gio/gunixoutputstream.h>
+
 #include "ot-main.h"
 #include "ot-builtins.h"
 #include "ostree.h"
@@ -32,6 +34,7 @@
 #include <signal.h>
 
 static char *opt_port_file = NULL;
+static char *opt_log = NULL;
 static gboolean opt_daemonize;
 static gboolean opt_autoexit;
 static gboolean opt_force_ranges;
@@ -40,6 +43,7 @@ static gint opt_port = 0;
 typedef struct {
   GFile *root;
   gboolean running;
+  GOutputStream *log;
 } OtTrivialHttpd;
 
 static GOptionEntry options[] = {
@@ -48,8 +52,27 @@ static GOptionEntry options[] = {
   { "port", 'P', 0, G_OPTION_ARG_INT, &opt_port, "Use the specified TCP port", NULL },
   { "port-file", 'p', 0, G_OPTION_ARG_FILENAME, &opt_port_file, "Write port number to PATH (- for standard output)", "PATH" },
   { "force-range-requests", 0, 0, G_OPTION_ARG_NONE, &opt_force_ranges, "Force range requests by only serving half of files", NULL },
+  { "log-file", 0, 0, G_OPTION_ARG_FILENAME, &opt_log, "Put logs here", "PATH" },
   { NULL }
 };
+
+static void
+httpd_log (OtTrivialHttpd *httpd, const gchar *format, ...)
+{
+  g_autoptr(GString) str = NULL;
+  va_list args;
+  gsize written;
+
+  if (!httpd->log)
+    return;
+
+  str = g_string_new (NULL);
+  va_start (args, format);
+  g_string_vprintf (str, format, args);
+  va_end (args);
+
+  g_output_stream_write_all (httpd->log, str->str, str->len, &written, NULL, NULL);
+}
 
 static int
 compare_strings (gconstpointer a, gconstpointer b)
@@ -154,6 +177,7 @@ do_get (OtTrivialHttpd    *self,
   struct stat stbuf;
   g_autofree char *safepath = NULL;
 
+  httpd_log (self, "serving %s\n", path);
   if (strstr (path, "../") != NULL)
     {
       soup_message_set_status (msg, SOUP_STATUS_FORBIDDEN);
@@ -296,6 +320,16 @@ do_get (OtTrivialHttpd    *self,
       soup_message_set_status (msg, SOUP_STATUS_OK);
     }
  out:
+  {
+    guint status = 0;
+    g_autofree gchar *reason = NULL;
+
+    g_object_get (msg,
+                  "status-code", &status,
+                  "reason-phrase", &reason,
+                  NULL);
+    httpd_log (self, "  status: %s (%u)\n", reason, status);
+  }
   return;
 }
 
@@ -350,6 +384,30 @@ ostree_builtin_trivial_httpd (int argc, char **argv, GCancellable *cancellable, 
     dirpath = ".";
 
   app->root = g_file_new_for_path (dirpath);
+
+  if (opt_log)
+    {
+      GOutputStream *stream = NULL;
+
+      if (g_strcmp0(opt_log, "-") == 0)
+        stream = G_OUTPUT_STREAM (g_unix_output_stream_new (STDOUT_FILENO, FALSE));
+      else
+        {
+          g_autoptr(GFile) log_file;
+          GFileOutputStream* log_stream;
+
+          log_file = g_file_new_for_path (opt_log);
+          log_stream = g_file_create (log_file,
+                                      G_FILE_CREATE_PRIVATE,
+                                      cancellable,
+                                      error);
+          if (!log_stream)
+            goto out;
+          stream = G_OUTPUT_STREAM (log_stream);
+        }
+
+      app->log = stream;
+    }
 
 #if SOUP_CHECK_VERSION(2, 48, 0)
   server = soup_server_new (SOUP_SERVER_SERVER_HEADER, "ostree-httpd ", NULL);
@@ -456,13 +514,17 @@ ostree_builtin_trivial_httpd (int argc, char **argv, GCancellable *cancellable, 
         goto out;
       g_signal_connect (dirmon, "changed", G_CALLBACK (on_dir_changed), app);
     }
-
+  {
+    g_autofree gchar *path = g_file_get_path (app->root);
+    httpd_log (app, "serving at root %s\n", path);
+  }
   while (app->running)
     g_main_context_iteration (NULL, TRUE);
- 
+
   ret = TRUE;
  out:
   g_clear_object (&app->root);
+  g_clear_object (&app->log);
   if (context)
     g_option_context_free (context);
   return ret;

--- a/tests/test-pull-override-url.sh
+++ b/tests/test-pull-override-url.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive-z2"
+
+echo '1..1'
+
+cd ${test_tmpdir}
+# get a list of XX/XXXXXXX...XX.commit
+find ostree-srv/gnomerepo/objects -name '*.commit' | cut -d/ -f4- | sort >${test_tmpdir}/original_commits
+
+
+gnomerepo_url="$(cat httpd-address)/ostree/gnomerepo"
+mkdir mirror-srv
+cd mirror-srv
+mkdir gnomerepo
+${CMD_PREFIX} ostree --repo=gnomerepo init --mode "archive-z2"
+${CMD_PREFIX} ostree --repo=gnomerepo remote add --set=gpg-verify=false origin ${gnomerepo_url}
+${CMD_PREFIX} ostree --repo=gnomerepo pull --mirror --depth=-1 origin main
+
+find gnomerepo/objects -name '*.commit' | cut -d/ -f3- | sort >${test_tmpdir}/mirror_commits
+
+if ! cmp --quiet ${test_tmpdir}/original_commits ${test_tmpdir}/mirror_commits
+then
+    assert_not_reached 'original repository and its mirror should have the same commits'
+fi
+
+cd ${test_tmpdir}
+mkdir mirror-httpd
+cd mirror-httpd
+ln -s ${test_tmpdir}/mirror-srv ostree
+mirror_log="${test_tmpdir}/mirror_log"
+${CMD_PREFIX} ostree trivial-httpd --log-file=${mirror_log} --autoexit --daemonize -p ${test_tmpdir}/mirror-httpd-port
+port=$(cat ${test_tmpdir}/mirror-httpd-port)
+echo "http://127.0.0.1:${port}" > ${test_tmpdir}/mirror-httpd-address
+
+cd ${test_tmpdir}
+mirrorrepo_url="$(cat mirror-httpd-address)/ostree/gnomerepo"
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin ${gnomerepo_url}
+rm -rf ${test_tmpdir}/ostree-srv/gnomerepo
+if ${CMD_PREFIX} ostree --repo=repo pull --depth=-1 origin main
+then
+    assert_not_reached 'pulling from removed remote should have failed'
+fi
+
+if ! ${CMD_PREFIX} ostree --repo=repo pull --depth=-1 --url=${mirrorrepo_url} origin main
+then
+    cat ${mirror_log}
+    assert_not_reached 'fetching from the overridden URL should succeed'
+fi
+find repo/objects -name '*.commit' | cut -d/ -f3- | sort >${test_tmpdir}/repo_commits
+
+if ! cmp --quiet ${test_tmpdir}/original_commits ${test_tmpdir}/repo_commits
+then
+    assert_not_reached 'original repository and its mirror should have the same commits'
+fi
+
+echo "ok pull url override"


### PR DESCRIPTION
This adds an `override-url` option to `ostree_repo_pull_with_options`, which, if specified, overrides the URL taken from repo config for a given remote.

This also adds a `--url` option to `ostree pull` which uses the above option.