### PR TITLE
[merged] repo: Simplify internal has_object() lookup code

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -573,11 +573,8 @@ _ostree_repo_open_trusted_content_bare (OstreeRepo          *self,
   g_autofree char *temp_filename = NULL;
   g_autoptr(GOutputStream) ret_stream = NULL;
   gboolean have_obj;
-  char loose_objpath[_OSTREE_LOOSE_PATH_MAX];
 
-  if (!_ostree_repo_has_loose_object (self, checksum, OSTREE_OBJECT_TYPE_FILE,
-                                      &have_obj, loose_objpath,
-                                      NULL,
+  if (!_ostree_repo_has_loose_object (self, checksum, OSTREE_OBJECT_TYPE_FILE, &have_obj,
                                       cancellable, error))
     goto out;
 
@@ -662,7 +659,6 @@ write_object (OstreeRepo         *self,
   gboolean temp_file_is_regular;
   gboolean temp_file_is_symlink;
   gboolean object_is_symlink = FALSE;
-  char loose_objpath[_OSTREE_LOOSE_PATH_MAX];
   gssize unpacked_size = 0;
   gboolean indexable = FALSE;
 
@@ -673,9 +669,8 @@ write_object (OstreeRepo         *self,
 
   if (expected_checksum)
     {
-      if (!_ostree_repo_has_loose_object (self, expected_checksum, objtype,
-                                          &have_obj, loose_objpath,
-                                          NULL, cancellable, error))
+      if (!_ostree_repo_has_loose_object (self, expected_checksum, objtype, &have_obj,
+                                          cancellable, error))
         goto out;
       if (have_obj)
         {
@@ -852,8 +847,7 @@ write_object (OstreeRepo         *self,
       repo_store_size_entry (self, actual_checksum, unpacked_size, stbuf.st_size);
     }
 
-  if (!_ostree_repo_has_loose_object (self, actual_checksum, objtype,
-                                      &have_obj, loose_objpath, NULL,
+  if (!_ostree_repo_has_loose_object (self, actual_checksum, objtype, &have_obj,
                                       cancellable, error))
     goto out;
           

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -135,8 +135,6 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
                                const char           *checksum,
                                OstreeObjectType      objtype,
                                gboolean             *out_is_stored,
-                               char                 *loose_path_buf,
-                               GFile               **out_stored_path,
                                GCancellable         *cancellable,
                                GError             **error);
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3285,15 +3285,13 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
                                const char           *checksum,
                                OstreeObjectType      objtype,
                                gboolean             *out_is_stored,
-                               char                 *loose_path_buf,
-                               GFile               **out_stored_path,
                                GCancellable         *cancellable,
                                GError             **error)
 {
   gboolean ret = FALSE;
   struct stat stbuf;
   int res = -1;
-  gboolean tmp_file = FALSE;
+  char loose_path_buf[_OSTREE_LOOSE_PATH_MAX];
 
   _ostree_loose_path (loose_path_buf, checksum, objtype, self->mode);
 
@@ -3309,9 +3307,7 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
         }
     }
 
-  if (res == 0)
-    tmp_file = TRUE;
-  else
+  if (res < 0)
     {
       do
         res = fstatat (self->objects_dir_fd, loose_path_buf, &stbuf, AT_SYMLINK_NOFOLLOW);
@@ -3325,30 +3321,8 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
 
   ret = TRUE;
   *out_is_stored = (res != -1);
-
-  if (out_stored_path)
-    {
-      if (res != -1)
-        *out_stored_path = g_file_resolve_relative_path (tmp_file ? self->tmp_dir : self->objects_dir, loose_path_buf);
-      else
-        *out_stored_path = NULL;
-    }
 out:
   return ret;
-}
-
-gboolean
-_ostree_repo_find_object (OstreeRepo           *self,
-                          OstreeObjectType      objtype,
-                          const char           *checksum,
-                          GFile               **out_stored_path,
-                          GCancellable         *cancellable,
-                          GError             **error)
-{
-  gboolean has_object;
-  char loose_path[_OSTREE_LOOSE_PATH_MAX];
-  return _ostree_repo_has_loose_object (self, checksum, objtype, &has_object, loose_path,
-                                        out_stored_path, cancellable, error);
 }
 
 /**
@@ -3375,13 +3349,12 @@ ostree_repo_has_object (OstreeRepo           *self,
 {
   gboolean ret = FALSE;
   gboolean ret_have_object;
-  g_autoptr(GFile) loose_path = NULL;
 
-  if (!_ostree_repo_find_object (self, objtype, checksum, &loose_path,
-                                 cancellable, error))
+  if (!_ostree_repo_has_loose_object (self, checksum, objtype, &ret_have_object,
+                                      cancellable, error))
     goto out;
 
-  ret_have_object = (loose_path != NULL);
+  /* In the future, here is where we would also look up in metadata pack files */
 
   if (!ret_have_object && self->parent_repo)
     {


### PR DESCRIPTION
There was some leftover intermediate cruft here I noticed
while reviewing another patch:

 - We had an output `GFile*` for that was never used
 - We required the caller to allocate the loose pathbuf, but
   none of them ever reused it
 - We had an extra intermediate function

Also while looking at this, I'm now uncertain whether some of the
callers of `_ostree_repo_has_loose_object` should really be invoking
`ostree_repo_has_object()`, but let's leave that aside for now.