### PR TITLE
[merged] repo: Fix temporary directory allocation

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5012,7 +5012,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
   if (!glnx_dirfd_iterator_init_at (tmpdir_dfd, ".", FALSE, &dfd_iter, error))
     return FALSE;
 
-  while (TRUE)
+  while (tmpdir_name == NULL)
     {
       gs_dirfd_iterator_cleanup GSDirFdIterator child_dfd_iter = { 0, };
       struct dirent *dent;


### PR DESCRIPTION
We looked for and locked old temporary directories so we can
reuse them if not in use. However, once we found one that
we can reuse we didn't stop iterating, and eventually we
reached the end. This means we can lock multiple dirs.