### PR TITLE
[merged] test-parent: this test requires user xattrs

### DIFF
--- a/tests/test-parent.sh
+++ b/tests/test-parent.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_user_xattrs
+
 echo '1..2'
 
 setup_test_repository "archive-z2"


### PR DESCRIPTION
---

Detected by Debian autobuilders, some of which place the entire build chroot on tmpfs.