### PR TITLE
[merged] build: Introduce --with-dracut=yesbutnoconf

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -21,7 +21,8 @@ if BUILDOPT_DRACUT
 # Not using $(libdir) here is intentional, dracut modules go in prefix/lib
 dracutmoddir = $(prefix)/lib/dracut/modules.d/98ostree
 dracutmod_SCRIPTS = src/boot/dracut/module-setup.sh
-
+endif
+if BUILDOPT_DRACUT_CONF
 dracutconfdir = $(sysconfdir)/dracut.conf.d
 dracutconf_DATA = src/boot/dracut/ostree.conf
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -231,7 +231,14 @@ AC_ARG_WITH(dracut,
             AS_HELP_STRING([--with-dracut],
                            [Install dracut module (default: no)]),,
               [with_dracut=no])
-AM_CONDITIONAL(BUILDOPT_DRACUT, test x$with_dracut = xyes)
+case x$with_dracut in
+    xno) ;;
+    xyes) ;;
+    xyesbutnoconf) ;;
+    *) AC_MSG_ERROR([Unknown --with-dracut value $with_dracut])
+esac    
+AM_CONDITIONAL(BUILDOPT_DRACUT, test x$with_dracut = xyes || test x$with_dracut = xyesbutnoconf)
+AM_CONDITIONAL(BUILDOPT_DRACUT_CONF, test x$with_dracut = xyes)
 
 AC_ARG_WITH(mkinitcpio,
             AS_HELP_STRING([--with-mkinitcpio],
@@ -239,7 +246,7 @@ AC_ARG_WITH(mkinitcpio,
               [with_mkinitcpio=no])
 AM_CONDITIONAL(BUILDOPT_MKINITCPIO, test x$with_mkinitcpio = xyes)
 
-AS_IF([test "x$with_dracut" = "xyes" || test "x$with_mkinitcpio" = "xyes"], [
+AS_IF([test "x$with_dracut" = "xyes" || test "x$with_dracut" = "xyesbutnoconf" || test "x$with_mkinitcpio" = "xyes"], [
   with_systemd=yes
   AC_ARG_WITH([systemdsystemunitdir],
               AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),

--- a/packaging/ostree.spec.in
+++ b/packaging/ostree.spec.in
@@ -72,7 +72,7 @@ env NOCONFIGURE=1 ./autogen.sh
 %configure --disable-silent-rules \
 	   --enable-gtk-doc \
 	   --with-selinux \
-	   --with-dracut
+	   --with-dracut=yesbutnoconf
 make %{?_smp_mflags}
 
 %install
@@ -94,7 +94,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/ostree
 %{_sbindir}/ostree-prepare-root
 %{_sbindir}/ostree-remount
-%{_sysconfdir}/dracut.conf.d/ostree.conf
 %dir %{_prefix}/lib/dracut/modules.d/98ostree
 %{_prefix}/lib/systemd/system/ostree*.service
 %{_prefix}/lib/dracut/modules.d/98ostree/*


### PR DESCRIPTION
It's actually just easier for build systems (e.g. rpm-ostree)
using dracut to use `--add ostree` rather than indirecting
through the conf file.

This makes it easier for yum-managed systems to install ostree without
side effects.