### PR TITLE
[merged] repo: Fix reading repos on read-only media

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2416,7 +2416,6 @@ ostree_repo_open (OstreeRepo    *self,
   g_autofree char *version = NULL;
   g_autofree char *mode = NULL;
   g_autofree char *parent_repo_path = NULL;
-  g_autoptr(GError) temp_error = NULL;
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
@@ -2550,32 +2549,13 @@ ostree_repo_open (OstreeRepo    *self,
   if (!glnx_opendirat (self->repo_dir_fd, "tmp", TRUE, &self->tmp_dir_fd, error))
     goto out;
 
-  if (!glnx_shutil_mkdir_p_at (self->tmp_dir_fd, _OSTREE_CACHE_DIR, 0775, cancellable, &temp_error))
+  if (self->writable)
     {
-      if (g_error_matches (temp_error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED))
-        {
-          g_clear_error (&temp_error);
-          g_debug ("No permissions to create cache dir");
-        }
-      else
-        {
-          g_propagate_error (error, g_steal_pointer (&temp_error));
-          goto out;
-        }
-    }
+      if (!glnx_shutil_mkdir_p_at (self->tmp_dir_fd, _OSTREE_CACHE_DIR, 0775, cancellable, error))
+        goto out;
 
-  if (!glnx_opendirat (self->tmp_dir_fd, _OSTREE_CACHE_DIR, TRUE, &self->cache_dir_fd, &temp_error))
-    {
-      if (g_error_matches (temp_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-        {
-          g_clear_error (&temp_error);
-          g_debug ("No cache dir");
-        }
-      else
-        {
-          g_propagate_error (error, g_steal_pointer (&temp_error));
-          goto out;
-        }
+      if (!glnx_opendirat (self->tmp_dir_fd, _OSTREE_CACHE_DIR, TRUE, &self->cache_dir_fd, error))
+        goto out;
     }
 
   if (self->mode == OSTREE_REPO_MODE_ARCHIVE_Z2 && self->enable_uncompressed_cache)


### PR DESCRIPTION
I have a cache drive I often mount read-only, and the previous commit
for opening `tmp/cache` broke since `errno == EROFS`, not `EPERM`.

It turns out we already had the concept of a "writable" repo, so just
piggy back off that.