### PR TITLE
[merged] libglnx porting: Migrate to glnx_stream_fstat()

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -613,7 +613,7 @@ ostree_content_file_parse_at (gboolean                compressed,
                               cancellable, error))
     goto out;
       
-  if (!gs_stream_fstat ((GFileDescriptorBased*)file_input, &stbuf, cancellable, error))
+  if (!glnx_stream_fstat ((GFileDescriptorBased*)file_input, &stbuf, error))
     goto out;
   
   if (!ostree_content_stream_parse (compressed, file_input, stbuf.st_size, trusted,

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -1067,7 +1067,7 @@ _ostree_fetcher_bytes_transferred (OstreeFetcher       *self)
       
       if (G_IS_FILE_DESCRIPTOR_BASED (stream))
         {
-          if (gs_stream_fstat ((GFileDescriptorBased*)stream, &stbuf, NULL, NULL))
+          if (glnx_stream_fstat ((GFileDescriptorBased*)stream, &stbuf, NULL))
             ret += stbuf.st_size;
         }
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2925,7 +2925,7 @@ load_metadata_internal (OstreeRepo       *self,
             {
               struct stat stbuf;
 
-              if (!gs_stream_fstat ((GFileDescriptorBased*)ret_stream, &stbuf, cancellable, error))
+              if (!glnx_stream_fstat ((GFileDescriptorBased*)ret_stream, &stbuf, error))
                 goto out;
               *out_size = stbuf.st_size;
             }
@@ -3100,8 +3100,8 @@ ostree_repo_load_file (OstreeRepo         *self,
           tmp_stream = g_unix_input_stream_new (fd, TRUE);
           fd = -1; /* Transfer ownership */
           
-          if (!gs_stream_fstat ((GFileDescriptorBased*) tmp_stream, &stbuf,
-                                cancellable, error))
+          if (!glnx_stream_fstat ((GFileDescriptorBased*) tmp_stream, &stbuf,
+                                  error))
             goto out;
           
           if (!ostree_content_stream_parse (TRUE, tmp_stream, stbuf.st_size, TRUE,


### PR DESCRIPTION
I ended up deciding to move this one into libglnx, seems like
something other libglnx-using software might want to do, even though
xdg-app doesn't right now.