### PR TITLE
[merged] lib: Add more filename validations (no ., .. or /) in commit logic

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -159,6 +159,11 @@ ostree_mutable_tree_replace_file (OstreeMutableTree *self,
 {
   gboolean ret = FALSE;
 
+  g_return_val_if_fail (name != NULL, FALSE);
+
+  if (!ot_util_filename_validate (name, error))
+    goto out;
+
   if (g_hash_table_lookup (self->subdirs, name))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
@@ -186,6 +191,9 @@ ostree_mutable_tree_ensure_dir (OstreeMutableTree *self,
   glnx_unref_object OstreeMutableTree *ret_dir = NULL;
 
   g_return_val_if_fail (name != NULL, FALSE);
+
+  if (!ot_util_filename_validate (name, error))
+    goto out;
 
   if (g_hash_table_lookup (self->files, name))
     {

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2225,6 +2225,10 @@ create_tree_variant_from_hashes (GHashTable            *file_checksums,
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
     {
       const char *name = key;
+
+      /* Should have been validated earlier, but be paranoid */
+      g_assert (ot_util_filename_validate (name, NULL));
+
       sorted_filenames = g_slist_prepend (sorted_filenames, (char*)name);
     }
 


### PR DESCRIPTION
The filesystem commit code will never give us potentially hostile
filenames, and when importing from archives, we do some validation.

However, we should be extra paranoid and also add error messages in
the mtree in case someone tries to import a hostile
libarchive-supported format.