### PR TITLE
trivial-httpd: Add __attribute__((format))

### DIFF
--- a/src/ostree/ot-builtin-trivial-httpd.c
+++ b/src/ostree/ot-builtin-trivial-httpd.c
@@ -57,6 +57,9 @@ static GOptionEntry options[] = {
 };
 
 static void
+httpd_log (OtTrivialHttpd *httpd, const gchar *format, ...) __attribute__ ((format(printf, 2, 3)));
+
+static void
 httpd_log (OtTrivialHttpd *httpd, const gchar *format, ...)
 {
   g_autoptr(GString) str = NULL;


### PR DESCRIPTION
I was briefly looking at building with clang mostly since it
detects unused variables with cleanup attributes, but then
I hit this fatal error.

It's a hard compile error with `-Wformat-nonliteral` since clang
doesn't know it's a format string.