### PR TITLE
[merged] OstreeRepo: add extensions directory

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2210,6 +2210,13 @@ ostree_repo_create (OstreeRepo     *self,
   if (!g_file_make_directory (self->tmp_dir, cancellable, error))
     goto out;
 
+  {
+    g_autoptr(GFile) extensions_dir =
+      g_file_resolve_relative_path (self->repodir, "extensions");
+    if (!g_file_make_directory (extensions_dir, cancellable, error))
+      goto out;
+  }
+
   g_clear_object (&child);
   child = g_file_get_child (self->repodir, "refs");
   if (!g_file_make_directory (child, cancellable, error))

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..55"
+echo "1..56"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -508,5 +508,9 @@ cd ..
 if cmp timestamp-{orig,new}.txt; then
     assert_not_reached "failed to update mtime on repo"
 fi
-
 echo "ok mtime updated"
+
+cd ${test_tmpdir}
+$OSTREE init --mode=bare --repo=repo-extensions
+assert_has_dir repo-extensions/extensions
+echo "ok extensions dir"


### PR DESCRIPTION
It's very useful for third-party applications to have someplace to store
their data guaranteed to be on the same device as the repo (thus
ensuring hardlinks) while still being shielded away from any of OSTree's
timely garbage collections.

We create a new "extensions/" subdirectory where apps can include
whatever they wish in "extensions/myapp/". This subdirectory is
completely unmanaged by ostree.

NB: I didn't bother making it a member of the OstreeRepo proper since we
don't really use it for anything else yet.