### PR TITLE
[merged] libostree: Variant-related leak plugs and fixes

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2384,7 +2384,7 @@ get_modified_xattrs (OstreeRepo                       *self,
 
       if (label)
         {
-          GVariantBuilder *builder;
+          g_autoptr(GVariantBuilder) builder = NULL;
 
           /* ret_xattrs may be NULL */
           builder = ot_util_variant_builder_from_variant (ret_xattrs,

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -331,6 +331,7 @@ aic_ensure_parent_dir_with_file_info (OstreeRepoArchiveImportContext *ctx,
 {
   const char *name = glnx_basename (fullpath);
   g_auto(GVariantBuilder) xattrs_builder;
+  g_autoptr(GVariant) xattrs = NULL;
 
   /* is this the root directory itself? transform into empty string */
   if (name[0] == '/' && name[1] == '\0')
@@ -343,8 +344,9 @@ aic_ensure_parent_dir_with_file_info (OstreeRepoArchiveImportContext *ctx,
                             DEFAULT_DIRMODE, cancellable, error))
       return FALSE;
 
+  xattrs = g_variant_ref_sink (g_variant_builder_end (&xattrs_builder));
   return mtree_ensure_dir_with_meta (ctx->repo, parent, name, file_info,
-                                     g_variant_builder_end (&xattrs_builder),
+                                     xattrs,
                                      FALSE /* error_if_exist */, out_dir,
                                      cancellable, error);
 }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1759,6 +1759,8 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
                           GError                  **error)
 {
   GVariantBuilder builder;
+  g_autoptr(GVariant) options = NULL;
+
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
 
   if (dir_to_pull)
@@ -1770,7 +1772,8 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
     g_variant_builder_add (&builder, "{s@v}", "refs",
                            g_variant_new_variant (g_variant_new_strv ((const char *const*) refs_to_fetch, -1)));
 
-  return ostree_repo_pull_with_options (self, remote_name, g_variant_builder_end (&builder),
+  options = g_variant_ref_sink (g_variant_builder_end (&builder));
+  return ostree_repo_pull_with_options (self, remote_name, options,
                                         progress, cancellable, error);
 }
 


### PR DESCRIPTION
This tries to avoid leaking GVariantBuilders and GVariants in some
situations. The leaks were usually happening when some error occurred
or because of unclear variant ownership situation.

The former is mostly about making sure that g_variant_builder_clear is
called on builders that didn't finish their variant building process.

The latter is surely more work - sometimes the result of
g_variant_builder_end() should not be passed directly to a function,
but rather stored in a g_autoptr(GVariant), sunk and then passed to a
function. IMO, with an advent of g_autoptr, GVariants should be always
sunk instead of relying on some receiver function sinking it. This
would make an easy-to-follow policy of always sinking your
variants. Functions could then assume that the passed variant is
already sunk. These leaks are still happenning in commands, but they
are less harmful, since that code will not be used by some daemon as a
library routine.