### PR TITLE
[merged] libostree: Fix bracket-missing warnings

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1253,7 +1253,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
   guint min_fallback_size;
   guint max_bsdiff_size;
   guint max_chunk_size;
-  g_auto(GVariantBuilder) metadata_builder = {0,};
+  g_auto(GVariantBuilder) metadata_builder = {{0,}};
   DeltaOpts delta_opts = DELTAOPT_FLAG_NONE;
   guint64 total_compressed_size = 0;
   guint64 total_uncompressed_size = 0;
@@ -1384,8 +1384,8 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
       g_autoptr(GVariant) delta_part_content = NULL;
       g_autoptr(GVariant) delta_part = NULL;
       g_autoptr(GVariant) delta_part_header = NULL;
-      g_auto(GVariantBuilder) mode_builder = {0,};
-      g_auto(GVariantBuilder) xattr_builder = {0,};
+      g_auto(GVariantBuilder) mode_builder = {{0,}};
+      g_auto(GVariantBuilder) xattr_builder = {{0,}};
       guint8 compression_type_char;
 
       g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(uuu)"));

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3510,7 +3510,7 @@ ostree_repo_delete_object (OstreeRepo           *self,
 
       if (tombstone_commits)
         {
-          g_auto(GVariantBuilder) builder = {0,};
+          g_auto(GVariantBuilder) builder = {{0,}};
           g_autoptr(GVariant) variant = NULL;
 
           g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
@@ -4956,7 +4956,7 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
   g_autoptr(GVariant) summary = NULL;
   GList *ordered_keys = NULL;
   GList *iter = NULL;
-  g_auto(GVariantDict) additional_metadata_builder = {0,};
+  g_auto(GVariantDict) additional_metadata_builder = {{0,}};
 
   if (!ostree_repo_list_refs (self, NULL, &refs, cancellable, error))
     goto out;
@@ -4989,7 +4989,7 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
   {
     guint i;
     g_autoptr(GPtrArray) delta_names = NULL;
-    g_auto(GVariantDict) deltas_builder = {0,};
+    g_auto(GVariantDict) deltas_builder = {{0,}};
     g_autoptr(GVariant) deltas = NULL;
 
     if (!ostree_repo_list_static_delta_names (self, &delta_names, cancellable, error))


### PR DESCRIPTION
Apparently I got the bracketing wrong in
862e6ecdcc58f025696b1394adfc0fcf7322df23:

src/libostree/ostree-repo.c: In function 'ostree_repo_delete_object':
src/libostree/ostree-repo.c:3538:11: warning: missing braces around
initializer [-Wmissing-braces]
           g_auto(GVariantBuilder) builder = {0,};