### PR TITLE
[merged] build: Install new autocleanups header

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -21,6 +21,7 @@
 libostree_public_headers = \
 	src/libostree/ostree.h \
 	src/libostree/ostree-async-progress.h \
+	src/libostree/ostree-autocleanups.h \
 	src/libostree/ostree-core.h \
 	src/libostree/ostree-dummy-enumtypes.h \
 	src/libostree/ostree-mutable-tree.h \


### PR DESCRIPTION
This is a brown-paperbag PR.

Haven't noticed before that there is a separate variable for a list of
OSTree public headers. This fixes an embarrassing error that prohibits
building a project that includes ostree.h.