### PR TITLE
add ostree-autocleanups.h to public headers

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -34,4 +34,5 @@ libostree_public_headers = \
 	src/libostree/ostree-sysroot-upgrader.h \
 	src/libostree/ostree-deployment.h \
 	src/libostree/ostree-bootconfig-parser.h \
+	src/libostree/ostree-autocleanups.h \
 	$(NULL)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2010,6 +2010,7 @@ ostree_repo_write_commit (OstreeRepo      *self,
  * @body: (allow-none): Body
  * @metadata: (allow-none): GVariant of type a{sv}, or %NULL for none
  * @root: The tree to point the commit to
+ * @time: The time to use to stamp the commit
  * @out_commit: (out): Resulting ASCII SHA256 checksum for commit
  * @cancellable: Cancellable
  * @error: Error


### PR DESCRIPTION
Also add a missing arg in write_commit() docstring.

Resolves #301.