### PR TITLE
[merged] tests: Fix build with old glib

### DIFF
--- a/tests/test-checksum.c
+++ b/tests/test-checksum.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "libgsystem.h"
 #include <glib.h>
 #include <stdlib.h>


### PR DESCRIPTION
test-checksum.c was using g_autofree without including libglnx.h which
has the backport for that.