### PR TITLE
[merged] Editor runs only when requested; otherwise, empty commits are performed,

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -57,7 +57,7 @@ Boston, MA 02111-1307, USA.
         <title>Description</title>
 
         <para>
-            This allows you to commit changes to a branch.  The specification of the branch is required.  If no commit message is specified with <option>--subject</option> then a text editor will be opened.  The commit will be aborted if the commit subject is left empty.  The command will print the checksum of a successful commit.
+            This allows you to commit changes to a branch.  The specification of the branch is required.  The command will print the checksum of a successful commit.
         </para>
     </refsect1>
 
@@ -68,7 +68,7 @@ Boston, MA 02111-1307, USA.
                 <term><option>--subject</option>, <option>-s</option>="SUBJECT"</term>
 
                 <listitem><para>
-                    One line subject.
+                    One line subject. (optional)
                 </para></listitem>
             </varlistentry>
 
@@ -76,7 +76,15 @@ Boston, MA 02111-1307, USA.
                 <term><option>--body</option>, <option>-m</option>="BODY"</term>
 
                 <listitem><para>
-                    Full description.
+                    Full description. (optional)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--editor</option>, <option>-e</option></term>
+
+                <listitem><para>
+                    Open a text editor for the commit description.  It will use OSTREE_EDITOR, VISUAL, EDITOR, or vi, in descending order of preference.  The commit will be aborted if the message is left empty.
                 </para></listitem>
             </varlistentry>
 
@@ -84,7 +92,7 @@ Boston, MA 02111-1307, USA.
                 <term><option>--branch</option>, <option>-b</option>="BRANCH"</term>
 
                 <listitem><para>
-                    Branch.
+                    Branch.  Required, unless --orphan is given.
                 </para></listitem>
             </varlistentry>
 
@@ -219,7 +227,7 @@ Boston, MA 02111-1307, USA.
                 <term><option>--orphan</option></term>
 
                 <listitem><para>
-                    Create a commit without writing a ref
+                    Create a commit without writing to a ref (branch)
                 </para></listitem>
             </varlistentry>
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1962,7 +1962,7 @@ create_empty_gvariant_dict (void)
  * ostree_repo_write_commit:
  * @self: Repo
  * @parent: (allow-none): ASCII SHA256 checksum for parent, or %NULL for none
- * @subject: Subject
+ * @subject: (allow-none): Subject
  * @body: (allow-none): Body
  * @metadata: (allow-none): GVariant of type a{sv}, or %NULL for none
  * @root: The tree to point the commit to
@@ -2006,7 +2006,7 @@ ostree_repo_write_commit (OstreeRepo      *self,
  * ostree_repo_write_commit_with_time:
  * @self: Repo
  * @parent: (allow-none): ASCII SHA256 checksum for parent, or %NULL for none
- * @subject: Subject
+ * @subject: (allow-none): Subject
  * @body: (allow-none): Body
  * @metadata: (allow-none): GVariant of type a{sv}, or %NULL for none
  * @root: The tree to point the commit to
@@ -2036,8 +2036,6 @@ ostree_repo_write_commit_with_time (OstreeRepo      *self,
   g_autofree guchar *commit_csum = NULL;
   OstreeRepoFile *repo_root = OSTREE_REPO_FILE (root);
 
-  g_return_val_if_fail (subject != NULL, FALSE);
-
   /* Add sizes information to our metadata object */
   if (!add_size_index_to_metadata (self, metadata, &new_metadata,
                                    cancellable, error))
@@ -2047,7 +2045,7 @@ ostree_repo_write_commit_with_time (OstreeRepo      *self,
                           new_metadata ? new_metadata : create_empty_gvariant_dict (),
                           parent ? ostree_checksum_to_bytes_v (parent) : ot_gvariant_new_bytearray (NULL, 0),
                           g_variant_new_array (G_VARIANT_TYPE ("(say)"), NULL, 0),
-                          subject, body ? body : "",
+                          subject ? subject : "", body ? body : "",
                           GUINT64_TO_BE (time),
                           ostree_checksum_to_bytes_v (ostree_repo_file_tree_get_contents_checksum (repo_root)),
                           ostree_checksum_to_bytes_v (ostree_repo_file_tree_get_metadata_checksum (repo_root)));

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -32,6 +32,7 @@
 
 static char *opt_subject;
 static char *opt_body;
+static gboolean opt_editor;
 static char *opt_parent;
 static gboolean opt_orphan;
 static char *opt_branch;
@@ -73,6 +74,7 @@ static GOptionEntry options[] = {
   { "parent", 0, 0, G_OPTION_ARG_STRING, &opt_parent, "Parent ref, or \"none\"", "REF" },
   { "subject", 's', 0, G_OPTION_ARG_STRING, &opt_subject, "One line subject", "SUBJECT" },
   { "body", 'm', 0, G_OPTION_ARG_STRING, &opt_body, "Full description", "BODY" },
+  { "editor", 'e', 0, G_OPTION_ARG_NONE, &opt_editor, "Use an editor to write the commit message", NULL },
   { "branch", 'b', 0, G_OPTION_ARG_STRING, &opt_branch, "Branch", "BRANCH" },
   { "orphan", 0, 0, G_OPTION_ARG_NONE, &opt_orphan, "Create a commit without writing a ref", NULL },
   { "tree", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_trees, "Overlay the given argument as a tree", "dir=PATH or tar=TARFILE or ref=COMMIT" },
@@ -425,7 +427,7 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
         goto out;
     }
 
-  if (!opt_subject && !opt_body)
+  if (opt_editor)
     {
       if (!commit_editor (repo, opt_branch, &opt_subject, &opt_body, cancellable, error))
         goto out;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -218,14 +218,18 @@ commit_editor (OstreeRepo     *repo,
   char **lines = NULL;
   int i;
 
-  *subject = NULL;
-  *body = NULL;
-
   input = g_strdup_printf ("\n"
       "# Please enter the commit message for your changes. The first line will\n"
       "# become the subject, and the remainder the body. Lines starting\n"
       "# with '#' will be ignored, and an empty message aborts the commit."
-      "%s%s\n", branch ? "\n#\n# Branch: " : "", branch ?: "");
+      "%s%s%s%s%s%s\n"
+              , branch ? "\n#\n# Branch: " : "", branch ? branch : ""
+              , *subject ? "\n" : "", *subject ? *subject : ""
+              , *body ? "\n" : "", *body ? *body : ""
+              );
+
+  *subject = NULL;
+  *body = NULL;
 
   output = ot_editor_prompt (repo, input, cancellable, error);
   if (output == NULL)

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -437,13 +437,6 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
         goto out;
     }
 
-  if (!opt_subject)
-    {
-      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "A subject must be specified with --subject");
-      goto out;
-    }
-
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -118,8 +118,15 @@ dump_commit (GVariant            *variant,
       g_print ("Version: %s\n", version);
     }
 
-  g_print ("\n");
-  dump_indented_lines (subject);
+  if (subject[0])
+    {
+      g_print ("\n");
+      dump_indented_lines (subject);
+    }
+  else
+    {
+      g_print ("(no subject)\n");
+    }
 
   if (body[0])
     {

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..56"
+echo "1..57"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -102,6 +102,12 @@ assert_streq $($OSTREE log test2-no-parent |grep '^commit' | wc -l) "1"
 $OSTREE commit -b test2-no-parent -s '' --parent=none $test_tmpdir/checkout-test2-4
 assert_streq $($OSTREE log test2-no-parent |grep '^commit' | wc -l) "1"
 echo "ok commit no parent"
+
+cd ${test_tmpdir}
+empty_rev=$($OSTREE commit -b test2-no-subject -s '' --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
+omitted_rev=$($OSTREE commit -b test2-no-subject-2 --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
+assert_streq $empty_rev $omitted_rev
+echo "ok commit no subject"
 
 cd ${test_tmpdir}
 $OSTREE commit -b test2-custom-parent -s '' $test_tmpdir/checkout-test2-4


### PR DESCRIPTION
This is what I ended up with for https://bugzilla.gnome.org/show_bug.cgi?id=707069.

Sorry about the whitespace changes, I'm not sure how to avoid them.

With this patch, ostree commit will just do a commit, without an editor; you need to pass ``-e`` or ``--editor`` to run the editor.