### PR TITLE
[merged] Build on older versions of glib

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -26,11 +26,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <gio/gfiledescriptorbased.h>
+#include "libglnx.h"
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-chain-input-stream.h"
 #include "otutil.h"
-#include "libglnx.h"
 
 #define ALIGN_VALUE(this, boundary) \
   (( ((unsigned long)(this)) + (((unsigned long)(boundary)) -1)) & (~(((unsigned long)(boundary))-1)))

--- a/src/libostree/ostree-diff.c
+++ b/src/libostree/ostree-diff.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ostree.h"
 #include "otutil.h"
 

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -25,6 +25,7 @@
 #include <gio/gfiledescriptorbased.h>
 #include <gio/gunixoutputstream.h>
 
+#include "libglnx.h"
 #include "ostree-fetcher.h"
 #ifdef HAVE_LIBSOUP_CLIENT_CERTS
 #include "ostree-tls-cert-interaction.h"

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"

--- a/src/libostree/ostree-repo-traverse.c
+++ b/src/libostree/ostree-repo-traverse.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ostree.h"
 #include "otutil.h"
 

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -20,11 +20,11 @@
 
 #include "config.h"
 
+#include "ot-main.h"
 #include "ot-builtins.h"
 #include "ot-admin-instutil-builtins.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "ostree.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-functions.c
+++ b/src/ostree/ot-admin-functions.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ot-admin-functions.h"
 #include "otutil.h"
 #include "ostree.h"

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -22,10 +22,10 @@
 
 #include "config.h"
 
+#include "ot-main.h"
 #include "ot-builtins.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "ostree.h"
 #include "ostree-repo-file.h"
 

--- a/src/ostree/ot-editor.c
+++ b/src/ostree/ot-editor.c
@@ -22,9 +22,9 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ot-editor.h"
 #include "libgsystem.h"
-#include "libglnx.h"
 
 #include <sys/wait.h>
 #include <string.h>

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -27,9 +27,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ot-main.h"
 #include "ostree.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static char *opt_repo;

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include "ostree.h"
 #include "libglnx.h"
+#include "ostree.h"
 
 typedef enum {
   OSTREE_BUILTIN_FLAG_NONE = 0,


### PR DESCRIPTION
Various places need to include libglnx.h for the autoptr backport
fallbacks to be there before ostree-autocleanups.h is included.

This fixes the build on centos7·