### PR TITLE
[merged] lib: Drop GFile variant mapping API for fd-relative

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2098,8 +2098,9 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
   g_autoptr(GVariant) ret_metadata = NULL;
   GError *temp_error = NULL;
   
-  if (!ot_util_variant_map (metadata_path, G_VARIANT_TYPE ("a{sv}"),
-                            TRUE, &ret_metadata, &temp_error))
+  if (!ot_util_variant_map_at (AT_FDCWD, gs_file_get_path_cached (metadata_path),
+                               G_VARIANT_TYPE ("a{sv}"),
+                               TRUE, &ret_metadata, &temp_error))
     {
       if (g_error_matches (temp_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         {

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -512,6 +512,7 @@ _ostree_static_delta_part_open (GInputStream   *part_in,
                                                                     g_bytes_get_size (inline_part_bytes) - 1);
           ret_part = g_variant_new_from_bytes (G_VARIANT_TYPE (OSTREE_STATIC_DELTA_PART_PAYLOAD_FORMAT_V0),
                                                content_bytes, trusted);
+          g_variant_ref_sink (ret_part);
         }
 
       if (!skip_checksum)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4587,8 +4587,9 @@ ostree_repo_add_gpg_signature_summary (OstreeRepo     *self,
   if (!summary_data)
     goto out;
 
-  if (!ot_util_variant_map (signature_path, G_VARIANT_TYPE (OSTREE_SUMMARY_SIG_GVARIANT_STRING),
-                            TRUE, &existing_signatures, &temp_error))
+  if (!ot_util_variant_map_at (AT_FDCWD, gs_file_get_path_cached (signature_path),
+                               G_VARIANT_TYPE (OSTREE_SUMMARY_SIG_GVARIANT_STRING),
+                               TRUE, &existing_signatures, &temp_error))
     {
       if (g_error_matches (temp_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         {

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -117,46 +117,6 @@ ot_util_variant_take_ref (GVariant *variant)
   return g_variant_take_ref (variant);
 }
 
-/**
- * ot_util_variant_map:
- * @src: a #GFile
- * @type: Use this for variant
- * @trusted: See documentation of g_variant_new_from_data()
- * @out_variant: (out): Return location for new variant
- * @error:
- *
- * Memory-map @src, and store a new #GVariant referring to this memory
- * in @out_variant.  Note the returned @out_variant is not floating.
- */
-gboolean
-ot_util_variant_map (GFile              *src,
-                     const GVariantType *type,
-                     gboolean            trusted,
-                     GVariant          **out_variant,
-                     GError            **error)
-{
-  gboolean ret = FALSE;
-  g_autoptr(GVariant) ret_variant = NULL;
-  GMappedFile *mfile = NULL;
-
-  mfile = gs_file_map_noatime (src, NULL, error);
-  if (!mfile)
-    goto out;
-
-  ret_variant = g_variant_new_from_data (type,
-                                         g_mapped_file_get_contents (mfile),
-                                         g_mapped_file_get_length (mfile),
-                                         trusted,
-                                         (GDestroyNotify) g_mapped_file_unref,
-                                         mfile);
-  g_variant_ref_sink (ret_variant);
-  
-  ret = TRUE;
-  ot_transfer_out_value(out_variant, &ret_variant);
- out:
-  return ret;
-}
-
 gboolean
 ot_util_variant_map_at (int dfd,
                         const char *path,

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -166,7 +166,6 @@ ot_util_variant_map_at (int dfd,
                         GError  **error)
 {
   glnx_fd_close int fd = -1;
-  g_autoptr(GVariant) ret_variant = NULL;
 
   fd = openat (dfd, path, O_RDONLY | O_CLOEXEC);
   if (fd < 0)
@@ -224,8 +223,8 @@ ot_util_variant_map_fd (int                    fd,
   mdata->len = len;
 
   ret = TRUE;
-  *out_variant = g_variant_new_from_data (type, map, len, trusted,
-                                          variant_map_data_destroy, mdata);
+  *out_variant = g_variant_ref_sink (g_variant_new_from_data (type, map, len, trusted,
+                                                              variant_map_data_destroy, mdata));
  out:
   return ret;
 }

--- a/src/libotutil/ot-variant-utils.h
+++ b/src/libotutil/ot-variant-utils.h
@@ -42,12 +42,6 @@ gboolean ot_util_variant_save (GFile *dest,
                                GCancellable *cancellable,
                                GError  **error);
 
-gboolean ot_util_variant_map (GFile *src,
-                              const GVariantType *type,
-                              gboolean trusted,
-                              GVariant **out_variant,
-                              GError  **error);
-
 gboolean ot_util_variant_map_at (int dfd,
                                  const char *path,
                                  const GVariantType *type,

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -51,12 +51,9 @@ do_print_variant_generic (const GVariantType *type,
                           GError **error)
 {
   gboolean ret = FALSE;
-  g_autoptr(GFile) f = NULL;
   g_autoptr(GVariant) variant = NULL;
 
-  f = g_file_new_for_path (filename);
-
-  if (!ot_util_variant_map (f, type, TRUE, &variant, error))
+  if (!ot_util_variant_map_at (AT_FDCWD, filename, type, TRUE, &variant, error))
     goto out;
 
   ot_dump_variant (variant);


### PR DESCRIPTION
In addition to generic fd relative porting,
this is a necessary preparatory step for libglnx porting, because
when I tried to use `g_mapped_file_new` I hit an issue with
it using a different error domain from GIO.

Thankfully libglnx consistently uses the GIO error domain, and here
we're now using it for the `open()` call.