### PR TITLE
[merged] tests/test-pull-c: New test that runs through the pull API via C

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -140,7 +140,7 @@ endif
 test_programs = tests/test-varint tests/test-ot-unix-utils tests/test-bsdiff tests/test-mutable-tree \
 	tests/test-keyfile-utils tests/test-ot-opt-utils tests/test-ot-tool-util \
 	tests/test-gpg-verify-result tests/test-checksum tests/test-lzma tests/test-rollsum \
-	tests/test-basic-c tests/test-sysroot-c
+	tests/test-basic-c tests/test-sysroot-c tests/test-pull-c
 
 # An interactive tool
 noinst_PROGRAMS += tests/test-rollsum-cli
@@ -176,6 +176,9 @@ tests_test_basic_c_LDADD = $(TESTS_LDADD)
 
 tests_test_sysroot_c_CFLAGS = $(TESTS_CFLAGS)
 tests_test_sysroot_c_LDADD = $(TESTS_LDADD)
+
+tests_test_pull_c_CFLAGS = $(TESTS_CFLAGS)
+tests_test_pull_c_LDADD = $(TESTS_LDADD)
 
 tests_test_ot_unix_utils_CFLAGS = $(TESTS_CFLAGS)
 tests_test_ot_unix_utils_LDADD = $(TESTS_LDADD)

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -28,8 +28,8 @@
 /* This function hovers in a quantum superposition of horrifying and
  * beautiful.  Future generations may interpret it as modern art.
  */
-static gboolean
-run_libtest (const char *cmd, GError **error)
+gboolean
+ot_test_run_libtest (const char *cmd, GError **error)
 {
   gboolean ret = FALSE;
   const char *builddir = g_getenv ("G_TEST_BUILDDIR");
@@ -68,7 +68,7 @@ ot_test_setup_repo (GCancellable *cancellable,
   g_autoptr(GFile) repo_path = g_file_new_for_path ("repo");
   glnx_unref_object OstreeRepo* ret_repo = NULL;
 
-  if (!run_libtest ("setup_test_repository archive-z2", error))
+  if (!ot_test_run_libtest ("setup_test_repository archive-z2", error))
     goto out;
 
   ret_repo = ostree_repo_new (repo_path);
@@ -91,7 +91,7 @@ ot_test_setup_sysroot (GCancellable *cancellable,
   g_autoptr(GFile) sysroot_path = g_file_new_for_path ("sysroot");
   glnx_unref_object OstreeSysroot *ret_sysroot = NULL;
 
-  if (!run_libtest ("setup_os_repository \"archive-z2\" \"syslinux\"", error))
+  if (!ot_test_run_libtest ("setup_os_repository \"archive-z2\" \"syslinux\"", error))
     goto out;
 
   ret_sysroot = ostree_sysroot_new (sysroot_path);

--- a/tests/libostreetest.h
+++ b/tests/libostreetest.h
@@ -27,6 +27,7 @@
 
 G_BEGIN_DECLS
 
+gboolean ot_test_run_libtest (const char *cmd, GError **error);
 
 OstreeRepo *ot_test_setup_repo (GCancellable *cancellable,
                                 GError **error);

--- a/tests/test-pull-c.c
+++ b/tests/test-pull-c.c
@@ -1,0 +1,132 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+#include "libostreetest.h"
+
+typedef struct {
+  OstreeRepo *repo;
+} TestData;
+
+static void
+test_data_init (TestData *td)
+{
+  GError *local_error = NULL;
+  GError **error = &local_error;
+  g_autofree char *http_address = NULL;
+  g_autofree char *repo_url = NULL;
+
+  td->repo = ot_test_setup_repo (NULL, error);
+  if (!td->repo)
+    goto out;
+
+  if (!ot_test_run_libtest ("setup_fake_remote_repo1 archive-z2", error))
+    goto out;
+
+  if (!g_file_get_contents ("httpd-address", &http_address, NULL, error))
+    goto out;
+
+  repo_url = g_strconcat (http_address, "/ostree/gnomerepo", NULL);
+
+  { g_autoptr(GVariantBuilder) builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
+    g_autoptr(GVariant) opts = NULL;
+
+    g_variant_builder_add (builder, "{s@v}", "gpg-verify", g_variant_new_variant (g_variant_new_boolean (FALSE)));
+    opts = g_variant_ref_sink (g_variant_builder_end (builder));
+
+    if (!ostree_repo_remote_change (td->repo, NULL, OSTREE_REPO_REMOTE_CHANGE_ADD,
+                                    "origin", repo_url, opts, NULL, error))
+      goto out;
+  }
+
+ out:
+  g_assert_no_error (local_error);
+}
+
+static void
+test_pull_multi_nochange (gconstpointer data)
+{
+  GError *local_error = NULL;
+  GError **error = &local_error;
+  TestData *td = (void*)data;
+  char *refs[] = { "main", NULL };
+
+  if (!ostree_repo_pull (td->repo, "origin", (char**)&refs, 0, NULL, NULL, error))
+    goto out;
+  if (!ostree_repo_pull (td->repo, "origin", (char**)&refs, 0, NULL, NULL, error))
+    goto out;
+  if (!ostree_repo_pull (td->repo, "origin", (char**)&refs, 0, NULL, NULL, error))
+    goto out;
+  
+ out:
+  g_assert_no_error (local_error);
+}
+
+static void
+test_pull_multi_error_then_ok (gconstpointer data)
+{
+  GError *local_error = NULL;
+  GError **error = &local_error;
+  
+  TestData *td = (void*)data;
+  char *ok_refs[] = { "main", NULL };
+  char *bad_refs[] = { "nosuchbranch", NULL };
+
+  for (guint i = 0; i < 3; i++)
+    {
+      g_autoptr(GError) tmp_error = NULL;
+      if (!ostree_repo_pull (td->repo, "origin", (char**)&ok_refs, 0, NULL, NULL, error))
+        goto out;
+      if (ostree_repo_pull (td->repo, "origin", (char**)&bad_refs, 0, NULL, NULL, &tmp_error))
+        g_assert_not_reached ();
+      g_clear_error (&tmp_error);
+      if (ostree_repo_pull (td->repo, "origin", (char**)&bad_refs, 0, NULL, NULL, &tmp_error))
+        g_assert_not_reached ();
+      g_clear_error (&tmp_error);
+      if (!ostree_repo_pull (td->repo, "origin", (char**)&ok_refs, 0, NULL, NULL, error))
+        goto out;
+    }
+  
+ out:
+  g_assert_no_error (local_error);
+}
+
+int main (int argc, char **argv)
+{
+  TestData td = {NULL,};
+  int r;
+
+  test_data_init (&td);
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_data_func ("/test-pull-c/multi-nochange", &td, test_pull_multi_nochange);
+  g_test_add_data_func ("/test-pull-c/multi-ok-error-repeat", &td, test_pull_multi_error_then_ok);
+
+  r = g_test_run();
+
+  return r;
+}


### PR DESCRIPTION
We have had in the past issues with running `ostree_repo_pull()`
multiple times in the same process, embarassingly enough.  Nothing in
the current test suite covers this, so let's start.