### PR TITLE
[merged] lib: Port some manual close() cleanups to be glnx_fd_close

### DIFF
--- a/src/libostree/ostree-linuxfsutil.c
+++ b/src/libostree/ostree-linuxfsutil.c
@@ -107,7 +107,7 @@ _ostree_linuxfs_alter_immutable_flag (GFile         *path,
                                       GError       **error)
 {
   gboolean ret = FALSE;
-  int fd = -1;
+  glnx_fd_close int fd = -1;
 
   if (g_cancellable_set_error_if_cancelled (cancellable, error))
     return FALSE;
@@ -129,7 +129,5 @@ _ostree_linuxfs_alter_immutable_flag (GFile         *path,
 
   ret = TRUE;
  out:
-  if (fd != -1)
-    (void) close (fd);
   return ret;
 }

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -632,7 +632,7 @@ checkout_tree_at (OstreeRepo                        *self,
 {
   gboolean ret = FALSE;
   gboolean did_exist = FALSE;
-  int destination_dfd = -1;
+  glnx_fd_close int destination_dfd = -1;
   int res;
   g_autoptr(GVariant) xattrs = NULL;
   g_autoptr(GFileEnumerator) dir_enum = NULL;
@@ -779,8 +779,6 @@ checkout_tree_at (OstreeRepo                        *self,
 
   ret = TRUE;
  out:
-  if (destination_dfd != -1)
-    (void) close (destination_dfd);
   return ret;
 }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2925,7 +2925,7 @@ load_metadata_internal (OstreeRepo       *self,
 {
   gboolean ret = FALSE;
   char loose_path_buf[_OSTREE_LOOSE_PATH_MAX];
-  int fd = -1;
+  glnx_fd_close int fd = -1;
   g_autoptr(GInputStream) ret_stream = NULL;
   g_autoptr(GVariant) ret_variant = NULL;
 
@@ -2953,8 +2953,6 @@ load_metadata_internal (OstreeRepo       *self,
           mfile = g_mapped_file_new_from_fd (fd, FALSE, error);
           if (!mfile)
             goto out;
-          (void) close (fd); /* Ignore errors, we have it mapped */
-          fd = -1;
           ret_variant = g_variant_new_from_data (ostree_metadata_variant_type (objtype),
                                                  g_mapped_file_get_contents (mfile),
                                                  g_mapped_file_get_length (mfile),
@@ -2999,8 +2997,6 @@ load_metadata_internal (OstreeRepo       *self,
   ot_transfer_out_value (out_variant, &ret_variant);
   ot_transfer_out_value (out_stream, &ret_stream);
  out:
-  if (fd != -1)
-    (void) close (fd);
   return ret;
 }
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -172,8 +172,8 @@ copy_dir_recurse (int              src_parent_dfd,
                   GError         **error)
 {
   gboolean ret = FALSE;
-  int src_dfd = -1;
-  int dest_dfd = -1;
+  glnx_fd_close int src_dfd = -1;
+  glnx_fd_close int dest_dfd = -1;
   DIR *srcd = NULL;
   struct dirent *dent;
 
@@ -240,10 +240,6 @@ copy_dir_recurse (int              src_parent_dfd,
       /* Note the srcd owns src_dfd */
       src_dfd = -1;
     }
-  if (src_dfd != -1)
-    (void) close (src_dfd);
-  if (dest_dfd != -1)
-    (void) close (dest_dfd);
   return ret;
 }
 
@@ -459,9 +455,9 @@ merge_etc_changes (GFile          *orig_etc,
   g_autoptr(GPtrArray) removed = NULL;
   g_autoptr(GPtrArray) added = NULL;
   guint i;
-  int orig_etc_fd = -1;
-  int modified_etc_fd = -1;
-  int new_etc_fd = -1; 
+  glnx_fd_close int orig_etc_fd = -1;
+  glnx_fd_close int modified_etc_fd = -1;
+  glnx_fd_close int new_etc_fd = -1; 
 
   modified = g_ptr_array_new_with_free_func ((GDestroyNotify) ostree_diff_item_unref);
   removed = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
@@ -538,12 +534,6 @@ merge_etc_changes (GFile          *orig_etc,
 
   ret = TRUE;
  out:
-  if (orig_etc_fd != -1)
-    (void) close (orig_etc_fd);
-  if (modified_etc_fd != -1)
-    (void) close (modified_etc_fd);
-  if (new_etc_fd != -1)
-    (void) close (new_etc_fd);
   return ret;
 }
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -253,8 +253,8 @@ ensure_directory_from_template (int                 orig_etc_fd,
                                 GError            **error)
 {
   gboolean ret = FALSE;
-  int src_dfd = -1;
-  int target_dfd = -1;
+  glnx_fd_close int src_dfd = -1;
+  glnx_fd_close int target_dfd = -1;
 
   g_assert (path != NULL);
   g_assert (*path != '/' && *path != '\0');
@@ -312,10 +312,6 @@ ensure_directory_from_template (int                 orig_etc_fd,
       target_dfd = -1;
     }
  out:
-  if (src_dfd != -1)
-    (void) close (src_dfd);
-  if (target_dfd != -1)
-    (void) close (target_dfd);
   return ret;
 }
 
@@ -337,7 +333,7 @@ copy_modified_config_file (int                 orig_etc_fd,
   gboolean ret = FALSE;
   struct stat modified_stbuf;
   struct stat new_stbuf;
-  int dest_parent_dfd = -1;
+  glnx_fd_close int dest_parent_dfd = -1;
 
   if (fstatat (modified_etc_fd, path, &modified_stbuf, AT_SYMLINK_NOFOLLOW) < 0)
     {
@@ -427,8 +423,6 @@ copy_modified_config_file (int                 orig_etc_fd,
 
   ret = TRUE;
  out:
-  if (dest_parent_dfd != -1)
-    (void) close (dest_parent_dfd);
   return ret;
 }
 

--- a/src/libotutil/ot-gio-utils.c
+++ b/src/libotutil/ot-gio-utils.c
@@ -357,7 +357,7 @@ ot_gfile_replace_contents_fsync (GFile          *path,
                                  GError        **error)
 {
   gboolean ret = FALSE;
-  int parent_dfd;
+  glnx_fd_close int parent_dfd = -1;
   const char *target_basename = glnx_basename (gs_file_get_path_cached (path));
   g_autoptr(GFile) parent = NULL;
 
@@ -374,8 +374,6 @@ ot_gfile_replace_contents_fsync (GFile          *path,
 
   ret = TRUE;
  out:
-  if (parent_dfd != -1)
-    (void) close (parent_dfd);
   return ret;
 }
 
@@ -412,7 +410,7 @@ ot_util_fsync_directory (GFile         *dir,
                          GError       **error)
 {
   gboolean ret = FALSE;
-  int dfd = -1;
+  glnx_fd_close int dfd = -1;
 
   if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (dir), TRUE,
                        &dfd, error))
@@ -426,8 +424,6 @@ ot_util_fsync_directory (GFile         *dir,
 
   ret = TRUE;
  out:
-  if (dfd != -1)
-    (void) close (dfd);
   return ret;
 }
 
@@ -446,7 +442,7 @@ ot_util_ensure_directory_and_fsync (GFile         *dir,
                                     GError       **error)
 {
   gboolean ret = FALSE;
-  int parentfd = -1;
+  glnx_fd_close int parentfd = -1;
   const char *basename = glnx_basename (gs_file_get_path_cached (dir));
   g_autoptr(GFile) parent = g_file_get_parent (dir);
   
@@ -495,7 +491,5 @@ ot_util_ensure_directory_and_fsync (GFile         *dir,
 
   ret = TRUE;
  out:
-  if (parentfd != -1)
-    (void) close (parentfd);
   return ret;
 }


### PR DESCRIPTION
Just noticed this while reading some code, we didn't have many manual
`out: close()` bits left, this pushes us over the edge to autocleanup
almost everywhere.