### PR TITLE
[merged] tests: Exit valgrind tests if a leak is detected

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -77,7 +77,7 @@ if test -n "${OT_TESTS_DEBUG:-}"; then
 fi
 
 if test -n "${OT_TESTS_VALGRIND:-}"; then
-    CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
+    CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
 else
     CMD_PREFIX="env LD_PRELOAD=${test_builddir}/libreaddir-rand.so"
 fi


### PR DESCRIPTION
This fails the test if OT_TESTS_VALGRIND is set and valgrind
detects a leak.

I noticed this was needed when I started looking at using valgrind in flatpak.

Note: This adds various failures when OT_TESTS_VALGRIND is set.