### PR TITLE
[merged] Link libreaddir-rand to libdl

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -133,7 +133,10 @@ endif
 test_ltlibraries = libreaddir-rand.la
 libreaddir_rand_la_SOURCES = tests/readdir-rand.c
 libreaddir_rand_la_CFLAGS = $(OT_INTERNAL_GIO_UNIX_CFLAGS)
-libreaddir_rand_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS)
+libreaddir_rand_la_LIBADD = \
+	-ldl \
+	$(OT_INTERNAL_GIO_UNIX_LIBS) \
+	$(NULL)
 libreaddir_rand_la_LDFLAGS = -avoid-version
 if !ENABLE_INSTALLED_TESTS
 libreaddir_rand_la_LDFLAGS += -rpath $(abs_builddir)


### PR DESCRIPTION
It uses dlsym(). There's no point in being extra-portable here
because OSTree only targets Linux anyway.

---

I suspect this caused a test failure in Ubuntu which @alexlarsson worked around in his PPA; see <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826857>.