### PR TITLE
[merged] refs: add "ostree refs --create" and unit tests

### DIFF
--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -43,7 +43,6 @@ static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellab
   GHashTableIter hashiter;
   gpointer hashkey, hashvalue;
   gboolean ret = FALSE;
-  g_autofree char *parent = NULL;
 
   if (opt_delete || opt_list)
     {

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -75,14 +75,14 @@ static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellab
       g_autofree char *checksum = NULL;
       g_autofree char *checksum_existing = NULL;
 
-      if (ostree_repo_resolve_rev (repo, opt_create, TRUE, &checksum_existing, error))
+      if (!ostree_repo_resolve_rev (repo, opt_create, TRUE, &checksum_existing, error))
+        goto out;
+
+      if (checksum_existing != NULL)
         {
-          if (checksum_existing != NULL)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "--create specified but ref %s already exists", opt_create);
-              goto out;
-            }
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "--create specified but ref %s already exists", opt_create);
+          goto out;
         }
 
       if (!ostree_repo_resolve_rev (repo, refspec_prefix, FALSE, &checksum, error))

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -72,11 +72,21 @@ ${CMD_PREFIX} ostree --repo=repo commit --branch=foo/ctest -m ctest -s ctest tre
 ${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount
 assert_file_has_content refscount "^5$"
 
-${CMD_PREFIX} ostree --repo=repo refs --create=ctest-new 2>/dev/null && (echo 1>&2 "refs --create unexpectedly succeeded without specifying an existing ref!"; exit 1)
-${CMD_PREFIX} ostree --repo=repo refs ctest --create 2>/dev/null && (echo 1>&2 "refs --create unexpectedly succeeded without specifying the ref to create!"; exit 1)
-${CMD_PREFIX} ostree --repo=repo refs does-not-exist --create=ctest-new 2>/dev/null && (echo 1>&2 "refs --create unexpectedly succeeded for a prefix that doesn't exist!"; exit 1)
-${CMD_PREFIX} ostree --repo=repo refs ctest --create=foo 2>/dev/null && (echo 1>&2 "refs --create unexpectedly succeeded for a prefix that is already in use by a folder!"; exit 1)
-${CMD_PREFIX} ostree --repo=repo refs foo/ctest --create=ctest 2>/dev/null && (echo 1>&2 "refs --create unexpectedly succeeded in overwriting an existing prefix!"; exit 1)
+if ${CMD_PREFIX} ostree --repo=repo refs --create=ctest-new; then
+    assert_not_reached "refs --create unexpectedly succeeded without specifying an existing ref!"
+fi
+if ${CMD_PREFIX} ostree --repo=repo refs ctest --create; then
+    assert_not_reached "refs --create unexpectedly succeeded without specifying the ref to create!"
+fi
+if ${CMD_PREFIX} ostree --repo=repo refs does-not-exist --create=ctest-new; then
+    assert_not_reached "refs --create unexpectedly succeeded for a prefix that doesn't exist!"
+fi
+if ${CMD_PREFIX} ostree --repo=repo refs ctest --create=foo; then
+    assert_not_reached "refs --create unexpectedly succeeded for a prefix that is already in use by a folder!"
+fi
+if ${CMD_PREFIX} ostree --repo=repo refs foo/ctest --create=ctest; then
+    assert_not_reached "refs --create unexpectedly succeeded in overwriting an existing prefix!"
+fi
 
 #Check to see if any uncleaned tmp files were created after failed --create
 ${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount.create1


### PR DESCRIPTION
Add the ability to create a ref (much like a git tag) for an
existing commit through "ostree refs EXISTING --create=NEWREF".
Previously the only way to create a new ref was by creating a new commit,
but refs --create allows multiple refs to point to the same commit.

The command will fail if:
 - None/more than one existing ref is specified
 - The specified EXISTING tag does not exist, or was not specified
 - The specified NEWREF already exists, or is the name of a folder

Add unit tests in tests-ref.sh to verify above functionality