### PR TITLE
POC: fsck repair

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -340,6 +340,7 @@ global:
 
 LIBOSTREE_2016.6 {
 global:
+        ostree_get_relative_object_path;
         ostree_gpg_verify_result_require_valid_signature;
         ostree_raw_file_to_archive_z2_stream;
         ostree_repo_gpg_verify_data;

--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -88,11 +88,6 @@ GFileInfo * _ostree_header_gfile_info_new (mode_t mode, uid_t uid, gid_t gid);
  */
 #define _OSTREE_LOOSE_PATH_MAX (256)
 
-char *
-_ostree_get_relative_object_path (const char        *checksum,
-                                  OstreeObjectType   type,
-                                  gboolean           compressed);
-
 
 char *
 _ostree_get_relative_static_delta_path (const char        *from,

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1469,8 +1469,8 @@ _ostree_loose_path_with_suffix (char              *buf,
             suffix);
 }
 
-/*
- * _ostree_get_relative_object_path:
+/**
+ * ostree_get_relative_object_path:
  * @checksum: ASCII checksum string
  * @type: Object type
  * @compressed: Whether or not the repository object is compressed
@@ -1478,9 +1478,9 @@ _ostree_loose_path_with_suffix (char              *buf,
  * Returns: (transfer full): Relative path for a loose object
  */
 char *
-_ostree_get_relative_object_path (const char         *checksum,
-                                  OstreeObjectType    type,
-                                  gboolean            compressed)
+ostree_get_relative_object_path (const char         *checksum,
+                                 OstreeObjectType    type,
+                                 gboolean            compressed)
 {
   GString *path;
 

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -243,16 +243,20 @@ void ostree_object_from_string (const char *str,
                                 OstreeObjectType *out_objtype);
 
 _OSTREE_PUBLIC
-gboolean
-ostree_content_stream_parse (gboolean                compressed,
-                             GInputStream           *input,
-                             guint64                 input_length,
-                             gboolean                trusted,
-                             GInputStream          **out_input,
-                             GFileInfo             **out_file_info,
-                             GVariant              **out_xattrs,
-                             GCancellable           *cancellable,
-                             GError                **error);
+char * ostree_get_relative_object_path (const char        *checksum,
+                                        OstreeObjectType   type,
+                                        gboolean           compressed);
+
+_OSTREE_PUBLIC
+gboolean ostree_content_stream_parse (gboolean                compressed,
+                                      GInputStream           *input,
+                                      guint64                 input_length,
+                                      gboolean                trusted,
+                                      GInputStream          **out_input,
+                                      GFileInfo             **out_file_info,
+                                      GVariant              **out_xattrs,
+                                      GCancellable           *cancellable,
+                                      GError                **error);
 
 _OSTREE_PUBLIC
 gboolean ostree_content_file_parse (gboolean                compressed,
@@ -276,13 +280,12 @@ gboolean ostree_content_file_parse_at (gboolean                compressed,
                                        GError                **error);
 
 _OSTREE_PUBLIC
-gboolean
-ostree_raw_file_to_archive_z2_stream (GInputStream       *input,
-                                      GFileInfo          *file_info,
-                                      GVariant           *xattrs,
-                                      GInputStream      **out_input,
-                                      GCancellable       *cancellable,
-                                      GError            **error);
+gboolean ostree_raw_file_to_archive_z2_stream (GInputStream       *input,
+                                               GFileInfo          *file_info,
+                                               GVariant           *xattrs,
+                                               GInputStream      **out_input,
+                                               GCancellable       *cancellable,
+                                               GError            **error);
 
 _OSTREE_PUBLIC
 gboolean ostree_raw_file_to_content_stream (GInputStream       *input,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1322,7 +1322,7 @@ enqueue_one_object_request (OtPullData        *pull_data,
     }
   else
     {
-      objpath = _ostree_get_relative_object_path (checksum, objtype, TRUE);
+      objpath = ostree_get_relative_object_path (checksum, objtype, TRUE);
       obj_uri = suburi_new (pull_data->base_uri, objpath, NULL);
     }
 


### PR DESCRIPTION
This is something I quickly hacked up, since I haven't seen any possibility to tell ostree to fetch the missing objects after doing `ostree fsck --delete`.

For now it only tries to download content objects, as doing that with metadata objects seems to be a bit more involved. And in my case all the corrupted objects were actually content objects.

WDYT?
