### PR TITLE
[merged] libostree.sym: Fix test-symbols

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -350,6 +350,6 @@ global:
 /*
 LIBOSTREE_2016.7 {
 global:
-        ostree_some_new_symbol;
+        someostree_some_new_symbol;
 } LIBOSTREE_2016.6;
 */


### PR DESCRIPTION
The test isn't smart enough to ignore comments, so change the prefix.