### PR TITLE
add function to check if the repository exists on the filesystem

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -356,4 +356,5 @@ global:
         ostree_checksum_b64_to_bytes;
         ostree_checksum_b64_from_bytes;
         ostree_repo_checkout_at;
+        ostree_repo_is_created;
 } LIBOSTREE_2016.7;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2094,6 +2094,26 @@ append_remotes_d (OstreeRepo          *self,
 }
 
 gboolean
+ostree_repo_is_created (OstreeRepo    *self,
+                        gboolean      *is_created,
+                        GCancellable  *cancellable,
+                        GError        **error)
+{
+  if (!ostree_repo_open (self, cancellable, error))
+    {
+      if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        {
+          *is_created = FALSE;
+          return TRUE;
+        }
+      *is_created = FALSE;
+      return FALSE;
+    }
+  *is_created = TRUE;
+  return TRUE;
+}
+
+gboolean
 ostree_repo_open (OstreeRepo    *self,
                   GCancellable  *cancellable,
                   GError       **error)

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -55,6 +55,12 @@ _OSTREE_PUBLIC
 OstreeRepo* ostree_repo_new_default (void);
 
 _OSTREE_PUBLIC
+gboolean      ostree_repo_is_created (OstreeRepo    *self,
+                                      gboolean      *does_exist,
+                                      GCancellable  *cancellable,
+                                      GError        **error);
+
+_OSTREE_PUBLIC
 gboolean      ostree_repo_open   (OstreeRepo     *self,
                                   GCancellable   *cancellable,
                                   GError        **error);

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -23,9 +23,12 @@
 #include <stdlib.h>
 #include <gio/gio.h>
 #include <string.h>
+#include <ostree.h>
 
 #include "libglnx.h"
 #include "libostreetest.h"
+
+#include <stdio.h>
 
 static void
 test_repo_is_not_system (gconstpointer data)
@@ -171,6 +174,37 @@ test_raw_file_to_archive_z2_stream (gconstpointer data)
   g_assert_cmpint (checks, >, 0);
 }
 
+static void
+test_repo_is_created (gconstpointer data)
+{
+  OstreeRepo *repo = OSTREE_REPO (data);
+  gboolean exists = 0;
+  gboolean created = 0;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GFile) path;
+  g_autoptr(GCancellable) cancellable;
+  int success;
+
+  /* Test a return value of TRUE on a repo that exists */
+  success = ostree_repo_is_created (repo, &exists, cancellable, &error);
+  g_assert (success);
+  g_assert(exists);
+  g_object_unref(repo);
+  /* Test a return value of FALSE on a repo that does not exist */
+  // Create an empty directory
+  mkdir ("not-a-repo", 0777);
+  // Create a repo struct associated with that directory
+  path = g_file_new_for_path ("not-a-repo");
+  repo = ostree_repo_new (path);
+  // Check to see if that repo has been initialized in the filesystem (it shouldn't have been)
+  error = NULL;
+  success = ostree_repo_is_created (repo, &exists, cancellable, &error);
+  if (error)
+    printf("%s\n", error->message);
+  g_assert (success);
+  g_assert (!exists);
+}
+
 int main (int argc, char **argv)
 {
   g_autoptr(GError) error = NULL;
@@ -184,6 +218,7 @@ int main (int argc, char **argv)
   
   g_test_add_data_func ("/repo-not-system", repo, test_repo_is_not_system);
   g_test_add_data_func ("/raw-file-to-archive-z2-stream", repo, test_raw_file_to_archive_z2_stream);
+  g_test_add_data_func ("/repo-created", repo, test_repo_is_created);
 
   return g_test_run();
  out:


### PR DESCRIPTION
Add a function to check if a repository exists in the filesystem.  Can be used before attempting to create a repo with ostree_repo_create, which will fail if the repository already exists