### PR TITLE
[merged] entry_pathname_test_helper: these tests need extended attributes

### DIFF
--- a/tests/test-libarchive-import.c
+++ b/tests/test-libarchive-import.c
@@ -433,6 +433,9 @@ entry_pathname_test_helper (gconstpointer data, gboolean on)
   OstreeRepoCommitModifier *modifier = NULL;
   gboolean met_etc_file = FALSE;
 
+  if (skip_if_no_xattr (td))
+    goto out;
+
   modifier = ostree_repo_commit_modifier_new (0, NULL, NULL, NULL);
   ostree_repo_commit_modifier_set_xattr_callback (modifier, path_cb,
                                                   NULL, &met_etc_file);


### PR DESCRIPTION
This is another test that fails when the entire filesystem is tmpfs, as is done on some Debian autobuilders.