### PR TITLE
[merged] Fix tests' use of libtool

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -245,7 +245,7 @@ ALL_LOCAL_RULES += tests/libreaddir-rand.so
 CLEANFILES += tests/libreaddir-rand.so tests/ostree-symlink-stamp tests/ostree
 
 tests/ostree-symlink-stamp: Makefile
-	@real_bin=`cd $(top_builddir) && libtool --mode=execute echo ostree`; \
+	@real_bin=`cd $(top_builddir) && ./libtool --mode=execute echo ostree`; \
 	ln -sf "$${real_bin}" tests/ostree; \
 	touch $@
 

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -245,7 +245,8 @@ ALL_LOCAL_RULES += tests/libreaddir-rand.so
 CLEANFILES += tests/libreaddir-rand.so tests/ostree-symlink-stamp tests/ostree
 
 tests/ostree-symlink-stamp: Makefile
-	@real_bin=`cd $(top_builddir) && ./libtool --mode=execute echo ostree`; \
+	@set -e; \
+	real_bin=`cd $(top_builddir) && ./libtool --mode=execute echo ostree`; \
 	ln -sf "$${real_bin}" tests/ostree; \
 	touch $@
 


### PR DESCRIPTION
libtoolize creates a version of libtool for the right architecture in $(top_builddir), which is guaranteed to be present, and is guaranteed to match what we are compiling (even during cross-compilation).

The libtool in $PATH might be for a different architecture, or even not exist at all.

Also stop the tests from proceeding (and later using the wrong ostree binary, or failing if ostree is not already installed) if a preparation step fails.