### PR TITLE
[merged] Upstream build fixes

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -38,6 +38,9 @@ endif
 if BUILDOPT_SYSTEMD
 systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
 	src/boot/ostree-remount.service
+
+# Allow the distcheck install under $prefix test to pass
+AM_DISTCHECK_CONFIGURE_FLAGS += --with-systemdsystemunitdir='$${libdir}/systemd/system'
 endif
 
 if !BUILDOPT_BUILTIN_GRUB2_MKCONFIG

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -232,12 +232,7 @@ EXTRA_DIST += \
 	tests/libostreetest.h \
 	tests/libtest.sh \
 	tests/gpg-verify-data/README.md \
-	tests/gpg-verify-data/lgpl2 \
-	tests/gpg-verify-data/lgpl2.sig \
-	tests/gpg-verify-data/pubring.gpg \
-	tests/gpg-verify-data/secring.gpg \
-	tests/gpg-verify-data/trustdb.gpg \
-	tests/gpg-verify-data/gpg.conf
+	$(NULL)
 
 tests/libreaddir-rand.so: Makefile
 	$(AM_V_GEN) ln -fns ../.libs/libreaddir-rand.so tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,12 +60,14 @@ libglnx_srcpath := $(srcdir)/libglnx
 libglnx_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(libglnx_srcpath)"
 libglnx_libs := $(OT_DEP_GIO_UNIX_LIBS)
 include libglnx/Makefile-libglnx.am.inc
+EXTRA_DIST += libglnx/Makefile-libglnx.am
 noinst_LTLIBRARIES += libglnx.la
 
 libbsdiff_srcpath := $(srcdir)/bsdiff
 libbsdiff_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(bsdiff_srcpath)"
 libbsdiff_libs := $(OT_DEP_GIO_UNIX_LIBS)
 include bsdiff/Makefile-bsdiff.am.inc
+EXTRA_DIST += bsdiff/Makefile-bsdiff.am
 noinst_LTLIBRARIES += libbsdiff.la
 
 include Makefile-otutil.am

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -94,6 +94,9 @@ ot_test_setup_sysroot (GCancellable *cancellable,
   if (!ot_test_run_libtest ("setup_os_repository \"archive-z2\" \"syslinux\"", error))
     goto out;
 
+  /* Make sure deployments are mutable */
+  g_setenv ("OSTREE_SYSROOT_DEBUG", "mutable-deployments", TRUE);
+
   ret_sysroot = ostree_sysroot_new (sysroot_path);
 
   ret = TRUE;

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -43,10 +43,9 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'option
 echo "ok deploy with --karg, but same config"
 
 ${CMD_PREFIX} ostree admin deploy --karg-proc-cmdline --os=testos testos:testos/buildmaster/x86_64-runtime
-# Here we're asserting that the *host* system has a root= kernel
-# argument.  I think it's unlikely that anyone doesn't have one, but
-# if this is not true for you, please file a bug!
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*root=.'
+for arg in $(cat /proc/cmdline); do
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+done
 
 echo "ok deploy --karg-proc-cmdline"
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -54,8 +54,7 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'option
 echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
-# Here we're asserting that the *host* system has a root= kernel
-# argument.  I think it's unlikely that anyone doesn't have one, but
-# if this is not true for you, please file a bug!
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*root=.'
+for arg in $(cat /proc/cmdline); do
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+done
 echo "ok instutil set-kargs --import-proc-cmdline"

--- a/tests/test-auto-summary.sh
+++ b/tests/test-auto-summary.sh
@@ -31,30 +31,30 @@ mkdir test
 
 echo hello > test/a
 
-${CMD_PREFIX} $OSTREE commit -b test -s "A commit" test
+$OSTREE commit -b test -s "A commit" test
 echo "ok commit 1"
 
-${CMD_PREFIX} $OSTREE summary --update
+$OSTREE summary --update
 
 OLD_MD5=$(md5sum repo/summary)
 
 echo hello2 > test/a
 
-${CMD_PREFIX} $OSTREE commit -b test -s "Another commit" test
+$OSTREE commit -b test -s "Another commit" test
 echo "ok commit 2"
 
 assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
 
-${CMD_PREFIX} $OSTREE --repo=repo config set core.commit-update-summary true
+$OSTREE --repo=repo config set core.commit-update-summary true
 
 echo hello3 > test/a
 
-${CMD_PREFIX} $OSTREE commit -b test -s "Another commit..." test
+$OSTREE commit -b test -s "Another commit..." test
 echo "ok commit 3"
 
 assert_not_streq "$OLD_MD5" "$(md5sum repo/summary)"
 
 # Check that summary --update deletes the .sig file
 touch repo/summary.sig
-${CMD_PREFIX} $OSTREE summary --update
+$OSTREE summary --update
 assert_not_has_file repo/summary.sig


### PR DESCRIPTION
Some fixes I found while rebasing our Endless version on 2016.5 and 2016.6. Our process uses `distcheck` to create a tarball from git to build a package from, so it hits some things that probably aren't normally seen upstream. We can keep some of these downstream, but I'd love to reduce our delta.