### PR TITLE
[merged] delta: Add --if-not-exists option

### DIFF
--- a/src/libostree/ostree-cmdprivate.c
+++ b/src/libostree/ostree-cmdprivate.c
@@ -47,6 +47,7 @@ ostree_cmd__private__ (void)
   static OstreeCmdPrivateVTable table = {
     impl_ostree_generate_grub2_config,
     _ostree_repo_static_delta_dump,
+    _ostree_repo_static_delta_query_exists,
     _ostree_repo_static_delta_delete
   };
 

--- a/src/libostree/ostree-cmdprivate.h
+++ b/src/libostree/ostree-cmdprivate.h
@@ -27,6 +27,7 @@ G_BEGIN_DECLS
 typedef struct {
   gboolean (* ostree_generate_grub2_config) (OstreeSysroot *sysroot, int bootversion, int target_fd, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_dump) (OstreeRepo *repo, const char *delta_id, GCancellable *cancellable, GError **error);
+  gboolean (* ostree_static_delta_query_exists) (OstreeRepo *repo, const char *delta_id, gboolean *out_exists, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_delete) (OstreeRepo *repo, const char *delta_id, GCancellable *cancellable, GError **error);
 } OstreeCmdPrivateVTable;
 

--- a/src/libostree/ostree-repo-static-delta-private.h
+++ b/src/libostree/ostree-repo-static-delta-private.h
@@ -191,6 +191,13 @@ _ostree_delta_compute_similar_objects (OstreeRepo                 *repo,
                                        GError                    **error);
 
 gboolean
+_ostree_repo_static_delta_query_exists (OstreeRepo                 *repo,
+                                        const char                 *delta_id,
+                                        gboolean                   *out_exists,
+                                        GCancellable               *cancellable,
+                                        GError                    **error);
+
+gboolean
 _ostree_repo_static_delta_dump (OstreeRepo                 *repo,
                                 const char                 *delta_id,
                                 GCancellable               *cancellable,

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -93,9 +93,12 @@ ${CMD_PREFIX} ostree --repo=repo commit -b test -s test --tree=dir=files
 
 newrev=$(${CMD_PREFIX} ostree --repo=repo rev-parse test)
 
-${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} --inline
+${CMD_PREFIX} ostree --repo=repo static-delta generate --if-not-exists --from=${origrev} --to=${newrev} --inline
 ${CMD_PREFIX} ostree --repo=repo static-delta generate --if-not-exists --from=${origrev} --to=${newrev} --inline > out.txt
 assert_file_has_content out.txt "${origrev}-${newrev} already exists"
+# Should regenerate
+${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} --inline > out.txt
+assert_not_file_has_content out.txt "${origrev}-${newrev} already exists"
 
 deltaprefix=$(get_assert_one_direntry_matching repo/deltas '.')
 deltadir=$(get_assert_one_direntry_matching repo/deltas/${deltaprefix} '-')

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -82,6 +82,8 @@ get_assert_one_direntry_matching() {
 origrev=$(${CMD_PREFIX} ostree --repo=repo rev-parse test)
 
 ${CMD_PREFIX} ostree --repo=repo static-delta generate --empty --to=${origrev}
+${CMD_PREFIX} ostree --repo=repo static-delta generate --if-not-exists --empty --to=${origrev} > out.txt
+assert_file_has_content out.txt "${origrev} already exists"
 ${CMD_PREFIX} ostree --repo=repo static-delta list | grep ${origrev} || exit 1
 ${CMD_PREFIX} ostree --repo=repo prune
 ${CMD_PREFIX} ostree --repo=repo static-delta list | grep ${origrev} || exit 1
@@ -92,6 +94,8 @@ ${CMD_PREFIX} ostree --repo=repo commit -b test -s test --tree=dir=files
 newrev=$(${CMD_PREFIX} ostree --repo=repo rev-parse test)
 
 ${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} --inline
+${CMD_PREFIX} ostree --repo=repo static-delta generate --if-not-exists --from=${origrev} --to=${newrev} --inline > out.txt
+assert_file_has_content out.txt "${origrev}-${newrev} already exists"
 
 deltaprefix=$(get_assert_one_direntry_matching repo/deltas '.')
 deltadir=$(get_assert_one_direntry_matching repo/deltas/${deltaprefix} '-')


### PR DESCRIPTION
I often want to have "idempotent" systems that iterate to a known
state.  If after generating a commit, the system is interrupted, I'd
like the next run to still generate a delta.  But we don't want to
regenerate if one exists, hence this option.