### PR TITLE
[merged] libostree: Fix build failure with glib 2.42

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -23,6 +23,7 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ostree-gpg-verifier.h"
 #include "ostree-gpg-verify-result-private.h"
 #include "otutil.h"

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -22,12 +22,12 @@
 
 #include "config.h"
 
+#include "libglnx.h"
 #include "ostree.h"
 #include "otutil.h"
 
 #ifdef HAVE_LIBSOUP
 
-#include "libglnx.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
 #include "ostree-repo-static-delta-private.h"


### PR DESCRIPTION
G_DEFINE_AUTOPTR_CLEANUP_FUNC is a new function in GLib 2.44, but
libglnx contains a backported version of it. A few source files were
however using G_DEFINE_AUTOPTR_CLEANUP_FUNC either without including
libglnx.h, or without including it early enough.

Closes #376