### PR TITLE
[merged] tests: Fix karg tests on ostree-booted system

### DIFF
--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -44,8 +44,12 @@ echo "ok deploy with --karg, but same config"
 
 ${CMD_PREFIX} ostree admin deploy --karg-proc-cmdline --os=testos testos:testos/buildmaster/x86_64-runtime
 for arg in $(cat /proc/cmdline); do
-    if test "${arg#ostree=*}" != ${arg}; then continue; fi
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+    case "$arg" in
+	ostree=*) # Skip ostree arg that gets stripped out
+	   ;;
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+	   ;;
+    esac
 done
 
 echo "ok deploy --karg-proc-cmdline"

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -44,6 +44,7 @@ echo "ok deploy with --karg, but same config"
 
 ${CMD_PREFIX} ostree admin deploy --karg-proc-cmdline --os=testos testos:testos/buildmaster/x86_64-runtime
 for arg in $(cat /proc/cmdline); do
+    if test "${arg#ostree=*}" != ${arg}; then continue; fi
     assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
 done
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -55,7 +55,11 @@ echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
 for arg in $(cat /proc/cmdline); do
-    if test "${arg#ostree=*}" != ${arg}; then continue; fi
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+    case "$arg" in
+	ostree=*) # Skip ostree arg that gets stripped out
+	   ;;
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+	   ;;
+    esac
 done
 echo "ok instutil set-kargs --import-proc-cmdline"

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -55,6 +55,7 @@ echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
 for arg in $(cat /proc/cmdline); do
+    if test "${arg#ostree=*}" != ${arg}; then continue; fi
     assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
 done
 echo "ok instutil set-kargs --import-proc-cmdline"


### PR DESCRIPTION
https://github.com/ostreedev/ostree/pull/372 caused these tests to
start failing when the host system is managed using ostree - since the
tests *do* replace the `ostree=` kernel argument.