### PR TITLE
[merged] repo: Fix leak with ostree_repo_commit_traverse_iter_init_commit()

### DIFF
--- a/src/libostree/ostree-repo-traverse.c
+++ b/src/libostree/ostree-repo-traverse.c
@@ -264,6 +264,7 @@ ostree_repo_commit_traverse_iter_clear (OstreeRepoCommitTraverseIter *iter)
 {
   struct _OstreeRepoRealCommitTraverseIter *real =
     (struct _OstreeRepoRealCommitTraverseIter*)iter;
+  g_clear_object (&real->repo);
   g_clear_pointer (&real->commit, g_variant_unref);
   g_clear_pointer (&real->current_dir, g_variant_unref);
 }


### PR DESCRIPTION
I noticed this using `OT_TEST_VALGRIND=1` on `test-basic.sh`.