### PR TITLE
[merged] Revert "tests/libtest.sh: Print non-matching file on failure"

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -138,7 +138,6 @@ assert_file_has_content () {
     if ! grep -q -e "$2" "$1"; then
         sed -e 's/^/# /' < "$1" >&2
         echo 1>&2 "File '$1' doesn't match regexp '$2'"
-	cat $1
         exit 1
     fi
 }


### PR DESCRIPTION
This reverts commit 71301d18244a3a26a6ba6fd3934633ef94811a15.

I was confused by the fact that the non-matching content was
empty and forgot we already did print it.

Reported-by: smcv