### PR TITLE
[merged] Makefile-tests.am: make check uses the built binaries

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -243,28 +243,15 @@ CLEANFILES += tests/libreaddir-rand.so tests/ostree-symlink-stamp \
 		tests/ostree-prepare-root-symlink-stamp tests/ostree-remount-symlink-stamp \
 		tests/rofiles-fuse-symlink-stamp tests/ostree
 
-tests/ostree-symlink-stamp: Makefile
+tests/%-symlink-stamp: Makefile
 	@set -e; \
-	real_bin=`cd $(top_builddir) && ./libtool --mode=execute echo ostree`; \
-	ln -sf "$${real_bin}" tests/ostree; \
-	touch $@
-
-tests/rofiles-fuse-symlink-stamp: Makefile
-	@set -e; \
-	real_bin=$(abs_top_builddir)/rofiles-fuse; \
-	ln -sf "$${real_bin}" tests/rofiles-fuse; \
-	touch $@
-
-tests/ostree-remount-symlink-stamp: Makefile
-	@set -e; \
-	real_bin=$(abs_top_builddir)/ostree-remount; \
-	ln -sf "$${real_bin}" tests/ostree-remount; \
-	touch $@
-
-tests/ostree-prepare-root-symlink-stamp: Makefile
-	@set -e; \
-	real_bin=$(abs_top_builddir)/ostree-prepare-root; \
-	ln -sf "$${real_bin}" tests/ostree-prepare-root; \
+	lt_bin=`cd $(top_builddir) && ./libtool --mode=execute echo $*`; \
+	if test "$${lt_bin}" = "$*"; then \
+		real_bin=$(abs_top_builddir)/$*; \
+	else \
+		real_bin="$${lt_bin}"; \
+	fi; \
+	ln -sf "$${real_bin}" tests/$*; \
 	touch $@
 
 # Unfortunately the glib test data APIs don't actually handle

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -33,7 +33,8 @@ TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	PATH=$$(cd $(top_builddir)/tests && pwd):$${PATH} \
 	$(NULL)
 
-uninstalled_test_data = tests/ostree-symlink-stamp
+uninstalled_test_data = tests/ostree-symlink-stamp tests/ostree-prepare-root-symlink-stamp \
+			tests/ostree-remount-symlink-stamp tests/rofiles-fuse-symlink-stamp
 
 dist_uninstalled_test_scripts = tests/test-symbols.sh
 
@@ -238,12 +239,32 @@ EXTRA_DIST += \
 tests/libreaddir-rand.so: Makefile
 	$(AM_V_GEN) ln -fns ../.libs/libreaddir-rand.so tests
 ALL_LOCAL_RULES += tests/libreaddir-rand.so
-CLEANFILES += tests/libreaddir-rand.so tests/ostree-symlink-stamp tests/ostree
+CLEANFILES += tests/libreaddir-rand.so tests/ostree-symlink-stamp \
+		tests/ostree-prepare-root-symlink-stamp tests/ostree-remount-symlink-stamp \
+		tests/rofiles-fuse-symlink-stamp tests/ostree
 
 tests/ostree-symlink-stamp: Makefile
 	@set -e; \
 	real_bin=`cd $(top_builddir) && ./libtool --mode=execute echo ostree`; \
 	ln -sf "$${real_bin}" tests/ostree; \
+	touch $@
+
+tests/rofiles-fuse-symlink-stamp: Makefile
+	@set -e; \
+	real_bin=$(abs_top_builddir)/rofiles-fuse; \
+	ln -sf "$${real_bin}" tests/rofiles-fuse; \
+	touch $@
+
+tests/ostree-remount-symlink-stamp: Makefile
+	@set -e; \
+	real_bin=$(abs_top_builddir)/ostree-remount; \
+	ln -sf "$${real_bin}" tests/ostree-remount; \
+	touch $@
+
+tests/ostree-prepare-root-symlink-stamp: Makefile
+	@set -e; \
+	real_bin=$(abs_top_builddir)/ostree-prepare-root; \
+	ln -sf "$${real_bin}" tests/ostree-prepare-root; \
 	touch $@
 
 # Unfortunately the glib test data APIs don't actually handle


### PR DESCRIPTION
The tests suite was failing locally as it was using the installed
version of rofiles-fuse, instead of the built one.  Create the needed
symlinks in tests/ as we are already doing for the "ostree" binary.

ostree-prepare-root and ostree-remount added for completeness.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>