### PR TITLE
Ostree will block out chown when run as non-root

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -62,6 +62,7 @@ struct OstreeRepoCommitModifier {
 struct OstreeRepo {
   GObject parent;
 
+  int privileged;
   char *stagedir_prefix;
   int commit_stagedir_fd;
   char *commit_stagedir_name;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2116,7 +2116,8 @@ ostree_repo_open (OstreeRepo    *self,
    */
   { const char *env_bootid = getenv ("OSTREE_BOOTID");
     g_autofree char *boot_id = NULL;
-
+    //Have it as ostree flag and pass it from atomic? Or have it detect if running as non-root?
+    self->privileged = FALSE;
     if (env_bootid != NULL)
       boot_id = g_strdup (env_bootid);
     else


### PR DESCRIPTION
@rhatdan @cgwalters This isn't mergeable yet, but I'd like feedback on the changes. Essentially in order to pull as non-root user, I blocked out any chown calls hat would require root privilege. Right now, the "privileged" flag is set to false, but I was wondering if we should create flag in ostree, or simply have it check if running as non-root. 