### PR TITLE
[merged] ostree-prepare-root as init

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -87,6 +87,7 @@ dist_test_scripts = \
 	tests/test-prune.sh \
 	tests/test-refs.sh \
 	tests/test-demo-buildsystem.sh \
+	tests/test-switchroot.sh \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -156,12 +156,10 @@ main(int argc, char *argv[])
   int orig_cwd_dfd;
 
   if (argc < 2)
-    {
-      fprintf (stderr, "usage: ostree-prepare-root SYSROOT\n");
-      exit (EXIT_FAILURE);
-    }
+    root_mountpoint = "/";
+  else
+    root_mountpoint = argv[1];
 
-  root_mountpoint = argv[1];
   deploy_path = resolve_deploy_path (root_mountpoint);
 
   /* Create a temporary target for our mounts in the initramfs; this will
@@ -303,6 +301,15 @@ main(int argc, char *argv[])
       perrorv ("failed to MS_MOVE %s to %s", deploy_path, root_mountpoint);
       exit (EXIT_FAILURE);
     }
-  
-  exit (EXIT_SUCCESS);
+
+  if (getpid() == 1)
+    {
+      execl ("/sbin/init", "/sbin/init", NULL);
+      perrorv ("failed to exec init inside ostree");
+      exit (EXIT_FAILURE);
+    }
+  else
+    {
+      exit (EXIT_SUCCESS);
+    }
 }

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -215,7 +215,7 @@ main(int argc, char *argv[])
    * https://bugzilla.redhat.com/show_bug.cgi?id=847418 */
   if (mount (NULL, "/", NULL, MS_REC|MS_PRIVATE, NULL) < 0)
     {
-      perrorv ("Failed to make \"/\" private mount: %m");
+      perrorv ("failed to make \"/\" private mount: %m");
       exit (EXIT_FAILURE);
     }
 
@@ -272,7 +272,7 @@ main(int argc, char *argv[])
 	{
 	  if (mount (".", ".", NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
 	    {
-	      perrorv ("Failed to remount rootfs writable (for overlayfs)");
+	      perrorv ("failed to remount rootfs writable (for overlayfs)");
 	      exit (EXIT_FAILURE);
 	    }
 	}

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -222,7 +222,7 @@ main(int argc, char *argv[])
   /* Make deploy_path a bind mount, so we can move it later */
   if (mount (deploy_path, deploy_path, NULL, MS_BIND, NULL) < 0)
     {
-      perrorv ("failed to initial bind mount %s", deploy_path);
+      perrorv ("failed to make initial bind mount %s", deploy_path);
       exit (EXIT_FAILURE);
     }
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -399,34 +399,25 @@ os_repository_new_commit ()
     cd ${test_tmpdir}
 }
 
+skip() {
+    echo "1..0 # SKIP" "$@"
+    exit 0
+}
+
 skip_without_user_xattrs () {
     touch test-xattrs
-    if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
-        echo "1..0 # SKIP this test requires xattr support"
-        exit 0
-    fi
+    setfattr -n user.testvalue -v somevalue test-xattrs || \
+        skip "this test requires xattr support"
 }
 
 skip_without_fuse () {
-    if ! fusermount --version >/dev/null 2>&1; then
-        echo "1..0 # SKIP no fusermount"
-        exit 0
-    fi
+    fusermount --version >/dev/null 2>&1 || skip "no fusermount"
 
-    if ! capsh --print | grep -q 'Bounding set.*[^a-z]cap_sys_admin'; then
-	echo "1..0 # SKIP No cap_sys_admin in bounding set, can't use FUSE"
-        exit 0
-    fi
+    capsh --print | grep -q 'Bounding set.*[^a-z]cap_sys_admin' || \
+        skip "No cap_sys_admin in bounding set, can't use FUSE"
 
-    if ! [ -w /dev/fuse ]; then
-        echo "1..0 # SKIP no write access to /dev/fuse"
-        exit 0
-    fi
-
-    if ! [ -e /etc/mtab ]; then
-        echo "1..0 # SKIP no /etc/mtab"
-        exit 0
-    fi
+    [ -w /dev/fuse ] || skip "no write access to /dev/fuse"
+    [ -e /etc/mtab ] || skip "no /etc/mtab"
 }
 
 libtest_cleanup_gpg () {

--- a/tests/test-switchroot.sh
+++ b/tests/test-switchroot.sh
@@ -76,12 +76,32 @@ test_that_prepare_root_sets_sysroot_up_correctly_with_initrd() {
 	echo "ok ostree-prepare-root sets sysroot up correctly with initrd"
 }
 
+setup_no_initrd_env() {
+	mount --bind "$1" "$1"
+	setup_rootfs "$1"
+	setup_bootfs "$1"
+}
+
+test_that_prepare_root_sets_root_up_correctly_with_no_initrd() {
+	find_in_env setup_no_initrd_env >files
+
+	grep -qx "/this_is_ostree_root" files
+	grep -qx "/sysroot/this_is_bootfs" files
+	grep -qx "/sysroot/this_is_real_root" files
+	grep -qx "/var/this_is_ostree_var" files
+	grep -qx "/usr/this_is_ostree_usr" files
+
+	grep -qx "/usr is not writable" files
+	echo "ok ostree-prepare-root sets root up correctly with no initrd"
+}
+
 # This script sources itself so we only want to run tests if we're the parent:
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	. $(dirname $0)/libtest.sh
 	unshare -m true || \
 	    skip "this test needs to set up mount namespaces, rerun as root"
 
-	echo "1..1"
+	echo "1..2"
 	test_that_prepare_root_sets_sysroot_up_correctly_with_initrd
+	test_that_prepare_root_sets_root_up_correctly_with_no_initrd
 fi

--- a/tests/test-switchroot.sh
+++ b/tests/test-switchroot.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -ex
+
+this_script="${BASH_SOURCE:-$(readlink -f "$0")}"
+
+setup_bootfs() {
+	mkdir -p "$1/proc" "$1/bin"
+	echo "quiet ostree=/ostree/boot.0 ro" >"$1/proc/cmdline"
+	touch "$1/this_is_bootfs"
+	cp "$(dirname "$this_script")/../src/switchroot/ostree-prepare-root" "$1/bin"
+}
+
+setup_rootfs() {
+	mkdir -p "$1/ostree/deploy/linux/deploy/1334/sysroot" \
+	         "$1/ostree/deploy/linux/deploy/1334/var" \
+	         "$1/ostree/deploy/linux/deploy/1334/usr" \
+	         "$1/ostree/deploy/linux/var" \
+	         "$1/bin"
+	ln -s "deploy/linux/deploy/1334" "$1/ostree/boot.0"
+	ln -s . "$1/sysroot"
+	touch "$1/ostree/deploy/linux/deploy/1334/this_is_ostree_root" \
+	      "$1/ostree/deploy/linux/var/this_is_ostree_var" \
+	      "$1/ostree/deploy/linux/deploy/1334/usr/this_is_ostree_usr" \
+	      "$1/this_is_real_root"
+	cp /bin/busybox "$1/bin"
+	busybox --list | xargs -n1 -I '{}' ln -s busybox "$1/bin/{}"
+	cp -r "$1/bin" "$1/ostree/deploy/linux/deploy/1334/"
+}
+
+enter_fs() {
+	cd "$1"
+	mkdir testroot
+	pivot_root . testroot
+	export PATH=$PATH:/sysroot/bin
+	cd /
+	umount -l testroot
+	rmdir testroot
+}
+
+find_in_env() {
+	tmpdir="$(mktemp -dt ostree-test-switchroot.XXXXXX)"
+	unshare -m <<-EOF
+		set -e
+		. "$this_script"
+		"$1" "$tmpdir"
+		enter_fs "$tmpdir"
+		ostree-prepare-root /sysroot
+		find /
+		touch /usr/usr_writable 2>/null \
+			&& echo "/usr is writable" \
+			|| echo "/usr is not writable"
+		touch /sysroot/usr/sysroot_usr_writable 2>/null \
+			&& echo "/sysroot/usr is writable" \
+			|| echo "/sysroot/usr is not writable"
+		EOF
+	rm -rf "$tmpdir"
+}
+
+setup_initrd_env() {
+	mount -t tmpfs tmpfs "$1"
+	setup_bootfs "$1"
+	mkdir "$1/sysroot"
+	mount -t tmpfs tmpfs "$1/sysroot"
+	setup_rootfs "$1/sysroot"
+}
+
+test_that_prepare_root_sets_sysroot_up_correctly_with_initrd() {
+	find_in_env setup_initrd_env >files
+
+	grep -qx "/this_is_bootfs" files
+	grep -qx "/sysroot/this_is_ostree_root" files
+	grep -qx "/sysroot/sysroot/this_is_real_root" files
+	grep -qx "/sysroot/var/this_is_ostree_var" files
+	grep -qx "/sysroot/usr/this_is_ostree_usr" files
+
+	grep -qx "/sysroot/usr is not writable" files
+	echo "ok ostree-prepare-root sets sysroot up correctly with initrd"
+}
+
+# This script sources itself so we only want to run tests if we're the parent:
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+	. $(dirname $0)/libtest.sh
+	unshare -m true || \
+	    skip "this test needs to set up mount namespaces, rerun as root"
+
+	echo "1..1"
+	test_that_prepare_root_sets_sysroot_up_correctly_with_initrd
+fi


### PR DESCRIPTION
These commits generalise `ostree-prepare-root` for the purposes of using it to boot Linux for Tegra (Ubuntu 14.04) on the Nvidia Tegra TK1 dev-boards.  On the Tegra we don't use an initrd or systemd so the existing way that `ostree-prepare-root` is integrated is insufficient.

This has required 3 main generalisations.  They are mostly separable:

1. After setup `exec` a new init rather than `exit`ing.
2. Cope with `/proc` not having been mounted for the purposes of reading `/proc/cmdline`
3. Allow the eventual sysroot to already be mounted on `/` rather than `/sysroot` by using `pivot_root` where appropriate

I'm aware this has been [discussed on the mailing list](https://mail.gnome.org/archives/ostree-list/2015-October/msg00015.html) last October.

I do rather like this ostree model.  The main ostree binary itself takes advantage of various complex dependencies for it's advanced behaviour, but I can easily build `ostree-prepare-root` statically for boot integration.

These changes seem to work well on the device.  I've not completed the bootloader integration for this board but I think this work on `ostree-prepare-root` stands for itself.

I've opened this PR to gain some early feedback such as:

* Are these changes within the scope of the tool?
* Would they in principle be accepted?
* What other TODO items do I need to add to the list before this can be merged?

I'm not sure that this is the workflow that ostree follows but it seemed to be consistent with some of the other PRs open at the moment.

**TODO:**

- [x] Test that I haven't broken the existing systemd+dracut integration
- [x] Test that I haven't broken `overlayfs` integration
- [x] Test that we don't reintroduce the bug fixed in 4f75d4e where there are two filesystems mounted at `/sysroot`
- [x] Add automated tests

**For future PRs**

- Build `ostree-prepare-root` as a static binary