### PR TITLE
[merged] pull: Don't execute static deltas when mirroring

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2705,7 +2705,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                     &from_revision, error))
         goto out;
 
-      if (!disable_static_deltas && (from_revision == NULL || g_strcmp0 (from_revision, to_revision) != 0))
+      if (!disable_static_deltas && !pull_data->is_mirror &&
+          (from_revision == NULL || g_strcmp0 (from_revision, to_revision) != 0))
         {
           if (!request_static_delta_superblock_sync (pull_data, from_revision, to_revision,
                                                      &delta_superblock, cancellable, error))

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -35,7 +35,7 @@ function verify_initial_contents() {
     assert_file_has_content baz/cow '^moo$'
 }
 
-echo "1..11"
+echo "1..12"
 
 # Try both syntaxes
 repo_init
@@ -56,6 +56,17 @@ ${CMD_PREFIX} ostree --repo=mirrorrepo pull --mirror origin main
 ${CMD_PREFIX} ostree --repo=mirrorrepo fsck
 $OSTREE show main >/dev/null
 echo "ok pull mirror"
+
+cd ${test_tmpdir}
+rm checkout-origin-main -rf
+$OSTREE --repo=ostree-srv/gnomerepo checkout main checkout-origin-main
+echo moomoo > checkout-origin-main/baz/cow
+${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo commit -b main -s "" --tree=dir=checkout-origin-main
+${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo static-delta generate main
+${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo fsck
+${CMD_PREFIX} ostree --repo=mirrorrepo pull --mirror origin main
+${CMD_PREFIX} ostree --repo=mirrorrepo fsck
+echo "ok pull mirror (should not apply deltas)"
 
 cd ${test_tmpdir}
 mkdir mirrorrepo-local


### PR DESCRIPTION
We don't presently support this, since the static delta code assumes
it can just `mmap()` file objects.  We could at some point implement
this, but for now just skip executing deltas when doing
`archive -> archive` mirroring.

I noticed this when trying to mirror a repo in Jenkins in
[CAHC](https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel).