### PR TITLE
[merged] Allow deltas with empty parts

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -42,8 +42,7 @@ _ostree_static_delta_parse_checksum_array (GVariant      *array,
 
   n_checksums = n / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN;
 
-  if (G_UNLIKELY(n == 0 ||
-                 n > (G_MAXUINT32/OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN) ||
+  if (G_UNLIKELY(n > (G_MAXUINT32/OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN) ||
                  (n_checksums * OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN) != n))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -214,8 +214,14 @@ _ostree_static_delta_part_execute (OstreeRepo      *repo,
                                                   error))
     goto out;
 
+  /* Skip processing for empty delta part */
+  if (state->n_checksums == 0)
+    {
+      ret = TRUE;
+      goto out;
+    }
+
   state->checksums = checksums_data;
-  g_assert (state->n_checksums > 0);
 
   g_variant_get (part, "(@a(uuu)@aa(ayay)@ay@ay)",
                  &mode_dict,


### PR DESCRIPTION
OSTree will create deltas that have no objects if the 2 commits have no change in content. However, it currently refuses to process these valid deltas.

https://github.com/ostreedev/ostree/issues/419