### PR TITLE
[merged] repo: Make ostree_repo_create() nonfatal on existing repos

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -42,8 +42,8 @@ echo "ok shortened checksum"
 echo "ok repo-in-cwd"
 
 rm test-repo -rf
-ostree --repo=test-repo init --mode=bare-user
-ostree --repo=test-repo init --mode=bare-user
+$OSTREE --repo=test-repo init --mode=bare-user
+$OSTREE --repo=test-repo init --mode=bare-user
 rm test-repo -rf
 echo "ok repo-init on existing repo"
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..57"
+echo "1..58"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -40,6 +40,12 @@ echo "ok shortened checksum"
 
 (cd repo && ${CMD_PREFIX} ostree rev-parse test2)
 echo "ok repo-in-cwd"
+
+rm test-repo -rf
+ostree --repo=test-repo init --mode=bare-user
+ostree --repo=test-repo init --mode=bare-user
+rm test-repo -rf
+echo "ok repo-init on existing repo"
 
 cd checkout-test2
 assert_has_file firstfile


### PR DESCRIPTION
In general we want to support "idempotentcy" or "state
synchronization" across interruption.  If a repo is only partially
created due to a crash or whatever, it's hard for a user to know that.
Let's just make `ostree_repo_create()` idempotent. Since all we're
doing is a set of `mkdirat()` invocations, it's quite simple.

This also involved porting to fd-relative, which IMO makes the
code a lot clearer.