### PR TITLE
[merged] repo: Flip the fsync default to off for new checkout API

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -106,7 +106,7 @@ static gboolean
 fsync_is_enabled (OstreeRepo   *self,
                   OstreeRepoCheckoutAtOptions *options)
 {
-  return !(self->disable_fsync || options->disable_fsync);
+  return options->enable_fsync || !self->disable_fsync;
 }
 
 static gboolean
@@ -860,7 +860,7 @@ ostree_repo_checkout_tree_at (OstreeRepo                        *self,
   new_opts.mode = options->mode;
   new_opts.overwrite_mode = options->overwrite_mode;
   new_opts.enable_uncompressed_cache = options->enable_uncompressed_cache;
-  new_opts.disable_fsync = options->disable_fsync;
+  new_opts.enable_fsync = !options->disable_fsync;
   new_opts.process_whiteouts = options->process_whiteouts;
   new_opts.no_copy_fallback = options->no_copy_fallback;
   new_opts.subpath = options->subpath;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -748,8 +748,8 @@ typedef struct {
   OstreeRepoCheckoutMode mode;
   OstreeRepoCheckoutOverwriteMode overwrite_mode;
 
-  gboolean enable_uncompressed_cache;
-  gboolean disable_fsync;
+  gboolean enable_uncompressed_cache;  /* Deprecated */
+  gboolean enable_fsync;  /* Deprecated */
   gboolean process_whiteouts;
   gboolean no_copy_fallback;
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -554,11 +554,6 @@ checkout_deployment_tree (OstreeSysroot     *sysroot,
   glnx_fd_close int osdeploy_dfd = -1;
   int ret_fd;
 
-  /* We end up using syncfs for the entire filesystem, so turn off
-   * OstreeRepo level fsync.
-   */
-  checkout_opts.disable_fsync = TRUE;
-
   osdeploy_path = g_strconcat ("ostree/deploy/", ostree_deployment_get_osname (deployment), "/deploy", NULL);
   checkout_target_name = g_strdup_printf ("%s.%d", csum, ostree_deployment_get_deployserial (deployment));
 


### PR DESCRIPTION
Since we're adding a new API, we have the opportunity to fix
the defaults.  We expect clients to do a `syncfs()` or equivalent
on their own now, since it's way more efficient.

Flip the checkout fsync default to off.