### PR TITLE
[merged] lib: Add padding booleans to OstreeRepoCheckoutAtOptions

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -752,6 +752,7 @@ typedef struct {
   gboolean enable_fsync;  /* Deprecated */
   gboolean process_whiteouts;
   gboolean no_copy_fallback;
+  gboolean unused_bools[7];
 
   const char *subpath;
 


### PR DESCRIPTION
Since this is a new API, and adding booleans is the most likely thing
we'll do, let's stick some explicit padding for them in here now.

We could use the `unused_ints[]` but it'd be out of order, and this
will more clearly remind people about the padding.  The efficiency hit
versus bitfields is annoying, but oh well, not a real world problem.