### PR TITLE
[merged] lib: Use libglnx file replace API more consistently

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2791,16 +2791,24 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   if (pull_data->is_mirror && pull_data->summary_data)
     {
-      if (!ot_file_replace_contents_at (pull_data->repo->repo_dir_fd, "summary",
-                                        pull_data->summary_data, !pull_data->repo->disable_fsync,
-                                        cancellable, error))
+      GLnxFileReplaceFlags replaceflag =
+        pull_data->repo->disable_fsync ? GLNX_FILE_REPLACE_NODATASYNC : 0;
+      gsize len;
+      const guint8 *buf = g_bytes_get_data (pull_data->summary_data, &len);
+
+      if (!glnx_file_replace_contents_at (pull_data->repo->repo_dir_fd, "summary",
+                                          buf, len, replaceflag,
+                                          cancellable, error))
         goto out;
 
-      if (pull_data->summary_data_sig &&
-          !ot_file_replace_contents_at (pull_data->repo->repo_dir_fd, "summary.sig",
-                                        pull_data->summary_data_sig, !pull_data->repo->disable_fsync,
-                                        cancellable, error))
-        goto out;
+      if (pull_data->summary_data_sig)
+        {
+          buf = g_bytes_get_data (pull_data->summary_data_sig, &len);
+          if (!glnx_file_replace_contents_at (pull_data->repo->repo_dir_fd, "summary.sig",
+                                              buf, len, replaceflag,
+                                              cancellable, error))
+            goto out;
+        }
     }
 
   if (!ostree_repo_commit_transaction (pull_data->repo, NULL, cancellable, error))


### PR DESCRIPTION
We have a better API now, drop use of the internal helper, which also
depended on libgsystem.

This required bumping libglnx to pull in a fix.