### PR TITLE
[merged] repo: Drop more internally unused GFile members

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -75,13 +75,10 @@ struct OstreeRepo {
   char  *cache_dir;
   int objects_dir_fd;
   GFile *deltas_dir;
-  GFile *uncompressed_objects_dir;
   int uncompressed_objects_dir_fd;
-  GFile *config_file;
   GFile *sysroot_dir;
   char *remotes_config_dir;
 
-  GFile *transaction_lock_path;
   GHashTable *txn_refs;
   GMutex txn_stats_lock;
   OstreeRepoTransactionStats txn_stats;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -523,13 +523,10 @@ ostree_repo_finalize (GObject *object)
   if (self->objects_dir_fd != -1)
     (void) close (self->objects_dir_fd);
   g_clear_object (&self->deltas_dir);
-  g_clear_object (&self->uncompressed_objects_dir);
   if (self->uncompressed_objects_dir_fd != -1)
     (void) close (self->uncompressed_objects_dir_fd);
   g_clear_object (&self->sysroot_dir);
   g_free (self->remotes_config_dir);
-
-  g_clear_object (&self->transaction_lock_path);
 
   if (self->loose_object_devino_hash)
     g_hash_table_destroy (self->loose_object_devino_hash);
@@ -611,7 +608,6 @@ ostree_repo_constructed (GObject *object)
   self->tmp_dir = g_file_resolve_relative_path (self->repodir, "tmp");
 
   self->deltas_dir = g_file_get_child (self->repodir, "deltas");
-  self->uncompressed_objects_dir = g_file_get_child (self->repodir, "uncompressed-objects-cache");
 
   /* Ensure the "sysroot-path" property is set. */
   if (self->sysroot_dir == NULL)


### PR DESCRIPTION
I forgot to actually remove `config_file` in the previous
commit, the txn lock hasn't been used in a long time, and
for the uncompressed cache, everything uses the fd already.