### PR TITLE
[merged] Run tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+dist: trusty
+sudo: required
+
+env:
+  - ci_distro=ubuntu ci_suite=trusty
+  - ci_docker=debian:jessie ci_distro=debian ci_suite=jessie
+  - ci_docker=debian:unstable ci_distro=debian ci_suite=unstable
+  - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
+
+script:
+  - tests/ci-install.sh
+  - ci_parallel=2 ci_sudo=yes tests/ci-build.sh

--- a/tests/ci-Dockerfile.in
+++ b/tests/ci-Dockerfile.in
@@ -1,0 +1,10 @@
+FROM @ci_docker@
+ENV container docker
+
+ADD tests/ci-install.sh /ci-install.sh
+RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /ci-install.sh
+
+ADD . /home/user/ostree
+RUN chown -R user:user /home/user/ostree
+WORKDIR /home/user/ostree
+USER user

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+NULL=
+: "${ci_docker:=}"
+: "${ci_parallel:=1}"
+: "${ci_sudo:=no}"
+: "${ci_test:=yes}"
+: "${ci_test_fatal:=yes}"
+
+if [ -n "$ci_docker" ]; then
+    exec docker run \
+        --env=ci_docker="" \
+        --env=ci_parallel="${ci_parallel}" \
+        --env=ci_sudo=yes \
+        --env=ci_test="${ci_test}" \
+        --env=ci_test_fatal="${ci_test_fatal}" \
+        --privileged \
+        ostree-ci \
+        tests/ci-build.sh
+fi
+
+NOCONFIGURE=1 ./autogen.sh
+
+srcdir="$(pwd)"
+mkdir ci-build
+cd ci-build
+
+make="make -j${ci_parallel} V=1 VERBOSE=1"
+
+../configure \
+    --enable-always-build-tests \
+    --enable-installed-tests \
+    "$@"
+
+${make}
+
+maybe_fail_tests () {
+    if [ "$ci_test_fatal" = yes ]; then
+        exit 1
+    fi
+}
+
+[ "$ci_test" = no ] || ${make} check || maybe_fail_tests
+# TODO: if ostree aims to support distcheck, run that too
+
+${make} install DESTDIR=$(pwd)/DESTDIR
+
+( cd DESTDIR && find . )
+
+if [ -n "$ci_sudo" ] && [ -n "$ci_test" ]; then
+    sudo ${make} install
+    env \
+        LD_LIBRARY_PATH=/usr/local/lib \
+        GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0 \
+        ${make} installcheck || \
+    maybe_fail_tests
+    env \
+        LD_LIBRARY_PATH=/usr/local/lib \
+        GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0 \
+        gnome-desktop-testing-runner -d /usr/local/share ostree/ || \
+    maybe_fail_tests
+fi
+
+# vim:set sw=4 sts=4 et:

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+NULL=
+: "${ci_docker:=}"
+: "${ci_in_docker:=}"
+: "${ci_suite:=jessie}"
+
+if [ $(id -u) = 0 ]; then
+    sudo=
+else
+    sudo=sudo
+fi
+
+if [ -n "$ci_docker" ]; then
+    sed \
+        -e "s/@ci_distro@/${ci_distro}/" \
+        -e "s/@ci_docker@/${ci_docker}/" \
+        -e "s/@ci_suite@/${ci_suite}/" \
+        < tests/ci-Dockerfile.in > Dockerfile
+    exec docker build -t ostree-ci .
+fi
+
+case "$ci_distro" in
+    (debian)
+        # Docker images use httpredir.debian.org but it seems to be
+        # unreliable; use a CDN instead
+        sed -i -e 's/httpredir\.debian\.org/deb.debian.org/g' /etc/apt/sources.list
+        ;;
+esac
+
+case "$ci_suite" in
+    (jessie)
+        # Add alexl's Debian 8 backport repository to get libgsystem
+        # TODO: remove this when libgsystem is no longer needed
+        $sudo apt-get -y update
+        $sudo apt-get -y install apt-transport-https wget
+        wget -O - https://sdk.gnome.org/apt/debian/conf/alexl.gpg.key | $sudo apt-key add -
+        echo "deb [arch=amd64] https://sdk.gnome.org/apt/debian/ jessie main" | $sudo tee /etc/apt/sources.list.d/flatpak.list
+        ;;
+
+    (trusty|xenial)
+        # Add alexl's Flatpak PPA, again to get libgsystem
+        # TODO: remove this when libgsystem is no longer needed
+        $sudo apt-get -y update
+        $sudo apt-get -y install software-properties-common
+        $sudo add-apt-repository --yes ppa:alexlarsson/flatpak
+        ;;
+esac
+
+case "$ci_distro" in
+    (debian|ubuntu)
+        # TODO: fetch this list from the Debian packaging git repository?
+        $sudo apt-get -y update
+        $sudo apt-get -y install \
+            attr \
+            bison \
+            cpio \
+            debhelper \
+            dh-autoreconf \
+            dh-systemd \
+            docbook-xml \
+            docbook-xsl \
+            e2fslibs-dev \
+            elfutils \
+            fuse \
+            gjs \
+            gnome-desktop-testing \
+            gobject-introspection \
+            gtk-doc-tools \
+            libarchive-dev \
+            libattr1-dev \
+            libcap-dev \
+            libfuse-dev \
+            libgirepository1.0-dev \
+            libglib2.0-dev \
+            libgpgme11-dev \
+            libgsystem-dev \
+            liblzma-dev \
+            libmount-dev \
+            libselinux1-dev \
+            libsoup2.4-dev \
+            procps \
+            zlib1g-dev \
+            ${NULL}
+
+        if [ -n "$ci_in_docker" ]; then
+            # Add the user that we will use to do the build inside the
+            # Docker container, and let them use sudo
+            adduser --disabled-password user </dev/null
+            apt-get -y install sudo systemd-sysv
+            echo "user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
+            chmod 0440 /etc/sudoers.d/nopasswd
+        fi
+        ;;
+
+    (*)
+        echo "Don't know how to set up ${ci_distro}" >&2
+        exit 1
+        ;;
+esac
+
+# vim:set sw=4 sts=4 et:


### PR DESCRIPTION
This is not suitable for merge yet, because it disables Colin's
Homu integration, so that I can run it against arbitrary branches.
We'll need to discuss how to deal with that.

The structure is loosely based on what I've done for dbus and OpenJK, with a small .travis.yml driving larger CI-agnostic install and build scripts. The new thing in this version (which I should try in dbus too) is using Docker containers to get environments other than a 2 year old copy of Ubuntu.

---

.travis.yml is obviously still Travis-specific, but tests/ci-* are
designed to be shareable with other CI environments if there is interest
in doing so.

At the moment I'm only testing on Debian and Ubuntu. In principle we
could try a non-Debian-derived Docker container such as Fedora or CentOS
inside travis-ci's Ubuntu environment, similar to what I'm doing
for Debian, but I don't know the correct setup commands to use there.