### PR TITLE
Support for booting without initramfs

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -90,6 +90,7 @@ dist_test_scripts = \
 	tests/test-switchroot.sh \
 	tests/test-pull-contenturl.sh \
 	tests/test-pull-mirrorlist.sh \
+	tests/test-no-initramfs.sh \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# To use a custrom script for generating grub.cfg, set the --with-grub2-mkconfig=no
-# configure switch when configuring and building OSTree.
+# The builtin grub.cfg generator.
 #
 # This script is called by ostree/src/libostree/ostree-bootloader-grub2.c whenever
 # boot loader configuration file needs to be updated. It can be used as a template

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -28,7 +28,7 @@ entries_path=$(dirname $new_grub2_cfg)/entries
 
 read_config()
 {
-    config_file=${entries_path}/${1}
+    config_file=${1}
     title=""
     initrd=""
     options=""
@@ -62,11 +62,13 @@ read_config()
 populate_menu()
 {
     boot_prefix="${OSTREE_BOOT_PARTITION}"
-    for config in $(ls ${entries_path}); do
+    for config in $(ls $entries_path/*.conf); do
         read_config ${config}
         menu="${menu}menuentry '${title}' {\n"
         menu="${menu}\t linux ${boot_prefix}${linux} ${options}\n"
-        menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+        if [ -n "${initrd}" ] ; then
+            menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+        fi
         menu="${menu}}\n\n"
     done
     # The printf command seems to be more reliable across shells for special character (\n, \t) evaluation

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1458,20 +1458,28 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
     ostree_bootconfig_parser_set (bootconfig, "linux", boot_relpath);
   }
 
+  val = ostree_bootconfig_parser_get (bootconfig, "options");
+  kargs = _ostree_kernel_args_from_string (val);
+
   if (dest_initramfs_name)
     {
       g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", dest_initramfs_name, NULL);
       ostree_bootconfig_parser_set (bootconfig, "initrd", boot_relpath);
     }
-
-  val = ostree_bootconfig_parser_get (bootconfig, "options");
+  else
+    {
+      g_autofree char *prepare_root_arg = NULL;
+      prepare_root_arg = g_strdup_printf ("init=/ostree/boot.%d/%s/%s/%d/usr/lib/ostree/ostree-prepare-root",
+                                             new_bootversion, osname, bootcsum,
+                                             ostree_deployment_get_bootserial (deployment));
+      _ostree_kernel_args_replace_take (kargs, g_steal_pointer (&prepare_root_arg));
+    }
 
   ostree_kernel_arg = g_strdup_printf ("ostree=/ostree/boot.%d/%s/%s/%d",
                                        new_bootversion, osname, bootcsum,
                                        ostree_deployment_get_bootserial (deployment));
-  kargs = _ostree_kernel_args_from_string (val);
-  _ostree_kernel_args_replace_take (kargs, ostree_kernel_arg);
-  ostree_kernel_arg = NULL;
+  _ostree_kernel_args_replace_take (kargs, g_steal_pointer (&ostree_kernel_arg));
+
   options_key = _ostree_kernel_args_to_string (kargs);
   ostree_bootconfig_parser_set (bootconfig, "options", options_key);
   

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -38,6 +38,7 @@ static char **opt_kernel_argv_append;
 static gboolean opt_kernel_proc_cmdline;
 static char *opt_osname;
 static char *opt_origin_path;
+static gboolean opt_kernel_arg_none;
 
 static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
@@ -46,6 +47,7 @@ static GOptionEntry options[] = {
   { "karg-proc-cmdline", 0, 0, G_OPTION_ARG_NONE, &opt_kernel_proc_cmdline, "Import current /proc/cmdline", NULL },
   { "karg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_kernel_argv, "Set kernel argument, like root=/dev/sda1; this overrides any earlier argument with the same name", "NAME=VALUE" },
   { "karg-append", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_kernel_argv_append, "Append kernel argument; useful with e.g. console= that can be used multiple times", "NAME=VALUE" },
+  { "karg-none", 0, 0, G_OPTION_ARG_NONE, &opt_kernel_arg_none, "Do not import kernel arguments", NULL },
   { NULL }
 };
 
@@ -76,6 +78,12 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
       ot_util_usage_error (context, "REF/REV must be specified", error);
       goto out;
     }
+
+  if (opt_kernel_proc_cmdline && opt_kernel_arg_none)
+  {
+    ot_util_usage_error (context, "Can't specify both --karg-proc-cmdline and --karg-none", error);
+    goto out;
+  }
 
   refspec = argv[1];
 
@@ -135,7 +143,7 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
       if (!_ostree_kernel_args_append_proc_cmdline (kargs, cancellable, error))
         goto out;
     }
-  else if (merge_deployment)
+  else if (merge_deployment && !opt_kernel_arg_none)
     {
       OstreeBootconfigParser *bootconfig = ostree_deployment_get_bootconfig (merge_deployment);
       g_auto(GStrv) previous_args = g_strsplit (ostree_bootconfig_parser_get (bootconfig, "options"), " ", -1);

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -164,10 +164,16 @@ main(int argc, char *argv[])
   struct stat stbuf;
   int we_mounted_proc = 0;
 
-  if (argc < 2)
-    root_arg = "/";
+  if (getpid() == 1)
+    {
+      root_arg = "/";
+    }
   else
-    root_arg = argv[1];
+    {
+      if (argc < 2)
+        err (EXIT_FAILURE, "usage: ostree-prepare-root SYSROOT");
+      root_arg = argv[1];
+    }
 
   if (stat ("/proc/cmdline", &stbuf) < 0)
     {

--- a/tests/test-no-initramfs.sh
+++ b/tests/test-no-initramfs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+. $(dirname $0)/libtest.sh
+
+echo "1..3"
+
+setup_os_repository "archive-z2" "uboot"
+
+cd ${test_tmpdir}
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=rootfs --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+
+echo "ok deployment with initramfs"
+
+cd ${test_tmpdir}/osdata/boot
+rm -f initramfs* vmlinuz*
+echo "the kernel only" > vmlinuz-3.6.0
+bootcsum=$(cat vmlinuz-3.6.0 | sha256sum | cut -f 1 -d ' ')
+mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
+cd -
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+
+echo "ok switching to bootdir with no initramfs"
+
+cd ${test_tmpdir}/osdata/boot
+rm -f initramfs* vmlinuz*
+echo "the kernel" > vmlinuz-3.6.0
+echo "initramfs to assist the kernel" > initramfs-3.6.0
+bootcsum=$(cat vmlinuz-3.6.0 initramfs-3.6.0 | sha256sum | cut -f 1 -d ' ')
+mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
+mv initramfs-3.6.0 initramfs-3.6.0-${bootcsum}
+cd -
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+
+echo "ok switching from no initramfs to initramfs enabled sysroot"
+


### PR DESCRIPTION
WIP

I have tested that this patch works fine with u-boot and grub backends.

What is missing here is an automake rule that would create:

`/usr/lib/ostree-boot/ostree-prepare-root`-> `../../sbin/ostree-prepare-root`

or other way around:

`/usr/sbin/ostree-prepare-root`-> `../lib/ostree-boot/ostree-prepare-root`

@cgwalters You mentioned once that you want to move`ostree-prepare-root`and `ostree-remount` from `sbin` to `libexecdir`. I am thinking that maybe `/usr/lib/ostree-boot` is a better location? As this path would be the same on all systems and seems like a more natural place for all these "boot related" files (including `ostree-grub-generator`). Having this well known path would guarantee that this always works:

`init=/ostree/boot.%d/%s/%s/%d/usr/lib/ostree-boot/ostree-prepare-root /`

Related change: https://github.com/ostreedev/ostree/pull/268/commits/54168bc28be5079f5b23f9f996a15d38594ae202#diff-f0c889fb056dc4a713f8a87702fdd27eR1452
When copying `/usr/lib/ostree-boot,` exclude `ostree-{grub-generator, remount, prepare-root}`
