### PR TITLE
[merged] Final excision of libgsystem dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AM_PATH_GLIB_2_0
 dnl When bumping the gio-unix-2.0 dependency (or glib-2.0 in general),
 dnl remember to bump GLIB_VERSION_MIN_REQUIRED and
 dnl GLIB_VERSION_MAX_ALLOWED in Makefile.am
-GIO_DEPENDENCY="gio-unix-2.0 >= 2.40.0 libgsystem >= 2015.1"
+GIO_DEPENDENCY="gio-unix-2.0 >= 2.40.0"
 PKG_CHECK_MODULES(OT_DEP_GIO_UNIX, $GIO_DEPENDENCY)
 
 dnl 5.1.0 is an arbitrary version here

--- a/packaging/ostree.spec.in
+++ b/packaging/ostree.spec.in
@@ -15,7 +15,6 @@ BuildRequires: gtk-doc
 # Core requirements
 BuildRequires: pkgconfig(gio-unix-2.0)
 BuildRequires: pkgconfig(libsoup-2.4)
-BuildRequires: pkgconfig(libgsystem)
 BuildRequires: pkgconfig(e2p)
 # Extras
 BuildRequires: pkgconfig(libarchive)

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -21,7 +21,6 @@
 #include "config.h"
 
 #include "ot-fs-utils.h"
-#include "libgsystem.h"
 #include "libglnx.h"
 #include <sys/xattr.h>
 #include <gio/gunixinputstream.h>

--- a/src/libotutil/ot-gio-utils.h
+++ b/src/libotutil/ot-gio-utils.h
@@ -115,4 +115,14 @@ ot_file_enumerator_iterate (GFileEnumerator  *direnum,
 #endif
 #define g_file_enumerator_iterate ot_file_enumerator_iterate
 
+const char *
+ot_file_get_path_cached (GFile *file);
+
+static inline
+const char *
+gs_file_get_path_cached (GFile *file)
+{
+  return ot_file_get_path_cached (file);
+}
+
 G_END_DECLS

--- a/src/libotutil/otutil.h
+++ b/src/libotutil/otutil.h
@@ -23,9 +23,7 @@
 #pragma once
 
 #include <gio/gio.h>
-#include <libgsystem.h>
 #include <string.h> /* Yeah...let's just do that here. */
-#include <gsystem-local-alloc.h>
 #include <libglnx.h>
 
 #define ot_gobject_refz(o) (o ? g_object_ref (o) : o)

--- a/src/ostree/ot-editor.c
+++ b/src/ostree/ot-editor.c
@@ -23,8 +23,8 @@
 #include "config.h"
 
 #include "libglnx.h"
+#include "otutil.h"
 #include "ot-editor.h"
-#include "libgsystem.h"
 
 #include <sys/wait.h>
 #include <string.h>

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -31,25 +31,6 @@ case "$ci_distro" in
         ;;
 esac
 
-case "$ci_suite" in
-    (jessie)
-        # Add alexl's Debian 8 backport repository to get libgsystem
-        # TODO: remove this when libgsystem is no longer needed
-        $sudo apt-get -y update
-        $sudo apt-get -y install apt-transport-https wget
-        wget -O - https://sdk.gnome.org/apt/debian/conf/alexl.gpg.key | $sudo apt-key add -
-        echo "deb [arch=amd64] https://sdk.gnome.org/apt/debian/ jessie main" | $sudo tee /etc/apt/sources.list.d/flatpak.list
-        ;;
-
-    (trusty|xenial)
-        # Add alexl's Flatpak PPA, again to get libgsystem
-        # TODO: remove this when libgsystem is no longer needed
-        $sudo apt-get -y update
-        $sudo apt-get -y install software-properties-common
-        $sudo add-apt-repository --yes ppa:alexlarsson/flatpak
-        ;;
-esac
-
 case "$ci_distro" in
     (debian|ubuntu)
         # TODO: fetch this list from the Debian packaging git repository?

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -58,7 +58,6 @@ case "$ci_distro" in
             libgirepository1.0-dev \
             libglib2.0-dev \
             libgpgme11-dev \
-            libgsystem-dev \
             liblzma-dev \
             libmount-dev \
             libselinux1-dev \

--- a/tests/test-checksum.c
+++ b/tests/test-checksum.c
@@ -21,7 +21,6 @@
 #include "config.h"
 
 #include "libglnx.h"
-#include "libgsystem.h"
 #include <glib.h>
 #include <stdlib.h>
 #include <gio/gio.h>

--- a/tests/test-gpg-verify-result.c
+++ b/tests/test-gpg-verify-result.c
@@ -20,8 +20,8 @@
 
 #include "config.h"
 
-#include <libgsystem.h>
 #include <gpgme.h>
+#include "libglnx.h"
 
 #include "ostree-gpg-verify-result-private.h"
 


### PR DESCRIPTION
Lots and lots of preparation led to this moment - when nothing
apparent changes for users!  Woo!

But seriously, having the extra dependency is a minor annoyance, and
in the big picture I think the libgsystem idea was wrong - we need to
land things in GLib, and use git submodules for API-unstable or
Linux-specific sharing.  For a lot of OSTree, the libgsystem `GFile*`
orientation was also wrong, we really want fd-relative.