### PR TITLE
[merged] pull: Disable static deltas by default for local pulls

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2413,6 +2413,12 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         }
     }
 
+  /* For local pulls, default to disabling static deltas so that the
+   * exact object files are copied.
+   */
+  if (pull_data->remote_repo_local && !require_static_deltas)
+    disable_static_deltas = TRUE;
+
   pull_data->static_delta_superblocks = g_ptr_array_new_with_free_func ((GDestroyNotify)g_variant_unref);
 
   {

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1584,13 +1584,14 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
 
   ret = TRUE;
  out:
-  for (i = 0; i < part_temp_fds->len; i++)
-    {
-      int fd = g_array_index (part_temp_fds, int, i);
-      if (fd == -1)
-        continue;
-      (void) close (fd);
-    }
+  if (part_temp_fds)
+    for (i = 0; i < part_temp_fds->len; i++)
+      {
+        int fd = g_array_index (part_temp_fds, int, i);
+        if (fd == -1)
+          continue;
+        (void) close (fd);
+      }
   g_clear_pointer (&builder.parts, g_ptr_array_unref);
   g_clear_pointer (&builder.fallback_objects, g_ptr_array_unref);
   return ret;

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1362,7 +1362,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
     }
   else
     {
-      tmp_dfd = fcntl (self->tmp_dir_fd, F_DUPFD_CLOEXEC);
+      tmp_dfd = fcntl (self->tmp_dir_fd, F_DUPFD_CLOEXEC, 3);
       if (tmp_dfd < 0)
         {
           glnx_set_error_from_errno (error);

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -33,6 +33,7 @@
 static char *opt_remote;
 static gboolean opt_disable_fsync;
 static gboolean opt_untrusted;
+static gboolean opt_require_static_deltas;
 static gboolean opt_gpg_verify;
 static gboolean opt_gpg_verify_summary;
 static int opt_depth = 0;
@@ -41,6 +42,7 @@ static GOptionEntry options[] = {
   { "remote", 0, 0, G_OPTION_ARG_STRING, &opt_remote, "Add REMOTE to refspec", "REMOTE" },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
   { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Do not trust source", NULL },
+  { "require-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_require_static_deltas, "Require static deltas", NULL },
   { "gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify, "GPG verify commits (must specify --remote)", NULL },
   { "gpg-verify-summary", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify_summary, "GPG verify summary (must specify --remote)", NULL },
   { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
@@ -146,6 +148,8 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
     if (opt_remote)
       g_variant_builder_add (&builder, "{s@v}", "override-remote-name",
                              g_variant_new_variant (g_variant_new_string (opt_remote)));
+    g_variant_builder_add (&builder, "{s@v}", "require-static-deltas",
+                           g_variant_new_variant (g_variant_new_boolean (opt_require_static_deltas)));
     if (opt_gpg_verify)
       g_variant_builder_add (&builder, "{s@v}", "gpg-verify",
                              g_variant_new_variant (g_variant_new_boolean (TRUE)));

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -158,8 +158,10 @@ assert_streq "${totalsize_legacy_big}" "${totalsize_legacy_little}"
 
 echo 'ok heuristic endian detection'
 
+${CMD_PREFIX} ostree --repo=repo summary -u
+
 mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=archive-z2
-${CMD_PREFIX} ostree --repo=repo2 pull-local repo ${newrev}
+${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${newrev}
 ${CMD_PREFIX} ostree --repo=repo2 fsck
 ${CMD_PREFIX} ostree --repo=repo2 ls ${newrev} >/dev/null
 
@@ -223,10 +225,12 @@ assert_streq "${totalsize_empty}" "Total Uncompressed Size: 0 (0 bytes)"
 
 echo 'ok generate + show empty delta part'
 
+${CMD_PREFIX} ostree --repo=repo summary -u
+
 rm -rf repo2
 mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=archive-z2
 ${CMD_PREFIX} ostree --repo=repo2 pull-local repo ${newrev}
-${CMD_PREFIX} ostree --repo=repo2 pull-local repo ${samerev}
+${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${samerev}
 ${CMD_PREFIX} ostree --repo=repo2 fsck
 ${CMD_PREFIX} ostree --repo=repo2 ls ${samerev} >/dev/null
 

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -26,7 +26,7 @@ unset OSTREE_GPG_HOME
 
 skip_without_user_xattrs
 
-echo "1..7"
+echo "1..8"
 
 setup_test_repository "archive-z2"
 echo "ok setup"
@@ -95,3 +95,13 @@ ${OSTREE} summary -u update --gpg-sign=${TEST_GPG_KEYID_1} --gpg-homedir=${TEST_
 ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-summary repo test2 2>&1
 
 echo "ok --gpg-verify-summary"
+
+mkdir repo7
+${CMD_PREFIX} ostree --repo=repo7 init --mode="archive-z2"
+${CMD_PREFIX} ostree --repo=repo7 pull-local repo
+${CMD_PREFIX} ostree --repo=repo7 fsck
+for src_object in `find repo/objects -name '*.filez'`; do
+    dst_object=${src_object/repo/repo7}
+    assert_files_hardlinked "$src_object" "$dst_object"
+done
+echo "ok pull-local z2 to z2 default hardlink"


### PR DESCRIPTION
For local pulls there's no benefit pulling the static delta over the
individual object files since there's no HTTP overhead. Furthermore,
processing deltas always generates the objects whereas a standard pull
ensures that the exact object files are copied. Using deltas also
prevents hardlinking the objects if the repos exist on the same
filesystem.