### PR TITLE
[merged] Move ostree-* executables to /usr/lib/ostree

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -53,7 +53,7 @@ grub2configdir = $(sysconfdir)/grub.d
 INSTALL_DATA_HOOKS += install-grub2-config-hook
 else
 # We're using our internal generator
-libexec_SCRIPTS = src/boot/grub2/ostree-grub-generator
+ostree_boot_SCRIPTS = src/boot/grub2/ostree-grub-generator
 endif
 
 EXTRA_DIST += src/boot/dracut/module-setup.sh \

--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -43,6 +43,8 @@ gir_DATA =
 typelibdir = $(libdir)/girepository-1.0
 typelib_DATA =
 gsettings_SCHEMAS =
+ostree_bootdir = /usr/lib/ostree
+ostree_boot_PROGRAMS =
 
 # This is a special facility to chain together hooks easily
 INSTALL_DATA_HOOKS =

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -16,8 +16,10 @@
 # Boston, MA 02111-1307, USA.
 
 if BUILDOPT_SYSTEMD
-sbin_PROGRAMS += ostree-prepare-root
-sbin_PROGRAMS += ostree-remount
+
+ostree_boot_PROGRAMS += ostree-prepare-root
+ostree_boot_PROGRAMS += ostree-remount
+
 noinst_LTLIBRARIES += libswitchroot-mountutil.la
 endif
 

--- a/src/boot/dracut/module-setup.sh
+++ b/src/boot/dracut/module-setup.sh
@@ -20,7 +20,7 @@
 # Boston, MA 02111-1307, USA.
 
 check() {
-    if [[ -x $systemdutildir/systemd ]] && [[ -x /usr/sbin/ostree-prepare-root ]]; then
+    if [[ -x $systemdutildir/systemd ]] && [[ -x /usr/lib/ostree/ostree-prepare-root ]]; then
        return 255
     fi
 
@@ -32,7 +32,7 @@ depends() {
 }
 
 install() {
-    dracut_install ostree-prepare-root
+    dracut_install /usr/lib/ostree/ostree-prepare-root
     inst_simple "${systemdsystemunitdir}/ostree-prepare-root.service"
     mkdir -p "${initdir}${systemdsystemconfdir}/initrd-switch-root.target.wants"
     ln_r "${systemdsystemunitdir}/ostree-prepare-root.service" \

--- a/src/boot/mkinitcpio/ostree
+++ b/src/boot/mkinitcpio/ostree
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 build() {
-    add_binary /usr/sbin/ostree-prepare-root
-    add_binary /usr/sbin/ostree-remount
+    add_binary /usr/lib/ostree/ostree-prepare-root
+    add_binary /usr/lib/ostree/ostree-remount
 
     add_file /usr/lib/systemd/system/ostree-prepare-root.service
     add_symlink /usr/lib/systemd/system/initrd-switch-root.target.wants/ostree-prepare-root.service \

--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -27,7 +27,7 @@ Before=plymouth-switch-root.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/ostree-prepare-root /sysroot
+ExecStart=/usr/lib/ostree/ostree-prepare-root /sysroot
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog+console

--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -31,7 +31,7 @@ Before=systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/ostree-remount
+ExecStart=/usr/lib/ostree/ostree-remount
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog+console

--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -315,7 +315,7 @@ _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
         use_system_grub2_mkconfig = FALSE;
     }
   else
-    grub_exec = use_system_grub2_mkconfig ? GRUB2_MKCONFIG_PATH : LIBEXECDIR "/ostree-grub-generator";
+    grub_exec = use_system_grub2_mkconfig ? GRUB2_MKCONFIG_PATH : "/usr/lib/ostree/ostree-grub-generator";
 
   if (use_system_grub2_mkconfig && ostree_sysroot_get_booted_deployment (self->sysroot) == NULL
       && g_file_has_parent (self->sysroot->path, NULL))


### PR DESCRIPTION
The "ostree-boot" directory is for boot related files. Therefore is
a more appropriate place for ostree-{prepare-root,remount,grub-generator}
executibles and in addition saves us some typing in a console
when wanting to access the "ostree" cmd line.

Why not to use libexecdir instead? Because this directory does not
exist on some distros or paths between distros varies. There are several
reasons why a well known path is prefered (for example when passing
init=${ostree}/usr/lib/ostree-boot/ostree-prepare-root via kernel
command line).