### PR TITLE
[merged] ostree_bootdir: prepend $(prefix) to path

### DIFF
--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -43,7 +43,7 @@ gir_DATA =
 typelibdir = $(libdir)/girepository-1.0
 typelib_DATA =
 gsettings_SCHEMAS =
-ostree_bootdir = /usr/lib/ostree
+ostree_bootdir = $(prefix)/usr/lib/ostree
 ostree_boot_PROGRAMS =
 
 # This is a special facility to chain together hooks easily


### PR DESCRIPTION
Otherwise we break local installs. :boom: