### PR TITLE
[merged] repo: Really ignore progress changed user data

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3839,10 +3839,6 @@ ostree_repo_pull_default_console_progress_changed (OstreeAsyncProgress *progress
   guint fetched_delta_parts;
   guint total_delta_parts;
 
-  /* Historical note; we used to treat this as a GSConsole instance */
-  if (user_data == NULL)
-    return;
-
   buf = g_string_new ("");
 
   status = ostree_async_progress_get_status (progress);


### PR DESCRIPTION
The documentation says this is ignored, implying that you should pass
NULL to it. However, the function immediately returns in this case even
though the argument isn't used anywhere.