### PR TITLE
[merged] rofiles-fuse: Rework to be based on nlink

### DIFF
--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -30,7 +30,7 @@ echo "1..6"
 
 mkdir mnt
 
-$OSTREE checkout test2 checkout-test2
+$OSTREE checkout -U test2 checkout-test2
 
 rofiles-fuse checkout-test2 mnt
 cleanup_fuse() {


### PR DESCRIPTION
Programs like `useradd` try to `open(/etc/passwd, O_RDWR)` to append,
which didn't work with rofiles-fuse.  Thinking about this, I realized
that there's a simpler algorithm for "can we write to this file" which
is "does it have a hardlink count <= 1"?

Switching to this both drops complexity (we no longer need to keep a
hash table of files we created), and also lets useradd work.