### PR TITLE
[merged] Add contenturl and mirrorlist support

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -88,6 +88,8 @@ dist_test_scripts = \
 	tests/test-refs.sh \
 	tests/test-demo-buildsystem.sh \
 	tests/test-switchroot.sh \
+	tests/test-pull-contenturl.sh \
+	tests/test-pull-mirrorlist.sh \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -1058,16 +1058,16 @@ on_request_sent (GObject        *object,
 }
 
 static void
-ostree_fetcher_mirrorred_request_internal (OstreeFetcher         *self,
-                                           GSList                *mirrorlist,
-                                           const char            *filename,
-                                           gboolean               is_stream,
-                                           guint64                max_size,
-                                           int                    priority,
-                                           GCancellable          *cancellable,
-                                           GAsyncReadyCallback    callback,
-                                           gpointer               user_data,
-                                           gpointer               source_tag)
+ostree_fetcher_mirrored_request_internal (OstreeFetcher         *self,
+                                          GSList                *mirrorlist,
+                                          const char            *filename,
+                                          gboolean               is_stream,
+                                          guint64                max_size,
+                                          int                    priority,
+                                          GCancellable          *cancellable,
+                                          GAsyncReadyCallback    callback,
+                                          gpointer               user_data,
+                                          gpointer               source_tag)
 {
   g_autoptr(GTask) task = NULL;
   OstreeFetcherPendingURI *pending;
@@ -1099,57 +1099,57 @@ ostree_fetcher_mirrorred_request_internal (OstreeFetcher         *self,
 }
 
 void
-_ostree_fetcher_mirrorred_request_with_partial_async (OstreeFetcher         *self,
-                                                      GSList                *mirrorlist,
-                                                      const char            *filename,
-                                                      guint64                max_size,
-                                                      int                    priority,
-                                                      GCancellable          *cancellable,
-                                                      GAsyncReadyCallback    callback,
-                                                      gpointer               user_data)
+_ostree_fetcher_mirrored_request_with_partial_async (OstreeFetcher         *self,
+                                                     GSList                *mirrorlist,
+                                                     const char            *filename,
+                                                     guint64                max_size,
+                                                     int                    priority,
+                                                     GCancellable          *cancellable,
+                                                     GAsyncReadyCallback    callback,
+                                                     gpointer               user_data)
 {
-  ostree_fetcher_mirrorred_request_internal (self, mirrorlist, filename, FALSE,
-                                             max_size, priority, cancellable,
-                                             callback, user_data,
-                                             _ostree_fetcher_mirrorred_request_with_partial_async);
+  ostree_fetcher_mirrored_request_internal (self, mirrorlist, filename, FALSE,
+                                            max_size, priority, cancellable,
+                                            callback, user_data,
+                                            _ostree_fetcher_mirrored_request_with_partial_async);
 }
 
 char *
-_ostree_fetcher_mirrorred_request_with_partial_finish (OstreeFetcher         *self,
-                                                       GAsyncResult          *result,
-                                                       GError               **error)
+_ostree_fetcher_mirrored_request_with_partial_finish (OstreeFetcher         *self,
+                                                      GAsyncResult          *result,
+                                                      GError               **error)
 {
   g_return_val_if_fail (g_task_is_valid (result, self), NULL);
   g_return_val_if_fail (g_async_result_is_tagged (result,
-                        _ostree_fetcher_mirrorred_request_with_partial_async), NULL);
+                        _ostree_fetcher_mirrored_request_with_partial_async), NULL);
 
   return g_task_propagate_pointer (G_TASK (result), error);
 }
 
 static void
-ostree_fetcher_stream_mirrorred_uri_async (OstreeFetcher         *self,
-                                           GSList                *mirrorlist,
-                                           const char            *filename,
-                                           guint64                max_size,
-                                           int                    priority,
-                                           GCancellable          *cancellable,
-                                           GAsyncReadyCallback    callback,
-                                           gpointer               user_data)
+ostree_fetcher_stream_mirrored_uri_async (OstreeFetcher         *self,
+                                          GSList                *mirrorlist,
+                                          const char            *filename,
+                                          guint64                max_size,
+                                          int                    priority,
+                                          GCancellable          *cancellable,
+                                          GAsyncReadyCallback    callback,
+                                          gpointer               user_data)
 {
-  ostree_fetcher_mirrorred_request_internal (self, mirrorlist, filename, TRUE,
-                                             max_size, priority, cancellable,
-                                             callback, user_data,
-                                             ostree_fetcher_stream_mirrorred_uri_async);
+  ostree_fetcher_mirrored_request_internal (self, mirrorlist, filename, TRUE,
+                                            max_size, priority, cancellable,
+                                            callback, user_data,
+                                            ostree_fetcher_stream_mirrored_uri_async);
 }
 
 static GInputStream *
-ostree_fetcher_stream_mirrorred_uri_finish (OstreeFetcher         *self,
-                                            GAsyncResult          *result,
-                                            GError               **error)
+ostree_fetcher_stream_mirrored_uri_finish (OstreeFetcher         *self,
+                                           GAsyncResult          *result,
+                                           GError               **error)
 {
   g_return_val_if_fail (g_task_is_valid (result, self), NULL);
   g_return_val_if_fail (g_async_result_is_tagged (result,
-                        ostree_fetcher_stream_mirrorred_uri_async), NULL);
+                        ostree_fetcher_stream_mirrored_uri_async), NULL);
 
   return g_task_propagate_pointer (G_TASK (result), error);
 }
@@ -1200,21 +1200,21 @@ fetch_uri_sync_on_complete (GObject        *object,
 {
   FetchUriSyncData *data = user_data;
 
-  data->result_stream = ostree_fetcher_stream_mirrorred_uri_finish ((OstreeFetcher*)object,
+  data->result_stream = ostree_fetcher_stream_mirrored_uri_finish ((OstreeFetcher*)object,
                                                                     result, data->error);
   data->done = TRUE;
 }
 
 gboolean
-_ostree_fetcher_mirrorred_request_to_membuf (OstreeFetcher  *fetcher,
-                                             GSList         *mirrorlist,
-                                             const char     *filename,
-                                             gboolean        add_nul,
-                                             gboolean        allow_noent,
-                                             GBytes         **out_contents,
-                                             guint64        max_size,
-                                             GCancellable   *cancellable,
-                                             GError         **error)
+_ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher  *fetcher,
+                                            GSList         *mirrorlist,
+                                            const char     *filename,
+                                            gboolean        add_nul,
+                                            gboolean        allow_noent,
+                                            GBytes         **out_contents,
+                                            guint64        max_size,
+                                            GCancellable   *cancellable,
+                                            GError         **error)
 {
   gboolean ret = FALSE;
   const guint8 nulchar = 0;
@@ -1235,7 +1235,7 @@ _ostree_fetcher_mirrorred_request_to_membuf (OstreeFetcher  *fetcher,
   data.done = FALSE;
   data.error = error;
 
-  ostree_fetcher_stream_mirrorred_uri_async (fetcher, mirrorlist, filename, max_size,
+  ostree_fetcher_stream_mirrored_uri_async (fetcher, mirrorlist, filename, max_size,
                                    OSTREE_FETCHER_DEFAULT_PRIORITY, cancellable,
                                    fetch_uri_sync_on_complete, &data);
   while (!data.done)
@@ -1292,7 +1292,7 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
 {
   GSList *mirrorlist = g_slist_append (NULL, uri);
   gboolean ret =
-    _ostree_fetcher_mirrorred_request_to_membuf (fetcher, mirrorlist, NULL,
+    _ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist, NULL,
                                                  add_nul, allow_noent,
                                                  out_contents, max_size,
                                                  cancellable, error);

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -971,6 +971,11 @@ on_request_sent (GObject        *object,
             {
               pending->mirrorlist_idx++;
               create_pending_soup_request (pending, &local_error);
+              if (local_error != NULL)
+                goto out;
+
+              if (pending->request_body)
+                (void) g_input_stream_close (pending->request_body, NULL, NULL);
               g_queue_insert_sorted (&pending->thread_closure->pending_queue,
                                      g_object_ref (task), pending_task_compare,
                                      NULL);

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -974,8 +974,7 @@ on_request_sent (GObject        *object,
               if (local_error != NULL)
                 goto out;
 
-              if (pending->request_body)
-                (void) g_input_stream_close (pending->request_body, NULL, NULL);
+              (void) g_input_stream_close (pending->request_body, NULL, NULL);
               g_queue_insert_sorted (&pending->thread_closure->pending_queue,
                                      g_object_ref (task), pending_task_compare,
                                      NULL);

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -70,20 +70,31 @@ void _ostree_fetcher_set_tls_database (OstreeFetcher *self,
 
 guint64 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self);
 
-void _ostree_fetcher_request_uri_with_partial_async (OstreeFetcher         *self,
-                                                    SoupURI               *uri,
-                                                    guint64                max_size,
-                                                    int                    priority,
-                                                    GCancellable          *cancellable,
-                                                    GAsyncReadyCallback    callback,
-                                                    gpointer               user_data);
+void _ostree_fetcher_mirrorred_request_with_partial_async (OstreeFetcher         *self,
+                                                           GSList                *mirrorlist,
+                                                           const char            *filename,
+                                                           guint64                max_size,
+                                                           int                    priority,
+                                                           GCancellable          *cancellable,
+                                                           GAsyncReadyCallback    callback,
+                                                           gpointer               user_data);
 
-char *_ostree_fetcher_request_uri_with_partial_finish (OstreeFetcher *self,
-                                                       GAsyncResult  *result,
-                                                       GError       **error);
+char *_ostree_fetcher_mirrorred_request_with_partial_finish (OstreeFetcher *self,
+                                                             GAsyncResult  *result,
+                                                             GError       **error);
+
+gboolean _ostree_fetcher_mirrorred_request_to_membuf (OstreeFetcher *fetcher,
+                                                      GSList        *mirrorlist,
+                                                      const char    *filename,
+                                                      gboolean       add_nul,
+                                                      gboolean       allow_noent,
+                                                      GBytes         **out_contents,
+                                                      guint64        max_size,
+                                                      GCancellable   *cancellable,
+                                                      GError         **error);
 
 gboolean _ostree_fetcher_request_uri_to_membuf (OstreeFetcher *fetcher,
-                                                SoupURI        *uri,
+                                                SoupURI       *uri,
                                                 gboolean       add_nul,
                                                 gboolean       allow_noent,
                                                 GBytes         **out_contents,

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -71,7 +71,7 @@ void _ostree_fetcher_set_tls_database (OstreeFetcher *self,
 guint64 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self);
 
 void _ostree_fetcher_mirrored_request_with_partial_async (OstreeFetcher         *self,
-                                                          GSList                *mirrorlist,
+                                                          GPtrArray             *mirrorlist,
                                                           const char            *filename,
                                                           guint64                max_size,
                                                           int                    priority,
@@ -84,7 +84,7 @@ char *_ostree_fetcher_mirrored_request_with_partial_finish (OstreeFetcher *self,
                                                             GError       **error);
 
 gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
-                                                     GSList        *mirrorlist,
+                                                     GPtrArray     *mirrorlist,
                                                      const char    *filename,
                                                      gboolean       add_nul,
                                                      gboolean       allow_noent,

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -70,28 +70,28 @@ void _ostree_fetcher_set_tls_database (OstreeFetcher *self,
 
 guint64 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self);
 
-void _ostree_fetcher_mirrorred_request_with_partial_async (OstreeFetcher         *self,
-                                                           GSList                *mirrorlist,
-                                                           const char            *filename,
-                                                           guint64                max_size,
-                                                           int                    priority,
-                                                           GCancellable          *cancellable,
-                                                           GAsyncReadyCallback    callback,
-                                                           gpointer               user_data);
+void _ostree_fetcher_mirrored_request_with_partial_async (OstreeFetcher         *self,
+                                                          GSList                *mirrorlist,
+                                                          const char            *filename,
+                                                          guint64                max_size,
+                                                          int                    priority,
+                                                          GCancellable          *cancellable,
+                                                          GAsyncReadyCallback    callback,
+                                                          gpointer               user_data);
 
-char *_ostree_fetcher_mirrorred_request_with_partial_finish (OstreeFetcher *self,
-                                                             GAsyncResult  *result,
-                                                             GError       **error);
+char *_ostree_fetcher_mirrored_request_with_partial_finish (OstreeFetcher *self,
+                                                            GAsyncResult  *result,
+                                                            GError       **error);
 
-gboolean _ostree_fetcher_mirrorred_request_to_membuf (OstreeFetcher *fetcher,
-                                                      GSList        *mirrorlist,
-                                                      const char    *filename,
-                                                      gboolean       add_nul,
-                                                      gboolean       allow_noent,
-                                                      GBytes         **out_contents,
-                                                      guint64        max_size,
-                                                      GCancellable   *cancellable,
-                                                      GError         **error);
+gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
+                                                     GSList        *mirrorlist,
+                                                     const char    *filename,
+                                                     gboolean       add_nul,
+                                                     gboolean       allow_noent,
+                                                     GBytes         **out_contents,
+                                                     guint64        max_size,
+                                                     GCancellable   *cancellable,
+                                                     GError         **error);
 
 gboolean _ostree_fetcher_request_uri_to_membuf (OstreeFetcher *fetcher,
                                                 SoupURI       *uri,

--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -593,7 +593,6 @@ gboolean
 _ostree_metalink_request_sync (OstreeMetalink        *self,
                                SoupURI               **out_target_uri,
                                GBytes                **out_data,
-                               SoupURI               **fetching_sync_uri,
                                GCancellable          *cancellable,
                                GError                **error)
 {
@@ -603,9 +602,6 @@ _ostree_metalink_request_sync (OstreeMetalink        *self,
   GBytes *out_contents = NULL;
   gsize len;
   const guint8 *data;
-
-  if (fetching_sync_uri != NULL)
-    *fetching_sync_uri = _ostree_metalink_get_uri (self);
 
   mainctx = g_main_context_new ();
   g_main_context_push_thread_default (mainctx);

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -53,7 +53,6 @@ SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         SoupURI               **out_target_uri,
                                         GBytes                **out_data,
-                                        SoupURI               **fetching_sync_uri,
                                         GCancellable          *cancellable,
                                         GError                **error);
 G_END_DECLS

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -46,8 +46,8 @@ typedef struct {
   char         *remote_name;
   OstreeRepoMode remote_mode;
   OstreeFetcher *fetcher;
-  SoupURI      *base_uri;
-  SoupURI      *base_content_uri;
+  GSList       *meta_mirrorlist;    /* List of base URIs for fetching metadata */
+  GSList       *content_mirrorlist; /* List of base URIs for fetching content */
   OstreeRepo   *remote_repo_local;
 
   GMainContext    *main_context;
@@ -137,11 +137,6 @@ typedef struct {
   guint recursion_depth;
 } ScanObjectQueueData;
 
-static SoupURI *
-suburi_new (SoupURI   *base,
-            const char *first,
-            ...) G_GNUC_NULL_TERMINATED;
-
 static void queue_scan_one_metadata_object (OtPullData         *pull_data,
                                             const char         *csum,
                                             OstreeObjectType    objtype,
@@ -158,39 +153,6 @@ static gboolean scan_one_metadata_object_c (OtPullData         *pull_data,
                                             guint               recursion_depth,
                                             GCancellable       *cancellable,
                                             GError            **error);
-
-static SoupURI *
-suburi_new (SoupURI   *base,
-            const char *first,
-            ...)
-{
-  va_list args;
-  GPtrArray *arg_array;
-  const char *arg;
-  char *subpath;
-  SoupURI *ret;
-
-  arg_array = g_ptr_array_new ();
-  g_ptr_array_add (arg_array, (char*)soup_uri_get_path (base));
-  g_ptr_array_add (arg_array, (char*)first);
-
-  va_start (args, first);
-  
-  while ((arg = va_arg (args, const char *)) != NULL)
-    g_ptr_array_add (arg_array, (char*)arg);
-  g_ptr_array_add (arg_array, NULL);
-
-  subpath = g_build_filenamev ((char**)arg_array->pdata);
-  g_ptr_array_unref (arg_array);
-  
-  ret = soup_uri_copy (base);
-  soup_uri_set_path (ret, subpath);
-  g_free (subpath);
-  
-  va_end (args);
-  
-  return ret;
-}
 
 static gboolean
 update_progress (gpointer user_data)
@@ -346,21 +308,23 @@ typedef struct {
 } OstreeFetchUriSyncData;
 
 static gboolean
-fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
-                              SoupURI     *uri,
-                              char       **out_contents,
-                              GCancellable  *cancellable,
-                              GError     **error)
+fetch_mirrorred_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
+                                        GSList         *mirrorlist,
+                                        const char     *filename,
+                                        char          **out_contents,
+                                        GCancellable   *cancellable,
+                                        GError        **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GBytes) bytes = NULL;
   g_autofree char *ret_contents = NULL;
   gsize len;
 
-  if (!_ostree_fetcher_request_uri_to_membuf (fetcher, uri, TRUE,
-                                              FALSE, &bytes,
-                                              OSTREE_MAX_METADATA_SIZE,
-                                              cancellable, error))
+  if (!_ostree_fetcher_mirrorred_request_to_membuf (fetcher, mirrorlist,
+                                                    filename, TRUE, FALSE,
+                                                    &bytes,
+                                                    OSTREE_MAX_METADATA_SIZE,
+                                                    cancellable, error))
     goto out;
 
   ret_contents = g_bytes_unref_to_data (bytes, &len);
@@ -376,6 +340,21 @@ fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
   ret = TRUE;
   ot_transfer_out_value (out_contents, &ret_contents);
  out:
+  return ret;
+}
+
+static gboolean
+fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
+                              SoupURI        *uri,
+                              char          **out_contents,
+                              GCancellable   *cancellable,
+                              GError        **error)
+{
+  GSList *mirrorlist = g_slist_append (NULL, uri);
+  gboolean ret =
+    fetch_mirrorred_uri_contents_utf8_sync (fetcher, mirrorlist, NULL,
+                                            out_contents, cancellable, error);
+  g_slist_free (mirrorlist);
   return ret;
 }
 
@@ -545,12 +524,14 @@ fetch_ref_contents (OtPullData    *pull_data,
 {
   gboolean ret = FALSE;
   g_autofree char *ret_contents = NULL;
-  SoupURI *target_uri = NULL;
+  g_autofree char *filename = NULL;
 
-  target_uri = suburi_new (pull_data->base_uri, "refs", "heads", ref, NULL);
+  filename = g_build_filename ("refs", "heads", ref, NULL);
   
-  if (!fetch_uri_contents_utf8_sync (pull_data->fetcher, target_uri,
-                                     &ret_contents, cancellable, error))
+  if (!fetch_mirrorred_uri_contents_utf8_sync (pull_data->fetcher,
+                                               pull_data->meta_mirrorlist,
+                                               filename, &ret_contents,
+                                               cancellable, error))
     goto out;
 
   g_strchomp (ret_contents);
@@ -561,8 +542,6 @@ fetch_ref_contents (OtPullData    *pull_data,
   ret = TRUE;
   ot_transfer_out_value (out_contents, &ret_contents);
  out:
-  if (target_uri)
-    soup_uri_free (target_uri);
   return ret;
 }
 
@@ -670,7 +649,7 @@ content_fetch_on_complete (GObject        *object,
   OstreeObjectType objtype;
   gboolean free_fetch_data = TRUE;
 
-  temp_path = _ostree_fetcher_request_uri_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     goto out;
 
@@ -808,7 +787,7 @@ meta_fetch_on_complete (GObject           *object,
   g_debug ("fetch of %s%s complete", checksum_obj,
            fetch_data->is_detached_meta ? " (detached)" : "");
 
-  temp_path = _ostree_fetcher_request_uri_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     {
       if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -953,7 +932,7 @@ static_deltapart_fetch_on_complete (GObject           *object,
 
   g_debug ("fetch static delta part %s complete", fetch_data->expected_checksum);
 
-  temp_path = _ostree_fetcher_request_uri_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     goto out;
 
@@ -1292,12 +1271,12 @@ enqueue_one_object_request (OtPullData        *pull_data,
                             gboolean           is_detached_meta,
                             gboolean           object_is_stored)
 {
-  SoupURI *obj_uri = NULL;
+  g_autofree char *obj_subpath = NULL;
   gboolean is_meta;
   FetchObjectData *fetch_data;
-  g_autofree char *objpath = NULL;
   guint64 *expected_max_size_p;
   guint64 expected_max_size;
+  GSList *mirrorlist = NULL;
 
   g_debug ("queuing fetch of %s.%s%s", checksum,
            ostree_object_type_to_string (objtype),
@@ -1307,12 +1286,13 @@ enqueue_one_object_request (OtPullData        *pull_data,
     {
       char buf[_OSTREE_LOOSE_PATH_MAX];
       _ostree_loose_path (buf, checksum, OSTREE_OBJECT_TYPE_COMMIT_META, pull_data->remote_mode);
-      obj_uri = suburi_new (pull_data->base_uri, "objects", buf, NULL);
+      obj_subpath = g_build_filename ("objects", buf, NULL);
+      mirrorlist = pull_data->meta_mirrorlist;
     }
   else
     {
-      objpath = _ostree_get_relative_object_path (checksum, objtype, TRUE);
-      obj_uri = suburi_new (pull_data->base_content_uri, objpath, NULL);
+      obj_subpath = _ostree_get_relative_object_path (checksum, objtype, TRUE);
+      mirrorlist = pull_data->content_mirrorlist;
     }
 
   is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
@@ -1340,13 +1320,12 @@ enqueue_one_object_request (OtPullData        *pull_data,
   else
     expected_max_size = 0;
 
-  _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, obj_uri,
-                                                  expected_max_size,
-                                                  is_meta ? OSTREE_REPO_PULL_METADATA_PRIORITY
-                                                          : OSTREE_REPO_PULL_CONTENT_PRIORITY,
-                                                  pull_data->cancellable,
-                                                  is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
-  soup_uri_free (obj_uri);
+  _ostree_fetcher_mirrorred_request_with_partial_async (pull_data->fetcher, mirrorlist,
+                                                        obj_subpath, expected_max_size,
+                                                        is_meta ? OSTREE_REPO_PULL_METADATA_PRIORITY
+                                                                : OSTREE_REPO_PULL_CONTENT_PRIORITY,
+                                                        pull_data->cancellable,
+                                                        is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
 }
 
 static gboolean
@@ -1358,12 +1337,11 @@ load_remote_repo_config (OtPullData    *pull_data,
   gboolean ret = FALSE;
   g_autofree char *contents = NULL;
   GKeyFile *ret_keyfile = NULL;
-  SoupURI *target_uri = NULL;
 
-  target_uri = suburi_new (pull_data->base_uri, "config", NULL);
-  
-  if (!fetch_uri_contents_utf8_sync (pull_data->fetcher, target_uri, &contents,
-                                     cancellable, error))
+  if (!fetch_mirrorred_uri_contents_utf8_sync (pull_data->fetcher,
+                                               pull_data->meta_mirrorlist,
+                                               "config", &contents,
+                                               cancellable, error))
     goto out;
 
   ret_keyfile = g_key_file_new ();
@@ -1375,7 +1353,6 @@ load_remote_repo_config (OtPullData    *pull_data,
   ot_transfer_out_value (out_keyfile, &ret_keyfile);
  out:
   g_clear_pointer (&ret_keyfile, (GDestroyNotify) g_key_file_unref);
-  g_clear_pointer (&target_uri, (GDestroyNotify) soup_uri_free);
   return ret;
 }
 
@@ -1394,17 +1371,15 @@ request_static_delta_superblock_sync (OtPullData  *pull_data,
   g_autoptr(GBytes) delta_superblock_data = NULL;
   g_autoptr(GBytes) delta_meta_data = NULL;
   g_autoptr(GVariant) delta_superblock = NULL;
-  SoupURI *target_uri = NULL;
-  
-  target_uri = suburi_new (pull_data->base_content_uri, delta_name, NULL);
-  
-  if (!_ostree_fetcher_request_uri_to_membuf (pull_data->fetcher, target_uri,
-                                              FALSE, TRUE,
-                                              &delta_superblock_data,
-                                              OSTREE_MAX_METADATA_SIZE,
-                                              pull_data->cancellable, error))
+
+  if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
+                                                    pull_data->content_mirrorlist,
+                                                    delta_name, FALSE, TRUE,
+                                                    &delta_superblock_data,
+                                                    OSTREE_MAX_METADATA_SIZE,
+                                                    pull_data->cancellable, error))
     goto out;
-  
+
   if (delta_superblock_data)
     {
       {
@@ -1449,7 +1424,6 @@ request_static_delta_superblock_sync (OtPullData  *pull_data,
   if (out_delta_superblock)
     *out_delta_superblock = g_steal_pointer (&ret_delta_superblock);
  out:
-  g_clear_pointer (&target_uri, (GDestroyNotify) soup_uri_free);
   return ret;
 }
 
@@ -1615,7 +1589,6 @@ process_one_static_delta (OtPullData   *pull_data,
       const guchar *csum;
       g_autoptr(GVariant) header = NULL;
       gboolean have_all = FALSE;
-      SoupURI *target_uri = NULL;
       g_autofree char *deltapart_path = NULL;
       FetchStaticDeltaData *fetch_data;
       g_autoptr(GVariant) csum_v = NULL;
@@ -1689,7 +1662,7 @@ process_one_static_delta (OtPullData   *pull_data,
                                                NULL, &inline_delta_part,
                                                cancellable, error))
             goto out;
-                                               
+
           _ostree_static_delta_part_execute_async (pull_data->repo,
                                                    fetch_data->objects,
                                                    inline_delta_part,
@@ -1701,14 +1674,14 @@ process_one_static_delta (OtPullData   *pull_data,
         }
       else
         {
-          target_uri = suburi_new (pull_data->base_content_uri, deltapart_path, NULL);
-          _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, target_uri, size,
-                                                          OSTREE_FETCHER_DEFAULT_PRIORITY,
-                                                          pull_data->cancellable,
-                                                          static_deltapart_fetch_on_complete,
-                                                          fetch_data);
+          _ostree_fetcher_mirrorred_request_with_partial_async (pull_data->fetcher,
+                                                                pull_data->content_mirrorlist,
+                                                                deltapart_path, size,
+                                                                OSTREE_FETCHER_DEFAULT_PRIORITY,
+                                                                pull_data->cancellable,
+                                                                static_deltapart_fetch_on_complete,
+                                                                fetch_data);
           pull_data->n_outstanding_deltapart_fetches++;
-          soup_uri_free (target_uri);
         }
     }
 
@@ -1947,7 +1920,7 @@ out:
 static gboolean
 _ostree_preload_metadata_file (OstreeRepo    *self,
                                OstreeFetcher *fetcher,
-                               SoupURI       *base_uri,
+                               GSList        *mirrorlist,
                                const char    *filename,
                                gboolean      is_metalink,
                                GBytes        **out_bytes,
@@ -1961,9 +1934,11 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
       glnx_unref_object OstreeMetalink *metalink = NULL;
       GError *local_error = NULL;
 
+      /* the metalink uri is buried in the mirrorlist as the first (and only)
+       * element */
       metalink = _ostree_metalink_new (fetcher, filename,
                                        OSTREE_MAX_METADATA_SIZE,
-                                       base_uri);
+                                       mirrorlist->data);
 
       _ostree_metalink_request_sync (metalink, NULL, out_bytes,
                                      cancellable, &local_error);
@@ -1981,20 +1956,11 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
     }
   else
     {
-      SoupURI *uri;
-      const char *base_path;
-      g_autofree char *path = NULL;
-
-      base_path = soup_uri_get_path (base_uri);
-      path = g_build_filename (base_path, filename, NULL);
-      uri = soup_uri_new_with_base (base_uri, path);
-
-      ret = _ostree_fetcher_request_uri_to_membuf (fetcher, uri,
-                                                   FALSE, TRUE,
-                                                   out_bytes,
-                                                   OSTREE_MAX_METADATA_SIZE,
-                                                   cancellable, error);
-      soup_uri_free (uri);
+      ret = _ostree_fetcher_mirrorred_request_to_membuf (fetcher, mirrorlist,
+                                                         filename, FALSE, TRUE,
+                                                         out_bytes,
+                                                         OSTREE_MAX_METADATA_SIZE,
+                                                         cancellable, error);
 
       if (!ret)
         goto out;
@@ -2002,6 +1968,105 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
 
   ret = TRUE;
 out:
+  return ret;
+}
+
+static gboolean
+fetch_mirrorlist (OstreeFetcher  *fetcher,
+                  const char     *mirrorlist_url,
+                  GSList        **out_mirrorlist,
+                  GCancellable   *cancellable,
+                  GError        **error)
+{
+  gboolean ret = FALSE;
+  char **lines = NULL;
+  g_autofree char *contents = NULL;
+  GSList *ret_mirrorlist = NULL;
+  SoupURI *mirrorlist = NULL;
+
+  mirrorlist = soup_uri_new (mirrorlist_url);
+  if (mirrorlist == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to parse mirrorlist URL '%s'", mirrorlist_url);
+      goto out;
+    }
+
+  if (!fetch_uri_contents_utf8_sync (fetcher, mirrorlist, &contents,
+                                     cancellable, error))
+    {
+      g_prefix_error (error, "While fetching mirrorlist '%s': ",
+                      mirrorlist_url);
+      goto out;
+    }
+
+  /* go through each mirror in mirrorlist and do a quick sanity check that it
+   * works so that we don't waste the fetcher's time when it goes through them.
+   * we basically check that we can fetch the repo's config without errors.
+   * */
+  lines = g_strsplit (contents, "\n", -1);
+  g_debug ("Scanning mirrorlist from '%s'", mirrorlist_url);
+  for (char **iter = lines; iter && *iter; iter++)
+    {
+      const char *mirror_uri_str = *iter;
+      GError *local_error = NULL;
+      SoupURI *mirror_uri = NULL;
+      SoupURI *config_uri = NULL;
+      g_autofree char *config_uri_str = NULL;
+
+      /* let's be nice and support empty lines and comments */
+      if (*mirror_uri_str == '\0' || *mirror_uri_str == '#')
+        continue;
+
+      mirror_uri = soup_uri_new (mirror_uri_str);
+      if (mirror_uri == NULL)
+        {
+          g_debug ("Can't parse mirrorlist line '%s'", mirror_uri_str);
+          continue;
+        }
+      else if (strcmp (soup_uri_get_scheme (mirror_uri), "file") == 0)
+        {
+          /* let's not support mirrorlists that contain local URIs for now -- we
+           * need to think about if and how we want to support this since we set
+           * up things differently depending on whether we're pulling locally or
+           * not */
+          g_debug ("Ignoring local mirrorlist entry '%s'", mirror_uri_str);
+          soup_uri_free (mirror_uri);
+          continue;
+        }
+
+      config_uri_str = g_build_filename (mirror_uri_str, "config", NULL);
+
+      config_uri = soup_uri_new (config_uri_str);
+      if (fetch_uri_contents_utf8_sync (fetcher, config_uri, NULL,
+                                        cancellable, &local_error))
+        ret_mirrorlist = g_slist_append (ret_mirrorlist,
+                                         g_steal_pointer (&mirror_uri));
+      else
+        {
+          g_debug ("Failed to fetch config from mirror '%s': %s",
+                   mirror_uri_str, local_error->message);
+          g_clear_error (&local_error);
+        }
+
+      if (mirror_uri != NULL)
+        soup_uri_free (mirror_uri);
+      soup_uri_free (config_uri);
+    }
+
+  if (ret_mirrorlist == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "All mirrors were tried in mirrorlist '%s'", mirrorlist_url);
+      goto out;
+    }
+
+  *out_mirrorlist = g_steal_pointer (&ret_mirrorlist);
+  ret = TRUE;
+
+out:
+  if (mirrorlist != NULL)
+    soup_uri_free (mirrorlist);
   return ret;
 }
 
@@ -2018,9 +2083,9 @@ repo_remote_fetch_summary (OstreeRepo    *self,
   glnx_unref_object OstreeFetcher *fetcher = NULL;
   g_autoptr(GMainContext) mainctx = NULL;
   gboolean ret = FALSE;
-  SoupURI *base_uri = NULL;
   gboolean from_cache = FALSE;
   g_autofree char *url_override = NULL;
+  GSList *mirrorlist = NULL;
 
   if (options)
     (void) g_variant_lookup (options, "override-url", "&s", &url_override);
@@ -2041,18 +2106,31 @@ repo_remote_fetch_summary (OstreeRepo    *self,
     else if (!ostree_repo_remote_get_url (self, name, &url_string, error))
       goto out;
 
-    base_uri = soup_uri_new (url_string);
-    if (base_uri == NULL)
+    if (metalink_url_string == NULL &&
+        g_str_has_prefix (url_string, "mirrorlist="))
       {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Invalid URL '%s'", url_string);
-        goto out;
+        if (!fetch_mirrorlist (fetcher, url_string + strlen ("mirrorlist="),
+                               &mirrorlist, cancellable, error))
+          goto out;
+      }
+    else
+      {
+        SoupURI *uri = soup_uri_new (url_string);
+
+        if (uri == NULL)
+          {
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "Failed to parse url '%s'", url_string);
+            goto out;
+          }
+
+        mirrorlist = g_slist_append (NULL, uri);
       }
   }
 
   if (!_ostree_preload_metadata_file (self,
                                       fetcher,
-                                      base_uri,
+                                      mirrorlist,
                                       "summary.sig",
                                       metalink_url_string ? TRUE : FALSE,
                                       out_signatures,
@@ -2077,7 +2155,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
     {
       if (!_ostree_preload_metadata_file (self,
                                           fetcher,
-                                          base_uri,
+                                          mirrorlist,
                                           "summary",
                                           metalink_url_string ? TRUE : FALSE,
                                           out_summary,
@@ -2112,8 +2190,8 @@ repo_remote_fetch_summary (OstreeRepo    *self,
  out:
   if (mainctx)
     g_main_context_pop_thread_default (mainctx);
-  if (base_uri != NULL)
-    soup_uri_free (base_uri);
+  if (mirrorlist != NULL)
+    g_slist_free_full (mirrorlist, (GDestroyNotify) soup_uri_free);
   return ret;
 }
 
@@ -2181,6 +2259,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   gboolean opt_gpg_verify_set = FALSE;
   gboolean opt_gpg_verify_summary_set = FALSE;
   const char *url_override = NULL;
+  g_autofree char *base_meta_url = NULL;
+  g_autofree char *base_content_url = NULL;
 
   if (options)
     {
@@ -2304,13 +2384,26 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       else if (!ostree_repo_remote_get_url (self, remote_name_or_baseurl, &baseurl, error))
         goto out;
 
-      pull_data->base_uri = soup_uri_new (baseurl);
-
-      if (!pull_data->base_uri)
+      if (g_str_has_prefix (baseurl, "mirrorlist="))
         {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Failed to parse url '%s'", baseurl);
-          goto out;
+          if (!fetch_mirrorlist (pull_data->fetcher,
+                                 baseurl + strlen ("mirrorlist="),
+                                 &pull_data->meta_mirrorlist,
+                                 cancellable, error))
+            goto out;
+        }
+      else
+        {
+          SoupURI *baseuri = soup_uri_new (baseurl);
+
+          if (baseuri == NULL)
+            {
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "Failed to parse url '%s'", baseurl);
+              goto out;
+            }
+
+          pull_data->meta_mirrorlist = g_slist_append (NULL, baseuri);
         }
     }
   else
@@ -2337,10 +2430,14 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                            error))
         goto out;
 
+      /* XXX: would be interesting to implement metalink as another source of
+       * mirrors here since we use it as such anyway (rather than the "usual"
+       * use case of metalink, which is only for a single target filename) */
       {
+        /* reuse target_uri and take ownership */
         g_autofree char *repo_base = g_path_get_dirname (soup_uri_get_path (target_uri));
-        pull_data->base_uri = soup_uri_copy (target_uri);
-        soup_uri_set_path (pull_data->base_uri, repo_base);
+        soup_uri_set_path (target_uri, repo_base);
+        pull_data->meta_mirrorlist = g_slist_append (NULL, target_uri);
       }
 
       pull_data->summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT,
@@ -2358,15 +2455,31 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       goto out;
 
     if (contenturl == NULL)
-      pull_data->base_content_uri = soup_uri_copy (pull_data->base_uri);
+      /* this is a bit hacky but greatly simplifies coding elsewhere; we take
+       * care in the out path to not double free if they're the same list */
+      pull_data->content_mirrorlist = pull_data->meta_mirrorlist;
     else
       {
-        pull_data->base_content_uri = soup_uri_new (contenturl);
-        if (!pull_data->base_content_uri)
+        if (g_str_has_prefix (contenturl, "mirrorlist="))
           {
-            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                         "Failed to parse contenturl '%s'", contenturl);
-            goto out;
+            if (!fetch_mirrorlist (pull_data->fetcher,
+                                   contenturl + strlen ("mirrorlist="),
+                                   &pull_data->content_mirrorlist,
+                                   cancellable, error))
+              goto out;
+          }
+        else
+          {
+            SoupURI *contenturi = soup_uri_new (contenturl);
+
+            if (contenturi == NULL)
+              {
+                g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                             "Failed to parse contenturl '%s'", contenturl);
+                goto out;
+              }
+
+            pull_data->content_mirrorlist = g_slist_append (NULL, contenturi);
           }
       }
   }
@@ -2376,9 +2489,12 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                            &configured_branches, error))
     goto out;
 
-  if (strcmp (soup_uri_get_scheme (pull_data->base_uri), "file") == 0)
+  /* NB: we don't support local mirrors in mirrorlists, so if this passes, it
+   * means that we're not using mirrorlists (see also fetch_mirrorlist()) */
+  if (strcmp (soup_uri_get_scheme (pull_data->meta_mirrorlist->data), "file") == 0)
     {
-      g_autoptr(GFile) remote_repo_path = g_file_new_for_path (soup_uri_get_path (pull_data->base_uri));
+      g_autoptr(GFile) remote_repo_path =
+        g_file_new_for_path (soup_uri_get_path (pull_data->meta_mirrorlist->data));
       pull_data->remote_repo_local = ostree_repo_new (remote_repo_path);
       if (!ostree_repo_open (pull_data->remote_repo_local, cancellable, error))
         goto out;
@@ -2417,7 +2533,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   pull_data->static_delta_superblocks = g_ptr_array_new_with_free_func ((GDestroyNotify)g_variant_unref);
 
   {
-    SoupURI *uri = NULL;
     g_autoptr(GBytes) bytes_sig = NULL;
     g_autofree char *ret_contents = NULL;
     gsize i, n;
@@ -2428,13 +2543,13 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (!pull_data->summary_data_sig)
       {
-        uri = suburi_new (pull_data->base_uri, "summary.sig", NULL);
-        if (!_ostree_fetcher_request_uri_to_membuf (pull_data->fetcher, uri,
-                                                    FALSE, TRUE, &bytes_sig,
-                                                    OSTREE_MAX_METADATA_SIZE,
-                                                    cancellable, error))
+        if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
+                                                          pull_data->meta_mirrorlist,
+                                                          "summary.sig", FALSE, TRUE,
+                                                          &bytes_sig,
+                                                          OSTREE_MAX_METADATA_SIZE,
+                                                          cancellable, error))
           goto out;
-        soup_uri_free (uri);
       }
 
     if (bytes_sig &&
@@ -2452,13 +2567,13 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (!pull_data->summary && !bytes_summary)
       {
-        uri = suburi_new (pull_data->base_uri, "summary", NULL);
-        if (!_ostree_fetcher_request_uri_to_membuf (pull_data->fetcher, uri,
-                                                    FALSE, TRUE, &bytes_summary,
-                                                    OSTREE_MAX_METADATA_SIZE,
-                                                    cancellable, error))
+        if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
+                                                          pull_data->meta_mirrorlist,
+                                                          "summary", FALSE, TRUE,
+                                                          &bytes_summary,
+                                                          OSTREE_MAX_METADATA_SIZE,
+                                                          cancellable, error))
           goto out;
-        soup_uri_free (uri);
       }
 
     if (!bytes_summary && pull_data->gpg_verify_summary)
@@ -2891,10 +3006,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_object (&pull_data->fetcher);
   g_clear_object (&pull_data->remote_repo_local);
   g_free (pull_data->remote_name);
-  if (pull_data->base_uri)
-    soup_uri_free (pull_data->base_uri);
-  if (pull_data->base_content_uri)
-    soup_uri_free (pull_data->base_content_uri);
+  g_slist_free_full (pull_data->meta_mirrorlist, (GDestroyNotify) soup_uri_free);
+  if (pull_data->content_mirrorlist != pull_data->meta_mirrorlist)
+    g_slist_free_full (pull_data->content_mirrorlist, (GDestroyNotify) soup_uri_free);
   g_clear_pointer (&pull_data->summary_data, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary_data_sig, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary, (GDestroyNotify) g_variant_unref);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3026,6 +3026,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_free (pull_data->remote_name);
   if (pull_data->content_mirrorlist != pull_data->meta_mirrorlist)
     g_clear_pointer (&pull_data->content_mirrorlist, (GDestroyNotify) g_ptr_array_unref);
+  /* we clear this *after* clearing content_mirrorlist to avoid unref'ing twice */
   g_clear_pointer (&pull_data->meta_mirrorlist, (GDestroyNotify) g_ptr_array_unref);
   g_clear_pointer (&pull_data->summary_data, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary_data_sig, (GDestroyNotify) g_bytes_unref);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3024,9 +3024,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_object (&pull_data->fetcher);
   g_clear_object (&pull_data->remote_repo_local);
   g_free (pull_data->remote_name);
-  g_clear_pointer (&pull_data->meta_mirrorlist, (GDestroyNotify) g_ptr_array_unref);
   if (pull_data->content_mirrorlist != pull_data->meta_mirrorlist)
     g_clear_pointer (&pull_data->content_mirrorlist, (GDestroyNotify) g_ptr_array_unref);
+  g_clear_pointer (&pull_data->meta_mirrorlist, (GDestroyNotify) g_ptr_array_unref);
   g_clear_pointer (&pull_data->summary_data, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary_data_sig, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary, (GDestroyNotify) g_variant_unref);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -47,6 +47,7 @@ typedef struct {
   OstreeRepoMode remote_mode;
   OstreeFetcher *fetcher;
   SoupURI      *base_uri;
+  SoupURI      *base_content_uri;
   OstreeRepo   *remote_repo_local;
 
   GMainContext    *main_context;
@@ -1347,7 +1348,7 @@ enqueue_one_object_request (OtPullData        *pull_data,
   else
     {
       objpath = _ostree_get_relative_object_path (checksum, objtype, TRUE);
-      obj_uri = suburi_new (pull_data->base_uri, objpath, NULL);
+      obj_uri = suburi_new (pull_data->base_content_uri, objpath, NULL);
     }
 
   is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
@@ -1431,7 +1432,7 @@ request_static_delta_superblock_sync (OtPullData  *pull_data,
   g_autoptr(GVariant) delta_superblock = NULL;
   SoupURI *target_uri = NULL;
   
-  target_uri = suburi_new (pull_data->base_uri, delta_name, NULL);
+  target_uri = suburi_new (pull_data->base_content_uri, delta_name, NULL);
   
   if (!fetch_uri_contents_membuf_sync (pull_data, target_uri, FALSE, TRUE,
                                        &delta_superblock_data,
@@ -1734,7 +1735,7 @@ process_one_static_delta (OtPullData   *pull_data,
         }
       else
         {
-          target_uri = suburi_new (pull_data->base_uri, deltapart_path, NULL);
+          target_uri = suburi_new (pull_data->base_content_uri, deltapart_path, NULL);
           _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, target_uri, size,
                                                           OSTREE_FETCHER_DEFAULT_PRIORITY,
                                                           pull_data->cancellable,
@@ -2381,6 +2382,30 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                                      summary_bytes, FALSE);
     }
 
+  {
+    g_autofree char *contenturl = NULL;
+
+    if (metalink_url_str == NULL && url_override != NULL)
+      contenturl = g_strdup (url_override);
+    else if (!ostree_repo_get_remote_option (self, remote_name_or_baseurl,
+                                             "contenturl", NULL,
+                                             &contenturl, error))
+      goto out;
+
+    if (contenturl == NULL)
+      pull_data->base_content_uri = soup_uri_copy (pull_data->base_uri);
+    else
+      {
+        pull_data->base_content_uri = soup_uri_new (contenturl);
+        if (!pull_data->base_content_uri)
+          {
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "Failed to parse contenturl '%s'", contenturl);
+            goto out;
+          }
+      }
+  }
+
   if (!ostree_repo_get_remote_list_option (self,
                                            remote_name_or_baseurl, "branches",
                                            &configured_branches, error))
@@ -2899,6 +2924,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_free (pull_data->remote_name);
   if (pull_data->base_uri)
     soup_uri_free (pull_data->base_uri);
+  if (pull_data->base_content_uri)
+    soup_uri_free (pull_data->base_content_uri);
   g_clear_pointer (&pull_data->summary_data, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary_data_sig, (GDestroyNotify) g_bytes_unref);
   g_clear_pointer (&pull_data->summary, (GDestroyNotify) g_variant_unref);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2024,13 +2024,14 @@ fetch_mirrorlist (OstreeFetcher  *fetcher,
           g_debug ("Can't parse mirrorlist line '%s'", mirror_uri_str);
           continue;
         }
-      else if (strcmp (soup_uri_get_scheme (mirror_uri), "file") == 0)
+      else if ((strcmp (soup_uri_get_scheme (mirror_uri), "http") != 0) &&
+               (strcmp (soup_uri_get_scheme (mirror_uri), "https") != 0))
         {
-          /* let's not support mirrorlists that contain local URIs for now -- we
-           * need to think about if and how we want to support this since we set
-           * up things differently depending on whether we're pulling locally or
-           * not */
-          g_debug ("Ignoring local mirrorlist entry '%s'", mirror_uri_str);
+          /* let's not support mirrorlists that contain non-http based URIs for
+           * now (e.g. local URIs) -- we need to think about if and how we want
+           * to support this since we set up things differently depending on
+           * whether we're pulling locally or not */
+          g_debug ("Ignoring non-http/s mirrorlist entry '%s'", mirror_uri_str);
           soup_uri_free (mirror_uri);
           continue;
         }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -308,23 +308,23 @@ typedef struct {
 } OstreeFetchUriSyncData;
 
 static gboolean
-fetch_mirrorred_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
-                                        GSList         *mirrorlist,
-                                        const char     *filename,
-                                        char          **out_contents,
-                                        GCancellable   *cancellable,
-                                        GError        **error)
+fetch_mirrored_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
+                                       GSList         *mirrorlist,
+                                       const char     *filename,
+                                       char          **out_contents,
+                                       GCancellable   *cancellable,
+                                       GError        **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GBytes) bytes = NULL;
   g_autofree char *ret_contents = NULL;
   gsize len;
 
-  if (!_ostree_fetcher_mirrorred_request_to_membuf (fetcher, mirrorlist,
-                                                    filename, TRUE, FALSE,
-                                                    &bytes,
-                                                    OSTREE_MAX_METADATA_SIZE,
-                                                    cancellable, error))
+  if (!_ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist,
+                                                   filename, TRUE, FALSE,
+                                                   &bytes,
+                                                   OSTREE_MAX_METADATA_SIZE,
+                                                   cancellable, error))
     goto out;
 
   ret_contents = g_bytes_unref_to_data (bytes, &len);
@@ -352,8 +352,8 @@ fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
 {
   GSList *mirrorlist = g_slist_append (NULL, uri);
   gboolean ret =
-    fetch_mirrorred_uri_contents_utf8_sync (fetcher, mirrorlist, NULL,
-                                            out_contents, cancellable, error);
+    fetch_mirrored_uri_contents_utf8_sync (fetcher, mirrorlist, NULL,
+                                           out_contents, cancellable, error);
   g_slist_free (mirrorlist);
   return ret;
 }
@@ -528,10 +528,10 @@ fetch_ref_contents (OtPullData    *pull_data,
 
   filename = g_build_filename ("refs", "heads", ref, NULL);
   
-  if (!fetch_mirrorred_uri_contents_utf8_sync (pull_data->fetcher,
-                                               pull_data->meta_mirrorlist,
-                                               filename, &ret_contents,
-                                               cancellable, error))
+  if (!fetch_mirrored_uri_contents_utf8_sync (pull_data->fetcher,
+                                              pull_data->meta_mirrorlist,
+                                              filename, &ret_contents,
+                                              cancellable, error))
     goto out;
 
   g_strchomp (ret_contents);
@@ -649,7 +649,7 @@ content_fetch_on_complete (GObject        *object,
   OstreeObjectType objtype;
   gboolean free_fetch_data = TRUE;
 
-  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrored_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     goto out;
 
@@ -787,7 +787,7 @@ meta_fetch_on_complete (GObject           *object,
   g_debug ("fetch of %s%s complete", checksum_obj,
            fetch_data->is_detached_meta ? " (detached)" : "");
 
-  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrored_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     {
       if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -932,7 +932,7 @@ static_deltapart_fetch_on_complete (GObject           *object,
 
   g_debug ("fetch static delta part %s complete", fetch_data->expected_checksum);
 
-  temp_path = _ostree_fetcher_mirrorred_request_with_partial_finish (fetcher, result, error);
+  temp_path = _ostree_fetcher_mirrored_request_with_partial_finish (fetcher, result, error);
   if (!temp_path)
     goto out;
 
@@ -1320,12 +1320,12 @@ enqueue_one_object_request (OtPullData        *pull_data,
   else
     expected_max_size = 0;
 
-  _ostree_fetcher_mirrorred_request_with_partial_async (pull_data->fetcher, mirrorlist,
-                                                        obj_subpath, expected_max_size,
-                                                        is_meta ? OSTREE_REPO_PULL_METADATA_PRIORITY
-                                                                : OSTREE_REPO_PULL_CONTENT_PRIORITY,
-                                                        pull_data->cancellable,
-                                                        is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
+  _ostree_fetcher_mirrored_request_with_partial_async (pull_data->fetcher, mirrorlist,
+                                                       obj_subpath, expected_max_size,
+                                                       is_meta ? OSTREE_REPO_PULL_METADATA_PRIORITY
+                                                               : OSTREE_REPO_PULL_CONTENT_PRIORITY,
+                                                       pull_data->cancellable,
+                                                       is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
 }
 
 static gboolean
@@ -1338,10 +1338,10 @@ load_remote_repo_config (OtPullData    *pull_data,
   g_autofree char *contents = NULL;
   GKeyFile *ret_keyfile = NULL;
 
-  if (!fetch_mirrorred_uri_contents_utf8_sync (pull_data->fetcher,
-                                               pull_data->meta_mirrorlist,
-                                               "config", &contents,
-                                               cancellable, error))
+  if (!fetch_mirrored_uri_contents_utf8_sync (pull_data->fetcher,
+                                              pull_data->meta_mirrorlist,
+                                              "config", &contents,
+                                              cancellable, error))
     goto out;
 
   ret_keyfile = g_key_file_new ();
@@ -1372,12 +1372,12 @@ request_static_delta_superblock_sync (OtPullData  *pull_data,
   g_autoptr(GBytes) delta_meta_data = NULL;
   g_autoptr(GVariant) delta_superblock = NULL;
 
-  if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
-                                                    pull_data->content_mirrorlist,
-                                                    delta_name, FALSE, TRUE,
-                                                    &delta_superblock_data,
-                                                    OSTREE_MAX_METADATA_SIZE,
-                                                    pull_data->cancellable, error))
+  if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
+                                                   pull_data->content_mirrorlist,
+                                                   delta_name, FALSE, TRUE,
+                                                   &delta_superblock_data,
+                                                   OSTREE_MAX_METADATA_SIZE,
+                                                   pull_data->cancellable, error))
     goto out;
 
   if (delta_superblock_data)
@@ -1674,13 +1674,13 @@ process_one_static_delta (OtPullData   *pull_data,
         }
       else
         {
-          _ostree_fetcher_mirrorred_request_with_partial_async (pull_data->fetcher,
-                                                                pull_data->content_mirrorlist,
-                                                                deltapart_path, size,
-                                                                OSTREE_FETCHER_DEFAULT_PRIORITY,
-                                                                pull_data->cancellable,
-                                                                static_deltapart_fetch_on_complete,
-                                                                fetch_data);
+          _ostree_fetcher_mirrored_request_with_partial_async (pull_data->fetcher,
+                                                               pull_data->content_mirrorlist,
+                                                               deltapart_path, size,
+                                                               OSTREE_FETCHER_DEFAULT_PRIORITY,
+                                                               pull_data->cancellable,
+                                                               static_deltapart_fetch_on_complete,
+                                                               fetch_data);
           pull_data->n_outstanding_deltapart_fetches++;
         }
     }
@@ -1956,11 +1956,11 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
     }
   else
     {
-      ret = _ostree_fetcher_mirrorred_request_to_membuf (fetcher, mirrorlist,
-                                                         filename, FALSE, TRUE,
-                                                         out_bytes,
-                                                         OSTREE_MAX_METADATA_SIZE,
-                                                         cancellable, error);
+      ret = _ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist,
+                                                        filename, FALSE, TRUE,
+                                                        out_bytes,
+                                                        OSTREE_MAX_METADATA_SIZE,
+                                                        cancellable, error);
 
       if (!ret)
         goto out;
@@ -2543,12 +2543,12 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (!pull_data->summary_data_sig)
       {
-        if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
-                                                          pull_data->meta_mirrorlist,
-                                                          "summary.sig", FALSE, TRUE,
-                                                          &bytes_sig,
-                                                          OSTREE_MAX_METADATA_SIZE,
-                                                          cancellable, error))
+        if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
+                                                         pull_data->meta_mirrorlist,
+                                                         "summary.sig", FALSE, TRUE,
+                                                         &bytes_sig,
+                                                         OSTREE_MAX_METADATA_SIZE,
+                                                         cancellable, error))
           goto out;
       }
 
@@ -2567,12 +2567,12 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (!pull_data->summary && !bytes_summary)
       {
-        if (!_ostree_fetcher_mirrorred_request_to_membuf (pull_data->fetcher,
-                                                          pull_data->meta_mirrorlist,
-                                                          "summary", FALSE, TRUE,
-                                                          &bytes_summary,
-                                                          OSTREE_MAX_METADATA_SIZE,
-                                                          cancellable, error))
+        if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
+                                                         pull_data->meta_mirrorlist,
+                                                         "summary", FALSE, TRUE,
+                                                         &bytes_summary,
+                                                         OSTREE_MAX_METADATA_SIZE,
+                                                         cancellable, error))
           goto out;
       }
 

--- a/src/ostree/ot-builtin-trivial-httpd.c
+++ b/src/ostree/ot-builtin-trivial-httpd.c
@@ -77,9 +77,15 @@ httpd_log (OtTrivialHttpd *httpd, const gchar *format, ...)
   if (!httpd->log)
     return;
 
-  str = g_string_new (NULL);
+  {
+    g_autoptr(GDateTime) now = g_date_time_new_now_local ();
+    g_autofree char *timestamp = g_date_time_format (now, "%F %T");
+    str = g_string_new (timestamp);
+    g_string_append_printf (str, ".%06d - ", g_date_time_get_microsecond (now));
+  }
+
   va_start (args, format);
-  g_string_vprintf (str, format, args);
+  g_string_append_vprintf (str, format, args);
   va_end (args);
 
   g_output_stream_write_all (httpd->log, str->str, str->len, &written, NULL, NULL);

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -30,12 +30,14 @@ static char **opt_set;
 static gboolean opt_no_gpg_verify;
 static gboolean opt_if_not_exists;
 static char *opt_gpg_import;
+static char *opt_contenturl;
 
 static GOptionEntry option_entries[] = {
   { "set", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_set, "Set config option KEY=VALUE for remote", "KEY=VALUE" },
   { "no-gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_no_gpg_verify, "Disable GPG verification", NULL },
   { "if-not-exists", 0, 0, G_OPTION_ARG_NONE, &opt_if_not_exists, "Do nothing if the provided remote exists", NULL },
   { "gpg-import", 0, 0, G_OPTION_ARG_FILENAME, &opt_gpg_import, "Import GPG key from FILE", "FILE" },
+  { "contenturl", 0, 0, G_OPTION_ARG_STRING, &opt_contenturl, "Use URL when fetching content", "URL" },
   { NULL }
 };
 
@@ -82,6 +84,14 @@ ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError 
                              "branches",
                              g_variant_new_variant (g_variant_new_strv ((const char*const*)branchesp->pdata, -1)));
     }
+
+  /* We could just make users use --set instead for this since it's a string,
+   * but e.g. when mirrorlist support is added, it'll be kinda awkward to type:
+   *   --set=contenturl=mirrorlist=... */
+
+  if (opt_contenturl != NULL)
+    g_variant_builder_add (optbuilder, "{s@v}",
+                           "contenturl", g_variant_new_variant (g_variant_new_string (opt_contenturl)));
 
   for (iter = opt_set; iter && *iter; iter++)
     {

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -54,7 +54,7 @@ ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError 
   g_autoptr(GVariantBuilder) optbuilder = NULL;
   gboolean ret = FALSE;
 
-  context = g_option_context_new ("NAME URL [BRANCH...] - Add a remote repository");
+  context = g_option_context_new ("NAME [metalink=|mirrorlist=]URL [BRANCH...] - Add a remote repository");
 
   if (!ostree_option_context_parse (context, option_entries, &argc, &argv,
                                     OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -420,6 +420,10 @@ skip_without_fuse () {
     [ -e /etc/mtab ] || skip "no /etc/mtab"
 }
 
+has_gpgme () {
+    ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'
+}
+
 libtest_cleanup_gpg () {
     gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye || true
 }

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -19,12 +19,12 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '\+gpgme'; then
+. $(dirname $0)/libtest.sh
+
+if ! has_gpgme; then
     echo "1..0 #SKIP no gpg support compiled in"
     exit 0
 fi
-
-. $(dirname $0)/libtest.sh
 
 echo "1..1"
 

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -20,12 +20,12 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '\+gpgme'; then
+. $(dirname $0)/libtest.sh
+
+if ! has_gpgme; then
     echo "1..0 #SKIP no gpgme support compiled in"
     exit 0
 fi
-
-. $(dirname $0)/libtest.sh
 
 echo "1..1"
 

--- a/tests/test-pull-contenturl.sh
+++ b/tests/test-pull-contenturl.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..2"
+
+COMMIT_SIGN=""
+if has_gpgme; then
+  COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
+fi
+
+setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+
+# create a summary
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo \
+  summary -u ${COMMIT_SIGN}
+
+# Let's bring up an identical server in which meta files are missing
+cd ${test_tmpdir}
+mkdir httpd-content
+cd httpd-content
+cp -a ${test_tmpdir}/ostree-srv ostree
+
+# delete all the meta stuff from here
+rm ostree/gnomerepo/summary
+if has_gpgme; then
+  rm ostree/gnomerepo/summary.sig
+  find ostree/gnomerepo/objects -name '*.commitmeta' | xargs rm
+fi
+
+# delete all the content stuff from there
+find ${test_tmpdir}/ostree-srv/gnomerepo/objects \
+  ! -name '*.commitmeta' -type f | xargs rm
+
+${CMD_PREFIX} ostree trivial-httpd --autoexit --daemonize \
+  -p ${test_tmpdir}/httpd-content-port
+content_port=$(cat ${test_tmpdir}/httpd-content-port)
+echo "http://127.0.0.1:${content_port}" > ${test_tmpdir}/httpd-content-address
+
+cd ${test_tmpdir}
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+if has_gpgme; then VERIFY=true; else VERIFY=false; fi
+${CMD_PREFIX} ostree --repo=repo remote add origin \
+  --set=gpg-verify=$VERIFY --set=gpg-verify-summary=$VERIFY \
+  --contenturl=$(cat httpd-content-address)/ostree/gnomerepo \
+  $(cat httpd-address)/ostree/gnomerepo
+${CMD_PREFIX} ostree --repo=repo pull origin:main
+
+echo "ok pull objects from contenturl"
+
+if ! has_gpgme; then
+  echo "ok don't pull sigs from contenturl # SKIP not compiled with gpgme"
+else
+  echo "ok don't pull sigs from contenturl"
+fi

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -61,7 +61,7 @@ find repo/objects -name '*.filez' | while read name; do
 done
 echo "ok pull mirror summary"
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then
+if ! has_gpgme; then
     exit 0;
 fi
 

--- a/tests/test-pull-mirrorlist.sh
+++ b/tests/test-pull-mirrorlist.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..3"
+
+setup_fake_remote_repo1 "archive-z2"
+
+setup_mirror () {
+  name=$1; shift
+
+  cd ${test_tmpdir}
+  mkdir $name
+  cd $name
+  cp -a ${test_tmpdir}/ostree-srv ostree
+
+  ${CMD_PREFIX} ostree trivial-httpd --autoexit --daemonize \
+    -p ${test_tmpdir}/${name}-port
+  port=$(cat ${test_tmpdir}/${name}-port)
+  echo "http://127.0.0.1:${port}" > ${test_tmpdir}/${name}-address
+}
+
+setup_mirror content_mirror1
+setup_mirror content_mirror2
+setup_mirror content_mirror3
+
+# Let's delete a file from 1 so that it falls back on 2
+cd ${test_tmpdir}/content_mirror1/ostree/gnomerepo
+filez=$(find objects/ -name '*.filez' | head -n 1)
+rm ${filez}
+
+# Let's delete a file from 1 and 2 so that it falls back on 3
+cd ${test_tmpdir}/content_mirror1/ostree/gnomerepo
+filez=$(find objects/ -name '*.filez' | head -n 1)
+rm ${filez}
+cd ${test_tmpdir}/content_mirror2/ostree/gnomerepo
+rm ${filez}
+
+# OK, let's just shove the mirrorlist in the first httpd
+cat > ${test_tmpdir}/ostree-srv/mirrorlist <<EOF
+
+# comment with empty lines around
+
+http://example.com/nonexistent
+
+$(cat ${test_tmpdir}/content_mirror1-address)/ostree/gnomerepo
+$(cat ${test_tmpdir}/content_mirror2-address)/ostree/gnomerepo
+$(cat ${test_tmpdir}/content_mirror3-address)/ostree/gnomerepo
+
+EOF
+
+# first let's try just url
+
+cd ${test_tmpdir}
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add origin --no-gpg-verify \
+  mirrorlist=$(cat httpd-address)/ostree/mirrorlist
+${CMD_PREFIX} ostree --repo=repo pull origin:main
+
+echo "ok pull objects from mirrorlist"
+
+# now let's try contenturl only mirrorlist
+
+cd ${test_tmpdir}
+rm -rf repo
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add origin --no-gpg-verify \
+  --contenturl=mirrorlist=$(cat httpd-address)/ostree/mirrorlist \
+  $(cat httpd-address)/ostree/gnomerepo
+${CMD_PREFIX} ostree --repo=repo pull origin:main
+
+echo "ok pull objects from contenturl mirrorlist"
+
+# both
+
+cd ${test_tmpdir}
+rm -rf repo
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add origin --no-gpg-verify \
+  --contenturl=mirrorlist=$(cat httpd-address)/ostree/mirrorlist \
+  mirrorlist=$(cat httpd-address)/ostree/mirrorlist
+${CMD_PREFIX} ostree --repo=repo pull origin:main
+
+echo "ok pull objects from split urls mirrorlists"

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -54,7 +54,7 @@ assert_file_has_content yet-another-copy/yet-another-hello-world "hello world ye
 ${CMD_PREFIX} ostree --repo=repo fsck
 echo "ok pull mirror summary"
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then
+if ! has_gpgme; then
     exit 0;
 fi
 


### PR DESCRIPTION
This PR adds the ability to specify a `contenturl` setting. If set, ostree will fetch static deltas and objects from `contenturl` but will use `url` for summaries & signatures. We also add mirrorlist support for both `url` and `contenturl` settings.

The overall goal here is to give content providers an easy way to make use of mirrors, while still making sure that files in the security chain are fetched from one (or maybe more) central location e.g. over pinned TLS if they so wish.