### PR TITLE
[merged] pull: use same name for parameter and documentation comment

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3005,7 +3005,7 @@ out:
 
 gboolean
 ostree_repo_pull_with_options (OstreeRepo             *self,
-                               const char             *remote_name,
+                               const char             *remote_name_or_baseurl,
                                GVariant               *options,
                                OstreeAsyncProgress    *progress,
                                GCancellable           *cancellable,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1006,7 +1006,7 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
 
 _OSTREE_PUBLIC
 gboolean ostree_repo_pull_with_options (OstreeRepo             *self,
-                                        const char             *remote_name,
+                                        const char             *remote_name_or_baseurl,
                                         GVariant               *options,
                                         OstreeAsyncProgress    *progress,
                                         GCancellable           *cancellable,


### PR DESCRIPTION
Fixes this warning:

src/libostree/ostree-repo-pull.c:2162: Warning: OSTree: ostree_repo_pull_with_options: unknown parameter 'remote_name_or_baseurl' in documentation comment, should be 'remote_name'

Noticed while trying "Add contenturl and mirrorlist support"

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>