### PR TITLE
[merged] commit: Don't delete tmp/cache dir

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1219,6 +1219,12 @@ cleanup_tmpdir (OstreeRepo        *self,
       if (dent == NULL)
         break;
 
+      /* Special case this; we create it when opening, and don't want
+       * to blow it away.
+       */
+      if (strcmp (dent->d_name, "cache") == 0)
+        continue;
+
       if (TEMP_FAILURE_RETRY (fstatat (dfd_iter.fd, dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW)) < 0)
         {
           if (errno == ENOENT) /* Did another cleanup win? */


### PR DESCRIPTION
We hold a fd open on this, and it's basically now expected
to be immortal.  Confer that status.

This was showing up in flatpak crashers, because we'd get
an unexpected errno.

(I didn't test this fixes the crasher, but it's clearly right)

https://bugzilla.redhat.com/show_bug.cgi?id=1347293