### PR TITLE
[merged] ostree-prepare-root: Allow building statically with musl

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -17,7 +17,6 @@
 
 if BUILDOPT_SYSTEMD
 
-ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_boot_PROGRAMS += ostree-remount
 
 noinst_LTLIBRARIES += libswitchroot-mountutil.la
@@ -28,9 +27,32 @@ libswitchroot_mountutil_la_SOURCES = \
 	src/switchroot/ostree-mount-util.h \
 	$(NULL)
 
-ostree_prepare_root_SOURCES = src/switchroot/ostree-prepare-root.c
-ostree_prepare_root_LDADD = libswitchroot-mountutil.la
+ostree_prepare_root_SOURCES = \
+    src/switchroot/ostree-mount-util.c \
+    src/switchroot/ostree-mount-util.h \
+    src/switchroot/ostree-prepare-root.c \
+    $(NULL)
+
+if BUILDOPT_USE_STATIC_COMPILER
+# ostree-prepare-root can be used as init in a system without a populated /lib.
+# To support this use case we need to link statically as we will be unable to
+# locate libc.so at run time if it's not installed in /lib.
+#
+# We support building ostree-prepare-root with a different compiler to the rest
+# of ostree so we can use musl rather than glibc.  This reduces the size of the
+# executable significantly: from ~700K -> ~30K.  We have to use _SCRIPTS here
+# to get autotools to install this as an executable but without generating rules
+# to make it itself which we have specified manually.  See
+# https://lists.gnu.org/archive/html/help-gnu-utils/2007-01/msg00007.html
+ostree_boot_SCRIPTS = ostree-prepare-root
+
+ostree-prepare-root : $(ostree_prepare_root_SOURCES)
+	$(STATIC_COMPILER) -o $@ -static $(ostree_prepare_root_SOURCES) $(AM_CPPFLAGS) $(AM_CFLAGS)
+else
+ostree_boot_PROGRAMS += ostree-prepare-root
+
 ostree_prepare_root_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot
+endif
 
 ostree_remount_SOURCES = src/switchroot/ostree-remount.c
 ostree_remount_LDADD = libswitchroot-mountutil.la

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,13 @@ AS_IF([test x$with_grub2_mkconfig_path = x], [
 ],[GRUB2_MKCONFIG=$with_grub2_mkconfig_path])
 AC_DEFINE_UNQUOTED([GRUB2_MKCONFIG_PATH], ["$GRUB2_MKCONFIG"], [The system grub2-mkconfig executible name])
 
+AC_ARG_WITH(static-compiler,
+            AS_HELP_STRING([--with-static-compiler],
+                           [Use the given compiler to build ostree-prepare-root statically linked (default: no)]),,
+              [with_static_compiler=no])
+AM_CONDITIONAL(BUILDOPT_USE_STATIC_COMPILER, test x$with_static_compiler != xno)
+AC_SUBST(STATIC_COMPILER, $with_static_compiler)
+
 dnl for tests
 AS_IF([test "x$found_introspection" = xyes], [
   AC_PATH_PROG(GJS, [gjs])
@@ -332,7 +339,8 @@ echo "
     api docs (gtk-doc):                           $enable_gtk_doc
     gjs-based tests:                              $have_gjs
     dracut:                                       $with_dracut
-    mkinitcpio:                                   $with_mkinitcpio"
+    mkinitcpio:                                   $with_mkinitcpio
+    Static compiler for ostree-prepare-root:      $with_static_compiler"
 AS_IF([test x$with_builtin_grub2_mkconfig = xyes], [
     echo "    builtin grub2-mkconfig (instead of system):   $with_builtin_grub2_mkconfig"
 ], [

--- a/src/switchroot/ostree-mount-util.c
+++ b/src/switchroot/ostree-mount-util.c
@@ -40,7 +40,13 @@ perrorv (const char *format, ...)
   char buf[1024];
   char *p;
 
+#ifdef _GNU_SOURCE
   p = strerror_r (errno, buf, sizeof (buf));
+#else
+  strerror_r (errno, buf, sizeof (buf));
+  buf[sizeof (buf) - 1] = '\0';
+  p = buf;
+#endif  /* _GNU_SOURCE */
 
   va_start (args, format);
 


### PR DESCRIPTION
If the `--with-static-compiler=musl-gcc` configure flag is given.

ostree-prepare-root can be used as init in a system without a populated /lib.  To support this use case we need to link statically as we will be unable to locate libc.so at run time if it's not installed in /lib.

We support building ostree-prepare-root with a different compiler to the rest of ostree so we can use musl rather than glibc.  This reduces the size of the executable significantly: from ~700K -> ~30K.  We have to use `_SCRIPTS` here to get autotools to install this as an executable but without generating rules to make it itself which we have specified manually.

See https://lists.gnu.org/archive/html/help-gnu-utils/2007-01/msg00007.html for advice on using autotools in this manner.

File size measurements from #403:  File sizes built for AMD64 with -O2 and stripped:

| configuration      | size |
|--------------------|-----|
| glibc static    |   724K |
| glibc shared    |   12K |
| musl static    |   30K |
