### PR TITLE
[merged] Distribute manual pages properly

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -40,7 +40,7 @@ man5_files = ostree.repo.5 ostree.repo-config.5
 man1_MANS = $(addprefix man/,$(man1_files))
 man5_MANS = $(addprefix man/,$(man5_files))
 
-EXTRA_DIST += $(man1_MANS) $(man5_MANS)
+EXTRA_DIST += $(man1_MANS) $(man5_MANS) $(man1_MANS:=.xml) $(man5_MANS:=.xml)
 
 XSLT_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,11 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' -DLIBEXECDIR='"$(libexecdir)"' \
 	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40 \
 	-DSOUP_VERSION_MIN_REQUIRED=SOUP_VERSION_2_40 -DSOUP_VERSION_MAX_ALLOWED=SOUP_VERSION_2_48
 AM_CFLAGS += -std=gnu99 $(WARN_CFLAGS)
-AM_DISTCHECK_CONFIGURE_FLAGS += --enable-gtk-doc --disable-maintainer-mode
+AM_DISTCHECK_CONFIGURE_FLAGS += \
+	--enable-gtk-doc \
+	--enable-man \
+	--disable-maintainer-mode \
+	$(NULL)
 
 GITIGNOREFILES = aclocal.m4 build-aux/ buildutil/*.m4 config.h.in gtk-doc.make
 


### PR DESCRIPTION
If using a `make dist` tarball, there are a couple issues.

* The XML is not distributed, so after `make clean`, a subsequent build will fail.
* The man page distribution depends on `ENABLE_MAN`. If `xsltproc` is not installed, this may be false.