### PR TITLE
[merged] build: Actually distribute man page XML source

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -40,7 +40,7 @@ man5_files = ostree.repo.5 ostree.repo-config.5
 man1_MANS = $(addprefix man/,$(man1_files))
 man5_MANS = $(addprefix man/,$(man5_files))
 
-EXTRA_DIST += $(man1_MANS) $(man5_MANS) $(man1_MANS:=.xml) $(man5_MANS:=.xml)
+EXTRA_DIST += $(man1_MANS) $(man5_MANS) $(man1_MANS:.1=.xml) $(man5_MANS:.5=.xml)
 
 XSLT_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
 


### PR DESCRIPTION
The make substitution pattern was wrong. The source files are
"ostree.xml", not "ostree.1.xml", for instance.