### PR TITLE
Narrow summary file race

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -381,6 +381,7 @@ ostree_repo_verify_commit
 ostree_repo_verify_commit_ext
 ostree_repo_verify_summary
 ostree_repo_regenerate_summary
+ostree_repo_regenerate_summary_ext
 <SUBSECTION Standard>
 OSTREE_REPO
 OSTREE_IS_REPO

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -360,9 +360,14 @@ global:
  *                         NOTE NOTE NOTE
  */
 
+LIBOSTREE_2016.10 {
+global:
+        ostree_repo_regenerate_summary_ext;
+} LIBOSTREE_2016.8;
+
 /* Remove comment when first new symbol is added
-LIBOSTREE_2016.10
+LIBOSTREE_2016.11 {
 global:
 	someostree_symbol_deleteme;
-} LIBOSTREE_2016.8;
+} LIBOSTREE_2016.10;
  * Remove comment when first new symbol is added */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4204,7 +4204,7 @@ ostree_repo_sign_delta (OstreeRepo     *self,
  * @cancellable: A #GCancellable
  * @error: a #GError
  *
- * Add a GPG signature to a static delta.
+ * Add a GPG signature to the summary file.
  */
 gboolean
 ostree_repo_add_gpg_signature_summary (OstreeRepo     *self,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1088,6 +1088,14 @@ gboolean ostree_repo_regenerate_summary (OstreeRepo     *self,
                                          GCancellable   *cancellable,
                                          GError        **error);
 
+_OSTREE_PUBLIC
+gboolean ostree_repo_regenerate_summary_ext (OstreeRepo     *self,
+                                             GVariant       *additional_metadata,
+                                             const gchar   **key_id,
+                                             const gchar    *homedir,
+                                             GCancellable   *cancellable,
+                                             GError        **error);
+
 
 G_END_DECLS
 

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -53,18 +53,11 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
       if (!ostree_ensure_repo_writable (repo, error))
         goto out;
 
-      if (!ostree_repo_regenerate_summary (repo, NULL, cancellable, error))
+      if (!ostree_repo_regenerate_summary_ext (repo, NULL,
+                                               (const gchar **) opt_key_ids,
+                                               opt_gpg_homedir,
+                                               cancellable, error))
         goto out;
-
-      if (opt_key_ids)
-        {
-          if (!ostree_repo_add_gpg_signature_summary (repo,
-                                                      (const gchar **) opt_key_ids,
-                                                      opt_gpg_homedir,
-                                                      cancellable,
-                                                      error))
-            goto out;
-        }
     }
   else
     {


### PR DESCRIPTION
Provide a new function, `ostree_repo_regenerate_summary_ext`, that creates and signs the summary file in a tmpdir before renaming them into place. This minimizes the race between summary generation and signing without going fully atomic. Hopefully this is good enough for now since being atomic on the client side is quite a bit more complicated.

Closes: #487
