### PR TITLE
[merged] delta: Add missing `goto out` for failure to mmap()

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -483,6 +483,8 @@ get_unpacked_unlinked_content (OstreeRepo       *repo,
     goto out;
   
   { GMappedFile *mfile = g_mapped_file_new_from_fd (fd, FALSE, error);
+    if (!mfile)
+      goto out;
     ret_content = g_mapped_file_get_bytes (mfile);
     g_mapped_file_unref (mfile);
   }


### PR DESCRIPTION
This was hit in practice when generating a delta for a flatpak app on ARM
it looks like.