### PR TITLE
[merged] sysroot: Avoid double cleanup, and ensure no cleanup if specified

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1713,6 +1713,18 @@ ostree_sysroot_write_deployments (OstreeSysroot     *self,
                                   GCancellable      *cancellable,
                                   GError           **error)
 {
+  return _ostree_sysroot_write_deployments_internal (self, new_deployments,
+                                                     OSTREE_SYSROOT_CLEANUP_ALL,
+                                                     cancellable, error);
+}
+
+gboolean
+_ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
+                                            GPtrArray         *new_deployments,
+                                            OstreeSysrootCleanupFlags cleanup_flags,
+                                            GCancellable      *cancellable,
+                                            GError           **error)
+{
   gboolean ret = FALSE;
   guint i;
   gboolean requires_new_bootversion = FALSE;
@@ -1937,7 +1949,8 @@ ostree_sysroot_write_deployments (OstreeSysroot     *self,
 
   /* And finally, cleanup of any leftover data.
    */
-  if (!ostree_sysroot_cleanup (self, cancellable, error))
+  if (!_ostree_sysroot_piecemeal_cleanup (self, cleanup_flags,
+                                          cancellable, error))
     {
       g_prefix_error (error, "Performing final cleanup: ");
       goto out;

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -121,4 +121,10 @@ gboolean _ostree_sysroot_piecemeal_cleanup (OstreeSysroot *sysroot,
                                             GCancellable *cancellable,
                                             GError **error);
 
+gboolean _ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
+                                                     GPtrArray         *new_deployments,
+                                                     OstreeSysrootCleanupFlags cleanup_flags,
+                                                     GCancellable      *cancellable,
+                                                     GError           **error);
+
 G_END_DECLS

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1591,14 +1591,10 @@ ostree_sysroot_simple_write_deployment (OstreeSysroot      *sysroot,
       added_new = TRUE;
     }
 
-  if (!ostree_sysroot_write_deployments (sysroot, new_deployments, cancellable, error))
+  if (!_ostree_sysroot_write_deployments_internal (sysroot, new_deployments,
+                                                   postclean ? OSTREE_SYSROOT_CLEANUP_ALL : 0,
+                                                   cancellable, error))
     goto out;
-
-  if (postclean)
-    {
-      if (!ostree_sysroot_cleanup (sysroot, cancellable, error))
-        goto out;
-    }
 
   ret = TRUE;
  out:


### PR DESCRIPTION
Since forever, we've been doing two cleanups.  In
https://github.com/ostreedev/ostree/commit/8ece4d6d51bdbe3e41ab318259276bb83e553aa0
I thought we were doing just one and wanted to go to zero (if specified),
but I actually just dropped one cleanup.

In https://github.com/projectatomic/rpm-ostree/pull/452
@jlebon pointed out the duplication.  Fix this by creating a new internal
deploy wrapper that takes cleanup flags.

(Since we already had the "piecemeal cleanup" API internally, let's
 frame it in terms of that, rather than passing down a boolean).