### PR TITLE
[merged] File descriptor fixes

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -516,9 +516,9 @@ ostree_repo_finalize (GObject *object)
   g_free (self->commit_stagedir_name);
   glnx_release_lock_file (&self->commit_stagedir_lock);
   g_clear_object (&self->tmp_dir);
-  if (self->tmp_dir_fd)
+  if (self->tmp_dir_fd != -1)
     (void) close (self->tmp_dir_fd);
-  if (self->cache_dir_fd)
+  if (self->cache_dir_fd != -1)
     (void) close (self->cache_dir_fd);
   if (self->objects_dir_fd != -1)
     (void) close (self->objects_dir_fd);
@@ -702,6 +702,7 @@ ostree_repo_init (OstreeRepo *self)
 
   self->repo_dir_fd = -1;
   self->cache_dir_fd = -1;
+  self->tmp_dir_fd = -1;
   self->commit_stagedir_fd = -1;
   self->objects_dir_fd = -1;
   self->uncompressed_objects_dir_fd = -1;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -260,7 +260,10 @@ void
 ostree_sysroot_unload (OstreeSysroot  *self)
 {
   if (self->sysroot_fd != -1)
-    (void) close (self->sysroot_fd);
+    {
+      (void) close (self->sysroot_fd);
+      self->sysroot_fd = -1;
+    }
 }
 
 /**


### PR DESCRIPTION
Here are some fixes for closing file descriptors - the problem with cache_dir_fd in ostree-repo.c was found because I saw a close(-1) when hunting the second bug which, was causing problems for gnome-continuous.