### PR TITLE
[merged] boot: Ensure we remount /var writable before systemd does journal flush

### DIFF
--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -25,7 +25,7 @@ After=-.mount
 After=systemd-remount-fs.service
 Before=local-fs.target umount.target
 # Other early boot units that need to write to /var
-Before=systemd-random-seed.service plymouth-read-write.service
+Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service
 # tmpfiles.d usually needs write access to a few places
 Before=systemd-tmpfiles-setup.service
 


### PR DESCRIPTION
Otherwise, we may not get a persistent journal for the first boot.
https://bugzilla.redhat.com/show_bug.cgi?id=1265295