### PR TITLE
[merged] checkout: Fix fsync defaults for new API to be off for real

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -106,7 +106,7 @@ static gboolean
 fsync_is_enabled (OstreeRepo   *self,
                   OstreeRepoCheckoutAtOptions *options)
 {
-  return options->enable_fsync || !self->disable_fsync;
+  return options->enable_fsync;
 }
 
 static gboolean
@@ -860,7 +860,7 @@ ostree_repo_checkout_tree_at (OstreeRepo                        *self,
   new_opts.mode = options->mode;
   new_opts.overwrite_mode = options->overwrite_mode;
   new_opts.enable_uncompressed_cache = options->enable_uncompressed_cache;
-  new_opts.enable_fsync = !options->disable_fsync;
+  new_opts.enable_fsync = options->disable_fsync ? FALSE : self->disable_fsync;
   new_opts.process_whiteouts = options->process_whiteouts;
   new_opts.no_copy_fallback = options->no_copy_fallback;
   new_opts.subpath = options->subpath;


### PR DESCRIPTION
My previous change in https://github.com/ostreedev/ostree/pull/425
actually broke things so we basically used the repository defaults =(

This is a subtle mess since we're only trying to flip things off
for the *new* API.

Clean this up so that the "default repo inheritance" lives only in one
place - in the compat layer for the old checkout API.  The new
checkout API defaults to off period, so the repository state is
irrelevant.