### PR TITLE
[merged] core: Do create hardlinks to symlinks for checkouts

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -437,7 +437,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
 
       need_copy = FALSE;
     }
-  else if (!is_symlink)
+  else
     {
       gboolean did_hardlink = FALSE;
       /* Try to do a hardlink first, if it's a regular file.  This also


### PR DESCRIPTION
I was noticing a recent performance issue with checkouts
which seemed to be mostly us going back to doing a `fsync()` on
directories.

Regardless, while looking at that, I saw we were spending time
creating new symlinks. Even though symlinks are small, it's still
better to hardlink them.

Going way back in time, the reason we weren't doing this is
because we were hitting `EMFILE` on ext4, but that was for
gnome-continuous which creates *many* build roots.  Even
there though, they're just a cache, and we handle `EMFILE`.

For ostree-for-host-system, we don't expect to have many roots (just 3
at most transiently), so hardlinking symlinks does make sense.