### PR TITLE
[merged] libglnx: Update to latest

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -335,6 +335,7 @@ echo "
     libarchive (parse tar files directly):        $with_libarchive
     static deltas:                                yes (always enabled now)
     O_TMPFILE:                                    $enable_otmpfile
+    wrpseudo-compat:                              $enable_wrpseudo_compat
     man pages (xsltproc):                         $enable_man
     api docs (gtk-doc):                           $enable_gtk_doc
     gjs-based tests:                              $have_gjs

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -21,6 +21,8 @@
 #include "config.h"
 
 #include "otutil.h"
+#include <sys/mount.h>
+#include <sys/wait.h>
 
 #include "ostree-core-private.h"
 #include "ostree-sysroot-private.h"


### PR DESCRIPTION
In preparation for a future update.  Making this one now because
we need to add some includes since glnx-libcontainer went away,
and with it some includes for `sys/mount.h` etc.