### PR TITLE
[merged] pull: Support multiple specifications of --subpath

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1157,7 +1157,7 @@ scan_commit_object (OtPullData         *pull_data,
         goto out;
 
       queue_scan_one_metadata_object_c (pull_data, tree_contents_csum_bytes,
-                                        OSTREE_OBJECT_TYPE_DIR_TREE, g_strdup ("/"), recursion_depth + 1);
+                                        OSTREE_OBJECT_TYPE_DIR_TREE, "/", recursion_depth + 1);
 
       queue_scan_one_metadata_object_c (pull_data, tree_meta_csum_bytes,
                                         OSTREE_OBJECT_TYPE_DIR_META, NULL, recursion_depth + 1);

--- a/tests/test-pull-subpath.sh
+++ b/tests/test-pull-subpath.sh
@@ -36,9 +36,10 @@ mkdir repo
 ${CMD_PREFIX} ostree --repo=repo init
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin ${remoteurl}
 
-${CMD_PREFIX} ostree --repo=repo pull --subpath=/baz origin main
+${CMD_PREFIX} ostree --repo=repo pull --subpath=/baz/deeper --subpath=/baz/another origin main
 
-${CMD_PREFIX} ostree --repo=repo ls origin:main /baz
+${CMD_PREFIX} ostree --repo=repo ls origin:main /baz/deeper
+${CMD_PREFIX} ostree --repo=repo ls origin:main /baz/another
 if ${CMD_PREFIX} ostree --repo=repo ls origin:main /firstfile 2>err.txt; then
     assert_not_reached
 fi


### PR DESCRIPTION
I need this in flatpak to avoid doing multiple pulls when doing
locale subsetting.