### PR TITLE
[merged] Fix proxy authentication

### DIFF
--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -43,14 +43,14 @@ deployment.  For short, we will call this the "tree", to
 distinguish it from the concept of a deployment.
 
 First, the tree must include a kernel stored as
-`/boot/vmlinuz(-.*)?-$checksum`.  The checksum should be a SHA256 hash
-of the kernel contents; it must be pre-computed before storing the
-kernel in the repository.  Optionally, the tree can contain an
-initramfs, stored as `/boot/initramfs(-.*)?-$checksum`.  If this
-exists, the checksum must include both the kernel and initramfs
-contents.  OSTree will use this to determine which kernels are shared.
-The rationale for this is to avoid computing checksums on the client
-by default.
+`vmlinuz(-.*)?-$checksum` in either `/boot` or `/usr/lib/ostree-boot`.
+The checksum should be a SHA256 hash of the kernel contents; it must be
+pre-computed before storing the kernel in the repository.  Optionally,
+the directory can also contain an initramfs, stored as
+`initramfs(-.*)?-$checksum`.  If this exists, the checksum must include
+both the kernel and initramfs contents.  OSTree will use this to
+determine which kernels are shared.  The rationale for this is to avoid
+computing checksums on the client by default.
 
 The deployment should not have a traditional UNIX `/etc`; instead, it
 should include `/usr/etc`.  This is the "default configuration".  When

--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -43,13 +43,14 @@ deployment.  For short, we will call this the "tree", to
 distinguish it from the concept of a deployment.
 
 First, the tree must include a kernel stored as
-`/boot/vmlinuz-$checksum`.  The checksum should be a SHA256 hash of
-the kernel contents; it must be pre-computed before storing the kernel
-in the repository.  Optionally, the tree can contain an initramfs,
-stored as `/boot/initramfs-$checksum`.  If this exists, the checksum
-must include both the kernel and initramfs contents.  OSTree will use
-this to determine which kernels are shared.  The rationale for this is
-to avoid computing checksums on the client by default.
+`/boot/vmlinuz(-.*)?-$checksum`.  The checksum should be a SHA256 hash
+of the kernel contents; it must be pre-computed before storing the
+kernel in the repository.  Optionally, the tree can contain an
+initramfs, stored as `/boot/initramfs(-.*)?-$checksum`.  If this
+exists, the checksum must include both the kernel and initramfs
+contents.  OSTree will use this to determine which kernels are shared.
+The rationale for this is to avoid computing checksums on the client
+by default.
 
 The deployment should not have a traditional UNIX `/etc`; instead, it
 should include `/usr/etc`.  This is the "default configuration".  When

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -280,18 +280,19 @@ static void
 on_authenticate (SoupSession *session, SoupMessage *msg, SoupAuth *auth,
                  gboolean retrying, gpointer user_data)
 {
-  if (msg->status_code == SOUP_STATUS_PROXY_UNAUTHORIZED) {
-    SoupURI *uri = NULL;
-    g_object_get (session, SOUP_SESSION_PROXY_URI, &uri, NULL);
-    if (retrying)
-      {
-        g_autofree char *s = soup_uri_to_string (uri, FALSE);
-        g_warning ("Invalid username or password for proxy '%s'", s);
-      }
-    else
-      soup_auth_authenticate (auth, soup_uri_get_user (uri),
-                                    soup_uri_get_password (uri));
-  }
+  if (msg->status_code == SOUP_STATUS_PROXY_UNAUTHORIZED)
+    {
+      SoupURI *uri = NULL;
+      g_object_get (session, SOUP_SESSION_PROXY_URI, &uri, NULL);
+      if (retrying)
+        {
+          g_autofree char *s = soup_uri_to_string (uri, FALSE);
+          g_warning ("Invalid username or password for proxy '%s'", s);
+        }
+      else
+        soup_auth_authenticate (auth, soup_uri_get_user (uri),
+                                      soup_uri_get_password (uri));
+    }
 }
 
 static void

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2002,7 +2002,7 @@ allocate_deployserial (OstreeSysroot           *self,
     g_ptr_array_new_with_free_func (g_object_unref);
 
   osdir = ot_gfile_get_child_build_path (self->path, "ostree/deploy", osname, NULL);
-  
+
   if (!_ostree_sysroot_list_deployment_dirs_for_os (osdir, tmp_current_deployments,
                                                     cancellable, error))
     goto out;
@@ -2010,9 +2010,7 @@ allocate_deployserial (OstreeSysroot           *self,
   for (i = 0; i < tmp_current_deployments->len; i++)
     {
       OstreeDeployment *deployment = tmp_current_deployments->pdata[i];
-      
-      if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
-        continue;
+
       if (strcmp (ostree_deployment_get_csum (deployment), revision) != 0)
         continue;
 


### PR DESCRIPTION
Make sure to pass the proxy authentication if asked for it. Though libsoup should do that by default (see https://bugzilla.gnome.org/show_bug.cgi?id=772932).

Also includes a few patches I had lying around. :)