### PR TITLE
[merged] Ostree cookies

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -80,7 +80,9 @@ ostree_SOURCES += \
 ostree_SOURCES += \
 	src/ostree/ot-remote-builtins.h \
 	src/ostree/ot-remote-builtin-add.c \
+	src/ostree/ot-remote-builtin-add-cookie.c \
 	src/ostree/ot-remote-builtin-delete.c \
+	src/ostree/ot-remote-builtin-delete-cookie.c \
 	src/ostree/ot-remote-builtin-gpg-import.c \
 	src/ostree/ot-remote-builtin-list.c \
 	src/ostree/ot-remote-builtin-list-cookies.c \

--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -83,6 +83,7 @@ ostree_SOURCES += \
 	src/ostree/ot-remote-builtin-delete.c \
 	src/ostree/ot-remote-builtin-gpg-import.c \
 	src/ostree/ot-remote-builtin-list.c \
+	src/ostree/ot-remote-builtin-list-cookies.c \
 	src/ostree/ot-remote-builtin-show-url.c \
 	src/ostree/ot-remote-builtin-refs.c \
 	src/ostree/ot-remote-builtin-summary.c \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -45,6 +45,7 @@ dist_test_scripts = \
 	tests/test-pull-subpath.sh \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \
+	tests/test-remote-cookies.sh \
 	tests/test-remote-gpg-import.sh \
 	tests/test-commit-sign.sh \
 	tests/test-export.sh \

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -69,6 +69,25 @@ Boston, MA 02111-1307, USA.
             <cmdsynopsis>
                 <command>ostree remote summary</command> <arg choice="opt" rep="repeat">OPTIONS</arg> <arg choice="req">NAME</arg>
             </cmdsynopsis>
+            <cmdsynopsis>
+                <command>ostree remote add-cookie</command>
+                <arg choice="req">NAME</arg>
+                <arg choice="req">DOMAIN</arg>
+                <arg choice="req">PATH</arg>
+                <arg choice="req">COOKIE_NAME</arg>
+                <arg choice="req">VALUE</arg>
+            </cmdsynopsis>
+            <cmdsynopsis>
+                <command>ostree remote delete-cookie</command>
+                <arg choice="req">NAME</arg>
+                <arg choice="req">DOMAIN</arg>
+                <arg choice="req">PATH</arg>
+                <arg choice="req">COOKIE_NAME</arg>
+                <arg choice="req">VALUE</arg>
+            </cmdsynopsis>
+            <cmdsynopsis>
+                <command>ostree remote list-cookies</command> <arg choice="req">NAME</arg>
+            </cmdsynopsis>
     </refsynopsisdiv>
 
     <refsect1>
@@ -82,6 +101,9 @@ Boston, MA 02111-1307, USA.
         </para>
         <para>
             The GPG keys to import may be in binary OpenPGP format or ASCII armored.  The optional <arg>KEY-ID</arg> list can restrict which keys are imported from a keyring file or input stream.  All keys are imported if this list is omitted.  If neither <option>--keyring</option> nor <option>--stdin</option> options are given, then keys are imported from the user's personal GPG keyring.
+        </para>
+        <para>
+            The various cookie related command allow management of a remote specific cookie jar.
         </para>
     </refsect1>
 

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -204,6 +204,18 @@ Boston, MA 02111-1307, USA.
       in the section <literal>GPG verification</literal>.
     </para>
   </refsect1>
+
+  <refsect1>
+    <title>Per-remote HTTP cookies</title>
+    <para>
+      Some content providers may want to control access to remote
+      repositories via HTTP cookies.  The <command>ostree remote
+      add-cookie</command> and <command>ostree remote
+      delete-cookie</command> commands will update a per-remote
+      lookaside cookie jar, named
+      <filename>$remotename.cookies.txt</filename>.
+    </para>
+  </refsect1>
   
   <refsect1>
     <title>See Also</title>

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -1057,6 +1057,7 @@ on_request_sent (GObject        *object,
               switch (msg->status_code)
                 {
                 case 404:
+                case 403:
                 case 410:
                   code = G_IO_ERROR_NOT_FOUND;
                   break;

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -326,6 +326,16 @@ session_thread_set_proxy_cb (ThreadClosure *thread_closure,
     }
 }
 
+static void
+session_thread_set_cookie_jar_cb (ThreadClosure *thread_closure,
+                                  gpointer data)
+{
+  SoupCookieJar *jar = data;
+
+  soup_session_add_feature (thread_closure->session,
+                            SOUP_SESSION_FEATURE (jar));
+}
+
 #ifdef HAVE_LIBSOUP_CLIENT_CERTS
 static void
 session_thread_set_tls_interaction_cb (ThreadClosure *thread_closure,
@@ -744,6 +754,23 @@ _ostree_fetcher_set_proxy (OstreeFetcher *self,
                                proxy_uri,  /* takes ownership */
                                (GDestroyNotify) soup_uri_free);
     }
+}
+
+void
+_ostree_fetcher_set_cookie_jar (OstreeFetcher *self,
+                                const char    *jar_path)
+{
+  SoupCookieJar *jar;
+
+  g_return_if_fail (OSTREE_IS_FETCHER (self));
+  g_return_if_fail (jar_path != NULL);
+
+  jar = soup_cookie_jar_text_new (jar_path, TRUE);
+
+  session_thread_idle_add (self->thread_closure,
+                           session_thread_set_cookie_jar_cb,
+                           jar,  /* takes ownership */
+                           (GDestroyNotify) g_object_unref);
 }
 
 void

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -59,6 +59,9 @@ OstreeFetcher *_ostree_fetcher_new (int                      tmpdir_dfd,
 
 int  _ostree_fetcher_get_dfd (OstreeFetcher *fetcher);
 
+void _ostree_fetcher_set_cookie_jar (OstreeFetcher *self,
+                                     const char    *jar_path);
+
 void _ostree_fetcher_set_proxy (OstreeFetcher *fetcher,
                                 const char    *proxy);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1964,6 +1964,19 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
       _ostree_fetcher_set_proxy (fetcher, http_proxy);
   }
 
+  {
+    g_autofree char *jar_path = NULL;
+    g_autofree char *cookie_file = g_strdup_printf ("%s.cookies.txt",
+                                                    remote_name);
+
+    jar_path = g_build_filename (g_file_get_path (self->repodir), cookie_file,
+                                 NULL);
+
+    if (g_file_test(jar_path, G_FILE_TEST_IS_REGULAR))
+      _ostree_fetcher_set_cookie_jar (fetcher, jar_path);
+
+  }
+
   success = TRUE;
 
 out:

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -36,6 +36,7 @@ static OstreeRemoteCommand remote_subcommands[] = {
   { "delete", ot_remote_builtin_delete },
   { "show-url", ot_remote_builtin_show_url },
   { "list", ot_remote_builtin_list },
+  { "list-cookies", ot_remote_builtin_list_cookies },
   { "gpg-import", ot_remote_builtin_gpg_import },
   { "refs", ot_remote_builtin_refs },
   { "summary", ot_remote_builtin_summary },

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -33,7 +33,9 @@ typedef struct {
 
 static OstreeRemoteCommand remote_subcommands[] = {
   { "add", ot_remote_builtin_add },
+  { "add-cookie", ot_remote_builtin_add_cookie },
   { "delete", ot_remote_builtin_delete },
+  { "delete-cookie", ot_remote_builtin_delete_cookie },
   { "show-url", ot_remote_builtin_show_url },
   { "list", ot_remote_builtin_list },
   { "list-cookies", ot_remote_builtin_list_cookies },

--- a/src/ostree/ot-remote-builtin-add-cookie.c
+++ b/src/ostree/ot-remote-builtin-add-cookie.c
@@ -1,0 +1,84 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ * Copyright (C) 2016 Sjoerd Simons <sjoerd@luon.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <libsoup/soup.h>
+
+#include "otutil.h"
+
+#include "ot-main.h"
+#include "ot-remote-builtins.h"
+#include "ostree-repo-private.h"
+
+
+static GOptionEntry option_entries[] = {
+  { NULL }
+};
+
+gboolean
+ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  const char *remote_name;
+  const char *domain;
+  const char *path;
+  const char *cookie_name;
+  const char *value;
+  g_autofree char *jar_path = NULL;
+  g_autofree char *cookie_file = NULL;
+  glnx_unref_object SoupCookieJar *jar = NULL;
+  SoupCookie *cookie;
+
+  context = g_option_context_new ("NAME DOMAIN PATH COOKIE_NAME VALUE - Add a cookie to remote");
+
+  if (!ostree_option_context_parse (context, option_entries, &argc, &argv,
+                                    OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    return FALSE;
+
+  if (argc < 6)
+    {
+      ot_util_usage_error (context, "NAME, DOMAIN, PATH, COOKIE_NAME and VALUE must be specified", error);
+      return FALSE;
+    }
+
+  remote_name = argv[1];
+  domain = argv[2];
+  path = argv[3];
+  cookie_name = argv[4];
+  value = argv[5];
+
+  cookie_file = g_strdup_printf ("%s.cookies.txt", remote_name);
+  jar_path = g_build_filename (g_file_get_path (repo->repodir), cookie_file, NULL);
+
+  jar = soup_cookie_jar_text_new (jar_path, FALSE);
+
+  /* Pick a silly long expire time, we're just storing the cookies in the
+   * jar and on pull the jar is read-only so expiry has little actual value */
+  cookie = soup_cookie_new (cookie_name, value, domain, path,
+                            SOUP_COOKIE_MAX_AGE_ONE_YEAR * 25);
+
+  /* jar takes ownership of cookie */
+  soup_cookie_jar_add_cookie (jar, cookie);
+
+  return TRUE;
+}

--- a/src/ostree/ot-remote-builtin-delete-cookie.c
+++ b/src/ostree/ot-remote-builtin-delete-cookie.c
@@ -1,0 +1,96 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ * Copyright (C) 2016 Sjoerd Simons <sjoerd@luon.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <libsoup/soup.h>
+
+#include "otutil.h"
+
+#include "ot-main.h"
+#include "ot-remote-builtins.h"
+#include "ostree-repo-private.h"
+
+
+static GOptionEntry option_entries[] = {
+  { NULL }
+};
+
+gboolean
+ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  const char *remote_name;
+  const char *domain;
+  const char *path;
+  const char *cookie_name;
+  g_autofree char *jar_path = NULL;
+  g_autofree char *cookie_file = NULL;
+  glnx_unref_object SoupCookieJar *jar = NULL;
+  GSList *cookies;
+  gboolean found = FALSE;
+
+  context = g_option_context_new ("NAME DOMAIN PATH COOKIE_NAME- Remote one cookie from remote");
+
+  if (!ostree_option_context_parse (context, option_entries, &argc, &argv,
+                                    OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    return FALSE;
+
+  if (argc < 5)
+    {
+      ot_util_usage_error (context, "NAME, DOMAIN, PATH and COOKIE_NAME must be specified", error);
+      return FALSE;
+    }
+
+  remote_name = argv[1];
+  domain = argv[2];
+  path = argv[3];
+  cookie_name = argv[4];
+
+  cookie_file = g_strdup_printf ("%s.cookies.txt", remote_name);
+  jar_path = g_build_filename (g_file_get_path (repo->repodir), cookie_file, NULL);
+
+  jar = soup_cookie_jar_text_new (jar_path, FALSE);
+  cookies = soup_cookie_jar_all_cookies (jar);
+
+  while (cookies != NULL)
+    {
+      SoupCookie *cookie = cookies->data;
+
+      if (!strcmp (domain, soup_cookie_get_domain (cookie)) &&
+          !strcmp (path, soup_cookie_get_path (cookie)) &&
+          !strcmp (cookie_name, soup_cookie_get_name (cookie)))
+        {
+          soup_cookie_jar_delete_cookie (jar, cookie);
+
+          found = TRUE;
+        }
+
+      soup_cookie_free (cookie);
+      cookies = g_slist_delete_link (cookies, cookies);
+    }
+
+  if (!found)
+    g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Cookie not found in jar");
+
+  return found;
+}

--- a/src/ostree/ot-remote-builtin-list-cookies.c
+++ b/src/ostree/ot-remote-builtin-list-cookies.c
@@ -1,0 +1,86 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ * Copyright (C) 2016 Sjoerd Simons <sjoerd@luon.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <libsoup/soup.h>
+
+#include "otutil.h"
+
+#include "ot-main.h"
+#include "ot-remote-builtins.h"
+#include "ostree-repo-private.h"
+
+
+static GOptionEntry option_entries[] = {
+  { NULL }
+};
+
+gboolean
+ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  const char *remote_name;
+  g_autofree char *jar_path = NULL;
+  g_autofree char *cookie_file = NULL;
+  glnx_unref_object SoupCookieJar *jar = NULL;
+  GSList *cookies;
+
+  context = g_option_context_new ("NAME - Show remote repository cookies");
+
+  if (!ostree_option_context_parse (context, option_entries, &argc, &argv,
+                                    OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    return FALSE;
+
+  if (argc < 2)
+    {
+      ot_util_usage_error (context, "NAME must be specified", error);
+      return FALSE;
+    }
+
+  remote_name = argv[1];
+
+  cookie_file = g_strdup_printf ("%s.cookies.txt", remote_name);
+  jar_path = g_build_filename (g_file_get_path (repo->repodir), cookie_file, NULL);
+
+  jar = soup_cookie_jar_text_new (jar_path, TRUE);
+  cookies = soup_cookie_jar_all_cookies (jar);
+
+  while (cookies != NULL)
+    {
+      SoupCookie *cookie = cookies->data;
+      SoupDate *expiry = soup_cookie_get_expires (cookie);
+
+      g_print ("--\n");
+      g_print ("Domain: %s\n", soup_cookie_get_domain (cookie));
+      g_print ("Path: %s\n", soup_cookie_get_path (cookie));
+      g_print ("Name: %s\n", soup_cookie_get_name (cookie));
+      g_print ("Secure: %s\n", soup_cookie_get_secure (cookie) ? "yes" : "no");
+      g_print ("Expires: %s\n", soup_date_to_string (expiry, SOUP_DATE_COOKIE));
+      g_print ("Value: %s\n", soup_cookie_get_value (cookie));
+
+      soup_cookie_free (cookie);
+      cookies = g_slist_delete_link (cookies, cookies);
+    }
+
+  return TRUE;
+}

--- a/src/ostree/ot-remote-builtins.h
+++ b/src/ostree/ot-remote-builtins.h
@@ -28,6 +28,7 @@ gboolean ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable
 gboolean ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_show_url (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error);

--- a/src/ostree/ot-remote-builtins.h
+++ b/src/ostree/ot-remote-builtins.h
@@ -25,7 +25,9 @@
 G_BEGIN_DECLS
 
 gboolean ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error);

--- a/tests/test-remote-cookies.sh
+++ b/tests/test-remote-cookies.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright (C) 2013 Jeremy Whiting <jeremy.whiting@collabora.com>
+# Copyright (C) 2016 Sjoerd Simons <sjoerd@luon.net>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+echo '1..4'
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive-z2" "" \
+  "--expected-cookies foo=bar --expected-cookies baz=badger"
+
+assert_fail (){ 
+  set +e
+  $@
+  if [ $? == 0 ] ; then
+    echo 1>&2 "$@ did not fail"; exit 1
+  fi
+  set -euo pipefail
+}
+
+cd ${test_tmpdir}
+rm repo -rf
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
+
+# Sanity check the setup, without cookies the pull should fail
+assert_fail ${CMD_PREFIX} ostree --repo=repo pull origin main
+
+echo "ok, setup done"
+
+# Add 2 cookies, pull should succeed now
+${CMD_PREFIX} ostree --repo=repo remote add-cookie origin 127.0.0.1 / foo bar
+${CMD_PREFIX} ostree --repo=repo remote add-cookie origin 127.0.0.1 / baz badger
+${CMD_PREFIX} ostree --repo=repo pull origin main
+
+echo "ok, initial cookie pull succeeded"
+
+# Delete one cookie, if successful pulls will fail again
+${CMD_PREFIX} ostree --repo=repo remote delete-cookie origin 127.0.0.1 / baz badger
+assert_fail ${CMD_PREFIX} ostree --repo=repo pull origin main
+
+echo "ok, delete succeeded"
+
+# Re-add the removed cooking and things succeed again, verified the removal
+# removed exactly one cookie
+${CMD_PREFIX} ostree --repo=repo remote add-cookie origin 127.0.0.1 / baz badger
+${CMD_PREFIX} ostree --repo=repo pull origin main
+
+echo "ok, second cookie pull succeeded"

--- a/tests/test-remote-cookies.sh
+++ b/tests/test-remote-cookies.sh
@@ -30,7 +30,7 @@ setup_fake_remote_repo1 "archive-z2" "" \
 assert_fail (){ 
   set +e
   $@
-  if [ $? == 0 ] ; then
+  if [ $? = 0 ] ; then
     echo 1>&2 "$@ did not fail"; exit 1
   fi
   set -euo pipefail


### PR DESCRIPTION
Add support for adding cookies to the http requests sent to repositories to enable e.g. the usage of signed cookies with cloudfront for private repositories.
