### PR TITLE
[merged] add .redhat-ci.yml and .redhat-ci.Dockerfile

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -1,0 +1,21 @@
+FROM fedora:24
+MAINTAINER Jonathan Lebon <jlebon@redhat.com>
+
+RUN dnf install -y \
+        gcc \
+        sudo \
+        which \
+        attr \
+        fuse \
+        gjs \
+        parallel \
+        gnome-desktop-testing \
+        redhat-rpm-config \
+        elfutils \
+        'dnf-command(builddep)' \
+ && dnf builddep -y \
+        ostree \
+ && dnf clean all
+
+# create an unprivileged user for testing
+RUN adduser testuser

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,0 +1,25 @@
+branches:
+    - master
+    - auto
+    - try
+
+container:
+    image: jlebon/ostree-tester:rhci
+
+tests:
+    - sh autogen.sh
+        --prefix=/usr
+        --libdir=/usr/lib64
+        --enable-installed-tests
+        --enable-gtk-doc
+    - make -j2
+    - make syntax-check
+    - make check
+    - make install
+    - gnome-desktop-testing-runner ostree
+    - sudo --user=testuser gnome-desktop-testing-runner ostree
+
+timeout: 30m
+
+artifacts:
+    - test-suite.log


### PR DESCRIPTION
Add a YAML file for the new Red Hat CI framework.

Rather than re-installing all the build deps everytime, which takes time, I added a Dockerfile that we can wire up to the Docker Hub. For now it lives at `jlebon/ostree-tester:rhci`, but we can move it under the `projectatomic` org (or a new `ostree` org).