### PR TITLE
[merged] .redhat-ci.yml: use projectatomic/ostree-tester

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -4,7 +4,7 @@ branches:
     - try
 
 container:
-    image: jlebon/ostree-tester:rhci
+    image: projectatomic/ostree-tester
 
 tests:
     - sh autogen.sh


### PR DESCRIPTION
Same Dockerfile, but automated to rebuild on pushes.