### PR TITLE
[merged] Fix regression for symlinks in bare-user repos

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -450,7 +450,9 @@ checkout_one_file_at (OstreeRepo                        *repo,
           gboolean is_bare = ((current_repo->mode == OSTREE_REPO_MODE_BARE
                                && options->mode == OSTREE_REPO_CHECKOUT_MODE_NONE) ||
                               (current_repo->mode == OSTREE_REPO_MODE_BARE_USER
-                               && options->mode == OSTREE_REPO_CHECKOUT_MODE_USER));
+                               && options->mode == OSTREE_REPO_CHECKOUT_MODE_USER
+                               /* NOTE: bare-user symlinks are not stored as symlinks */
+                               && !is_symlink));
           gboolean current_can_cache = (options->enable_uncompressed_cache
                                         && current_repo->enable_uncompressed_cache);
           gboolean is_archive_z2_with_cache = (current_repo->mode == OSTREE_REPO_MODE_ARCHIVE_Z2


### PR DESCRIPTION
Commit 1d4f1b8878addd28059c3a3928640491755cd615 started using hardlinks
checkouts of symlinks. However, symlinks are not stored as symlink in the
repo for bare-user repos, so this breaks user-mode checkouts of such repos.

We fix this by checking for !is_symlink in the bare-user case.

This fixes:
     https://github.com/ostreedev/ostree/issues/537