### PR TITLE
[merged] Fix some issues with detached metadata handling

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2044,6 +2044,12 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
       goto out;
     }
 
+  if (ret_metadata == NULL && self->parent_repo)
+    return ostree_repo_read_commit_detached_metadata (self->parent_repo,
+                                                      checksum,
+                                                      out_metadata,
+                                                      cancellable,
+                                                      error);
   ret = TRUE;
   ot_transfer_out_value (out_metadata, &ret_metadata);
  out:


### PR DESCRIPTION
This fixes two issues:
1) Reading detached metadata from the parent repo failed (this breaks in some cases when updating the system repo with flatpak)
2) Detached metadata writes go directly to the repo, even if there is a staging directory because there is an active transaction.