### PR TITLE
[merged] tests: Skip libarchive/selinux tests if in container without SELinux

### DIFF
--- a/tests/test-libarchive-import.c
+++ b/tests/test-libarchive-import.c
@@ -501,12 +501,10 @@ test_libarchive_selinux (gconstpointer data)
   {
     glnx_unref_object GFile *root = g_file_new_for_path ("/");
 
-    /* creation should always succeed */
-    sepol = ostree_sepolicy_new (root, NULL, &error);
-    g_assert (sepol != NULL);
+    sepol = ostree_sepolicy_new (root, NULL, NULL);
   }
 
-  if (ostree_sepolicy_get_name (sepol) == NULL)
+  if (sepol == NULL || ostree_sepolicy_get_name (sepol) == NULL)
     {
       g_test_skip ("SELinux disabled");
       goto out;


### PR DESCRIPTION
I'm doing builds and `make check` inside a Docker container, with
selinux on as a build-time option, but no policy in the container.
This currently aborts.  Let's not do that.

(This type of thing is why installed tests are a better model)