### PR TITLE
[merged] tree-wide: Use macros to initialize GVariant{Builder,Dict}

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1255,7 +1255,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
   guint min_fallback_size;
   guint max_bsdiff_size;
   guint max_chunk_size;
-  g_auto(GVariantBuilder) metadata_builder = {{0,}};
+  g_auto(GVariantBuilder) metadata_builder = OT_VARIANT_BUILDER_INITIALIZER;
   DeltaOpts delta_opts = DELTAOPT_FLAG_NONE;
   guint64 total_compressed_size = 0;
   guint64 total_uncompressed_size = 0;
@@ -1391,8 +1391,8 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
       g_autoptr(GVariant) delta_part_content = NULL;
       g_autoptr(GVariant) delta_part = NULL;
       g_autoptr(GVariant) delta_part_header = NULL;
-      g_auto(GVariantBuilder) mode_builder = {{0,}};
-      g_auto(GVariantBuilder) xattr_builder = {{0,}};
+      g_auto(GVariantBuilder) mode_builder = OT_VARIANT_BUILDER_INITIALIZER;
+      g_auto(GVariantBuilder) xattr_builder = OT_VARIANT_BUILDER_INITIALIZER;
       guint8 compression_type_char;
 
       g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(uuu)"));

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3164,7 +3164,7 @@ ostree_repo_delete_object (OstreeRepo           *self,
 
       if (tombstone_commits)
         {
-          g_auto(GVariantBuilder) builder = {{0,}};
+          g_auto(GVariantBuilder) builder = OT_VARIANT_BUILDER_INITIALIZER;
           g_autoptr(GVariant) variant = NULL;
 
           g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
@@ -4653,7 +4653,7 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
   g_autoptr(GVariant) summary = NULL;
   GList *ordered_keys = NULL;
   GList *iter = NULL;
-  g_auto(GVariantDict) additional_metadata_builder = {{0,}};
+  g_auto(GVariantDict) additional_metadata_builder = OT_VARIANT_BUILDER_INITIALIZER;
 
   if (!ostree_repo_list_refs (self, NULL, &refs, cancellable, error))
     goto out;
@@ -4686,7 +4686,7 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
   {
     guint i;
     g_autoptr(GPtrArray) delta_names = NULL;
-    g_auto(GVariantDict) deltas_builder = {{0,}};
+    g_auto(GVariantDict) deltas_builder = OT_VARIANT_BUILDER_INITIALIZER;
 
     if (!ostree_repo_list_static_delta_names (self, &delta_names, cancellable, error))
       goto out;

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -33,8 +33,7 @@
 GVariant *
 ot_gvariant_new_empty_string_dict (void)
 {
-  g_auto(GVariantBuilder) builder = {{0,}};
-
+  g_auto(GVariantBuilder) builder = OT_VARIANT_BUILDER_INITIALIZER;
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
   return g_variant_builder_end (&builder);
 }

--- a/src/libotutil/otutil.h
+++ b/src/libotutil/otutil.h
@@ -26,6 +26,13 @@
 #include <string.h> /* Yeah...let's just do that here. */
 #include <libglnx.h>
 
+/* https://bugzilla.gnome.org/show_bug.cgi?id=766370 */
+#if !GLIB_CHECK_VERSION(2, 49, 3)
+#define OT_VARIANT_BUILDER_INITIALIZER {{0,}}
+#else
+#define OT_VARIANT_BUILDER_INITIALIZER {{{0,}}}
+#endif
+
 #define ot_gobject_refz(o) (o ? g_object_ref (o) : o)
 
 #define ot_transfer_out_value(outp, srcp) G_STMT_START {   \


### PR DESCRIPTION
With at least `gcc-6.2.1-2.fc25.x86_64` I was seeing:

```
src/libostree/ostree-repo.c:4688:43: warning: missing braces around initializer [-Wmissing-braces]
     g_auto(GVariantDict) deltas_builder = {{0,}};
```

etc.  GLib has macros to initialize things, let's just use them.