### PR TITLE
[merged] .redhat-ci.yml: add clang

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -23,3 +23,22 @@ timeout: 30m
 
 artifacts:
     - test-suite.log
+
+---
+
+inherit: true
+
+packages:
+  - clang
+
+tests:
+    - sh autogen.sh
+        --prefix=/usr
+        --libdir=/usr/lib64
+        --enable-installed-tests
+        --enable-gtk-doc
+    - make -j2 CC=clang CFLAGS='-Wall'
+
+context: Clang
+
+artifacts:

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -37,7 +37,7 @@ tests:
         --libdir=/usr/lib64
         --enable-installed-tests
         --enable-gtk-doc
-    - make -j2 CC=clang CFLAGS='-Wall'
+    - make -j2 CC=clang CFLAGS='-Werror'
 
 context: Clang
 

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -37,7 +37,7 @@ tests:
         --libdir=/usr/lib64
         --enable-installed-tests
         --enable-gtk-doc
-    - make -j2 CC=clang CFLAGS='-Werror'
+    - make -j2 CC=clang CFLAGS='-Werror=unused-variable'
 
 context: Clang
 


### PR DESCRIPTION
Clang has better detection for unused vars when using auto cleanup
functions. We should eventually just fold this back into the first
testsuite. But let's just turn it on for now, at least until it's
satisfied with the whole codebase.