### PR TITLE
[merged] delta: return valid enum member

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -764,7 +764,7 @@ _ostree_delta_get_endianness (GVariant *superblock,
           }
       }
 
-    return G_BYTE_ORDER;
+    return OSTREE_DELTA_ENDIAN_INVALID;
   }
 }
 


### PR DESCRIPTION
If we can't figure out what endianness a delta is, we should just throw
ENDIAN_INVALID.

Resolves: #550