### PR TITLE
[merged] Some valgrind memcheck fixes

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3123,6 +3123,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_pointer (&pull_data->requested_content, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->requested_metadata, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->idle_src, (GDestroyNotify) g_source_destroy);
+  g_clear_pointer (&pull_data->dirs, (GDestroyNotify) g_ptr_array_unref);
   g_clear_pointer (&remote_config, (GDestroyNotify) g_key_file_unref);
   return ret;
 }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2593,7 +2593,7 @@ load_metadata_internal (OstreeRepo       *self,
             }
           else
             {
-              GBytes *data = glnx_fd_readall_bytes (fd, cancellable, error);
+              g_autoptr(GBytes) data = glnx_fd_readall_bytes (fd, cancellable, error);
               if (!data)
                 goto out;
               ret_variant = g_variant_new_from_bytes (ostree_metadata_variant_type (objtype),

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -936,7 +936,7 @@ keyfile_set_from_vardict (GKeyFile     *keyfile,
       else if (g_variant_is_of_type (child, G_VARIANT_TYPE_STRING_ARRAY))
         {
           gsize len;
-          const char *const*strv_child = g_variant_get_strv (child, &len);
+          g_autofree const gchar **strv_child = g_variant_get_strv (child, &len);
           g_key_file_set_string_list (keyfile, section, key, strv_child, len);
         }
       else

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1747,7 +1747,7 @@ _ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
 
   /* Assign a bootserial to each new deployment.
    */
-  assign_bootserials (new_deployments);
+  g_hash_table_unref (assign_bootserials (new_deployments));
 
   /* Determine whether or not we need to touch the bootloader
    * configuration.  If we have an equal number of deployments with

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -188,6 +188,7 @@ ostree_sysroot_upgrader_finalize (GObject *object)
   g_free (self->origin_remote);
   g_free (self->origin_ref);
   g_free (self->override_csum);
+  g_free (self->new_revision);
 
   G_OBJECT_CLASS (ostree_sysroot_upgrader_parent_class)->finalize (object);
 }

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -208,6 +208,7 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
   {
     GVariantBuilder builder;
+    g_autoptr(GVariant) options = NULL;
     g_auto(GLnxConsoleRef) console = { 0, };
     g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
 
@@ -265,7 +266,9 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
                                               &console);
       }
 
-    if (!ostree_repo_pull_with_options (repo, remote, g_variant_builder_end (&builder),
+    options = g_variant_ref_sink (g_variant_builder_end (&builder));
+
+    if (!ostree_repo_pull_with_options (repo, remote, options,
                                         progress, cancellable, error))
       goto out;
 

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -50,6 +50,7 @@ ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError 
   const char *remote_url;
   char **iter;
   g_autoptr(GVariantBuilder) optbuilder = NULL;
+  g_autoptr(GVariant) options = NULL;
   gboolean ret = FALSE;
 
   context = g_option_context_new ("NAME [metalink=|mirrorlist=]URL [BRANCH...] - Add a remote repository");
@@ -109,11 +110,13 @@ ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError 
                            "gpg-verify",
                            g_variant_new_variant (g_variant_new_boolean (FALSE)));
 
+  options = g_variant_ref_sink (g_variant_builder_end (optbuilder));
+
   if (!ostree_repo_remote_change (repo, NULL,
                                   opt_if_not_exists ? OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS : 
                                   OSTREE_REPO_REMOTE_CHANGE_ADD,
                                   remote_name, remote_url,
-                                  g_variant_builder_end (optbuilder),
+                                  options,
                                   cancellable, error))
     goto out;
 

--- a/src/ostree/ot-remote-builtin-show-url.c
+++ b/src/ostree/ot-remote-builtin-show-url.c
@@ -32,7 +32,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_show_url (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   g_autofree char *remote_url = NULL;


### PR DESCRIPTION
While trying to reproduce an intermittent test failure on Debian buildds (a segfault in `ostree pull`), I tried running the ostree tests under valgrind memcheck. I still can't reproduce the segfault, but I did find several memory leaks.

This is just a first round of fixes - I'm running with d258b124 reverted so I can fix leaks (and add new suppressions for OS libraries) incrementally.