### PR TITLE
[merged] Force C.UTF-8 or C locale for tests

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -35,6 +35,15 @@ assert_not_reached () {
 
 test_tmpdir=$(pwd)
 
+# Some tests look for specific English strings. Use a UTF-8 version
+# of the C (POSIX) locale if we have one, or fall back to POSIX
+# (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
+if locale -a | grep C.UTF-8 >/dev/null; then
+  export LC_ALL=C.UTF-8
+else
+  export LC_ALL=C
+fi
+
 # Sanity check that we're in a tmpdir that has
 # just .testtmp (created by tap-driver for `make check`,
 # or nothing at all (as ginstest-runner does)


### PR DESCRIPTION
Otherwise several tests fail, for example in this build done in a French
locale by Debian's reproducible builds initiative, to check whether
the resulting binaries are identical to what was produced in an
English locale:

<https://tests.reproducible-builds.org/debian/logs/unstable/amd64/ostree_2016.11-1.build2.log.gz>
```
(test-basic)
# error: Cannot write to repository: Permission non accordée
...
File 'error-message' doesn't match regexp 'Permission denied'

(test-help)
# Utilisation :
#   ostree [OPTION...] COMMAND
...
File 'out' doesn't match regexp '[Uu]sage'

(test-pull-metalink)
# error: Erreur à la ligne 1, caractère 1 : Le document doit commencer avec un élément (par ex. <book>)
...
File 'err.txt' doesn't match regexp 'Document must begin with an element'
```