### PR TITLE
[merged] Filter bootloader supplied kernel cmdline options

### DIFF
--- a/src/libostree/ostree-kernel-args.h
+++ b/src/libostree/ostree-kernel-args.h
@@ -39,6 +39,9 @@ void _ostree_kernel_args_append (OstreeKernelArgs  *kargs,
                                  const char     *key);
 void _ostree_kernel_args_append_argv (OstreeKernelArgs  *kargs,
                                       char **argv);
+void _ostree_kernel_args_append_argv_filtered (OstreeKernelArgs  *kargs,
+                                               char **argv,
+                                               char **prefixes);
 
 gboolean _ostree_kernel_args_append_proc_cmdline (OstreeKernelArgs *kargs,
                                                   GCancellable     *cancellable,

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -46,6 +46,8 @@ ${CMD_PREFIX} ostree admin deploy --karg-proc-cmdline --os=testos testos:testos/
 for arg in $(cat /proc/cmdline); do
     case "$arg" in
 	ostree=*) # Skip ostree arg that gets stripped out
+	  ;;
+	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
 	   ;;
 	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
 	   ;;

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -58,6 +58,8 @@ for arg in $(cat /proc/cmdline); do
     case "$arg" in
 	ostree=*) # Skip ostree arg that gets stripped out
 	   ;;
+	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
+	   ;;
 	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
 	   ;;
     esac


### PR DESCRIPTION
Various bootloader add kernel commandline options dynamically, filter
these out when grabbing boot options from /proc/cmdline. Specifically
grub adds BOOT_IMAGE and systemd-boot adds initrd.
