### PR TITLE
[merged] repo: Don't put remote refs in the summary file

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4669,7 +4669,6 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
       const char *ref = iter->data;
       const char *commit = g_hash_table_lookup (refs, ref);
       g_autofree char *remotename = NULL;
-      g_autofree char *ref_value = NULL;
       g_autoptr(GVariant) commit_obj = NULL;
 
       g_assert (commit);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4668,9 +4668,18 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
     {
       const char *ref = iter->data;
       const char *commit = g_hash_table_lookup (refs, ref);
+      g_autofree char *remotename = NULL;
+      g_autofree char *ref_value = NULL;
       g_autoptr(GVariant) commit_obj = NULL;
 
       g_assert (commit);
+
+      if (!ostree_parse_refspec (ref, &remotename, NULL, NULL))
+        g_assert_not_reached ();
+
+      /* Don't put remote refs in the summary */
+      if (remotename != NULL)
+        continue;
 
       if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT, commit, &commit_obj, error))
         goto out;


### PR DESCRIPTION
I was doing a chain of mirroring like A -> B -> C

And repo B had A as a remote.  When I added B as
a remote to C, the summary file of B had a ref
upstream:foo/bar/baz, which caused all pulls from
B to C to fail, since the summary file is only
expected to have refs, not refspecs.

Closes: https://github.com/ostreedev/ostree/issues/561