### PR TITLE
[merged] deltas: Only keep one file open at a time during compilation

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -530,8 +530,6 @@ try_content_rollsum (OstreeRepo                       *repo,
   gboolean ret = FALSE;
   g_autoptr(GBytes) tmp_from = NULL;
   g_autoptr(GBytes) tmp_to = NULL;
-  g_autoptr(GFileInfo) from_finfo = NULL;
-  g_autoptr(GFileInfo) to_finfo = NULL;
   OstreeRollsumMatches *matches = NULL;
   ContentRollsum *ret_rollsum = NULL;
 
@@ -626,7 +624,6 @@ process_one_rollsum (OstreeRepo                       *repo,
 {
   gboolean ret = FALSE;
   guint64 content_size;
-  g_autoptr(GBytes) tmp_from = NULL;
   g_autoptr(GBytes) tmp_to = NULL;
   g_autoptr(GFileInfo) content_finfo = NULL;
   g_autoptr(GVariant) content_xattrs = NULL;

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -498,7 +498,7 @@ try_content_bsdiff (OstreeRepo                       *repo,
   if (!ostree_repo_load_file (repo, from, NULL, &from_finfo, NULL,
                               cancellable, error))
     return FALSE;
-  if (!ostree_repo_load_file (repo, from, NULL, &to_finfo, NULL,
+  if (!ostree_repo_load_file (repo, to, NULL, &to_finfo, NULL,
                               cancellable, error))
     return FALSE;
 


### PR DESCRIPTION
Otherwise it's possible for us to exhaust available file descriptors
or (on 32 bit) run up against mmap limits.

In the rollsum case, we didn't need to hold open the "from" object
at all.  And in the bsdiff case, we weren't even looking at either of
the files until we started processing.

Also, while we have the patient open, switch to using O_TMPFILE
if available.