### PR TITLE
[merged] .redhat-ci.yml: use new build key

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -9,6 +9,8 @@ RUN dnf install -y \
         fuse \
         gjs \
         parallel \
+        clang \
+        libubsan \
         gnome-desktop-testing \
         redhat-rpm-config \
         elfutils \

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -6,20 +6,24 @@ branches:
 container:
     image: projectatomic/ostree-tester
 
+# XXX: we can wipe this off once a newer image is built with
+# it already included
 packages:
   - libubsan
 
+env:
+    CFLAGS: '-fsanitize=undefined'
+
+build:
+    config-opts: >
+      --prefix=/usr
+      --libdir=/usr/lib64
+      --enable-installed-tests
+      --enable-gtk-doc
+
 tests:
-    - sh autogen.sh
-        --prefix=/usr
-        --libdir=/usr/lib64
-        --enable-installed-tests
-        --enable-gtk-doc
-        CFLAGS='-fsanitize=undefined'
-    - make -j2
     - make syntax-check
     - make check
-    - make install
     - gnome-desktop-testing-runner ostree
     - sudo --user=testuser gnome-desktop-testing-runner ostree
 
@@ -32,17 +36,15 @@ artifacts:
 
 inherit: true
 
+# XXX: ditto
 packages:
   - clang
 
-tests:
-    - sh autogen.sh
-        --prefix=/usr
-        --libdir=/usr/lib64
-        --enable-installed-tests
-        --enable-gtk-doc
-    - make -j2 CC=clang CFLAGS='-Werror=unused-variable'
-
 context: Clang
 
+env:
+    CC: 'clang'
+    CFLAGS: '-Werror=unused-variable'
+
+tests:
 artifacts:


### PR DESCRIPTION
This allows us to more concisely separate building from testing, which
in turn gives us a nicer inheritance pattern in our case.

See also: https://github.com/jlebon/redhat-ci/issues/11