### PR TITLE
[merged] travis: Drop debian unstable since we can't fetch packages reliably

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 env:
   - ci_distro=ubuntu ci_suite=trusty
   - ci_docker=debian:jessie ci_distro=debian ci_suite=jessie
-  - ci_docker=debian:unstable ci_distro=debian ci_suite=unstable
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 
 script:


### PR DESCRIPTION
I don't know what's going on, I suspect mirror churn.  Anyways,
it seems to be consistently failing now, so let's drop it.