### PR TITLE
[merged] Add API to verify commit for a given remote

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -379,6 +379,7 @@ ostree_repo_add_gpg_signature_summary
 ostree_repo_gpg_verify_data
 ostree_repo_verify_commit
 ostree_repo_verify_commit_ext
+ostree_repo_verify_commit_for_remote
 ostree_repo_verify_summary
 ostree_repo_regenerate_summary
 <SUBSECTION Standard>

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -366,7 +366,7 @@ global:
 
 LIBOSTREE_2016.14 {
 global:
-	ostree_repo_verify_commit_for_remote;
+       ostree_repo_verify_commit_for_remote;
 } LIBOSTREE_2016.8;
 
 /* Section for the stable release *after* this development one; don't

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -364,9 +364,17 @@ global:
  *                         NOTE NOTE NOTE
  */
 
+LIBOSTREE_2016.14 {
+global:
+	ostree_repo_verify_commit_for_remote;
+} LIBOSTREE_2016.8;
+
+/* Section for the stable release *after* this development one; don't
+ * edit this other than to update the last number. */
+
 /* Remove comment when first new symbol is added, replace XX with new stable version.
-LIBOSTREE_2016.XX
+LIBOSTREE_2016.XX {
 global:
 	someostree_symbol_deleteme;
-} LIBOSTREE_2016.8;
+} LIBOSTREE_2016.14;
  * Remove comment when first new symbol is added */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4545,6 +4545,36 @@ ostree_repo_verify_commit_ext (OstreeRepo    *self,
 }
 
 /**
+ * ostree_repo_verify_commit_for_remote:
+ * @self: Repository
+ * @commit_checksum: ASCII SHA256 checksum
+ * @remote: OSTree remote to use for configuration
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Read GPG signature(s) on the commit named by the ASCII checksum
+ * @commit_checksum and return detailed results, based on the keyring
+ * configured for @remote.
+ *
+ * Returns: (transfer full): an #OstreeGpgVerifyResult, or %NULL on error
+ */
+OstreeGpgVerifyResult *
+ostree_repo_verify_commit_for_remote (OstreeRepo    *self,
+                                      const gchar   *commit_checksum,
+                                      const gchar   *remote_name,
+                                      GCancellable  *cancellable,
+                                      GError       **error)
+{
+  return _ostree_repo_verify_commit_internal (self,
+                                              commit_checksum,
+                                              remote_name,
+                                              NULL,
+                                              NULL,
+                                              cancellable,
+                                              error);
+}
+
+/**
  * ostree_repo_gpg_verify_data:
  * @self: Repository
  * @remote_name: (nullable): Name of remote

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1065,6 +1065,14 @@ OstreeGpgVerifyResult * ostree_repo_verify_commit_ext (OstreeRepo    *self,
                                                        GError       **error);
 
 _OSTREE_PUBLIC
+OstreeGpgVerifyResult *
+ostree_repo_verify_commit_for_remote (OstreeRepo    *self,
+                                      const gchar   *commit_checksum,
+                                      const gchar   *remote_name,
+                                      GCancellable  *cancellable,
+                                      GError       **error);
+
+_OSTREE_PUBLIC
 OstreeGpgVerifyResult * ostree_repo_gpg_verify_data (OstreeRepo    *self,
                                                      const gchar   *remote_name,
                                                      GBytes        *data,

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -34,6 +34,7 @@ static char* opt_print_metadata_key;
 static char* opt_print_detached_metadata_key;
 static gboolean opt_raw;
 static char *opt_gpg_homedir;
+static char *opt_gpg_verify_remote;
 
 static GOptionEntry options[] = {
   { "print-related", 0, 0, G_OPTION_ARG_NONE, &opt_print_related, "Show the \"related\" commits", NULL },
@@ -42,6 +43,7 @@ static GOptionEntry options[] = {
   { "print-detached-metadata-key", 0, 0, G_OPTION_ARG_STRING, &opt_print_detached_metadata_key, "Print string value of detached metadata key", "KEY" },
   { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "Show raw variant data" },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, "GPG Homedir to use when looking for keyrings", "HOMEDIR"},
+  { "gpg-verify-remote", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_verify_remote, "Use REMOTE name for GPG configuration", "REMOTE"},
   { NULL }
 };
 
@@ -170,9 +172,17 @@ print_object (OstreeRepo          *repo,
       GError *local_error = NULL;
       g_autoptr(GFile) gpg_homedir = opt_gpg_homedir ? g_file_new_for_path (opt_gpg_homedir) : NULL;
 
-      result = ostree_repo_verify_commit_ext (repo, checksum,
-                                              gpg_homedir, NULL, NULL,
-                                              &local_error);
+      if (opt_gpg_verify_remote)
+        {
+          result = ostree_repo_verify_commit_for_remote (repo, checksum, opt_gpg_verify_remote,
+                                                         NULL, &local_error);
+        }
+      else
+        {
+          result = ostree_repo_verify_commit_ext (repo, checksum,
+                                                  gpg_homedir, NULL, NULL,
+                                                  &local_error);
+        }
 
       if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         {

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -80,6 +80,8 @@ mkdir repo
 ${CMD_PREFIX} ostree --repo=repo init
 ${CMD_PREFIX} ostree --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo show --gpg-verify-remote=origin main | grep -o 'Found [[:digit:]] signature' > show-verify-remote
+assert_file_has_content show-verify-remote 'Found 1 signature'
 rm repo -rf
 
 # A test with corrupted detached signature


### PR DESCRIPTION
My other PR adding gpgkeypath provoked a bug in rpm-ostree - we need an API to verify a commit using a remote's configuration.
