### PR TITLE
[merged] commit: Fix reading xattrs from OstreeRepoFile:s

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2281,7 +2281,15 @@ get_modified_xattrs (OstreeRepo                       *self,
     }
   else if (!(modifier && (modifier->flags & OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS) > 0))
     {
-      if (path)
+      if (path && OSTREE_IS_REPO_FILE (path))
+        {
+          if (!ostree_repo_file_get_xattrs (OSTREE_REPO_FILE (path),
+                                            &ret_xattrs,
+                                            cancellable,
+                                            error))
+            goto out;
+        }
+      else if (path)
         {
           if (!glnx_dfd_name_get_all_xattrs (AT_FDCWD, gs_file_get_path_cached (path),
                                              &ret_xattrs, cancellable, error))

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..58"
+echo "1..59"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -177,6 +177,9 @@ echo "ok user checkout"
 
 $OSTREE commit -b test2 -s "Another commit" --tree=ref=test2
 echo "ok commit from ref"
+
+$OSTREE commit -b test2 -s "Another commit with modifier" --tree=ref=test2 --owner-uid=`id -u`
+echo "ok commit from ref with modifier"
 
 $OSTREE commit -b trees/test2 -s 'ref with / in it' --tree=ref=test2
 echo "ok commit ref with /"


### PR DESCRIPTION
When doing commit --tree=ref=XXX while at the same time applying some
form of modifier, ostree dies trying to read the xattrs using the
raw syscalls. We fix this by falling back to ostree_repo_file_get_xattrs()
in this case.

Also adds a testcase for this.