### PR TITLE
[merged] ostree commit: Fix combining trees with multiple --tree=ref arguments (alternative to https://github.com/ostreedev/ostree/pull/401)

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2550,16 +2550,6 @@ write_directory_to_mtree_internal (OstreeRepo                  *self,
 
       ostree_mutable_tree_set_metadata_checksum (mtree, ostree_repo_file_tree_get_metadata_checksum (repo_dir));
 
-      /* If the mtree was empty beforehand, the checksums on the mtree can simply
-       * become the checksums on the tree in the repo. Super simple. */
-      if (g_hash_table_size (ostree_mutable_tree_get_files (mtree)) == 0 &&
-          g_hash_table_size (ostree_mutable_tree_get_subdirs (mtree)) == 0)
-        {
-          ostree_mutable_tree_set_contents_checksum (mtree, ostree_repo_file_tree_get_contents_checksum (repo_dir));
-          ret = TRUE;
-          goto out;
-        }
-
       filter_result = OSTREE_REPO_COMMIT_FILTER_ALLOW;
     }
   else

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..59"
+echo "1..60"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -193,6 +193,20 @@ echo "ok commit --skip-if-unchanged"
 cd ${test_tmpdir}/checkout-test2-4
 $OSTREE commit -b test2 -s "no xattrs" --no-xattrs
 echo "ok commit with no xattrs"
+
+mkdir tree-A tree-B
+touch tree-A/file-a tree-B/file-b
+
+$OSTREE commit -b test3-1 -s "Initial tree" --tree=dir=tree-A
+$OSTREE commit -b test3-2 -s "Replacement tree" --tree=dir=tree-B
+$OSTREE commit -b test3-combined -s "combined tree" --tree=ref=test3-1 --tree=ref=test3-2
+
+$OSTREE checkout test3-combined checkout-test3-combined
+
+assert_has_file checkout-test3-combined/file-a
+assert_has_file checkout-test3-combined/file-b
+
+echo "ok commit combined ref trees"
 
 # NB: The + is optional, but we need to make sure we support it
 cd ${test_tmpdir}


### PR DESCRIPTION
This is a resubmit of the patches in https://github.com/ostreedev/ostree/pull/401 but with a rewritten test.

I dropped the old tests but kept author, commitlog  etc for the actual fix, then I added a new test in a separate commit, which creates the required data in the script and re-uses the basic test script for this.

I need this fixed for https://github.com/ostreedev/ostree/pull/578 which is why i'm resubmitting this.

Description from initial PR:

You'd expect
```
ostree commit --tree=ref=A --tree=ref=B
```
to produce a commit with the union of the trees given. Instead you'd get
a commit with the contents of just the latter commit. This was due to an
optimisation where we'd skip filling out the files and subdirs
members of the mtree, just filling in the metadata instead. This backfires
becuase this same code relies on checking the files and subdirs members
itself to work out whether the mtree is empty.

This commit removes the optimisation, fixing the bug. Maybe there's a way
to keep the optimisation and still fix the bug but it's not obvious to
me.
