### PR TITLE
[merged] [UBSAN] deltas: Don't call memset(NULL, NULL, 0) with no xattrs

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -157,6 +157,9 @@ xattr_chunk_equals (const void *one, const void *two)
   if (l1 != l2)
     return FALSE;
 
+  if (l1 == 0)
+    return l2 == 0;
+
   return memcmp (g_variant_get_data (v1), g_variant_get_data (v2), l1) == 0;
 }
 


### PR DESCRIPTION
This is actually fine in practice, but it triggers this
`-fsanitize=undefined` warning I saw in the test suite log:

```
src/libostree/ostree-repo-static-delta-compilation.c:160:10: runtime error: null pointer passed as argument 1, which is declared to never be null
```