### PR TITLE
[merged] tests: Support TEST_SKIP_CLEANUP=err

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -11,13 +11,24 @@ bn=$(basename $1)
 tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
-    if test -n "${TEST_SKIP_CLEANUP:-}"; then
-	echo "Skipping cleanup of ${tempdir}"
-    else if test -f ${tempdir}/.testtmp; then
+    if test -f ${tempdir}/.testtmp; then
 	rm "${tempdir}" -rf
     fi
-    fi
 }
-trap cleanup EXIT
+function skip_cleanup() {
+    echo "Skipping cleanup of ${tempdir}"
+}
 cd ${tempdir}
 ${srcd}/${bn} -k --tap
+rc=$?
+case "${TEST_SKIP_CLEANUP:-}" in
+    no|"") cleanup ;;
+    err)
+	if test $rc != 0; then
+	    skip_cleanup
+	else
+	    cleanup
+	fi ;;
+    *) skip_cleanup  ;;
+esac
+exit $rc


### PR DESCRIPTION
I find myself often wanting to debug interactively failing tests.
This makes it more convenient to keep around the temporary directories
just for those tests, rather than accumulating tons of tempdirs from
the successful tests as well.