### PR TITLE
ci: Add an ASAN context

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y \
         gjs \
         parallel \
         clang \
-        libubsan \
+        lib{ub,a,t}san \
         gnome-desktop-testing \
         redhat-rpm-config \
         elfutils \

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -39,3 +39,24 @@ env:
 
 tests:
 artifacts:
+
+---
+
+inherit: true
+context: ASAN
+# Until the container is regenerated
+packages:
+  - libasan
+
+env:
+    # Suppress leak detection in configure (and build, since
+    # g-ir-scanner uses glib), because sadly some of them leak
+    ASAN_OPTIONS: 'detect_leaks=false'
+    CFLAGS: '-fsanitize=address -fno-omit-frame-pointer'
+
+tests:
+    - env OT_SKIP_READDIR_RAND=1 ASAN_OPTIONS='detect_leaks=true:malloc_context_size=20' make check
+
+artifacts:
+    - config.log
+    - test-suite.log

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AS_IF([test "$YACC" != "bison -y"], [AC_MSG_ERROR([bison not found but required]
 
 PKG_PROG_PKG_CONFIG
 
-AM_PATH_GLIB_2_0
+AM_PATH_GLIB_2_0(,,AC_MSG_ERROR([GLib not found]))
 
 dnl When bumping the gio-unix-2.0 dependency (or glib-2.0 in general),
 dnl remember to bump GLIB_VERSION_MIN_REQUIRED and


### PR DESCRIPTION
Let's start doing this by default.  At some point, I'd like
to fold all of the sanitizers into one run or so.