### PR TITLE
[merged] Improve travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 env:
   - ci_distro=ubuntu ci_suite=trusty
-  - ci_docker=debian:jessie ci_distro=debian ci_suite=jessie
+  - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 env:
   - ci_distro=ubuntu ci_suite=trusty
   - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie
+  - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 
 script:

--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -46,6 +46,9 @@ gsettings_SCHEMAS =
 ostree_bootdir = $(prefix)/lib/ostree
 ostree_boot_PROGRAMS =
 
+# This initializes some more variables
+include $(top_srcdir)/buildutil/glib-tap.mk
+
 # This is a special facility to chain together hooks easily
 INSTALL_DATA_HOOKS =
 install-data-hook: $(INSTALL_DATA_HOOKS)

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -17,6 +17,10 @@
 
 if BUILDOPT_SYSTEMD
 ostree_boot_PROGRAMS += ostree-remount
+else
+# It is built anyway as a side-effect of having the symlink in tests/,
+# and if we declare it here, it gets cleaned up properly
+check_PROGRAMS += ostree-remount
 endif
 
 ostree_prepare_root_SOURCES = \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -17,8 +17,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-include $(top_srcdir)/buildutil/glib-tap.mk
-
 EXTRA_DIST += \
 	buildutil/tap-driver.sh \
 	buildutil/tap-test \

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# Copyright © 2015-2016 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 set -euo pipefail
 set -x
 

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -66,10 +66,10 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
 ${make}
 [ "$ci_test" = no ] || ${make} check || maybe_fail_tests
 cat test/test-suite.log || :
-# TODO: if ostree aims to support distcheck, run that too
+[ "$ci_test" = no ] || ${make} distcheck || maybe_fail_tests
+cat test/test-suite.log || :
 
 ${make} install DESTDIR=$(pwd)/DESTDIR
-
 ( cd DESTDIR && find . )
 
 if [ "$ci_sudo" = yes ] && [ "$ci_test" = yes ]; then

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -40,7 +40,7 @@ if [ -n "$ci_docker" ]; then
         --env=ci_test="${ci_test}" \
         --env=ci_test_fatal="${ci_test_fatal}" \
         --privileged \
-        ostree-ci \
+        ci-image \
         tests/ci-build.sh
 fi
 

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -26,10 +26,30 @@ set -euo pipefail
 set -x
 
 NULL=
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
+#
+# If empty, we test on "bare metal".
+# Typical values: ubuntu:xenial, debian:jessie-slim
 : "${ci_docker:=}"
+
+# ci_parallel:
+# A number of parallel jobs, passed to make -j
 : "${ci_parallel:=1}"
+
+# ci_sudo:
+# If yes, assume we can get root using sudo; if no, only use current user
 : "${ci_sudo:=no}"
+
+# ci_test:
+# If yes, run tests; if no, just build
 : "${ci_test:=yes}"
+
+# ci_test_fatal:
+# If yes, test failures break the build; if no, they are reported but ignored
 : "${ci_test_fatal:=yes}"
 
 if [ -n "$ci_docker" ]; then

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -44,6 +44,12 @@ if [ -n "$ci_docker" ]; then
         tests/ci-build.sh
 fi
 
+maybe_fail_tests () {
+    if [ "$ci_test_fatal" = yes ]; then
+        exit 1
+    fi
+}
+
 NOCONFIGURE=1 ./autogen.sh
 
 srcdir="$(pwd)"
@@ -58,13 +64,6 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
     "$@"
 
 ${make}
-
-maybe_fail_tests () {
-    if [ "$ci_test_fatal" = yes ]; then
-        exit 1
-    fi
-}
-
 [ "$ci_test" = no ] || ${make} check || maybe_fail_tests
 # TODO: if ostree aims to support distcheck, run that too
 

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -65,6 +65,7 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
 
 ${make}
 [ "$ci_test" = no ] || ${make} check || maybe_fail_tests
+cat test/test-suite.log || :
 # TODO: if ostree aims to support distcheck, run that too
 
 ${make} install DESTDIR=$(pwd)/DESTDIR
@@ -78,6 +79,8 @@ if [ "$ci_sudo" = yes ] && [ "$ci_test" = yes ]; then
         GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0 \
         ${make} installcheck || \
     maybe_fail_tests
+    cat test/test-suite.log || :
+
     env \
         LD_LIBRARY_PATH=/usr/local/lib \
         GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0 \

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -50,7 +50,7 @@ ${make} install DESTDIR=$(pwd)/DESTDIR
 
 ( cd DESTDIR && find . )
 
-if [ -n "$ci_sudo" ] && [ -n "$ci_test" ]; then
+if [ "$ci_sudo" = yes ] && [ "$ci_test" = yes ]; then
     sudo ${make} install
     env \
         LD_LIBRARY_PATH=/usr/local/lib \

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# Copyright © 2015-2016 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 set -euo pipefail
 set -x
 

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -43,7 +43,7 @@ if [ -n "$ci_docker" ]; then
         -e "s/@ci_docker@/${ci_docker}/" \
         -e "s/@ci_suite@/${ci_suite}/" \
         < tests/ci-Dockerfile.in > Dockerfile
-    exec docker build -t ostree-ci .
+    exec docker build -t ci-image .
 fi
 
 case "$ci_distro" in

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 set -x
 
 NULL=
+: "${ci_distro:=debian}"
 : "${ci_docker:=}"
 : "${ci_in_docker:=no}"
 : "${ci_suite:=jessie}"

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -5,7 +5,7 @@ set -x
 
 NULL=
 : "${ci_docker:=}"
-: "${ci_in_docker:=}"
+: "${ci_in_docker:=no}"
 : "${ci_suite:=jessie}"
 
 if [ $(id -u) = 0 ]; then
@@ -66,7 +66,7 @@ case "$ci_distro" in
             zlib1g-dev \
             ${NULL}
 
-        if [ -n "$ci_in_docker" ]; then
+        if [ "$ci_in_docker" = yes ]; then
             # Add the user that we will use to do the build inside the
             # Docker container, and let them use sudo
             adduser --disabled-password user </dev/null

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -26,9 +26,28 @@ set -euo pipefail
 set -x
 
 NULL=
+
+# ci_distro:
+# OS distribution in which we are testing
+# Typical values: ubuntu, debian; maybe fedora in future
 : "${ci_distro:=debian}"
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
 : "${ci_docker:=}"
+
+# ci_in_docker:
+# Used internally by ci-install.sh. If yes, we are inside the Docker image
+# (ci_docker is empty in this case).
 : "${ci_in_docker:=no}"
+
+# ci_suite:
+# OS suite (release, branch) in which we are testing.
+# Typical values for ci_distro=ubuntu: xenial, trusty
+# Typical values for ci_distro=debian: sid, jessie
+# Typical values for ci_distro=fedora might be 25, rawhide
 : "${ci_suite:=jessie}"
 
 if [ $(id -u) = 0 ]; then


### PR DESCRIPTION
I recently did a round of improvements to the dbus travis-ci integration, partly based on what I contributed to ostree. Here's the same back into ostree :-)

Highlights:

* test distcheck
* fix a distcheck failure when building without systemd (a file built for the tests is not cleaned up)
* more comments
* more logs
* use a smaller Docker image (with documentation stripped) to test Debian
* replace the lost Debian unstable test coverage by testing the future Debian 9 instead