### PR TITLE
[merged] tests: prepend to an existing LD_LIBRARY_PATH, GI_TYPELIB_PATH

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -28,8 +28,8 @@ EXTRA_DIST += \
 # include the builddir in $PATH so we find our just-built ostree
 # binary.
 TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
-	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd) \
-	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd) \
+	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
+	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$${LD_LIBRARY_PATH}} \
 	PATH=$$(cd $(top_builddir)/tests && pwd):$${PATH} \
 	$(NULL)
 


### PR DESCRIPTION
If we're using LD_LIBRARY_PATH for some locally-built library, we want
to search those after OSTree's own libraries.

---

My reproducer for #601, #605, #583 relies on this to pick up my locally-built (minimally optimized) GLib.