### PR TITLE
[merged] Terminate individual tests after 10 minutes

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -19,7 +19,11 @@ function skip_cleanup() {
     echo "Skipping cleanup of ${tempdir}"
 }
 cd ${tempdir}
-${srcd}/${bn} -k --tap
+timeout \
+    --kill-after=60 \
+    --signal=ABRT \
+    $(( 600 * ${TEST_TIMEOUT_FACTOR:-1} )) \
+    ${srcd}/${bn} -k --tap
 rc=$?
 case "${TEST_SKIP_CLEANUP:-}" in
     no|"") cleanup ;;


### PR DESCRIPTION
While using the Automake parallel test harness, if a test hangs for
long enough for an external watchdog to kill the entire build process
(as happens in Debian sbuild after 150 minutes with no activity on
stdout/stderr), the logs will not be shown. If we make an individual
test time out sooner, logs are more likely to be shown.

We use SIGABRT so that the process(es) under test will dump core,
allowing the point at which ostree is blocking to be analyzed.
After 1 minute, if any have not died, we kill them again with SIGKILL.

---

This could be useful for reproducing #583 in an automated way, or doing automated testing that will continue to collect core dumps despite #583.

It is an improved version of the patch I've been using for a while in Debian, which waits 30 minutes and uses SIGTERM.