### PR TITLE
[merged] tree-wide: Use g_hash_table_add() where applicable

### DIFF
--- a/src/libostree/ostree-bootconfig-parser.c
+++ b/src/libostree/ostree-bootconfig-parser.c
@@ -193,7 +193,7 @@ ostree_bootconfig_parser_write_at (OstreeBootconfigParser   *self,
       else
         {
           write_key (self, buf, key, value);
-          g_hash_table_insert (written_overrides, (gpointer)key, (gpointer)key);
+          g_hash_table_add (written_overrides, (gpointer)key);
         }
     }
 

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -554,7 +554,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
                                          g_ascii_xdigit_value (checksum[1]));
         if (repo->updated_uncompressed_dirs == NULL)
           repo->updated_uncompressed_dirs = g_hash_table_new (NULL, NULL);
-        g_hash_table_insert (repo->updated_uncompressed_dirs, key, key);
+        g_hash_table_add (repo->updated_uncompressed_dirs, key);
       }
       g_mutex_unlock (&repo->cache_lock);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -522,7 +522,7 @@ scan_dirtree_object (OtPullData   *pull_data,
         }
       else if (!file_is_stored && !g_hash_table_lookup (pull_data->requested_content, file_checksum))
         {
-          g_hash_table_insert (pull_data->requested_content, file_checksum, file_checksum);
+          g_hash_table_add (pull_data->requested_content, file_checksum);
           enqueue_one_object_request (pull_data, file_checksum, OSTREE_OBJECT_TYPE_FILE, path, FALSE, FALSE);
           file_checksum = NULL;  /* Transfer ownership */
         }
@@ -1294,7 +1294,7 @@ scan_one_metadata_object_c (OtPullData         *pull_data,
       char *duped_checksum = g_strdup (tmp_checksum);
       gboolean do_fetch_detached;
 
-      g_hash_table_insert (pull_data->requested_metadata, duped_checksum, duped_checksum);
+      g_hash_table_add (pull_data->requested_metadata, duped_checksum);
 
       do_fetch_detached = (objtype == OSTREE_OBJECT_TYPE_COMMIT);
       enqueue_one_object_request (pull_data, tmp_checksum, objtype, path, do_fetch_detached, FALSE);
@@ -1308,7 +1308,7 @@ scan_one_metadata_object_c (OtPullData         *pull_data,
                                pull_data->cancellable, error))
         goto out;
 
-      g_hash_table_insert (pull_data->scanned_metadata, g_variant_ref (object), object);
+      g_hash_table_add (pull_data->scanned_metadata, g_variant_ref (object));
       pull_data->n_scanned_metadata++;
     }
   else if (is_stored && objtype == OSTREE_OBJECT_TYPE_DIR_TREE)
@@ -1317,7 +1317,7 @@ scan_one_metadata_object_c (OtPullData         *pull_data,
                                 pull_data->cancellable, error))
         goto out;
 
-      g_hash_table_insert (pull_data->scanned_metadata, g_variant_ref (object), object);
+      g_hash_table_add (pull_data->scanned_metadata, g_variant_ref (object));
       pull_data->n_scanned_metadata++;
     }
 
@@ -1538,7 +1538,7 @@ process_one_static_delta_fallback (OtPullData   *pull_data,
           if (!g_hash_table_lookup (pull_data->requested_metadata, checksum))
             {
               gboolean do_fetch_detached;
-              g_hash_table_insert (pull_data->requested_metadata, checksum, checksum);
+              g_hash_table_add (pull_data->requested_metadata, checksum);
               
               do_fetch_detached = (objtype == OSTREE_OBJECT_TYPE_COMMIT);
               enqueue_one_object_request (pull_data, checksum, objtype, NULL, do_fetch_detached, FALSE);
@@ -1549,7 +1549,7 @@ process_one_static_delta_fallback (OtPullData   *pull_data,
         {
           if (!g_hash_table_lookup (pull_data->requested_content, checksum))
             {
-              g_hash_table_insert (pull_data->requested_content, checksum, checksum);
+              g_hash_table_add (pull_data->requested_content, checksum);
               enqueue_one_object_request (pull_data, checksum, OSTREE_OBJECT_TYPE_FILE, NULL, FALSE, FALSE);
               checksum = NULL;  /* Transfer ownership */
             }
@@ -2840,7 +2840,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           if (ostree_validate_checksum_string (branch, NULL))
             {
               char *key = g_strdup (branch);
-              g_hash_table_insert (commits_to_fetch, key, key);
+              g_hash_table_add (commits_to_fetch, key);
             }
           else
             {

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -311,7 +311,7 @@ ostree_builtin_fsck (int argc, char **argv, GCancellable *cancellable, GError **
           if (commitstate & OSTREE_REPO_COMMIT_STATE_PARTIAL)
             n_partial++;
           else
-            g_hash_table_insert (commits, g_variant_ref (serialized_key), serialized_key);
+            g_hash_table_add (commits, g_variant_ref (serialized_key));
         }
     }
 


### PR DESCRIPTION
Just noticed a few while reading some code, decided to do a quick
cleanup.  It's shorter and clearer.