### PR TITLE
[merged] lib: Remove unused ostree_metalink_get_uri()

### DIFF
--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -642,9 +642,3 @@ _ostree_metalink_request_sync (OstreeMetalink        *self,
   g_clear_pointer (&request.parser, g_markup_parse_context_free);
   return ret;
 }
-
-SoupURI *
-_ostree_metalink_get_uri (OstreeMetalink        *self)
-{
-  return self->uri;
-}

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -48,8 +48,6 @@ OstreeMetalink *_ostree_metalink_new (OstreeFetcher  *fetcher,
                                       guint64         max_size,
                                       SoupURI        *uri);
 
-SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
-
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         SoupURI               **out_target_uri,
                                         GBytes                **out_data,


### PR DESCRIPTION
While doing something else I noticed it was unused.