### PR TITLE
[merged] build: Add more default errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,9 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -Werror=return-type \
         -Werror=overflow \
         -Werror=int-conversion \
+        -Werror=parenthesis \
+        -Werror=incompatible-pointer-types \
+        -Werror=misleading-indentation \
 	-Werror=missing-include-dirs -Werror=aggregate-return \
 	-Werror=declaration-after-statement \
 ])


### PR DESCRIPTION
Newer gcc has `-Wincompatible-pointer-types`, hooray!
Add a few others that we pass today.