### PR TITLE
WIP: OCI support for export and commit

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -136,6 +136,8 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-json-oci.c \
 	src/libostree/ostree-json-oci.h \
 	src/libostree/ostree-json-oci-private.h \
+	src/libostree/ostree-oci-registry.c \
+	src/libostree/ostree-oci-registry.h \
 	$(NULL)
 if USE_LIBARCHIVE
 libostree_1_la_SOURCES += src/libostree/ostree-libarchive-input-stream.h \

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -133,6 +133,9 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-json.c \
 	src/libostree/ostree-json.h \
 	src/libostree/ostree-json-private.h \
+	src/libostree/ostree-json-oci.c \
+	src/libostree/ostree-json-oci.h \
+	src/libostree/ostree-json-oci-private.h \
 	$(NULL)
 if USE_LIBARCHIVE
 libostree_1_la_SOURCES += src/libostree/ostree-libarchive-input-stream.h \

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -130,6 +130,9 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-gpg-verify-result.c \
 	src/libostree/ostree-gpg-verify-result-private.h \
 	src/libostree/ostree-autocleanups.h \
+	src/libostree/ostree-json.c \
+	src/libostree/ostree-json.h \
+	src/libostree/ostree-json-private.h \
 	$(NULL)
 if USE_LIBARCHIVE
 libostree_1_la_SOURCES += src/libostree/ostree-libarchive-input-stream.h \
@@ -173,6 +176,9 @@ libostree_1_la_SOURCES += \
 libostree_1_la_CFLAGS += $(OT_INTERNAL_SOUP_CFLAGS)
 libostree_1_la_LIBADD += $(OT_INTERNAL_SOUP_LIBS)
 endif
+
+libostree_1_la_CFLAGS += $(OT_DEP_JSON_CFLAGS)
+libostree_1_la_LIBADD += $(OT_DEP_JSON_LIBS)
 
 if USE_LIBMOUNT
 libostree_1_la_CFLAGS += $(OT_DEP_LIBMOUNT_CFLAGS)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -93,6 +93,7 @@ dist_test_scripts = \
 	tests/test-switchroot.sh \
 	tests/test-pull-contenturl.sh \
 	tests/test-pull-mirrorlist.sh \
+	tests/test-oci.sh \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,8 @@ AS_IF([ test x$have_gpgme = xno ], [
 ])
 OSTREE_FEATURES="$OSTREE_FEATURES +gpgme"
 
+PKG_CHECK_MODULES(OT_DEP_JSON, [json-glib-1.0])
+
 LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
 # What's in RHEL7.2.
 FUSE_DEPENDENCY="fuse >= 2.9.2"

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -401,6 +401,20 @@ global:
        ostree_oci_image_set_architecture;
        ostree_oci_image_set_os;
        ostree_oci_image_set_layers;
+       ostree_oci_registry_get_type;
+       ostree_oci_registry_new;
+       ostree_oci_registry_load_ref;
+       ostree_oci_registry_set_ref;
+       ostree_oci_registry_download_blob;
+       ostree_oci_registry_download_blob_finish;
+       ostree_oci_registry_load_blob;
+       ostree_oci_registry_store_blob;
+       ostree_oci_registry_store_json;
+       ostree_oci_registry_load_versioned;
+       ostree_oci_registry_write_layer;
+       ostree_oci_layer_writer_get_type;
+       ostree_oci_layer_writer_get_archive;
+       ostree_oci_layer_writer_close;
 } LIBOSTREE_2016.14;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -364,7 +364,6 @@ global:
        ostree_repo_verify_commit_for_remote;
 } LIBOSTREE_2016.8;
 
-
 /*                         NOTE NOTE NOTE
  * Versions above here are released.  Only add symbols below this line.
  *                         NOTE NOTE NOTE
@@ -375,6 +374,33 @@ global:
        ostree_json_get_type;
        ostree_json_from_bytes;
        ostree_json_to_bytes;
+       ostree_oci_ref_get_type;
+       ostree_oci_ref_new;
+       ostree_oci_ref_get_mediatype;
+       ostree_oci_ref_get_digest;
+       ostree_oci_ref_get_size;
+       ostree_oci_ref_get_urls;
+       ostree_oci_ref_set_urls;
+       ostree_oci_versioned_get_type;
+       ostree_oci_versioned_from_json;
+       ostree_oci_versioned_get_mediatype;
+       ostree_oci_versioned_get_version;
+       ostree_oci_manifest_get_type;
+       ostree_oci_manifest_new;
+       ostree_oci_manifest_set_config;
+       ostree_oci_manifest_set_layers;
+       ostree_oci_manifest_get_n_layers;
+       ostree_oci_manifest_get_layer_digest;
+       ostree_oci_manifest_get_annotations;
+       ostree_oci_add_annotations_for_commit;
+       ostree_oci_parse_commit_annotations;
+       ostree_oci_manifest_list_get_type;
+       ostree_oci_image_get_type;
+       ostree_oci_image_new;
+       ostree_oci_image_set_created;
+       ostree_oci_image_set_architecture;
+       ostree_oci_image_set_os;
+       ostree_oci_image_set_layers;
 } LIBOSTREE_2016.14;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -364,17 +364,18 @@ global:
        ostree_repo_verify_commit_for_remote;
 } LIBOSTREE_2016.8;
 
+
 /*                         NOTE NOTE NOTE
  * Versions above here are released.  Only add symbols below this line.
  *                         NOTE NOTE NOTE
  */
 
-/* Remove comment when first new symbol is added
-LIBOSTREE_2016.XX {
+LIBOSTREE_2016.15 {
 global:
-	someostree_symbol_deleteme;
+       ostree_json_get_type;
+       ostree_json_from_bytes;
+       ostree_json_to_bytes;
 } LIBOSTREE_2016.14;
-*/
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste
@@ -382,5 +383,5 @@ global:
 LIBOSTREE_2016.XX {
 global:
 	someostree_symbol_deleteme;
-} LIBOSTREE_2016.14;
+} LIBOSTREE_2016.15;
 */

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -415,6 +415,7 @@ global:
        ostree_oci_layer_writer_get_type;
        ostree_oci_layer_writer_get_archive;
        ostree_oci_layer_writer_close;
+       ostree_repo_write_archive_fd_to_mtree;
 } LIBOSTREE_2016.14;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -47,6 +47,8 @@ struct OstreeFetcherClass
   GObjectClass parent_class;
 };
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeFetcher, g_object_unref)
+
 typedef enum {
   OSTREE_FETCHER_FLAGS_NONE = 0,
   OSTREE_FETCHER_FLAGS_TLS_PERMISSIVE = (1 << 0)

--- a/src/libostree/ostree-json-oci-private.h
+++ b/src/libostree/ostree-json-oci-private.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include "ostree-json-oci.h"
+#include "ostree-json-private.h"
+
+G_BEGIN_DECLS
+
+typedef struct {
+  char *mediatype;
+  char *digest;
+  gint64 size;
+  char **urls;
+} OstreeOciDescriptor;
+
+void ostree_oci_descriptor_destroy (OstreeOciDescriptor *self);
+void ostree_oci_descriptor_free (OstreeOciDescriptor *self);
+
+typedef struct
+{
+  char *architecture;
+  char *os;
+  char *os_version;
+  char **os_features;
+  char *variant;
+  char **features;
+} OstreeOciManifestPlatform;
+
+
+typedef struct
+{
+  OstreeOciDescriptor parent;
+  OstreeOciManifestPlatform platform;
+} OstreeOciManifestDescriptor;
+
+void ostree_oci_manifest_descriptor_destroy (OstreeOciManifestDescriptor *self);
+void ostree_oci_manifest_descriptor_free (OstreeOciManifestDescriptor *self);
+
+struct _OstreeOciRef {
+  OstreeJson parent;
+
+  OstreeOciDescriptor descriptor;
+};
+
+struct _OstreeOciRefClass {
+  OstreeJsonClass parent_class;
+};
+
+struct _OstreeOciVersioned {
+  OstreeJson parent;
+
+  int version;
+  char *mediatype;
+};
+
+struct _OstreeOciVersionedClass {
+  OstreeJsonClass parent_class;
+};
+
+struct _OstreeOciManifest
+{
+  OstreeOciVersioned parent;
+
+  OstreeOciDescriptor config;
+  OstreeOciDescriptor **layers;
+  GHashTable     *annotations;
+};
+
+struct _OstreeOciManifestClass
+{
+  OstreeOciVersionedClass parent_class;
+};
+
+struct _OstreeOciManifestList
+{
+  OstreeOciVersioned parent;
+
+  OstreeOciManifestDescriptor **manifests;
+  GHashTable     *annotations;
+};
+
+struct _OstreeOciManifestListClass
+{
+  OstreeOciVersionedClass parent_class;
+};
+
+typedef struct
+{
+  char *type;
+  char **diff_ids;
+} OstreeOciImageRootfs;
+
+typedef struct
+{
+  char *user;
+  char *working_dir;
+  gint64 memory;
+  gint64 memory_swap;
+  gint64 cpu_shares;
+  char **env;
+  char **cmd;
+  char **entrypoint;
+  char **exposed_ports;
+  char **volumes;
+  GHashTable *labels;
+} OstreeOciImageConfig;
+
+typedef struct
+{
+  char *created;
+  char *created_by;
+  char *author;
+  char *comment;
+  gboolean empty_layer;
+} OstreeOciImageHistory;
+
+struct _OstreeOciImage
+{
+  OstreeJson parent;
+
+  char *created;
+  char *author;
+  char *architecture;
+  char *os;
+  OstreeOciImageRootfs rootfs;
+  OstreeOciImageConfig config;
+  OstreeOciImageHistory **history;
+};
+
+struct _OstreeOciImageClass
+{
+  OstreeJsonClass parent_class;
+};
+
+G_END_DECLS

--- a/src/libostree/ostree-json-oci.c
+++ b/src/libostree/ostree-json-oci.c
@@ -1,0 +1,677 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+#include "string.h"
+
+#include "ostree-json-oci-private.h"
+#include "libglnx.h"
+
+void
+ostree_oci_descriptor_destroy (OstreeOciDescriptor *self)
+{
+  g_free (self->mediatype);
+  g_free (self->digest);
+  g_strfreev (self->urls);
+}
+
+void
+ostree_oci_descriptor_free (OstreeOciDescriptor *self)
+{
+  ostree_oci_descriptor_destroy (self);
+  g_free (self);
+}
+
+static OstreeJsonProp ostree_oci_descriptor_props[] = {
+  OSTREE_JSON_STRING_PROP (OstreeOciDescriptor, mediatype, "mediaType"),
+  OSTREE_JSON_STRING_PROP (OstreeOciDescriptor, digest, "digest"),
+  OSTREE_JSON_INT64_PROP (OstreeOciDescriptor, size, "size"),
+  OSTREE_JSON_STRV_PROP (OstreeOciDescriptor, urls, "urls"),
+  OSTREE_JSON_LAST_PROP
+};
+
+static void
+ostree_oci_manifest_platform_destroy (OstreeOciManifestPlatform *self)
+{
+  g_free (self->architecture);
+  g_free (self->os);
+  g_free (self->os_version);
+  g_strfreev (self->os_features);
+  g_free (self->variant);
+  g_strfreev (self->features);
+}
+
+void
+ostree_oci_manifest_descriptor_destroy (OstreeOciManifestDescriptor *self)
+{
+  ostree_oci_manifest_platform_destroy (&self->platform);
+  ostree_oci_descriptor_destroy (&self->parent);
+}
+
+void
+ostree_oci_manifest_descriptor_free (OstreeOciManifestDescriptor *self)
+{
+  ostree_oci_manifest_descriptor_destroy (self);
+  g_free (self);
+}
+
+static OstreeJsonProp ostree_oci_manifest_platform_props[] = {
+  OSTREE_JSON_STRING_PROP (OstreeOciManifestPlatform, architecture, "architecture"),
+  OSTREE_JSON_STRING_PROP (OstreeOciManifestPlatform, os, "os"),
+  OSTREE_JSON_STRING_PROP (OstreeOciManifestPlatform, os_version, "os.version"),
+  OSTREE_JSON_STRING_PROP (OstreeOciManifestPlatform, variant, "variant"),
+  OSTREE_JSON_STRV_PROP (OstreeOciManifestPlatform, os_features, "os.features"),
+  OSTREE_JSON_STRV_PROP (OstreeOciManifestPlatform, features, "features"),
+  OSTREE_JSON_LAST_PROP
+};
+static OstreeJsonProp ostree_oci_manifest_descriptor_props[] = {
+  OSTREE_JSON_PARENT_PROP (OstreeOciManifestDescriptor, parent, ostree_oci_descriptor_props),
+  OSTREE_JSON_STRUCT_PROP (OstreeOciManifestDescriptor, platform, "platform", ostree_oci_manifest_platform_props),
+  OSTREE_JSON_LAST_PROP
+};
+
+G_DEFINE_TYPE (OstreeOciRef, ostree_oci_ref, OSTREE_TYPE_JSON);
+
+static void
+ostree_oci_ref_finalize (GObject *object)
+{
+  OstreeOciRef *self = OSTREE_OCI_REF (object);
+
+  ostree_oci_descriptor_destroy (&self->descriptor);
+
+  G_OBJECT_CLASS (ostree_oci_ref_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_ref_class_init (OstreeOciRefClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  OstreeJsonClass *json_class = OSTREE_JSON_CLASS (klass);
+  static OstreeJsonProp props[] = {
+    OSTREE_JSON_PARENT_PROP (OstreeOciRef, descriptor, ostree_oci_descriptor_props),
+    OSTREE_JSON_LAST_PROP
+  };
+
+  object_class->finalize = ostree_oci_ref_finalize;
+  json_class->props = props;
+  json_class->mediatype = OSTREE_OCI_MEDIA_TYPE_DESCRIPTOR;
+}
+
+static void
+ostree_oci_ref_init (OstreeOciRef *self)
+{
+}
+
+OstreeOciRef *
+ostree_oci_ref_new (const char *mediatype,
+                    const char *digest,
+                    gint64 size)
+{
+  OstreeOciRef *ref;
+
+  ref = g_object_new (OSTREE_TYPE_OCI_REF, NULL);
+  ref->descriptor.mediatype = g_strdup (mediatype);
+  ref->descriptor.digest = g_strdup (digest);
+  ref->descriptor.size = size;
+
+  return ref;
+}
+
+const char *
+ostree_oci_ref_get_mediatype (OstreeOciRef *self)
+{
+  return self->descriptor.mediatype;
+}
+
+const char *
+ostree_oci_ref_get_digest (OstreeOciRef *self)
+{
+  return self->descriptor.digest;
+}
+
+gint64
+ostree_oci_ref_get_size (OstreeOciRef *self)
+{
+  return self->descriptor.size;
+}
+
+const char **
+ostree_oci_ref_get_urls (OstreeOciRef *self)
+{
+  return (const char **)self->descriptor.urls;
+}
+
+void
+ostree_oci_ref_set_urls (OstreeOciRef *self,
+                         const char **urls)
+{
+  g_strfreev (self->descriptor.urls);
+  self->descriptor.urls = g_strdupv ((char **)urls);
+}
+
+G_DEFINE_TYPE (OstreeOciVersioned, ostree_oci_versioned, OSTREE_TYPE_JSON);
+
+static void
+ostree_oci_versioned_finalize (GObject *object)
+{
+  OstreeOciVersioned *self = OSTREE_OCI_VERSIONED (object);
+
+  g_free (self->mediatype);
+
+  G_OBJECT_CLASS (ostree_oci_versioned_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_versioned_class_init (OstreeOciVersionedClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  OstreeJsonClass *json_class = OSTREE_JSON_CLASS (klass);
+  static OstreeJsonProp props[] = {
+    OSTREE_JSON_INT64_PROP (OstreeOciVersioned, version, "schemaVersion"),
+    OSTREE_JSON_STRING_PROP (OstreeOciVersioned, mediatype, "mediaType"),
+    OSTREE_JSON_LAST_PROP
+  };
+
+  object_class->finalize = ostree_oci_versioned_finalize;
+  json_class->props = props;
+}
+
+static void
+ostree_oci_versioned_init (OstreeOciVersioned *self)
+{
+}
+
+OstreeOciVersioned *
+ostree_oci_versioned_from_json (GBytes *bytes, GError **error)
+{
+  g_autoptr(JsonParser) parser = NULL;
+  JsonNode *root = NULL;
+  const gchar *mediatype;
+  JsonObject *object;
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser,
+                                   g_bytes_get_data (bytes, NULL),
+                                   g_bytes_get_size (bytes),
+                                   error))
+    return NULL;
+
+  root = json_parser_get_root (parser);
+  object = json_node_get_object (root);
+
+  mediatype = json_object_get_string_member (object, "mediaType");
+  if (mediatype == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   "Versioned object lacks mediatype");
+      return NULL;
+    }
+
+  if (strcmp (mediatype, OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFEST) == 0)
+    return (OstreeOciVersioned *) ostree_json_from_node (root, OSTREE_TYPE_OCI_MANIFEST, error);
+
+  if (strcmp (mediatype, OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFESTLIST) == 0)
+    return (OstreeOciVersioned *) ostree_json_from_node (root, OSTREE_TYPE_OCI_MANIFEST_LIST, error);
+
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+               "Unsupported media type %s", mediatype);
+  return NULL;
+}
+
+const char *
+ostree_oci_versioned_get_mediatype (OstreeOciVersioned *self)
+{
+  return self->mediatype;
+}
+
+gint64
+ostree_oci_versioned_get_version (OstreeOciVersioned *self)
+{
+  return self->version;
+}
+
+G_DEFINE_TYPE (OstreeOciManifest, ostree_oci_manifest, OSTREE_TYPE_OCI_VERSIONED);
+
+static void
+ostree_oci_manifest_finalize (GObject *object)
+{
+  OstreeOciManifest *self = (OstreeOciManifest *) object;
+  int i;
+
+  for (i = 0; self->layers != NULL && self->layers[i] != NULL; i++)
+    ostree_oci_descriptor_free (self->layers[i]);
+  g_free (self->layers);
+  ostree_oci_descriptor_destroy (&self->config);
+  if (self->annotations)
+    g_hash_table_destroy (self->annotations);
+
+  G_OBJECT_CLASS (ostree_oci_manifest_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_manifest_class_init (OstreeOciManifestClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  OstreeJsonClass *json_class = OSTREE_JSON_CLASS (klass);
+  static OstreeJsonProp props[] = {
+    OSTREE_JSON_STRUCT_PROP(OstreeOciManifest, config, "config", ostree_oci_descriptor_props),
+    OSTREE_JSON_STRUCTV_PROP(OstreeOciManifest, layers, "layers", ostree_oci_descriptor_props),
+    OSTREE_JSON_STRMAP_PROP(OstreeOciManifest, annotations, "annotations"),
+    OSTREE_JSON_LAST_PROP
+  };
+
+  object_class->finalize = ostree_oci_manifest_finalize;
+  json_class->props = props;
+  json_class->mediatype = OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFEST;
+}
+
+static void
+ostree_oci_manifest_init (OstreeOciManifest *self)
+{
+}
+
+OstreeOciManifest *
+ostree_oci_manifest_new (void)
+{
+  OstreeOciManifest *manifest;
+
+  manifest = g_object_new (OSTREE_TYPE_OCI_MANIFEST, NULL);
+  manifest->parent.version = 2;
+  manifest->parent.mediatype = g_strdup (OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFEST);
+
+  manifest->annotations = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  return manifest;
+}
+
+void
+ostree_oci_manifest_set_config (OstreeOciManifest *self,
+                                OstreeOciRef *ref)
+{
+  g_free (self->config.mediatype);
+  self->config.mediatype = g_strdup (ref->descriptor.mediatype);
+  g_free (self->config.digest);
+  self->config.digest = g_strdup (ref->descriptor.digest);
+  self->config.size = ref->descriptor.size;
+}
+
+static int
+ptrv_count (gpointer *ptrs)
+{
+  int count;
+
+  for (count = 0; ptrs != NULL && ptrs[count] != NULL; count++)
+    ;
+
+  return count;
+}
+
+void
+ostree_oci_manifest_set_layers (OstreeOciManifest *self,
+                                OstreeOciRef **refs)
+{
+  int i, count;
+
+  for (i = 0; self->layers != NULL && self->layers[i] != NULL; i++)
+    ostree_oci_descriptor_free (self->layers[i]);
+  g_free (self->layers);
+
+  count = ptrv_count ((gpointer *)refs);
+
+  self->layers = g_new0 (OstreeOciDescriptor *, count + 1);
+  for (i = 0; i < count; i++)
+    {
+      self->layers[i] = g_new0 (OstreeOciDescriptor, 1);
+      self->layers[i]->mediatype = g_strdup (refs[i]->descriptor.mediatype);
+      self->layers[i]->digest = g_strdup (refs[i]->descriptor.digest);
+      self->layers[i]->size = refs[i]->descriptor.size;
+    }
+}
+
+int
+ostree_oci_manifest_get_n_layers (OstreeOciManifest *self)
+{
+  return ptrv_count ((gpointer *)self->layers);
+}
+
+const char *
+ostree_oci_manifest_get_layer_digest (OstreeOciManifest *self,
+                                      int i)
+{
+  return self->layers[i]->digest;
+}
+
+GHashTable *
+ostree_oci_manifest_get_annotations (OstreeOciManifest *self)
+{
+  return self->annotations;
+}
+
+G_DEFINE_TYPE (OstreeOciManifestList, ostree_oci_manifest_list, OSTREE_TYPE_OCI_VERSIONED);
+
+static void
+ostree_oci_manifest_list_finalize (GObject *object)
+{
+  OstreeOciManifestList *self = (OstreeOciManifestList *) object;
+  int i;
+
+  for (i = 0; self->manifests != NULL && self->manifests[i] != NULL; i++)
+    ostree_oci_manifest_descriptor_free (self->manifests[i]);
+  g_free (self->manifests);
+
+  if (self->annotations)
+    g_hash_table_destroy (self->annotations);
+
+  G_OBJECT_CLASS (ostree_oci_manifest_list_parent_class)->finalize (object);
+}
+
+
+static void
+ostree_oci_manifest_list_class_init (OstreeOciManifestListClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  OstreeJsonClass *json_class = OSTREE_JSON_CLASS (klass);
+  static OstreeJsonProp props[] = {
+    OSTREE_JSON_STRUCTV_PROP(OstreeOciManifestList, manifests, "manifests", ostree_oci_manifest_descriptor_props),
+    OSTREE_JSON_STRMAP_PROP(OstreeOciManifestList, annotations, "annotations"),
+    OSTREE_JSON_LAST_PROP
+  };
+
+  object_class->finalize = ostree_oci_manifest_list_finalize;
+  json_class->props = props;
+  json_class->mediatype = OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFESTLIST;
+}
+
+static void
+ostree_oci_manifest_list_init (OstreeOciManifestList *self)
+{
+}
+
+G_DEFINE_TYPE (OstreeOciImage, ostree_oci_image, OSTREE_TYPE_JSON);
+
+static void
+ostree_oci_image_rootfs_destroy (OstreeOciImageRootfs *self)
+{
+  g_free (self->type);
+  g_strfreev (self->diff_ids);
+}
+
+static void
+ostree_oci_image_config_destroy (OstreeOciImageConfig *self)
+{
+  g_free (self->user);
+  g_free (self->working_dir);
+  g_strfreev (self->env);
+  g_strfreev (self->cmd);
+  g_strfreev (self->entrypoint);
+  g_strfreev (self->exposed_ports);
+  g_strfreev (self->volumes);
+  if (self->labels)
+    g_hash_table_destroy (self->labels);
+}
+
+static void
+ostree_oci_image_history_free (OstreeOciImageHistory *self)
+{
+  g_free (self->created);
+  g_free (self->created_by);
+  g_free (self->author);
+  g_free (self->comment);
+  g_free (self);
+}
+
+static void
+ostree_oci_image_finalize (GObject *object)
+{
+  OstreeOciImage *self = (OstreeOciImage *) object;
+  int i;
+
+  g_free (self->created);
+  g_free (self->author);
+  g_free (self->architecture);
+  g_free (self->os);
+  ostree_oci_image_rootfs_destroy (&self->rootfs);
+  ostree_oci_image_config_destroy (&self->config);
+
+  for (i = 0; self->history != NULL && self->history[i] != NULL; i++)
+    ostree_oci_image_history_free (self->history[i]);
+  g_free (self->history);
+
+  G_OBJECT_CLASS (ostree_oci_image_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_image_class_init (OstreeOciImageClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  OstreeJsonClass *json_class = OSTREE_JSON_CLASS (klass);
+  static OstreeJsonProp config_props[] = {
+    OSTREE_JSON_STRING_PROP (OstreeOciImageConfig, user, "User"),
+    OSTREE_JSON_INT64_PROP (OstreeOciImageConfig, memory, "Memory"),
+    OSTREE_JSON_INT64_PROP (OstreeOciImageConfig, memory_swap, "MemorySwap"),
+    OSTREE_JSON_INT64_PROP (OstreeOciImageConfig, cpu_shares, "CpuShares"),
+    OSTREE_JSON_BOOLMAP_PROP (OstreeOciImageConfig, exposed_ports, "ExposedPorts"),
+    OSTREE_JSON_STRV_PROP (OstreeOciImageConfig, env, "Env"),
+    OSTREE_JSON_STRV_PROP (OstreeOciImageConfig, entrypoint, "Entrypoint"),
+    OSTREE_JSON_STRV_PROP (OstreeOciImageConfig, cmd, "Cmd"),
+    OSTREE_JSON_BOOLMAP_PROP (OstreeOciImageConfig, volumes, "Volumes"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImageConfig, working_dir, "WorkingDir"),
+    OSTREE_JSON_STRMAP_PROP(OstreeOciImageConfig, labels, "Labels"),
+    OSTREE_JSON_LAST_PROP
+  };
+  static OstreeJsonProp rootfs_props[] = {
+    OSTREE_JSON_STRING_PROP (OstreeOciImageRootfs, type, "type"),
+    OSTREE_JSON_STRV_PROP (OstreeOciImageRootfs, diff_ids, "diff_ids"),
+    OSTREE_JSON_LAST_PROP
+  };
+  static OstreeJsonProp history_props[] = {
+    OSTREE_JSON_STRING_PROP (OstreeOciImageHistory, created, "created"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImageHistory, created_by, "created_by"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImageHistory, author, "author"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImageHistory, comment, "comment"),
+    OSTREE_JSON_BOOL_PROP (OstreeOciImageHistory, empty_layer, "empty_layer"),
+    OSTREE_JSON_LAST_PROP
+  };
+  static OstreeJsonProp props[] = {
+    OSTREE_JSON_STRING_PROP (OstreeOciImage, created, "created"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImage, author, "author"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImage, architecture, "architecture"),
+    OSTREE_JSON_STRING_PROP (OstreeOciImage, os, "os"),
+    OSTREE_JSON_STRUCT_PROP (OstreeOciImage, config, "config", config_props),
+    OSTREE_JSON_STRUCT_PROP (OstreeOciImage, rootfs, "rootfs", rootfs_props),
+    OSTREE_JSON_STRUCTV_PROP (OstreeOciImage, history, "history", history_props),
+    OSTREE_JSON_LAST_PROP
+  };
+
+  object_class->finalize = ostree_oci_image_finalize;
+  json_class->props = props;
+  json_class->mediatype = OSTREE_OCI_MEDIA_TYPE_IMAGE_CONFIG;
+}
+
+static void
+ostree_oci_image_init (OstreeOciImage *self)
+{
+}
+
+OstreeOciImage *
+ostree_oci_image_new (void)
+{
+  OstreeOciImage *image;
+  GTimeVal stamp;
+
+  stamp.tv_sec = time (NULL);
+  stamp.tv_usec = 0;
+
+  image = g_object_new (OSTREE_TYPE_OCI_IMAGE, NULL);
+
+  /* Some default values */
+  image->created = g_time_val_to_iso8601 (&stamp);
+  image->architecture = g_strdup ("arm64");
+  image->os = g_strdup ("linux");
+
+  image->rootfs.type = g_strdup ("layers");
+  image->rootfs.diff_ids = g_new0 (char *, 1);
+
+  return image;
+}
+
+void
+ostree_oci_image_set_created (OstreeOciImage *image,
+                              const char *created)
+{
+  g_free (image->created);
+  image->created = g_strdup (created);
+}
+
+void
+ostree_oci_image_set_architecture (OstreeOciImage *image,
+                                   const char *arch)
+{
+  g_free (image->architecture);
+  image->architecture = g_strdup (arch);
+}
+
+void
+ostree_oci_image_set_os (OstreeOciImage *image,
+                         const char *os)
+{
+  g_free (image->os);
+  image->os = g_strdup (os);
+}
+
+void
+ostree_oci_image_set_layers (OstreeOciImage *image,
+                             const char **layers)
+{
+  g_strfreev (image->rootfs.diff_ids);
+  image->rootfs.diff_ids = g_strdupv ((char **)layers);
+}
+
+static void
+add_annotation (GHashTable *annotations, const char *key, const char *value)
+{
+    g_hash_table_replace (annotations,
+                          g_strdup (key),
+                          g_strdup (value));
+}
+
+void
+ostree_oci_add_annotations_for_commit (GHashTable *annotations,
+                                       const char *commit,
+                                       GVariant *commit_data)
+{
+  if (commit)
+    add_annotation (annotations,"io.github.ostreedev.Commit", commit);
+
+  if (commit_data)
+    {
+      g_autofree char *parent = NULL;
+      g_autofree char *subject = NULL;
+      g_autofree char *body = NULL;
+      g_autofree char *timestamp = NULL;
+      g_autoptr(GVariant) metadata = NULL;
+      int i;
+
+      parent = ostree_commit_get_parent (commit_data);
+      if (parent)
+        add_annotation (annotations, "io.github.ostreedev.ParentCommit", parent);
+
+      metadata = g_variant_get_child_value (commit_data, 0);
+      for (i = 0; i < g_variant_n_children (metadata); i++)
+        {
+          g_autoptr(GVariant) elm = g_variant_get_child_value (metadata, i);
+          g_autoptr(GVariant) value = g_variant_get_child_value (elm, 1);
+          g_autofree char *key = NULL;
+          g_autofree char *full_key = NULL;
+          g_autofree char *value_base64 = NULL;
+
+          g_variant_get_child (elm, 0, "s", &key);
+          full_key = g_strdup_printf ("io.github.ostreedev.Metadata.%s", key);
+
+          value_base64 = g_base64_encode (g_variant_get_data (value), g_variant_get_size (value));
+          add_annotation (annotations, full_key, value_base64);
+        }
+
+      timestamp = g_strdup_printf ("%"G_GUINT64_FORMAT, ostree_commit_get_timestamp (commit_data));
+      add_annotation (annotations, "io.github.ostreedev.Timestamp", timestamp);
+
+      g_variant_get_child (commit_data, 3, "s", &subject);
+      add_annotation (annotations, "io.github.ostreedev.Subject", subject);
+
+      g_variant_get_child (commit_data, 4, "s", &body);
+      add_annotation (annotations, "io.github.ostreedev.Body", body);
+   }
+}
+
+void
+ostree_oci_parse_commit_annotations (GHashTable *annotations,
+                                     guint64 *out_timestamp,
+                                     char **out_subject,
+                                     char **out_body,
+                                     char **out_commit,
+                                     char **out_parent_commit,
+                                     GVariantBuilder *metadata_builder)
+{
+  const char *oci_timestamp, *oci_subject, *oci_body, *oci_parent_commit, *oci_commit;
+  GHashTableIter iter;
+  gpointer _key, _value;
+
+  oci_commit = g_hash_table_lookup (annotations, "io.github.ostreedev.Commit");
+  if (oci_commit != NULL && out_commit != NULL && *out_commit == NULL)
+    *out_commit = g_strdup (oci_commit);
+
+  oci_parent_commit = g_hash_table_lookup (annotations, "io.github.ostreedev.ParentCommit");
+  if (oci_parent_commit != NULL && out_parent_commit != NULL && *out_parent_commit == NULL)
+    *out_parent_commit = g_strdup (oci_parent_commit);
+
+  oci_timestamp = g_hash_table_lookup (annotations, "io.github.ostreedev.Timestamp");
+  if (oci_timestamp != NULL && out_timestamp != NULL && *out_timestamp == 0)
+    *out_timestamp = g_ascii_strtoull (oci_timestamp, NULL, 10);
+
+  oci_subject = g_hash_table_lookup (annotations, "io.github.ostreedev.Subject");
+  if (oci_subject != NULL && out_subject != NULL && *out_subject == NULL)
+    *out_subject = g_strdup (oci_subject);
+
+  oci_body = g_hash_table_lookup (annotations, "io.github.ostreedev.Body");
+  if (oci_body != NULL && out_body != NULL && *out_body == NULL)
+    *out_body = g_strdup (oci_body);
+
+  if (metadata_builder)
+    {
+      g_hash_table_iter_init (&iter, annotations);
+      while (g_hash_table_iter_next (&iter, &_key, &_value))
+        {
+          const char *key = _key;
+          const char *value = _value;
+          guchar *bin;
+          gsize bin_len;
+          g_autoptr(GVariant) data = NULL;
+
+          if (!g_str_has_prefix (key, "io.github.ostreedev.Metadata."))
+            continue;
+          key += strlen ("io.github.ostreedev.Metadata.");
+
+          bin = g_base64_decode (value, &bin_len);
+          data = g_variant_ref_sink (g_variant_new_from_data (G_VARIANT_TYPE("v"), bin, bin_len, FALSE,
+                                                              g_free, bin));
+          g_variant_builder_add (metadata_builder, "{s@v}", key, data);
+        }
+    }
+}

--- a/src/libostree/ostree-json-oci.h
+++ b/src/libostree/ostree-json-oci.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include "ostree-json.h"
+
+G_BEGIN_DECLS
+
+#define OSTREE_OCI_MEDIA_TYPE_DESCRIPTOR "application/vnd.oci.descriptor.v1+json"
+#define OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFEST "application/vnd.oci.image.manifest.v1+json"
+#define OSTREE_OCI_MEDIA_TYPE_IMAGE_MANIFESTLIST "application/vnd.oci.image.manifest.list.v1+json"
+#define OSTREE_OCI_MEDIA_TYPE_IMAGE_LAYER "application/vnd.oci.image.layer.v1.tar+gzip"
+#define OSTREE_OCI_MEDIA_TYPE_IMAGE_LAYER_NONDISTRIBUTABLE "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+#define OSTREE_OCI_MEDIA_TYPE_IMAGE_CONFIG "application/vnd.oci.image.config.v1+json"
+
+#define OSTREE_TYPE_OCI_REF ostree_oci_ref_get_type ()
+_OSTREE_PUBLIC
+G_DECLARE_FINAL_TYPE (OstreeOciRef, ostree_oci_ref, OSTREE_OCI, REF, OstreeJson)
+
+_OSTREE_PUBLIC
+OstreeOciRef * ostree_oci_ref_new (const char *mediatype,
+                                   const char *digest,
+                                   gint64 size);
+_OSTREE_PUBLIC
+const char * ostree_oci_ref_get_mediatype (OstreeOciRef *self);
+_OSTREE_PUBLIC
+const char * ostree_oci_ref_get_digest (OstreeOciRef *self);
+_OSTREE_PUBLIC
+gint64 ostree_oci_ref_get_size (OstreeOciRef *self);
+_OSTREE_PUBLIC
+const char ** ostree_oci_ref_get_urls (OstreeOciRef *self);
+_OSTREE_PUBLIC
+void ostree_oci_ref_set_urls (OstreeOciRef *self,
+                              const char **urls);
+
+#define OSTREE_TYPE_OCI_VERSIONED ostree_oci_versioned_get_type ()
+_OSTREE_PUBLIC
+G_DECLARE_FINAL_TYPE (OstreeOciVersioned, ostree_oci_versioned, OSTREE_OCI, VERSIONED, OstreeJson)
+
+_OSTREE_PUBLIC
+OstreeOciVersioned * ostree_oci_versioned_from_json (GBytes *bytes,
+                                                     GError **error);
+
+_OSTREE_PUBLIC
+const char * ostree_oci_versioned_get_mediatype (OstreeOciVersioned *self);
+_OSTREE_PUBLIC
+gint64 ostree_oci_versioned_get_version (OstreeOciVersioned *self);
+
+#define OSTREE_TYPE_OCI_MANIFEST ostree_oci_manifest_get_type ()
+_OSTREE_PUBLIC
+G_DECLARE_FINAL_TYPE (OstreeOciManifest, ostree_oci_manifest, OSTREE, OCI_MANIFEST, OstreeOciVersioned)
+
+_OSTREE_PUBLIC
+OstreeOciManifest * ostree_oci_manifest_new (void);
+_OSTREE_PUBLIC
+void ostree_oci_manifest_set_config (OstreeOciManifest *self,
+                                     OstreeOciRef *ref);
+_OSTREE_PUBLIC
+void ostree_oci_manifest_set_layers (OstreeOciManifest *self,
+                                     OstreeOciRef **refs);
+_OSTREE_PUBLIC
+int ostree_oci_manifest_get_n_layers (OstreeOciManifest *self);
+_OSTREE_PUBLIC
+const char *ostree_oci_manifest_get_layer_digest (OstreeOciManifest *self,
+                                                  int i);
+
+_OSTREE_PUBLIC
+GHashTable * ostree_oci_manifest_get_annotations (OstreeOciManifest *self);
+
+
+#define OSTREE_TYPE_OCI_MANIFEST_LIST ostree_oci_manifest_list_get_type ()
+_OSTREE_PUBLIC
+G_DECLARE_FINAL_TYPE (OstreeOciManifestList, ostree_oci_manifest_list, OSTREE, OCI_MANIFEST_LIST, OstreeOciVersioned)
+
+#define OSTREE_TYPE_OCI_IMAGE ostree_oci_image_get_type ()
+_OSTREE_PUBLIC
+G_DECLARE_FINAL_TYPE (OstreeOciImage, ostree_oci_image, OSTREE, OCI_IMAGE, OstreeJson)
+
+_OSTREE_PUBLIC
+OstreeOciImage * ostree_oci_image_new (void);
+
+_OSTREE_PUBLIC
+void ostree_oci_image_set_created (OstreeOciImage *image,
+                                   const char *created);
+_OSTREE_PUBLIC
+void ostree_oci_image_set_architecture (OstreeOciImage *image,
+                                        const char *arch);
+_OSTREE_PUBLIC
+void ostree_oci_image_set_os (OstreeOciImage *image,
+                              const char *os);
+_OSTREE_PUBLIC
+void ostree_oci_image_set_layers (OstreeOciImage *image,
+                                  const char **layers);
+
+
+_OSTREE_PUBLIC
+void ostree_oci_add_annotations_for_commit (GHashTable *annotations,
+                                            const char *commit,
+                                            GVariant *commit_data);
+_OSTREE_PUBLIC
+void ostree_oci_parse_commit_annotations (GHashTable *annotations,
+                                          guint64 *out_timestamp,
+                                          char **out_subject,
+                                          char **out_body,
+                                          char **out_commit,
+                                          char **out_parent_commit,
+                                          GVariantBuilder *metadata_builder);

--- a/src/libostree/ostree-json-private.h
+++ b/src/libostree/ostree-json-private.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include <ostree-json.h>
+#include <json-glib/json-glib.h>
+
+/* These were added in 1.1.2, add fallbacks if they are not there */
+
+#if !JSON_CHECK_VERSION(1,1,2)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonArray, json_array_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonBuilder, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonGenerator, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonNode, json_node_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonObject, json_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonParser, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonPath, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonReader, g_object_unref)
+#endif
+
+G_BEGIN_DECLS
+
+typedef enum {
+  OSTREE_JSON_PROP_TYPE_PARENT,
+  OSTREE_JSON_PROP_TYPE_INT64,
+  OSTREE_JSON_PROP_TYPE_BOOL,
+  OSTREE_JSON_PROP_TYPE_STRING,
+  OSTREE_JSON_PROP_TYPE_STRUCT,
+  OSTREE_JSON_PROP_TYPE_STRUCTV,
+  OSTREE_JSON_PROP_TYPE_STRV,
+  OSTREE_JSON_PROP_TYPE_STRMAP,
+  OSTREE_JSON_PROP_TYPE_BOOLMAP,
+} OstreeJsonPropType;
+
+struct _OstreeJsonProp {
+  const char *name;
+  gsize offset;
+  OstreeJsonPropType type;
+  gpointer type_data;
+  gpointer type_data2;
+} ;
+
+#define OSTREE_JSON_STRING_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_STRING }
+#define OSTREE_JSON_INT64_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_INT64 }
+#define OSTREE_JSON_BOOL_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_BOOL }
+#define OSTREE_JSON_STRV_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_STRV }
+#define OSTREE_JSON_STRMAP_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_STRMAP }
+#define OSTREE_JSON_BOOLMAP_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_BOOLMAP }
+#define OSTREE_JSON_STRUCT_PROP(_struct, _field, _name, _props) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_STRUCT, (gpointer)_props}
+#define OSTREE_JSON_PARENT_PROP(_struct, _field, _props) \
+  { "parent", G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_PARENT, (gpointer)_props}
+#define OSTREE_JSON_STRUCTV_PROP(_struct, _field, _name, _props) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), OSTREE_JSON_PROP_TYPE_STRUCTV, (gpointer)_props, (gpointer) sizeof (**((_struct *) 0)->_field) }
+#define OSTREE_JSON_LAST_PROP { NULL }
+
+OstreeJson *ostree_json_from_node (JsonNode       *node,
+                                   GType           type,
+                                   GError        **error);
+
+JsonNode   *ostree_json_to_node   (OstreeJson  *self);
+
+G_END_DECLS

--- a/src/libostree/ostree-json.c
+++ b/src/libostree/ostree-json.c
@@ -1,0 +1,596 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+#include "string.h"
+
+#include "ostree-json-private.h"
+#include "libglnx.h"
+
+G_DEFINE_TYPE (OstreeJson, ostree_json, G_TYPE_OBJECT);
+
+static void
+ostree_json_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (ostree_json_parent_class)->finalize (object);
+}
+
+static void
+ostree_json_class_init (OstreeJsonClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = ostree_json_finalize;
+}
+
+static void
+ostree_json_init (OstreeJson *self)
+{
+}
+
+static gboolean
+demarshal (JsonNode *parent_node,
+           const char *name,
+           gpointer dest,
+           OstreeJsonPropType type,
+           gpointer type_data,
+           gpointer type_data2,
+           GError **error)
+{
+  JsonObject *parent_object;
+  JsonNode *node;
+
+  if (type != OSTREE_JSON_PROP_TYPE_PARENT)
+    {
+      parent_object = json_node_get_object (parent_node);
+      node = json_object_get_member (parent_object, name);
+    }
+  else
+    node = parent_node;
+
+  if (node == NULL || JSON_NODE_TYPE (node) == JSON_NODE_NULL)
+    return TRUE;
+
+  switch (type)
+    {
+    case OSTREE_JSON_PROP_TYPE_STRING:
+      if (!JSON_NODE_HOLDS_VALUE (node) ||
+          json_node_get_value_type (node) != G_TYPE_STRING)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting string for property %s", name);
+          return FALSE;
+        }
+      *(char **)dest = g_strdup (json_node_get_string (node));
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_INT64:
+      if (!JSON_NODE_HOLDS_VALUE (node) ||
+          json_node_get_value_type (node) != G_TYPE_INT64)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting int64 for property %s", name);
+          return FALSE;
+        }
+      *(gint64 *)dest = json_node_get_int (node);
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_BOOL:
+      if (!JSON_NODE_HOLDS_VALUE (node) ||
+          json_node_get_value_type (node) != G_TYPE_BOOLEAN)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting bool for property %s", name);
+          return FALSE;
+        }
+      *(gboolean *)dest = json_node_get_boolean (node);
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_STRV:
+      if (!JSON_NODE_HOLDS_ARRAY (node))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting array for property %s", name);
+          return FALSE;
+        }
+      {
+        JsonArray *array = json_node_get_array (node);
+        guint i, array_len = json_array_get_length (array);
+        g_autoptr(GPtrArray) str_array = g_ptr_array_sized_new (array_len + 1);
+
+        for (i = 0; i < array_len; i++)
+          {
+            JsonNode *val = json_array_get_element (array, i);
+
+            if (JSON_NODE_TYPE (val) != JSON_NODE_VALUE)
+              continue;
+
+            if (json_node_get_string (val) != NULL)
+              g_ptr_array_add (str_array, (gpointer) g_strdup (json_node_get_string (val)));
+          }
+
+        g_ptr_array_add (str_array, NULL);
+        *(char ***)dest = (char **)g_ptr_array_free (g_steal_pointer (&str_array), FALSE);
+      }
+
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_PARENT:
+    case OSTREE_JSON_PROP_TYPE_STRUCT:
+      if (!JSON_NODE_HOLDS_OBJECT (node))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting object for property %s", name);
+          return FALSE;
+        }
+      {
+        OstreeJsonProp *struct_props = type_data;
+        int i;
+
+        for (i = 0; struct_props[i].name != NULL; i++)
+          {
+            if (!demarshal (node, struct_props[i].name,
+                            G_STRUCT_MEMBER_P (dest, struct_props[i].offset),
+                            struct_props[i].type, struct_props[i].type_data, struct_props[i].type_data2,
+                            error))
+              return FALSE;
+          }
+      }
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_STRUCTV:
+      if (!JSON_NODE_HOLDS_ARRAY (node))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting array for property %s", name);
+          return FALSE;
+        }
+      {
+        JsonArray *array = json_node_get_array (node);
+        guint array_len = json_array_get_length (array);
+        OstreeJsonProp *struct_props = type_data;
+        g_autoptr(GPtrArray) obj_array = g_ptr_array_sized_new (array_len + 1);
+        int i, j;
+        gboolean res = TRUE;
+
+        for (j = 0; res && j < array_len; j++)
+          {
+            JsonNode *val = json_array_get_element (array, j);
+            gpointer new_element;
+
+            if (!JSON_NODE_HOLDS_OBJECT (val))
+              {
+                g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                             "Expecting object elemen for property %s", name);
+                res = FALSE;
+                break;
+              }
+
+            new_element = g_malloc0 ((gsize)type_data2);
+            g_ptr_array_add (obj_array, new_element);
+
+            for (i = 0; struct_props[i].name != NULL; i++)
+              {
+                if (!demarshal (val, struct_props[i].name,
+                                G_STRUCT_MEMBER_P (new_element, struct_props[i].offset),
+                                struct_props[i].type, struct_props[i].type_data, struct_props[i].type_data2,
+                                error))
+                  {
+                    res = FALSE;
+                    break;
+                  }
+              }
+
+          }
+
+        /* NULL terminate */
+        g_ptr_array_add (obj_array, NULL);
+
+        /* We always set the array, even if it is partial, because we don't know how
+           to free what we demarshalled so far */
+        *(gpointer *)dest = (gpointer *)g_ptr_array_free (g_steal_pointer (&obj_array), FALSE);
+        return res;
+      }
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_STRMAP:
+      if (!JSON_NODE_HOLDS_OBJECT (node))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting object for property %s", name);
+          return FALSE;
+        }
+      {
+        g_autoptr(GHashTable) h = NULL;
+        JsonObject *object = json_node_get_object (node);
+        g_autoptr(GList) members = NULL;
+        GList *l;
+
+        h = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+        members = json_object_get_members (object);
+        for (l = members; l != NULL; l = l->next)
+          {
+            const char *member_name = l->data;
+            JsonNode *val;
+            const char *val_str;
+
+            val = json_object_get_member (object, member_name);
+            val_str = json_node_get_string (val);
+            if (val_str == NULL)
+              {
+                g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                             "Wrong type for string member %s", member_name);
+                return FALSE;
+              }
+
+            g_hash_table_insert (h, g_strdup (member_name), g_strdup (val_str));
+          }
+
+        *(GHashTable **)dest = g_steal_pointer (&h);
+      }
+      break;
+
+    case OSTREE_JSON_PROP_TYPE_BOOLMAP:
+      if (!JSON_NODE_HOLDS_OBJECT (node))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Expecting object for property %s", name);
+          return FALSE;
+        }
+      {
+        JsonObject *object = json_node_get_object (node);
+        g_autoptr(GPtrArray) res = g_ptr_array_new_with_free_func (g_free);
+        g_autoptr(GList) members = NULL;
+        GList *l;
+
+        members = json_object_get_members (object);
+        for (l = members; l != NULL; l = l->next)
+          {
+            const char *member_name = l->data;
+
+            g_ptr_array_add (res, g_strdup (member_name));
+          }
+
+        g_ptr_array_add (res, NULL);
+
+        *(char ***)dest =  (char **)g_ptr_array_free (g_steal_pointer (&res), FALSE);
+      }
+      break;
+
+    default:
+      g_assert_not_reached ();
+    }
+
+  return TRUE;
+}
+
+OstreeJson *
+ostree_json_from_node (JsonNode *node, GType type, GError **error)
+{
+  g_autoptr(OstreeJson) json = NULL;
+  OstreeJsonProp *props = NULL;
+  gpointer class;
+  int i;
+
+  /* We should handle these before we get here */
+  g_assert (node != NULL);
+  g_assert (JSON_NODE_TYPE (node) != JSON_NODE_NULL);
+
+  if (JSON_NODE_TYPE (node) != JSON_NODE_OBJECT)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Expecting a JSON object, but the node is of type `%s'",
+                   json_node_type_name (node));
+      return NULL;
+    }
+
+  json = g_object_new (type, NULL);
+
+  class = OSTREE_JSON_GET_CLASS (json);
+  while (OSTREE_JSON_CLASS (class)->props != NULL)
+    {
+      props = OSTREE_JSON_CLASS (class)->props;
+      for (i = 0; props[i].name != NULL; i++)
+        {
+          if (!demarshal (node, props[i].name,
+                          G_STRUCT_MEMBER_P (json, props[i].offset),
+                          props[i].type, props[i].type_data, props[i].type_data2,
+                          error))
+            return NULL;
+        }
+      class = g_type_class_peek_parent (class);
+    }
+
+  return g_steal_pointer (&json);
+}
+
+OstreeJson *
+ostree_json_from_bytes (GBytes         *bytes,
+                        GType           type,
+                        GError        **error)
+{
+  g_autoptr(JsonParser) parser = NULL;
+  JsonNode *root = NULL;
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser,
+                                   g_bytes_get_data (bytes, NULL),
+                                   g_bytes_get_size (bytes),
+                                   error))
+    return NULL;
+
+  root = json_parser_get_root (parser);
+
+  return ostree_json_from_node (root, type, error);
+}
+
+static JsonNode *
+marshal (JsonObject *parent,
+         const char *name,
+         gpointer src,
+         OstreeJsonPropType type,
+         gpointer type_data)
+{
+  JsonNode *retval = NULL;
+
+  switch (type)
+    {
+    case OSTREE_JSON_PROP_TYPE_STRING:
+      {
+        const char *str = *(const char **)src;
+        if (str != NULL)
+          retval = json_node_init_string (json_node_alloc (), str);
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_INT64:
+      {
+        retval = json_node_init_int (json_node_alloc (), *(gint64 *)src);
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_BOOL:
+      {
+        gboolean val = *(gboolean *)src;
+        if (val)
+          retval = json_node_init_boolean (json_node_alloc (), val);
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_STRV:
+      {
+        char **strv = *(char ***)src;
+        int i;
+        JsonArray *array;
+
+        if (strv != NULL && strv[0] != NULL)
+          {
+            array = json_array_sized_new (g_strv_length (strv));
+            for (i = 0; strv[i] != NULL; i++)
+              {
+                JsonNode *str = json_node_new (JSON_NODE_VALUE);
+
+                json_node_set_string (str, strv[i]);
+                json_array_add_element (array, str);
+              }
+
+            retval = json_node_init_array (json_node_alloc (), array);
+            json_array_unref (array);
+          }
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_PARENT:
+    case OSTREE_JSON_PROP_TYPE_STRUCT:
+      {
+        OstreeJsonProp *struct_props = type_data;
+        JsonObject *obj;
+        int i;
+
+        if (type == OSTREE_JSON_PROP_TYPE_PARENT)
+          obj = parent;
+        else
+          obj = json_object_new ();
+
+        for (i = 0; struct_props[i].name != NULL; i++)
+          {
+            JsonNode *val = marshal (obj, struct_props[i].name,
+                                     G_STRUCT_MEMBER_P (src, struct_props[i].offset),
+                                     struct_props[i].type, struct_props[i].type_data);
+
+            if (val == NULL)
+              continue;
+
+            json_object_set_member (obj, struct_props[i].name, val);
+          }
+
+        if (type != OSTREE_JSON_PROP_TYPE_PARENT)
+          {
+            retval = json_node_new (JSON_NODE_OBJECT);
+            json_node_take_object (retval, obj);
+          }
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_STRUCTV:
+      {
+        OstreeJsonProp *struct_props = type_data;
+        gpointer *structv = *(gpointer **)src;
+        int i, j;
+        JsonArray *array;
+
+        if (structv != NULL && structv[0] != NULL)
+          {
+            array = json_array_new ();
+            for (j = 0; structv[j] != NULL; j++)
+              {
+                JsonObject *obj = json_object_new ();
+                JsonNode *node;
+
+                for (i = 0; struct_props[i].name != NULL; i++)
+                  {
+                    JsonNode *val = marshal (obj, struct_props[i].name,
+                                             G_STRUCT_MEMBER_P (structv[j], struct_props[i].offset),
+                                             struct_props[i].type, struct_props[i].type_data);
+
+                    if (val == NULL)
+                      continue;
+
+                    json_object_set_member (obj, struct_props[i].name, val);
+                  }
+
+                node = json_node_new (JSON_NODE_OBJECT);
+                json_node_take_object (node, obj);
+                json_array_add_element (array, node);
+              }
+
+            retval = json_node_init_array (json_node_alloc (), array);
+            json_array_unref (array);
+          }
+
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_STRMAP:
+      {
+        GHashTable *map = *(GHashTable **)src;
+
+        if (map != NULL && g_hash_table_size (map) > 0)
+          {
+            GHashTableIter iter;
+            gpointer _key, _value;
+            JsonObject *object;
+
+            object = json_object_new ();
+
+            g_hash_table_iter_init (&iter, map);
+            while (g_hash_table_iter_next (&iter, &_key, &_value))
+              {
+                const char *key = _key;
+                const char *value = _value;
+                JsonNode *str = json_node_new (JSON_NODE_VALUE);
+
+                json_node_set_string (str, value);
+                json_object_set_member (object, key, str);
+              }
+
+            retval = json_node_init_object (json_node_alloc (), object);
+            json_object_unref (object);
+          }
+        break;
+      }
+
+    case OSTREE_JSON_PROP_TYPE_BOOLMAP:
+      {
+        char **map = *(char ***)src;
+
+        if (map != NULL && map[0] != NULL)
+          {
+            JsonObject *object;
+            int i;
+
+            object = json_object_new ();
+
+            for (i = 0; map[i] != NULL; i++)
+              {
+                const char *element = map[i];
+                JsonObject *empty_o = json_object_new ();
+                JsonNode *empty = json_node_init_object (json_node_alloc (), empty_o);
+                json_object_unref (empty_o);
+
+                json_object_set_member (object, element, empty);
+              }
+
+            retval = json_node_init_object (json_node_alloc (), object);
+            json_object_unref (object);
+          }
+        break;
+      }
+
+    default:
+      g_assert_not_reached ();
+    }
+
+  return retval;
+}
+
+static void
+marshal_props_for_class (OstreeJson *self,
+                         OstreeJsonClass *class,
+                         JsonObject *obj)
+{
+  OstreeJsonProp *props = NULL;
+  int i;
+  gpointer parent_class;
+
+  parent_class = g_type_class_peek_parent (class);
+
+  if (OSTREE_JSON_CLASS (parent_class)->props != NULL)
+    marshal_props_for_class (self,
+                             OSTREE_JSON_CLASS(parent_class),
+                             obj);
+
+  props = OSTREE_JSON_CLASS (class)->props;
+  for (i = 0; props[i].name != NULL; i++)
+    {
+      JsonNode *val = marshal (obj, props[i].name,
+                               G_STRUCT_MEMBER_P (self, props[i].offset),
+                               props[i].type, props[i].type_data);
+
+      if (val == NULL)
+        continue;
+
+      json_object_set_member (obj, props[i].name, val);
+    }
+}
+
+JsonNode *
+ostree_json_to_node (OstreeJson *self)
+{
+  JsonNode *retval;
+  JsonObject *obj;
+  gpointer class;
+
+  if (self == NULL)
+    json_node_new (JSON_NODE_NULL);
+
+  obj = json_object_new ();
+
+  class = OSTREE_JSON_GET_CLASS (self);
+  marshal_props_for_class (self, OSTREE_JSON_CLASS (class), obj);
+
+  retval = json_node_new (JSON_NODE_OBJECT);
+  json_node_take_object (retval, obj);
+
+  return retval;
+}
+
+GBytes *
+ostree_json_to_bytes (OstreeJson  *self)
+{
+  g_autoptr(JsonNode) node = NULL;
+  char *str;
+
+  node = ostree_json_to_node (OSTREE_JSON (self));
+
+  str = json_to_string (node, TRUE);
+  return g_bytes_new_take (str, strlen (str));
+}

--- a/src/libostree/ostree-json.h
+++ b/src/libostree/ostree-json.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include "ostree-core.h"
+#include "ostree-types.h"
+
+G_BEGIN_DECLS
+
+#define OSTREE_TYPE_JSON ostree_json_get_type ()
+
+typedef struct _OstreeJsonProp OstreeJsonProp;
+
+_OSTREE_PUBLIC
+G_DECLARE_DERIVABLE_TYPE (OstreeJson, ostree_json, OSTREE, JSON, GObject)
+
+struct _OstreeJsonClass {
+  GObjectClass parent_class;
+
+  OstreeJsonProp *props;
+  const char *mediatype;
+};
+
+_OSTREE_PUBLIC
+OstreeJson *ostree_json_from_bytes (GBytes         *bytes,
+                                    GType           type,
+                                    GError        **error);
+
+_OSTREE_PUBLIC
+GBytes     *ostree_json_to_bytes  (OstreeJson  *self);
+
+G_END_DECLS

--- a/src/libostree/ostree-oci-registry.c
+++ b/src/libostree/ostree-oci-registry.c
@@ -1,0 +1,1042 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include "libglnx.h"
+
+#include <libsoup/soup.h>
+#include "ostree-oci-registry.h"
+#include "ostree-json-oci-private.h"
+#include "ostree-fetcher.h"
+#include "ostree-libarchive-private.h"
+#include "otutil.h"
+
+/* We don't get these due to defining SOUP_VERSION_MAX_ALLOWED, so we
+   define our own versions: */
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupSession, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupMessage, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequest, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequestHTTP, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupURI, soup_uri_free)
+
+#define MAX_JSON_SIZE (1024 * 1024)
+
+static void ostree_oci_registry_initable_iface_init (GInitableIface *iface);
+
+struct OstreeOciRegistry
+{
+  GObject parent;
+
+  gboolean for_write;
+  gboolean valid;
+  char *uri;
+  int tmp_dfd;
+
+  /* Local repos */
+  int dfd;
+
+  /* Remote repos */
+  OstreeFetcher *fetcher;
+  SoupURI *base_uri;
+};
+
+typedef struct
+{
+  GObjectClass parent_class;
+} OstreeOciRegistryClass;
+
+enum {
+  PROP_0,
+
+  PROP_URI,
+  PROP_FOR_WRITE,
+  PROP_TMP_DFD,
+};
+
+G_DEFINE_TYPE_WITH_CODE (OstreeOciRegistry, ostree_oci_registry, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE,
+                                                ostree_oci_registry_initable_iface_init))
+
+static void
+ostree_oci_registry_finalize (GObject *object)
+{
+  OstreeOciRegistry *self = OSTREE_OCI_REGISTRY (object);
+
+  if (self->dfd != -1)
+    close (self->dfd);
+
+  g_clear_pointer (&self->base_uri, soup_uri_free);
+  g_clear_object (&self->fetcher);
+  g_free (self->uri);
+
+  G_OBJECT_CLASS (ostree_oci_registry_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_registry_set_property (GObject         *object,
+                                  guint            prop_id,
+                                  const GValue    *value,
+                                  GParamSpec      *pspec)
+{
+  OstreeOciRegistry *self = OSTREE_OCI_REGISTRY (object);
+  const char *uri;
+
+  switch (prop_id)
+    {
+    case PROP_URI:
+      /* Ensure the base uri ends with a / so relative urls work */
+      uri = g_value_get_string (value);
+      if (g_str_has_prefix (uri, "/"))
+        self->uri = g_strdup (uri);
+      else
+        self->uri = g_strconcat (uri, "/", NULL);
+      break;
+    case PROP_FOR_WRITE:
+      self->for_write = g_value_get_boolean (value);
+      break;
+    case PROP_TMP_DFD:
+      self->tmp_dfd = g_value_get_int (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+ostree_oci_registry_get_property (GObject         *object,
+                                  guint            prop_id,
+                                  GValue          *value,
+                                  GParamSpec      *pspec)
+{
+  OstreeOciRegistry *self = OSTREE_OCI_REGISTRY (object);
+
+  switch (prop_id)
+    {
+    case PROP_URI:
+      g_value_set_string (value, self->uri);
+      break;
+    case PROP_FOR_WRITE:
+      g_value_set_boolean (value, self->for_write);
+      break;
+    case PROP_TMP_DFD:
+      g_value_set_int (value, self->tmp_dfd);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+ostree_oci_registry_class_init (OstreeOciRegistryClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = ostree_oci_registry_finalize;
+  object_class->get_property = ostree_oci_registry_get_property;
+  object_class->set_property = ostree_oci_registry_set_property;
+
+  g_object_class_install_property (object_class,
+                                   PROP_URI,
+                                   g_param_spec_string ("uri",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property (object_class,
+                                   PROP_TMP_DFD,
+                                   g_param_spec_int ("tmp-dfd",
+                                                     "",
+                                                     "",
+                                                     -1, G_MAXINT, -1,
+                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property (object_class,
+                                   PROP_FOR_WRITE,
+                                   g_param_spec_boolean ("for-write",
+                                                         "",
+                                                         "",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+}
+
+static void
+ostree_oci_registry_init (OstreeOciRegistry *self)
+{
+  self->dfd = -1;
+  self->tmp_dfd = -1;
+}
+
+OstreeOciRegistry *
+ostree_oci_registry_new (const char *uri,
+                         gboolean for_write,
+                         int tmp_dfd,
+                         GCancellable *cancellable,
+                         GError **error)
+{
+  OstreeOciRegistry *oci_registry;
+
+  oci_registry = g_initable_new (OSTREE_TYPE_OCI_REGISTRY,
+                                 cancellable, error,
+                                 "uri", uri,
+                                 "for-write", for_write,
+                                 "tmp-dfd", tmp_dfd,
+                                 NULL);
+
+  return oci_registry;
+}
+
+static int
+local_open_file (int dfd,
+                 const char *subpath,
+                 GCancellable *cancellable,
+                 GError **error)
+{
+  glnx_fd_close int fd = -1;
+
+  do
+    fd = openat (dfd, subpath, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOCTTY);
+  while (G_UNLIKELY (fd == -1 && errno == EINTR));
+  if (fd == -1)
+    {
+      glnx_set_error_from_errno (error);
+      return -1;
+    }
+
+  return glnx_steal_fd (&fd);
+}
+
+static GBytes *
+local_load_file (int dfd,
+                 const char *subpath,
+                 GCancellable *cancellable,
+                 GError **error)
+{
+  glnx_fd_close int fd = -1;
+
+  fd = local_open_file (dfd, subpath, cancellable, error);
+  if (fd == -1)
+    return NULL;
+
+  return glnx_fd_readall_bytes (fd, cancellable, error);
+}
+
+static GBytes *
+remote_load_file (OstreeFetcher *fetcher,
+                  SoupURI *base,
+                  const char *subpath,
+                  GCancellable *cancellable,
+                  GError **error)
+{
+  g_autoptr(SoupURI) uri = NULL;
+  g_autoptr(GBytes) bytes = NULL;
+
+  uri = soup_uri_new_with_base (base, subpath);
+  if (uri == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   "Invalid relative url %s", subpath);
+      return NULL;
+    }
+
+  if (!_ostree_fetcher_request_uri_to_membuf (fetcher, uri, FALSE, FALSE,
+                                              &bytes, MAX_JSON_SIZE,
+                                              cancellable, error))
+    return NULL;
+
+  return g_steal_pointer (&bytes);
+}
+
+static GBytes *
+ostree_oci_registry_load_file (OstreeOciRegistry  *self,
+                               const char *subpath,
+                               GCancellable *cancellable,
+                               GError **error)
+{
+  if (self->dfd != -1)
+    return local_load_file (self->dfd, subpath, cancellable, error);
+  else
+    return remote_load_file (self->fetcher, self->base_uri, subpath, cancellable, error);
+}
+
+static JsonNode *
+parse_json (GBytes *bytes, GCancellable *cancellable, GError **error)
+{
+  g_autoptr(JsonParser) parser = NULL;
+  JsonNode *root = NULL;
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser,
+                                   g_bytes_get_data (bytes, NULL),
+                                   g_bytes_get_size (bytes),
+                                   error))
+    return NULL;
+
+  root = json_parser_get_root (parser);
+  if (root == NULL || !JSON_NODE_HOLDS_OBJECT (root))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Invalid json, no root object");
+      return NULL;
+    }
+
+  return json_node_ref (root);
+}
+
+static gboolean
+verify_oci_version (GBytes *oci_layout_bytes, GCancellable *cancellable, GError **error)
+{
+  const char *version;
+  g_autoptr(JsonNode) node = NULL;
+  JsonObject *oci_layout;
+
+  node = parse_json (oci_layout_bytes, cancellable, error);
+  if (node == NULL)
+    return FALSE;
+
+  oci_layout = json_node_get_object (node);
+
+  version = json_object_get_string_member (oci_layout, "imageLayoutVersion");
+  if (version == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Unsupported oci repo: oci-layout version missing");
+      return FALSE;
+    }
+
+  if (strcmp (version, "1.0.0") != 0)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                   "Unsupported existing oci-layout version %s (only 1.0.0 supported)", version);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+ostree_oci_registry_ensure_local (OstreeOciRegistry *self,
+                                  gboolean for_write,
+                                  GCancellable *cancellable,
+                                  GError **error)
+{
+  g_autoptr(GFile) dir = g_file_new_for_uri (self->uri);
+  glnx_fd_close int local_dfd = -1;
+  int dfd;
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GBytes) oci_layout_bytes = NULL;
+
+  if (self->dfd != -1)
+    dfd = self->dfd;
+  else
+    {
+      if (!glnx_opendirat (AT_FDCWD, ot_file_get_path_cached (dir),
+                           TRUE, &local_dfd, &local_error))
+        {
+          if (for_write && g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+            {
+              g_clear_error (&local_error);
+
+              if (!glnx_shutil_mkdir_p_at (AT_FDCWD, ot_file_get_path_cached (dir), 0755, cancellable, error))
+                return FALSE;
+
+              if (!glnx_opendirat (AT_FDCWD, ot_file_get_path_cached (dir),
+                                   TRUE, &local_dfd, error))
+                return FALSE;
+            }
+          else
+            {
+              g_propagate_error (error, g_steal_pointer (&local_error));
+              return FALSE;
+            }
+        }
+
+      dfd = local_dfd;
+    }
+
+  if (for_write)
+    {
+      if (!glnx_shutil_mkdir_p_at (dfd, "blobs/sha256", 0755, cancellable, error))
+        return FALSE;
+
+      if (!glnx_shutil_mkdir_p_at (dfd, "refs", 0755, cancellable, error))
+        return FALSE;
+    }
+
+  oci_layout_bytes = local_load_file (dfd, "oci-layout", cancellable, &local_error);
+  if (oci_layout_bytes == NULL)
+    {
+      if (for_write && g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        {
+          const char *new_layout_data = "{\"imageLayoutVersion\": \"1.0.0\"}";
+
+          g_clear_error (&local_error);
+
+          if (!glnx_file_replace_contents_at (dfd, "oci-layout",
+                                              (const guchar *)new_layout_data,
+                                              strlen (new_layout_data),
+                                              0,
+                                              cancellable, error))
+            return FALSE;
+        }
+      else
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+    }
+  else if (!verify_oci_version (oci_layout_bytes, cancellable, error))
+    return FALSE;
+
+  if (self->dfd == -1 && local_dfd != -1)
+    self->dfd = glnx_steal_fd (&local_dfd);
+
+  return TRUE;
+}
+
+static gboolean
+ostree_oci_registry_ensure_remote (OstreeOciRegistry *self,
+                                   gboolean for_write,
+                                   GCancellable *cancellable,
+                                   GError **error)
+{
+  g_autoptr(OstreeFetcher) fetcher = NULL;
+  g_autoptr(SoupURI) baseuri = NULL;
+  g_autoptr(GBytes) oci_layout_bytes = NULL;
+
+  if (for_write)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                   "Writes are not supported for remote OCI registries");
+      return FALSE;
+    }
+
+  baseuri = soup_uri_new (self->uri);
+  if (baseuri == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   "Invalid url %s", self->uri);
+      return FALSE;
+    }
+
+  fetcher = _ostree_fetcher_new (self->tmp_dfd, 0);
+
+  oci_layout_bytes = remote_load_file (fetcher, baseuri, "oci-layout", cancellable, error);
+  if (oci_layout_bytes == NULL)
+    return FALSE;
+
+  if (!verify_oci_version (oci_layout_bytes, cancellable, error))
+    return FALSE;
+
+  self->base_uri = g_steal_pointer (&baseuri);
+  self->fetcher = g_steal_pointer (&fetcher);
+
+  return TRUE;
+}
+
+static gboolean
+ostree_oci_registry_initable_init (GInitable     *initable,
+                                   GCancellable  *cancellable,
+                                   GError       **error)
+{
+  OstreeOciRegistry *self = OSTREE_OCI_REGISTRY (initable);
+  glnx_fd_close int dfd = -1;
+  g_autoptr(GFile) registry_blobs = NULL;
+  g_autoptr(GFile) registry_blobs_sha256 = NULL;
+  g_autoptr(GFile) registry_refs = NULL;
+  g_autoptr(JsonObject) oci_layout = NULL;
+  g_autoptr(GError) local_error = NULL;
+  gboolean res;
+
+  if (self->tmp_dfd == -1 &&
+      !glnx_opendirat (AT_FDCWD, "/tmp", TRUE, &self->tmp_dfd, error))
+    return FALSE;
+
+  if (g_str_has_prefix (self->uri, "file:/"))
+    res = ostree_oci_registry_ensure_local (self, self->for_write, cancellable, error);
+  else
+    res = ostree_oci_registry_ensure_remote (self, self->for_write, cancellable, error);
+
+  if (!res)
+    return FALSE;
+
+  self->valid = TRUE;
+
+  return TRUE;
+}
+
+static void
+ostree_oci_registry_initable_iface_init (GInitableIface *iface)
+{
+  iface->init = ostree_oci_registry_initable_init;
+}
+
+
+OstreeOciRef *
+ostree_oci_registry_load_ref (OstreeOciRegistry  *self,
+                              const char         *ref,
+                              GCancellable       *cancellable,
+                              GError            **error)
+{
+  g_autoptr(GBytes) bytes = NULL;
+  g_autofree char *subpath = g_strdup_printf ("refs/%s", ref);
+  g_autoptr(OstreeJson) descriptor = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  g_assert (self->valid);
+
+  bytes = ostree_oci_registry_load_file (self, subpath, cancellable, &local_error);
+  if (bytes == NULL)
+    {
+      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     "No tag '%s' found", ref);
+      else
+        g_propagate_error (error, g_steal_pointer (&local_error));
+      return NULL;
+    }
+
+  return (OstreeOciRef *)ostree_json_from_bytes (bytes, OSTREE_TYPE_OCI_REF, error);
+}
+
+gboolean
+ostree_oci_registry_set_ref (OstreeOciRegistry  *self,
+                             const char         *ref,
+                             OstreeOciRef       *data,
+                             GCancellable       *cancellable,
+                             GError            **error)
+{
+  g_autoptr(GBytes) bytes = NULL;
+  g_autofree char *subpath = g_strdup_printf ("refs/%s", ref);
+
+  g_assert (self->valid);
+
+  bytes = ostree_json_to_bytes (OSTREE_JSON (data));
+
+  if (!glnx_file_replace_contents_at (self->dfd, subpath,
+                                      g_bytes_get_data (bytes, NULL),
+                                      g_bytes_get_size (bytes),
+                                      0, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+typedef struct {
+  OstreeOciRegistry *self;
+  char *digest;
+} DownloadData;
+
+static void
+download_data_free (DownloadData *data)
+{
+  g_object_unref (data->self);
+  g_free (data->digest);
+  g_free (data);
+}
+
+static void
+download_blob_cb (GObject *source_object,
+                  GAsyncResult *res,
+                  gpointer user_data)
+{
+  g_autoptr(GTask) task = G_TASK (user_data);
+  DownloadData *data = g_task_get_task_data (task);
+  OstreeOciRegistry *self = data->self;
+  g_autofree char *name = NULL;
+  g_autofree char *checksum = NULL;
+  GError *local_error = NULL;
+  int fd;
+
+  name = _ostree_fetcher_mirrored_request_with_partial_finish (OSTREE_FETCHER (source_object),
+                                                               res, &local_error);
+  if (name == NULL)
+    {
+      g_task_return_error (task, local_error);
+      return;
+    }
+
+  fd = local_open_file (_ostree_fetcher_get_dfd (self->fetcher), name,
+                        g_task_get_cancellable (task), &local_error);
+  if (fd == -1)
+    {
+      g_task_return_error (task, local_error);
+      return;
+    }
+
+  checksum = ot_checksum_file_at (_ostree_fetcher_get_dfd (self->fetcher), name, G_CHECKSUM_SHA256,
+                                  g_task_get_cancellable (task), &local_error);
+
+  (void) unlinkat (self->tmp_dfd, name, 0);
+
+  if (checksum == NULL)
+    {
+      g_task_return_error (task, local_error);
+      return;
+    }
+
+  if (strcmp (checksum, data->digest + strlen ("sha256:")) != 0)
+    {
+      g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "Checksum digest did not match (%s != %s)", data->digest, checksum);
+      return;
+    }
+
+  g_task_return_int (task, fd);
+}
+
+void
+ostree_oci_registry_download_blob (OstreeOciRegistry    *self,
+                                   const char           *digest,
+                                   GCancellable         *cancellable,
+                                   GAsyncReadyCallback   callback,
+                                   gpointer              user_data)
+{
+  g_autoptr(GTask) task = NULL;
+  g_autofree char *subpath = NULL;
+  g_autoptr(SoupURI) uri = NULL;
+  g_autoptr(GPtrArray) mirrorlist = g_ptr_array_new ();
+  DownloadData *data;
+
+  g_assert (self->valid);
+
+  task = g_task_new (self, cancellable, callback, user_data);
+
+  data = g_new0 (DownloadData, 1);
+  data->self = g_object_ref (self);
+  data->digest = g_ascii_strdown (digest, -1);
+  g_task_set_task_data (task, data, (GDestroyNotify) download_data_free);
+
+  if (!g_str_has_prefix (digest, "sha256:"))
+    {
+      g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                               "Unsupported digest type %s", digest);
+      return;
+    }
+
+  subpath = g_strdup_printf ("blobs/sha256/%s", digest + strlen ("sha256:"));
+
+  if (self->dfd != -1)
+    {
+      GError *local_error = NULL;
+      int fd;
+
+      /* Local case, trust checksum */
+
+      fd = local_open_file (self->dfd, subpath, cancellable, &local_error);
+      if (fd == -1)
+        {
+          g_task_return_error (task, local_error);
+          return;
+        }
+      g_task_return_int (task, fd);
+      return;
+    }
+  else
+    {
+      /* remote case, download and verify */
+
+      g_ptr_array_add (mirrorlist, self->base_uri);
+      _ostree_fetcher_mirrored_request_with_partial_async (self->fetcher,
+                                                           mirrorlist,
+                                                           subpath,
+                                                           G_MAXINT64,
+                                                           0,
+                                                           cancellable,
+                                                           download_blob_cb,
+                                                           g_steal_pointer (&task));
+    }
+}
+
+int
+ostree_oci_registry_download_blob_finish (OstreeOciRegistry  *self,
+                                          GAsyncResult       *result,
+                                          GError            **error)
+{
+  return g_task_propagate_int (G_TASK (result), error);
+}
+
+GBytes *
+ostree_oci_registry_load_blob (OstreeOciRegistry  *self,
+                               const char         *digest,
+                               GCancellable       *cancellable,
+                               GError            **error)
+{
+  g_autofree char *subpath = NULL;
+
+  g_assert (self->valid);
+
+  if (!g_str_has_prefix (digest, "sha256:"))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                   "Unsupported digest type %s", digest);
+      return NULL;
+    }
+
+  subpath = g_strdup_printf ("blobs/sha256/%s", digest + strlen ("sha256:"));
+
+  return ostree_oci_registry_load_file (self, subpath, cancellable, error);
+}
+
+char *
+ostree_oci_registry_store_blob (OstreeOciRegistry  *self,
+                                GBytes             *data,
+                                GCancellable       *cancellable,
+                                GError            **error)
+{
+  g_autofree char *sha256 = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, data);
+  g_autofree char *subpath = NULL;
+
+  g_assert (self->valid);
+
+  subpath = g_strdup_printf ("blobs/sha256/%s", sha256);
+  if (!glnx_file_replace_contents_at (self->dfd, subpath,
+                                      g_bytes_get_data (data, NULL),
+                                      g_bytes_get_size (data),
+                                      0, cancellable, error))
+    return FALSE;
+
+  return g_strdup_printf ("sha256:%s", sha256);
+}
+
+OstreeOciRef *
+ostree_oci_registry_store_json (OstreeOciRegistry    *self,
+                                OstreeJson           *json,
+                                GCancellable         *cancellable,
+                                GError              **error)
+{
+  GBytes *bytes = ostree_json_to_bytes (json);
+  g_autofree char *digest = NULL;
+
+  digest = ostree_oci_registry_store_blob (self, bytes, cancellable, error);
+  if (digest == NULL)
+    return NULL;
+
+  return ostree_oci_ref_new (OSTREE_JSON_CLASS (OSTREE_JSON_GET_CLASS (json))->mediatype, digest, g_bytes_get_size (bytes));
+}
+
+OstreeOciVersioned *
+ostree_oci_registry_load_versioned (OstreeOciRegistry  *self,
+                                    const char         *digest,
+                                    GCancellable       *cancellable,
+                                    GError            **error)
+{
+  g_autoptr(GBytes) bytes = NULL;
+
+  g_assert (self->valid);
+
+  bytes = ostree_oci_registry_load_blob (self, digest, cancellable, error);
+  if (bytes == NULL)
+    return NULL;
+
+  return ostree_oci_versioned_from_json (bytes, error);
+}
+
+struct OstreeOciLayerWriter
+{
+  GObject parent;
+
+  OstreeOciRegistry *registry;
+
+  GChecksum *uncompressed_checksum;
+  GChecksum *compressed_checksum;
+  struct archive *archive;
+  GZlibCompressor *compressor;
+  guint64 uncompressed_size;
+  guint64 compressed_size;
+  char *tmp_path;
+  int tmp_fd;
+};
+
+typedef struct
+{
+  GObjectClass parent_class;
+} OstreeOciLayerWriterClass;
+
+G_DEFINE_TYPE (OstreeOciLayerWriter, ostree_oci_layer_writer, G_TYPE_OBJECT)
+
+static gboolean
+propagate_libarchive_error (GError      **error,
+                            struct archive *a)
+{
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+               "%s", archive_error_string (a));
+  return FALSE;
+}
+
+static void
+ostree_oci_layer_writer_reset (OstreeOciLayerWriter *self)
+{
+  if (self->tmp_path)
+    {
+      (void) unlinkat (self->registry->dfd, self->tmp_path, 0);
+      g_free (self->tmp_path);
+      self->tmp_path = NULL;
+    }
+
+  if (self->tmp_fd != -1)
+    {
+      close (self->tmp_fd);
+      self->tmp_fd = -1;
+    }
+
+  g_clear_object (&self->compressor);
+
+  g_checksum_reset (self->uncompressed_checksum);
+  g_checksum_reset (self->compressed_checksum);
+
+  if (self->archive)
+    {
+      archive_write_free (self->archive);
+      self->archive = NULL;
+    }
+}
+
+
+static void
+ostree_oci_layer_writer_finalize (GObject *object)
+{
+  OstreeOciLayerWriter *self = OSTREE_OCI_LAYER_WRITER (object);
+
+  ostree_oci_layer_writer_reset (self);
+
+  g_checksum_free (self->compressed_checksum);
+  g_checksum_free (self->uncompressed_checksum);
+
+  g_clear_object (&self->registry);
+
+  G_OBJECT_CLASS (ostree_oci_layer_writer_parent_class)->finalize (object);
+}
+
+static void
+ostree_oci_layer_writer_class_init (OstreeOciLayerWriterClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = ostree_oci_layer_writer_finalize;
+
+}
+
+static void
+ostree_oci_layer_writer_init (OstreeOciLayerWriter *self)
+{
+  self->uncompressed_checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  self->compressed_checksum = g_checksum_new (G_CHECKSUM_SHA256);
+}
+
+static int
+ostree_oci_layer_writer_open_cb (struct archive *archive,
+                                 void *client_data)
+{
+  return ARCHIVE_OK;
+}
+
+static gssize
+ostree_oci_layer_writer_compress (OstreeOciLayerWriter *self,
+                                  const void *buffer,
+                                  size_t length,
+                                  gboolean at_end)
+{
+  guchar compressed_buffer[8192];
+  GConverterResult res;
+  gsize total_bytes_read, bytes_read, bytes_written, to_write_len;
+  guchar *to_write;
+  g_autoptr(GError) local_error = NULL;
+  GConverterFlags flags = 0;
+  bytes_read = 0;
+
+  total_bytes_read = 0;
+
+  if (at_end)
+    flags |= G_CONVERTER_INPUT_AT_END;
+
+  do
+    {
+      res = g_converter_convert (G_CONVERTER (self->compressor),
+                                 buffer, length,
+                                 compressed_buffer, sizeof (compressed_buffer),
+                                 flags, &bytes_read, &bytes_written,
+                                 &local_error);
+      if (res == G_CONVERTER_ERROR)
+        {
+          archive_set_error (self->archive, EIO, "%s", local_error->message);
+          return -1;
+        }
+
+      g_checksum_update (self->uncompressed_checksum, buffer, bytes_read);
+      g_checksum_update (self->compressed_checksum, compressed_buffer, bytes_written);
+      self->uncompressed_size += bytes_read;
+      self->compressed_size += bytes_written;
+
+      to_write_len = bytes_written;
+      to_write = compressed_buffer;
+      while (to_write_len > 0)
+        {
+          ssize_t res = write (self->tmp_fd, to_write, to_write_len);
+          if (res <= 0)
+            {
+              if (errno == EINTR)
+                continue;
+              archive_set_error (self->archive, errno, "Write error");
+              return -1;
+            }
+
+          to_write_len -= res;
+          to_write += res;
+        }
+
+      total_bytes_read += bytes_read;
+    }
+  while ((length > 0 && bytes_read == 0) || /* Repeat if we consumed nothing */
+         (at_end && res != G_CONVERTER_FINISHED)); /* Or until finished if at_end */
+
+  return total_bytes_read;
+}
+
+static ssize_t
+ostree_oci_layer_writer_write_cb (struct archive *archive,
+                                   void *client_data,
+                                   const void *buffer,
+                                   size_t length)
+{
+  OstreeOciLayerWriter *self = OSTREE_OCI_LAYER_WRITER (client_data);
+
+  return ostree_oci_layer_writer_compress (self, buffer, length, FALSE);
+}
+
+static int
+ostree_oci_layer_writer_close_cb (struct archive *archive,
+                                   void *client_data)
+{
+  OstreeOciLayerWriter *self = OSTREE_OCI_LAYER_WRITER (client_data);
+  gssize res;
+  char buffer[1] = {0};
+
+  res = ostree_oci_layer_writer_compress (self, &buffer, 0, TRUE);
+  if (res < 0)
+    return ARCHIVE_FATAL;
+
+  return ARCHIVE_OK;
+}
+
+OstreeOciLayerWriter *
+ostree_oci_registry_write_layer (OstreeOciRegistry    *self,
+                                 GCancellable         *cancellable,
+                                 GError              **error)
+{
+  g_autoptr(OstreeOciLayerWriter) oci_layer_writer = NULL;
+  ot_cleanup_write_archive struct archive *a = NULL;
+  glnx_fd_close int tmp_fd = -1;
+  g_autofree char *tmp_path = NULL;
+
+  g_assert (self->valid);
+
+  if (!self->for_write)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                   "Write not supported to registry");
+      return NULL;
+    }
+
+  oci_layer_writer = g_object_new (OSTREE_TYPE_OCI_LAYER_WRITER, NULL);
+  oci_layer_writer->registry = g_object_ref (self);
+
+  if (!glnx_open_tmpfile_linkable_at (self->dfd,
+                                      "blobs/sha256",
+                                      O_WRONLY,
+                                      &tmp_fd,
+                                      &tmp_path,
+                                      error))
+    return NULL;
+
+  a = archive_write_new ();
+  if (archive_write_set_format_gnutar (a) != ARCHIVE_OK ||
+      archive_write_add_filter_none (a) != ARCHIVE_OK)
+    {
+      propagate_libarchive_error (error, a);
+      return NULL;
+    }
+
+  if (archive_write_open (a, oci_layer_writer,
+                          ostree_oci_layer_writer_open_cb,
+                          ostree_oci_layer_writer_write_cb,
+                          ostree_oci_layer_writer_close_cb) != ARCHIVE_OK)
+    {
+      propagate_libarchive_error (error, a);
+      return NULL;
+    }
+
+  ostree_oci_layer_writer_reset (oci_layer_writer);
+
+  oci_layer_writer->archive = g_steal_pointer (&a);
+  oci_layer_writer->tmp_fd = glnx_steal_fd (&tmp_fd);
+  oci_layer_writer->tmp_path = g_steal_pointer (&tmp_path);
+  oci_layer_writer->compressor = g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP, -1);
+
+  return g_steal_pointer (&oci_layer_writer);
+}
+
+gboolean
+ostree_oci_layer_writer_close (OstreeOciLayerWriter  *self,
+                               char                  **uncompressed_digest_out,
+                               OstreeOciRef         **ref_out,
+                               GCancellable           *cancellable,
+                               GError                **error)
+{
+  g_autofree char *path = NULL;
+
+  if (archive_write_close (self->archive) != ARCHIVE_OK)
+    return propagate_libarchive_error (error, self->archive);
+
+  path = g_strdup_printf ("blobs/sha256/%s",
+                          g_checksum_get_string (self->compressed_checksum));
+
+  if (!glnx_link_tmpfile_at (self->registry->dfd,
+                             GLNX_LINK_TMPFILE_REPLACE,
+                             self->tmp_fd,
+                             self->tmp_path,
+                             self->registry->dfd,
+                             path,
+                             error))
+    return FALSE;
+
+  close (self->tmp_fd);
+  self->tmp_fd = -1;
+  g_free (self->tmp_path);
+  self->tmp_path = NULL;
+
+  if (uncompressed_digest_out != NULL)
+    *uncompressed_digest_out = g_strdup_printf ("sha256:%s", g_checksum_get_string (self->uncompressed_checksum));
+  if (ref_out != NULL)
+    {
+      g_autofree char *digest = g_strdup_printf ("sha256:%s", g_checksum_get_string (self->compressed_checksum));
+
+      *ref_out = ostree_oci_ref_new (OSTREE_OCI_MEDIA_TYPE_IMAGE_LAYER, digest, self->compressed_size);
+    }
+
+  return TRUE;
+}
+
+struct archive *
+ostree_oci_layer_writer_get_archive (OstreeOciLayerWriter  *self)
+{
+  return self->archive;
+}

--- a/src/libostree/ostree-oci-registry.h
+++ b/src/libostree/ostree-oci-registry.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include "libglnx/libglnx.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <archive.h>
+#include "ostree-json-oci.h"
+
+#define OSTREE_TYPE_OCI_REGISTRY ostree_oci_registry_get_type ()
+#define OSTREE_OCI_REGISTRY(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSTREE_TYPE_OCI_REGISTRY, OstreeOciRegistry))
+#define OSTREE_IS_OCI_REGISTRY(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSTREE_TYPE_OCI_REGISTRY))
+
+_OSTREE_PUBLIC
+GType ostree_oci_registry_get_type (void);
+
+typedef struct OstreeOciRegistry OstreeOciRegistry;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeOciRegistry, g_object_unref)
+
+#define OSTREE_TYPE_OCI_LAYER_WRITER ostree_oci_layer_writer_get_type ()
+#define OSTREE_OCI_LAYER_WRITER(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSTREE_TYPE_OCI_LAYER_WRITER, OstreeOciLayerWriter))
+#define OSTREE_IS_OCI_LAYER_WRITER(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSTREE_TYPE_OCI_LAYER_WRITER))
+
+_OSTREE_PUBLIC
+GType ostree_oci_layer_writer_get_type (void);
+
+typedef struct OstreeOciLayerWriter OstreeOciLayerWriter;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeOciLayerWriter, g_object_unref)
+
+_OSTREE_PUBLIC
+OstreeOciRegistry  *ostree_oci_registry_new                  (const char           *uri,
+                                                              gboolean              for_write,
+                                                              int                   tmp_dfd,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+OstreeOciRef       *ostree_oci_registry_load_ref             (OstreeOciRegistry    *self,
+                                                              const char           *ref,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+gboolean            ostree_oci_registry_set_ref              (OstreeOciRegistry    *self,
+                                                              const char           *ref,
+                                                              OstreeOciRef         *data,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+void                ostree_oci_registry_download_blob        (OstreeOciRegistry    *self,
+                                                              const char           *digest,
+                                                              GCancellable         *cancellable,
+                                                              GAsyncReadyCallback   callback,
+                                                              gpointer              user_data);
+_OSTREE_PUBLIC
+int                 ostree_oci_registry_download_blob_finish (OstreeOciRegistry    *self,
+                                                              GAsyncResult         *result,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+GBytes             *ostree_oci_registry_load_blob            (OstreeOciRegistry    *self,
+                                                              const char           *digest,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+char *              ostree_oci_registry_store_blob           (OstreeOciRegistry    *self,
+                                                              GBytes               *data,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+OstreeOciRef *      ostree_oci_registry_store_json           (OstreeOciRegistry    *self,
+                                                              OstreeJson           *json,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+OstreeOciVersioned *ostree_oci_registry_load_versioned       (OstreeOciRegistry    *self,
+                                                              const char           *digest,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+_OSTREE_PUBLIC
+OstreeOciLayerWriter *ostree_oci_registry_write_layer        (OstreeOciRegistry    *self,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
+
+
+_OSTREE_PUBLIC
+struct archive *ostree_oci_layer_writer_get_archive (OstreeOciLayerWriter  *self);
+_OSTREE_PUBLIC
+gboolean        ostree_oci_layer_writer_close       (OstreeOciLayerWriter  *self,
+                                                     char                 **uncompressed_digest_out,
+                                                     OstreeOciRef         **ref_out,
+                                                     GCancellable          *cancellable,
+                                                     GError               **error);

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -604,6 +604,14 @@ gboolean      ostree_repo_write_archive_to_mtree (OstreeRepo                   *
                                                   gboolean                      autocreate_parents,
                                                   GCancellable                 *cancellable,
                                                   GError                      **error);
+_OSTREE_PUBLIC
+gboolean      ostree_repo_write_archive_fd_to_mtree (OstreeRepo                   *self,
+                                                     int                           fd,
+                                                     OstreeMutableTree            *mtree,
+                                                     OstreeRepoCommitModifier     *modifier,
+                                                     gboolean                      autocreate_parents,
+                                                     GCancellable                 *cancellable,
+                                                     GError                      **error);
 
 /**
  * OstreeRepoImportArchiveOptions: (skip)

--- a/src/libostree/ostree.h
+++ b/src/libostree/ostree.h
@@ -31,5 +31,6 @@
 #include <ostree-bootconfig-parser.h>
 #include <ostree-diff.h>
 #include <ostree-gpg-verify-result.h>
+#include <ostree-oci-registry.h>
 
 #include <ostree-autocleanups.h>

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_test_repository "bare"
+
+echo "1..2"
+
+$OSTREE export --oci --oci-tag=exported --output=oci-dir test2
+
+assert_has_file oci-dir/oci-layout
+assert_has_dir oci-dir/blobs/sha256
+assert_has_dir oci-dir/refs
+assert_file_has_content oci-dir/refs/exported "application/vnd.oci.image.manifest.v1+json"
+
+for i in oci-dir/blobs/sha256/*; do
+     echo $(basename $i) $i >> sums
+done
+sha256sum -c sums
+    
+echo "ok export oci"
+
+$OSTREE --repo=repo2 init
+
+$OSTREE commit --repo=repo2 --oci --oci-tag=exported --branch=imported oci-dir
+
+$OSTREE checkout --repo=repo2 imported checked-out
+
+assert_has_file checked-out/firstfile
+assert_has_file checked-out/baz/cow
+assert_file_has_content checked-out/baz/cow moo
+assert_has_file checked-out/baz/deeper/ohyeah
+
+echo "ok commit oci"
+
+
+


### PR DESCRIPTION
This series adds support to libostree to handle OCI repositories, and then adds support for the --oci argument the export and commit commands.

This allows you to export an ostree commit to an OCI image, and import single-layer OCI images into an ostree commit. Additionally, if the imported OCI image was exported from ostree the commit info like summary, body, timestamp and metadata are re-imported.

I'm putting this here not really as a request to pull it as-is, but rather as a starting point for a discussion on this.