### PR TITLE
[merged] build: Make libsoup optional again

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -80,16 +80,21 @@ ostree_SOURCES += \
 ostree_SOURCES += \
 	src/ostree/ot-remote-builtins.h \
 	src/ostree/ot-remote-builtin-add.c \
-	src/ostree/ot-remote-builtin-add-cookie.c \
 	src/ostree/ot-remote-builtin-delete.c \
-	src/ostree/ot-remote-builtin-delete-cookie.c \
 	src/ostree/ot-remote-builtin-gpg-import.c \
 	src/ostree/ot-remote-builtin-list.c \
-	src/ostree/ot-remote-builtin-list-cookies.c \
 	src/ostree/ot-remote-builtin-show-url.c \
 	src/ostree/ot-remote-builtin-refs.c \
 	src/ostree/ot-remote-builtin-summary.c \
 	$(NULL)
+
+if USE_LIBSOUP
+ostree_SOURCES += \
+	src/ostree/ot-remote-builtin-add-cookie.c \
+	src/ostree/ot-remote-builtin-delete-cookie.c \
+	src/ostree/ot-remote-builtin-list-cookies.c \
+	$(NULL)
+endif
 
 src/ostree/parse-datetime.c: src/ostree/parse-datetime.y Makefile
 	$(AM_V_GEN) $(YACC) $< -o $@

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -44,7 +44,6 @@ dist_test_scripts = \
 	tests/test-pull-subpath.sh \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \
-	tests/test-remote-cookies.sh \
 	tests/test-remote-headers.sh \
 	tests/test-remote-gpg-import.sh \
 	tests/test-commit-sign.sh \
@@ -99,6 +98,10 @@ if BUILDOPT_FUSE
 dist_test_scripts += tests/test-rofiles-fuse.sh
 else
 EXTRA_DIST += tests/test-rofiles-fuse.sh
+endif
+
+if USE_LIBSOUP
+dist_test_scripts += tests/test-remote-cookies.sh
 endif
 
 # This one uses corrupt-repo-ref.js

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -33,13 +33,15 @@ typedef struct {
 
 static OstreeRemoteCommand remote_subcommands[] = {
   { "add", ot_remote_builtin_add },
-  { "add-cookie", ot_remote_builtin_add_cookie },
   { "delete", ot_remote_builtin_delete },
-  { "delete-cookie", ot_remote_builtin_delete_cookie },
   { "show-url", ot_remote_builtin_show_url },
   { "list", ot_remote_builtin_list },
-  { "list-cookies", ot_remote_builtin_list_cookies },
   { "gpg-import", ot_remote_builtin_gpg_import },
+#ifdef HAVE_LIBSOUP
+  { "add-cookie", ot_remote_builtin_add_cookie },
+  { "delete-cookie", ot_remote_builtin_delete_cookie },
+  { "list-cookies", ot_remote_builtin_list_cookies },
+#endif
   { "refs", ot_remote_builtin_refs },
   { "summary", ot_remote_builtin_summary },
   { NULL, NULL }

--- a/src/ostree/ot-remote-builtins.h
+++ b/src/ostree/ot-remote-builtins.h
@@ -25,12 +25,14 @@
 G_BEGIN_DECLS
 
 gboolean ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError **error);
-gboolean ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error);
-gboolean ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error);
+#ifdef HAVE_LIBSOUP
+gboolean ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error);
+#endif
 gboolean ot_remote_builtin_show_url (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error);


### PR DESCRIPTION
The "remote cookies" code broke this.  While I'm not sure anyone is
actually using ostree-without-http, it isn't too hard to keep the
build time conditional going.  Further, this work is preparatory for
libcurl porting.