### PR TITLE
[merged] ci: Combine UBSAN and ASAN by default

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -11,6 +11,8 @@ RUN dnf install -y \
         parallel \
         clang \
         libubsan \
+        libasan \
+        libtsan \
         gnome-desktop-testing \
         redhat-rpm-config \
         elfutils \

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -8,8 +8,14 @@ required: true
 container:
     image: projectatomic/ostree-tester
 
+packages:
+  - libasan
+  - libubsan
+
 env:
-    CFLAGS: '-fsanitize=undefined'
+    CFLAGS: '-fsanitize=undefined -fsanitize=address'
+    ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
+    # TODO when we're doing leak checks: G_SLICE: "always-malloc"
 
 build:
     config-opts: >

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -21,8 +21,7 @@ build:
 tests:
     - make syntax-check
     - make check
-    - gnome-desktop-testing-runner ostree
-    - sudo --user=testuser gnome-desktop-testing-runner ostree
+    - gnome-desktop-testing-runner -p 0 ostree
 
 timeout: 30m
 

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -10,7 +10,6 @@ container:
 
 packages:
   - libasan
-  - libubsan
 
 env:
     CFLAGS: '-fsanitize=undefined -fsanitize=address'

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -281,18 +281,15 @@ tests/%-symlink-stamp: % Makefile
 # non-recursive Automake, so we change our code to canonically look
 # for tests/ which is just a symlink when installed.
 if ENABLE_INSTALLED_TESTS
-install-test-data-file-path-hack:
+install-installed-tests-extra:
 	if test -L $(DESTDIR)$(installed_testdir)/tests; then \
 	  rm $(DESTDIR)$(installed_testdir)/tests; \
 	fi
 	ln -s . $(DESTDIR)$(installed_testdir)/tests
-INSTALL_DATA_HOOKS += install-test-data-file-path-hack
-
-install-libtest:
 if BUILDOPT_ASAN
 	sed -e 's,^BUILT_WITH_ASAN=.*,BUILT_WITH_ASAN=1,' < $(srcdir)/tests/libtest.sh > $(DESTDIR)$(installed_testdir)/tests/libtest.sh
 else
 	install -m 0644 $(srcdir)/tests/libtest.sh $(DESTDIR)$(installed_testdir)/tests/libtest.sh
 endif
-INSTALL_DATA_HOOKS += install-libtest
+INSTALL_DATA_HOOKS += install-installed-tests-extra
 endif

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -116,7 +116,6 @@ endif
 
 dist_installed_test_data = tests/archive-test.sh \
 	tests/pull-test.sh \
-	tests/libtest.sh \
 	tests/admin-test.sh \
 	tests/basic-test.sh \
 	tests/test-basic-user.sh \
@@ -124,6 +123,8 @@ dist_installed_test_data = tests/archive-test.sh \
 	tests/pre-endian-deltas-repo-big.tar.xz \
 	tests/pre-endian-deltas-repo-little.tar.xz \
 	$(NULL)
+
+EXTRA_DIST += tests/libtest.sh 
 
 dist_test_extra_scripts = tests/bootloader-entries-crosscheck.py \
      tests/ostree-grub-generator
@@ -286,4 +287,12 @@ install-test-data-file-path-hack:
 	fi
 	ln -s . $(DESTDIR)$(installed_testdir)/tests
 INSTALL_DATA_HOOKS += install-test-data-file-path-hack
+
+install-libtest:
+if BUILDOPT_ASAN
+	sed -e 's,^BUILT_WITH_ASAN=.*,BUILT_WITH_ASAN=1,' < tests/libtest.sh > $(DESTDIR)$(installed_testdir)/tests/libtest.sh
+else
+	install -m 0644 tests/libtest.sh $(DESTDIR)$(installed_testdir)/tests/libtest.sh
+endif
+INSTALL_DATA_HOOKS += install-libtest
 endif

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -290,9 +290,9 @@ INSTALL_DATA_HOOKS += install-test-data-file-path-hack
 
 install-libtest:
 if BUILDOPT_ASAN
-	sed -e 's,^BUILT_WITH_ASAN=.*,BUILT_WITH_ASAN=1,' < tests/libtest.sh > $(DESTDIR)$(installed_testdir)/tests/libtest.sh
+	sed -e 's,^BUILT_WITH_ASAN=.*,BUILT_WITH_ASAN=1,' < $(srcdir)/tests/libtest.sh > $(DESTDIR)$(installed_testdir)/tests/libtest.sh
 else
-	install -m 0644 tests/libtest.sh $(DESTDIR)$(installed_testdir)/tests/libtest.sh
+	install -m 0644 $(srcdir)/tests/libtest.sh $(DESTDIR)$(installed_testdir)/tests/libtest.sh
 endif
 INSTALL_DATA_HOOKS += install-libtest
 endif

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -33,6 +33,9 @@ TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$${LD_LIBRARY_PATH}} \
 	PATH=$$(cd $(top_builddir)/tests && pwd):$${PATH} \
 	$(NULL)
+if BUILDOPT_ASAN
+TESTS_ENVIRONMENT += OT_SKIP_READDIR_RAND=1 G_SLICE=always-malloc
+endif
 
 uninstalled_test_data = tests/ostree-symlink-stamp tests/ostree-prepare-root-symlink-stamp \
 			tests/ostree-remount-symlink-stamp tests/rofiles-fuse-symlink-stamp
@@ -53,7 +56,6 @@ dist_test_scripts = \
 	tests/test-parent.sh \
 	tests/test-pull-archive-z.sh \
 	tests/test-pull-commit-only.sh \
-	tests/test-pull-corruption.sh \
 	tests/test-pull-depth.sh \
 	tests/test-pull-mirror-summary.sh \
 	tests/test-pull-large-metadata.sh \
@@ -104,10 +106,10 @@ if USE_LIBSOUP
 dist_test_scripts += tests/test-remote-cookies.sh
 endif
 
-# This one uses corrupt-repo-ref.js
-js_tests = tests/test-corruption.sh
+# These call into gjs scripts 
+js_tests = tests/test-corruption.sh tests/test-pull-corruption.sh
 if BUILDOPT_GJS
-dist_test_scripts += tests/test-corruption.sh
+dist_test_scripts += $(js_tests)
 else
 EXTRA_DIST += $(js_tests)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,15 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
 ])
 AC_SUBST(WARN_CFLAGS)
 
+AC_MSG_CHECKING([for -fsanitize=address in CFLAGS])
+if echo $CFLAGS | grep -q -e -fsanitize=address; then
+  AC_MSG_RESULT([yes])
+  using_asan=yes
+else
+  AC_MSG_RESULT([no])
+fi
+AM_CONDITIONAL(BUILDOPT_ASAN, [test x$using_asan = xyes])
+
 # Initialize libtool
 LT_PREREQ([2.2.4])
 LT_INIT([disable-static])
@@ -305,8 +314,9 @@ AC_ARG_WITH(static-compiler,
 AM_CONDITIONAL(BUILDOPT_USE_STATIC_COMPILER, test x$with_static_compiler != xno)
 AC_SUBST(STATIC_COMPILER, $with_static_compiler)
 
-dnl for tests
-AS_IF([test "x$found_introspection" = xyes], [
+dnl for tests (but we can't use asan with gjs or any introspection,
+dnl see https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso for more info)
+AS_IF([test "x$found_introspection" = xyes && test x$using_asan != xyes], [
   AC_PATH_PROG(GJS, [gjs])
   if test -n "$GJS"; then
     have_gjs=yes

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -86,13 +86,16 @@ if test -n "${OT_TESTS_DEBUG:-}"; then
     set -x
 fi
 
+# This is substituted by the build for installed tests
+BUILT_WITH_ASAN=""
+
 if test -n "${OT_TESTS_VALGRIND:-}"; then
     CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
 else
     # In some cases the LD_PRELOAD may cause obscure problems,
     # e.g. right now it breaks for me with -fsanitize=address, so
     # let's allow users to skip it.
-    if test -z "${OT_SKIP_READDIR_RAND:-}"; then
+    if test -z "${OT_SKIP_READDIR_RAND:-}" && test -z "${BUILT_WITH_ASAN:-}"; then
 	CMD_PREFIX="env LD_PRELOAD=${test_builddir}/libreaddir-rand.so"
     else
 	CMD_PREFIX=""


### PR DESCRIPTION
I only recently realized this was possible.  While we're still seeing
leaks in the CI environment for some reason, adding ASAN gives us
use-after-free detection etc., which is obviously still very useful
even if we're not doing leak checking.