### PR TITLE
[merged] [ASAN] sysroot: Squash a leak in lockfile acquisition

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1323,7 +1323,7 @@ ostree_sysroot_try_lock (OstreeSysroot         *self,
                          GError               **error)
 {
   gboolean ret = FALSE;
-  GError *local_error = NULL;
+  g_autoptr(GError) local_error = NULL;
 
   if (!ensure_sysroot_fd (self, error))
     goto out;
@@ -1338,7 +1338,7 @@ ostree_sysroot_try_lock (OstreeSysroot         *self,
         }
       else
         {
-          g_propagate_error (error, local_error);
+          g_propagate_error (error, g_steal_pointer (&local_error));
           goto out;
         }
     }


### PR DESCRIPTION
I installed `parallel` in my dev container, which got me
the sysroot locking tests, which caught this leak when
built with ASAN.