### PR TITLE
[merged] tree-wide: Switch to autoptr for GOptionContext

### DIFF
--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -36,7 +36,7 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   gboolean ret = FALSE;
 
@@ -55,7 +55,5 @@ ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GErr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -54,7 +54,7 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
 {
   gboolean ret = FALSE;
   const char *refspec;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   GKeyFile *origin = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
@@ -173,7 +173,5 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
  out:
   if (origin)
     g_key_file_unref (origin);
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -39,7 +39,7 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   gboolean ret = FALSE;
   glnx_unref_object OstreeDeployment *deployment = NULL;
@@ -95,7 +95,5 @@ ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError 
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -36,7 +36,7 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   gboolean ret = FALSE;
   glnx_fd_close int root_dfd = -1;
@@ -88,7 +88,5 @@ ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GErr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -109,7 +109,7 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (!subcommand->name)
     {
-      GOptionContext *context;
+      g_autoptr(GOptionContext) context = NULL;
       g_autofree char *help;
 
       context = ostree_admin_instutil_option_context_new_with_commands ();
@@ -133,8 +133,6 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-
-      g_option_context_free (context);
 
       goto out;
     }

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -36,7 +36,7 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   gboolean ret = FALSE;
   const char *osname = NULL;
@@ -66,7 +66,5 @@ ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GErr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -44,7 +44,7 @@ gboolean
 ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   const char *remotename = NULL;
   const char *url = NULL;
   const char *branch = NULL;
@@ -144,7 +144,5 @@ ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, G
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -83,7 +83,7 @@ out:
 gboolean
 ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   gboolean ret = FALSE;
   glnx_unref_object OstreeRepo *repo = NULL;
@@ -193,7 +193,5 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -43,7 +43,7 @@ gboolean
 ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   const char *new_provided_refspec = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
@@ -162,7 +162,5 @@ ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GErro
  out:
   if (new_origin)
     g_key_file_unref (new_origin);
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -36,7 +36,7 @@ gboolean
 ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   const char *deploy_index_str;
   int deploy_index;
@@ -91,7 +91,5 @@ ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GEr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-unlock.c
+++ b/src/ostree/ot-admin-builtin-unlock.c
@@ -42,7 +42,7 @@ gboolean
 ot_admin_builtin_unlock (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   OstreeDeployment *booted_deployment = NULL;
   OstreeDeploymentUnlockedState target_state;
@@ -95,7 +95,5 @@ ot_admin_builtin_unlock (int argc, char **argv, GCancellable *cancellable, GErro
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -49,7 +49,7 @@ gboolean
 ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   glnx_unref_object OstreeSysrootUpgrader *upgrader = NULL;
   g_autoptr(GKeyFile) origin = NULL;
@@ -140,7 +140,5 @@ ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GErr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -38,7 +38,7 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
 {
   gboolean ret = FALSE;
   guint bootversion;
-  GOptionContext *context = NULL;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
 
   context = g_option_context_new ("[BOOTVERSION] - generate GRUB2 configuration from given BLS entries");
@@ -76,7 +76,5 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -188,7 +188,7 @@ ot_admin_instutil_builtin_selinux_ensure_labeled (int argc, char **argv, GCancel
   glnx_unref_object OstreeSePolicy *sepolicy = NULL;
   g_autoptr(GPtrArray) deployments = NULL;
   OstreeDeployment *first_deployment;
-  GOptionContext *context = NULL;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   g_autoptr(GFile) deployment_path = NULL;
 
@@ -241,7 +241,5 @@ ot_admin_instutil_builtin_selinux_ensure_labeled (int argc, char **argv, GCancel
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -50,7 +50,7 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, GCancellable *cancel
   guint i;
   g_autoptr(GPtrArray) deployments = NULL;
   OstreeDeployment *first_deployment = NULL;
-  GOptionContext *context = NULL;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeSysroot *sysroot = NULL;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
 
@@ -115,7 +115,5 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, GCancellable *cancel
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -124,7 +124,7 @@ ostree_builtin_admin (int argc, char **argv, GCancellable *cancellable, GError *
 
   if (!subcommand->name)
     {
-      GOptionContext *context;
+      g_autoptr(GOptionContext) context = NULL;
       g_autofree char *help;
 
       context = ostree_admin_option_context_new_with_commands ();
@@ -148,8 +148,6 @@ ostree_builtin_admin (int argc, char **argv, GCancellable *cancellable, GError *
 
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-
-      g_option_context_free (context);
 
       goto out;
     }

--- a/src/ostree/ot-builtin-cat.c
+++ b/src/ostree/ot-builtin-cat.c
@@ -61,7 +61,7 @@ cat_one_file (GFile         *f,
 gboolean
 ostree_builtin_cat (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   int i;
@@ -98,7 +98,5 @@ ostree_builtin_cat (int argc, char **argv, GCancellable *cancellable, GError **e
  
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -230,7 +230,7 @@ process_many_checkouts (OstreeRepo         *repo,
 gboolean
 ostree_builtin_checkout (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *commit;
@@ -281,7 +281,5 @@ ostree_builtin_checkout (int argc, char **argv, GCancellable *cancellable, GErro
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-checksum.c
+++ b/src/ostree/ot-builtin-checksum.c
@@ -58,7 +58,7 @@ on_checksum_received (GObject    *obj,
 gboolean
 ostree_builtin_checksum (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   gboolean ret = FALSE;
   g_autoptr(GFile) f = NULL;
   AsyncChecksumData data = { 0, };
@@ -87,7 +87,5 @@ ostree_builtin_checksum (int argc, char **argv, GCancellable *cancellable, GErro
  out:
   if (data.loop)
     g_main_loop_unref (data.loop);
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -331,7 +331,7 @@ parse_keyvalue_strings (char             **strings,
 gboolean
 ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   gboolean skip_commit = FALSE;
@@ -672,8 +672,6 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
  out:
   if (repo)
     ostree_repo_abort_transaction (repo, cancellable, NULL);
-  if (context)
-    g_option_context_free (context);
   if (modifier)
     ostree_repo_commit_modifier_unref (modifier);
   return ret;

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -55,7 +55,7 @@ split_key_string (const char   *k,
 gboolean
 ostree_builtin_config (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context = NULL;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *op;
@@ -133,7 +133,5 @@ ostree_builtin_config (int argc, char **argv, GCancellable *cancellable, GError 
  out:
   if (config)
     g_key_file_free (config);
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-diff.c
+++ b/src/ostree/ot-builtin-diff.c
@@ -121,7 +121,7 @@ gboolean
 ostree_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *src;
   const char *target;
@@ -224,7 +224,5 @@ ostree_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -60,7 +60,7 @@ propagate_libarchive_error (GError      **error,
 gboolean
 ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
@@ -155,7 +155,5 @@ ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError 
   
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -240,7 +240,7 @@ gboolean
 ostree_builtin_fsck (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   GHashTableIter hash_iter;
   gpointer key, value;
@@ -355,7 +355,5 @@ ostree_builtin_fsck (int argc, char **argv, GCancellable *cancellable, GError **
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -197,7 +197,7 @@ out:
 gboolean
 ostree_builtin_gpg_sign (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   g_autofree char *resolved_commit = NULL;
   const char *commit;
@@ -254,8 +254,5 @@ ostree_builtin_gpg_sign (int argc, char **argv, GCancellable *cancellable, GErro
   ret = TRUE;
 
 out:
-  if (context)
-    g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-builtin-init.c
+++ b/src/ostree/ot-builtin-init.c
@@ -36,7 +36,7 @@ static GOptionEntry options[] = {
 gboolean
 ostree_builtin_init (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context = NULL;
+  g_autoptr(GOptionContext) context = NULL;
   g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   OstreeRepoMode mode;
@@ -54,7 +54,5 @@ ostree_builtin_init (int argc, char **argv, GCancellable *cancellable, GError **
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-log.c
+++ b/src/ostree/ot-builtin-log.c
@@ -81,7 +81,7 @@ ostree_builtin_log (int           argc,
                     GCancellable *cancellable,
                     GError      **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
@@ -111,7 +111,5 @@ ostree_builtin_log (int           argc,
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-ls.c
+++ b/src/ostree/ot-builtin-ls.c
@@ -242,7 +242,7 @@ print_one_argument (OstreeRepo   *repo,
 gboolean
 ostree_builtin_ls (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
@@ -280,7 +280,5 @@ ostree_builtin_ls (int argc, char **argv, GCancellable *cancellable, GError **er
   
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -169,7 +169,7 @@ gboolean
 ostree_builtin_prune (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   g_autofree char *formatted_freed_size = NULL;
   OstreeRepoPruneFlags pruneflags = 0;
@@ -235,7 +235,5 @@ ostree_builtin_prune (int argc, char **argv, GCancellable *cancellable, GError *
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -53,7 +53,7 @@ gboolean
 ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   int i;
   const char *src_repo_arg;
@@ -174,8 +174,6 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   if (repo)
     ostree_repo_abort_transaction (repo, cancellable, NULL);
   return ret;

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -109,7 +109,7 @@ dry_run_console_progress_changed (OstreeAsyncProgress *progress,
 gboolean
 ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   g_autofree char *remote = NULL;
@@ -308,7 +308,5 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
  out:
   if (signal_handler_id > 0)
     g_signal_handler_disconnect (repo, signal_handler_id);
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -130,7 +130,7 @@ gboolean
 ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   int i;
 
@@ -172,8 +172,6 @@ ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   if (repo)
     ostree_repo_abort_transaction (repo, cancellable, NULL);
   return ret;

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -111,7 +111,7 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
 
   if (!subcommand->name)
     {
-      GOptionContext *context;
+      g_autoptr(GOptionContext) context = NULL;
       g_autofree char *help;
 
       context = remote_option_context_new_with_commands ();
@@ -134,8 +134,6 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
 
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-
-      g_option_context_free (context);
 
       goto out;
     }

--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -37,7 +37,7 @@ ostree_builtin_reset (int           argc,
                       GCancellable *cancellable,
                       GError      **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   g_autoptr(GHashTable) known_refs = NULL;
   gboolean ret = FALSE;
@@ -83,8 +83,6 @@ ostree_builtin_reset (int           argc,
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   if (repo)
     ostree_repo_abort_transaction (repo, cancellable, NULL);
   return ret;

--- a/src/ostree/ot-builtin-rev-parse.c
+++ b/src/ostree/ot-builtin-rev-parse.c
@@ -34,7 +34,7 @@ static GOptionEntry options[] = {
 gboolean
 ostree_builtin_rev_parse (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *rev = "master";
@@ -63,7 +63,5 @@ ostree_builtin_rev_parse (int argc, char **argv, GCancellable *cancellable, GErr
  
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -252,7 +252,7 @@ print_if_found (OstreeRepo        *repo,
 gboolean
 ostree_builtin_show (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
@@ -361,7 +361,5 @@ ostree_builtin_show (int argc, char **argv, GCancellable *cancellable, GError **
  
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -110,7 +110,7 @@ ot_static_delta_builtin_list (int argc, char **argv, GCancellable *cancellable, 
   gboolean ret = FALSE;
   g_autoptr(GPtrArray) delta_names = NULL;
   guint i;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
 
   context = g_option_context_new ("LIST - list static delta files");
@@ -135,8 +135,6 @@ ot_static_delta_builtin_list (int argc, char **argv, GCancellable *cancellable, 
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }
 
@@ -144,7 +142,7 @@ static gboolean
 ot_static_delta_builtin_show (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *delta_id = NULL;
 
@@ -167,8 +165,6 @@ ot_static_delta_builtin_show (int argc, char **argv, GCancellable *cancellable, 
       
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }
 
@@ -176,7 +172,7 @@ static gboolean
 ot_static_delta_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *delta_id = NULL;
 
@@ -199,8 +195,6 @@ ot_static_delta_builtin_delete (int argc, char **argv, GCancellable *cancellable
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }
 
@@ -209,7 +203,7 @@ static gboolean
 ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
 
   context = g_option_context_new ("GENERATE [TO] - Generate static delta files");
@@ -348,8 +342,6 @@ ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellab
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }
 
@@ -359,7 +351,7 @@ ot_static_delta_builtin_apply_offline (int argc, char **argv, GCancellable *canc
   gboolean ret = FALSE;
   const char *patharg;
   g_autoptr(GFile) path = NULL;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
 
   context = g_option_context_new ("APPLY-OFFLINE - Apply static delta file");
@@ -390,8 +382,6 @@ ot_static_delta_builtin_apply_offline (int argc, char **argv, GCancellable *canc
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }
 

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -40,7 +40,7 @@ gboolean
 ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
 
   context = g_option_context_new ("Manage summary metadata");
@@ -75,7 +75,5 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
 
   ret = TRUE;
  out:
-  if (context)
-    g_option_context_free (context);
   return ret;
 }

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -83,7 +83,7 @@ int
 ostree_usage (OstreeCommand *commands,
               gboolean is_error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   g_autofree char *help;
 
   context = ostree_option_context_new_with_commands (commands);
@@ -96,8 +96,6 @@ ostree_usage (OstreeCommand *commands,
     g_printerr ("%s", help);
   else
     g_print ("%s", help);
-
-  g_option_context_free (context);
 
   return (is_error ? 1 : 0);
 }
@@ -172,7 +170,7 @@ ostree_run (int    argc,
 
   if (!command->fn)
     {
-      GOptionContext *context;
+      g_autoptr(GOptionContext) context = NULL;
       g_autofree char *help;
 
       context = ostree_option_context_new_with_commands (commands);
@@ -195,8 +193,6 @@ ostree_run (int    argc,
 
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-
-      g_option_context_free (context);
 
       goto out;
     }

--- a/src/ostree/ot-remote-builtin-add-cookie.c
+++ b/src/ostree/ot-remote-builtin-add-cookie.c
@@ -37,7 +37,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   const char *domain;
@@ -80,7 +80,5 @@ ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, 
   /* jar takes ownership of cookie */
   soup_cookie_jar_add_cookie (jar, cookie);
 
-  if (context)
-    g_option_context_free (context);
   return TRUE;
 }

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -44,7 +44,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   const char *remote_url;
@@ -149,7 +149,5 @@ ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError 
 
   ret = TRUE;
  out:
-  g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-remote-builtin-delete-cookie.c
+++ b/src/ostree/ot-remote-builtin-delete-cookie.c
@@ -37,7 +37,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   const char *domain;
@@ -92,7 +92,5 @@ ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellabl
   if (!found)
     g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Cookie not found in jar");
 
-  if (context)
-    g_option_context_free (context);
   return found;
 }

--- a/src/ostree/ot-remote-builtin-delete.c
+++ b/src/ostree/ot-remote-builtin-delete.c
@@ -35,7 +35,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   gboolean ret = FALSE;
@@ -63,7 +63,5 @@ ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GErr
 
   ret = TRUE;
  out:
-  g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-remote-builtin-gpg-import.c
+++ b/src/ostree/ot-remote-builtin-gpg-import.c
@@ -93,7 +93,7 @@ out:
 gboolean
 ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   g_autoptr(GInputStream) source_stream = NULL;
   const char *remote_name;
@@ -136,7 +136,5 @@ ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, 
   ret = TRUE;
 
  out:
-  g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-remote-builtin-list-cookies.c
+++ b/src/ostree/ot-remote-builtin-list-cookies.c
@@ -37,7 +37,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   g_autofree char *jar_path = NULL;

--- a/src/ostree/ot-remote-builtin-list.c
+++ b/src/ostree/ot-remote-builtin-list.c
@@ -33,7 +33,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   g_auto(GStrv) remotes = NULL;
   guint ii, n_remotes = 0;
@@ -73,7 +73,5 @@ ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError
   ret = TRUE;
 
  out:
-  g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -35,7 +35,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   gboolean ret = FALSE;
@@ -78,9 +78,6 @@ ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError
     }
 
   ret = TRUE;
-
 out:
-  g_option_context_free (context);
-
   return ret;
 }

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -39,7 +39,7 @@ static GOptionEntry option_entries[] = {
 gboolean
 ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
   const char *remote_name;
   g_autoptr(GBytes) summary_bytes = NULL;
@@ -120,9 +120,6 @@ ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GEr
     }
 
   ret = TRUE;
-
 out:
-  g_option_context_free (context);
-
   return ret;
 }


### PR DESCRIPTION
We were leaking in a few places that I noticed in an ASAN run.  Also,
this was one of the last non-autoptr cleanup sections we have in
`out:` cleanup sections, making us a lot closer to a potential
full-tree rewrite to `return FALSE`.