### PR TITLE
[merged] repo: Add unconfigured-state to remote config options

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -179,6 +179,11 @@ Boston, MA 02111-1307, USA.
         <term><varname>tls-ca-path</varname></term>
         <listitem><para>Path to file containing trusted anchors instead of the system CA database.</para></listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>unconfigured-state</varname></term>
+        <listitem><para>If set, pulls from this remote will fail with the configured text.  This is intended for OS vendors which have a subscription process to access content.</para></listitem>
+      </varlistentry>
     </variablelist>
 
   </refsect1>

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2458,6 +2458,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     }
   else
     {
+      g_autofree char *unconfigured_state = NULL;
+
       pull_data->remote_name = g_strdup (remote_name_or_baseurl);
 
       /* Fetch GPG verification settings from remote if it wasn't already
@@ -2471,6 +2473,19 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         if (!ostree_repo_remote_get_gpg_verify_summary (self, pull_data->remote_name,
                                                         &pull_data->gpg_verify_summary, error))
           goto out;
+
+      if (!ostree_repo_get_remote_option (self, pull_data->remote_name,
+                                          "unconfigured-state", NULL,
+                                          &unconfigured_state,
+                                          error))
+        goto out;
+
+      if (unconfigured_state)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "remote unconfigured-state: %s", unconfigured_state);
+          goto out;
+        }
     }
 
   pull_data->phase = OSTREE_PULL_PHASE_FETCHING_REFS;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2474,6 +2474,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                                         &pull_data->gpg_verify_summary, error))
           goto out;
 
+      /* NOTE: If changing this, see the matching implementation in
+       * ostree-sysroot-upgrader.c
+       */
       if (!ostree_repo_get_remote_option (self, pull_data->remote_name,
                                           "unconfigured-state", NULL,
                                           &unconfigured_state,

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -77,7 +77,9 @@ parse_refspec (OstreeSysrootUpgrader  *self,
 
   if ((self->flags & OSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED) == 0)
     {
-      /* If explicit action by the OS creator is requried to upgrade, print their text as an error */
+      /* If explicit action by the OS creator is requried to upgrade, print their text as an error.
+       * NOTE: If changing this, see the matching implementation in ostree-repo-pull.c.
+       */
       unconfigured_state = g_key_file_get_string (self->origin, "origin", "unconfigured-state", NULL);
       if (unconfigured_state)
         {

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -35,7 +35,7 @@ function verify_initial_contents() {
     assert_file_has_content baz/cow '^moo$'
 }
 
-echo "1..13"
+echo "1..14"
 
 # Try both syntaxes
 repo_init
@@ -249,3 +249,12 @@ assert_file_has_content baz/cow "further modified file for static deltas"
 assert_not_has_file baz/saucer
 
 echo "ok static delta 2"
+
+cd ${test_tmpdir}
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false --set=unconfigured-state="Access to ExampleOS requires ONE BILLION DOLLARS." origin-subscription file://$(pwd)/ostree-srv/gnomerepo
+if ${CMD_PREFIX} ostree --repo=repo pull origin-subscription main 2>err.txt; then
+    assert_not_reached "pull unexpectedly succeeded?"
+fi
+assert_file_has_content err.txt "ONE BILLION DOLLARS"
+
+echo "ok unconfigured"


### PR DESCRIPTION
This is a migration from the origin version.  It's
nicer to have it in the remote, since that's what one
needs to change.  Then tools don't need to mess with
the origin file.o

In fact in this scenario one can keep the "media source" like
`file:///install/repo` or whatever, since conceptually that's where it
came from.  We're just providing a better error.

Closes: https://github.com/ostreedev/ostree/issues/626