### PR TITLE
[merged] lib: Squash last use of GFile deltas_dir

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -72,7 +72,6 @@ struct OstreeRepo {
   int    cache_dir_fd;
   char  *cache_dir;
   int objects_dir_fd;
-  GFile *deltas_dir;
   int uncompressed_objects_dir_fd;
   GFile *sysroot_dir;
   char *remotes_config_dir;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -521,7 +521,6 @@ ostree_repo_finalize (GObject *object)
     (void) close (self->cache_dir_fd);
   if (self->objects_dir_fd != -1)
     (void) close (self->objects_dir_fd);
-  g_clear_object (&self->deltas_dir);
   if (self->uncompressed_objects_dir_fd != -1)
     (void) close (self->uncompressed_objects_dir_fd);
   g_clear_object (&self->sysroot_dir);
@@ -605,8 +604,6 @@ ostree_repo_constructed (GObject *object)
   g_assert (self->repodir != NULL);
 
   self->tmp_dir = g_file_resolve_relative_path (self->repodir, "tmp");
-
-  self->deltas_dir = g_file_get_child (self->repodir, "deltas");
 
   /* Ensure the "sysroot-path" property is set. */
   if (self->sysroot_dir == NULL)


### PR DESCRIPTION
I was having this thought today about making more of the OS readonly,
and ultimately if we got to the point where all ostree operations are
through the repo and sysroot dfds, we could have rpm-ostree be the
only process holding those fds open, and have a read-only bind mount
on top.

Anyways, we're not there, likely won't be soon, but this gets us
closer to being fully fd relative.