### PR TITLE
[merged] repo: Fix annotations for remote_fetch_summary functions

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3137,9 +3137,10 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
  * @self: Self
  * @name: name of a remote
  * @options: (nullable): A GVariant a{sv} with an extensible set of flags
- * @out_summary: (nullable): return location for raw summary data, or %NULL
- * @out_signatures: (nullable): return location for raw summary signature
- *                              data, or %NULL
+ * @out_summary: (out) (optional): return location for raw summary data, or
+ *               %NULL
+ * @out_signatures: (out) (optional): return location for raw summary
+ *                  signature data, or %NULL
  * @cancellable: a #GCancellable
  * @error: a #GError
  *

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1700,9 +1700,10 @@ out:
  * ostree_repo_remote_fetch_summary:
  * @self: Self
  * @name: name of a remote
- * @out_summary: (nullable): return location for raw summary data, or %NULL
- * @out_signatures: (nullable): return location for raw summary signature
- *                                data, or %NULL
+ * @out_summary: (out) (optional): return location for raw summary data, or
+ *               %NULL
+ * @out_signatures: (out) (optional): return location for raw summary
+ *                  signature data, or %NULL
  * @cancellable: a #GCancellable
  * @error: a #GError
  *


### PR DESCRIPTION
These are out parameters, so add the (out) annotation and switch
(nullable) to (optional) since the latter is used for the purpose of
optional out parameters.