### PR TITLE
[merged] Fix list_objects for bindings

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2456,12 +2456,12 @@ list_loose_objects_at (OstreeRepo             *self,
             continue;
         }
 
-        key = ostree_object_name_serialize (buf, objtype);
-        value = g_variant_new ("(b@as)",
-                               TRUE, g_variant_new_strv (NULL, 0));
-        /* transfer ownership */
-        g_hash_table_replace (inout_objects, key,
-                              g_variant_ref_sink (value));
+      key = ostree_object_name_serialize (buf, objtype);
+      value = g_variant_new ("(b@as)",
+                             TRUE, g_variant_new_strv (NULL, 0));
+      /* transfer ownership */
+      g_hash_table_replace (inout_objects, key,
+                            g_variant_ref_sink (value));
     }
 
   ret = TRUE;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2460,7 +2460,7 @@ list_loose_objects_at (OstreeRepo             *self,
       value = g_variant_new ("(b@as)",
                              TRUE, g_variant_new_strv (NULL, 0));
       /* transfer ownership */
-      g_hash_table_replace (inout_objects, key,
+      g_hash_table_replace (inout_objects, g_variant_ref_sink (key),
                             g_variant_ref_sink (value));
     }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3548,7 +3548,8 @@ ostree_repo_load_commit (OstreeRepo            *self,
  * ostree_repo_list_objects:
  * @self: Repo
  * @flags: Flags controlling enumeration
- * @out_objects: (out): Map of serialized object name to variant data
+ * @out_objects: (out) (transfer container) (element-type GVariant GVariant):
+ * Map of serialized object name to variant data
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -3605,7 +3606,8 @@ ostree_repo_list_objects (OstreeRepo                  *self,
  * ostree_repo_list_commit_objects_starting_with:
  * @self: Repo
  * @start: List commits starting with this checksum
- * @out_commits: Array of GVariants
+ * @out_commits: (out) (transfer container) (element-type GVariant GVariant):
+ * Map of serialized commit name to variant data
  * @cancellable: Cancellable
  * @error: Error
  *


### PR DESCRIPTION
There were a couple issues preventing using list_objects and list_commits from bindings.