### PR TITLE
[merged] admin: Use execlp() to look for systemctl as the shell would

### DIFF
--- a/src/ostree/ot-admin-functions.c
+++ b/src/ostree/ot-admin-functions.c
@@ -164,7 +164,7 @@ ot_admin_execve_reboot (OstreeSysroot *sysroot, GError **error)
       
   if (g_file_equal (ostree_sysroot_get_path (sysroot), real_sysroot))
     {
-      if (execl ("systemctl", "systemctl", "reboot", NULL) < 0)
+      if (execlp ("systemctl", "systemctl", "reboot", NULL) < 0)
         {
           glnx_set_error_from_errno (error);
           return FALSE;


### PR DESCRIPTION
Fixes the problem that `ostree admin upgrade --reboot` actually doesn't reboot after a successful deployment. The error is:

    error: No such file or directory
because of:

    execve("systemctl", ["systemctl", "reboot"], [/* 11 vars */]) = -1 ENOENT (No such file or directory)