### PR TITLE
[merged] .dir-locals.el: Standard Emacs indentation config

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((c-mode . ((indent-tabs-mode . nil) (c-file-style . "gnu"))))


### PR DESCRIPTION
Better than having it per-file.