### PR TITLE
lib: Move the bupsplit selftest into our test framework

### DIFF
--- a/src/libostree/bupsplit.c
+++ b/src/libostree/bupsplit.c
@@ -116,5 +116,3 @@ int bupsplit_find_ofs(const unsigned char *buf, int len, int *bits)
     }
     return 0;
 }
-
-

--- a/src/libostree/bupsplit.c
+++ b/src/libostree/bupsplit.c
@@ -80,7 +80,8 @@ static uint32_t rollsum_digest(Rollsum *r)
 }
 
 
-static uint32_t rollsum_sum(uint8_t *buf, size_t ofs, size_t len)
+uint32_t
+bupsplit_sum(uint8_t *buf, size_t ofs, size_t len)
 {
     size_t count;
     Rollsum r;
@@ -117,36 +118,3 @@ int bupsplit_find_ofs(const unsigned char *buf, int len, int *bits)
 }
 
 
-#ifndef BUP_NO_SELFTEST
-#define BUP_SELFTEST_SIZE 100000
-
-int bupsplit_selftest()
-{
-    uint8_t *buf = malloc(BUP_SELFTEST_SIZE);
-    uint32_t sum1a, sum1b, sum2a, sum2b, sum3a, sum3b;
-    unsigned count;
-    
-    srandom(1);
-    for (count = 0; count < BUP_SELFTEST_SIZE; count++)
-	buf[count] = random();
-    
-    sum1a = rollsum_sum(buf, 0, BUP_SELFTEST_SIZE);
-    sum1b = rollsum_sum(buf, 1, BUP_SELFTEST_SIZE);
-    sum2a = rollsum_sum(buf, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE*5/2,
-			BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
-    sum2b = rollsum_sum(buf, 0, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
-    sum3a = rollsum_sum(buf, 0, BUP_WINDOWSIZE+3);
-    sum3b = rollsum_sum(buf, 3, BUP_WINDOWSIZE+3);
-    
-    fprintf(stderr, "sum1a = 0x%08x\n", sum1a);
-    fprintf(stderr, "sum1b = 0x%08x\n", sum1b);
-    fprintf(stderr, "sum2a = 0x%08x\n", sum2a);
-    fprintf(stderr, "sum2b = 0x%08x\n", sum2b);
-    fprintf(stderr, "sum3a = 0x%08x\n", sum3a);
-    fprintf(stderr, "sum3b = 0x%08x\n", sum3b);
-    
-    free(buf);
-    return sum1a!=sum1b || sum2a!=sum2b || sum3a!=sum3b;
-}
-
-#endif // !BUP_NO_SELFTEST

--- a/src/libostree/bupsplit.h
+++ b/src/libostree/bupsplit.h
@@ -30,6 +30,9 @@
 #ifndef __BUPSPLIT_H
 #define __BUPSPLIT_H
 
+#include <stdint.h>
+#include <sys/types.h>
+
 #define BUP_BLOBBITS (13)
 #define BUP_BLOBSIZE (1<<BUP_BLOBBITS)
 #define BUP_WINDOWBITS (7)
@@ -38,9 +41,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
+uint32_t bupsplit_sum(uint8_t *buf, size_t ofs, size_t len);
 int bupsplit_find_ofs(const unsigned char *buf, int len, int *bits);
-int bupsplit_selftest(void);
 
 #ifdef __cplusplus
 }

--- a/tests/test-rollsum.c
+++ b/tests/test-rollsum.c
@@ -137,9 +137,35 @@ test_rollsum (void)
   test_rollsum_helper (a, MAX_BUFFER_SIZE, b, MAX_BUFFER_SIZE, FALSE);
 }
 
+#define BUP_SELFTEST_SIZE 100000
+
+static void
+test_bupsplit_sum(void)
+{
+    g_autofree uint8_t *buf = g_malloc (BUP_SELFTEST_SIZE);
+    uint32_t sum1a, sum1b, sum2a, sum2b, sum3a, sum3b;
+    unsigned count;
+
+    for (count = 0; count < BUP_SELFTEST_SIZE; count++)
+      buf[count] = g_random_int_range (0, 256);
+
+    sum1a = bupsplit_sum(buf, 0, BUP_SELFTEST_SIZE);
+    sum1b = bupsplit_sum(buf, 1, BUP_SELFTEST_SIZE);
+    sum2a = bupsplit_sum(buf, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE*5/2,
+			BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
+    sum2b = bupsplit_sum(buf, 0, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
+    sum3a = bupsplit_sum(buf, 0, BUP_WINDOWSIZE+3);
+    sum3b = bupsplit_sum(buf, 3, BUP_WINDOWSIZE+3);
+
+    g_assert_cmpint (sum1a, ==, sum1b);
+    g_assert_cmpint (sum2a, ==, sum2b);
+    g_assert_cmpint (sum3a, ==, sum3b);
+}
+
 int main (int argc, char **argv)
 {
   g_test_init (&argc, &argv, NULL);
   g_test_add_func ("/rollsum", test_rollsum);
+  g_test_add_func ("/bupsum", test_bupsplit_sum);
   return g_test_run();
 }


### PR DESCRIPTION
We weren't running it before. Also I switched it to use GLib. Preparation for
some oxidation work (having an implementation of bupsplit in Rust).

I exported another function to do the raw rollsum operation which is what this
test suite uses.