### PR TITLE
Rename to libOSTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
-OSTree
+libOSTree
 ======
 
 New! See the docs online at [Read The Docs (OSTree)](https://ostree.readthedocs.org/en/latest/ )
 
 -----
 
-OSTree is a tool that combines a "git-like" model for committing and
-downloading bootable filesystem trees, along with a layer for
-deploying them and managing the bootloader configuration.
+This project is now known as "libOSTree", renamed from "OSTree"; the focus is on
+the shared library. However, in most of the rest of the documentation, we will
+use the term "OSTree", since it's slightly shorter, and changing all
+documentation at once is impractical. We expect to transition to the new name
+over time.
 
-OSTree is like git in that it checksums individual files and has a
-content-addressed-object store.  It's unlike git in that it "checks
-out" the files via hardlinks, and they should thus be immutable.
-Therefore, another way to think of OSTree is that it's just a more
-polished version of
+libOSTree is a library and suite of command line tools that combines a
+"git-like" model for committing and downloading bootable filesystem trees, along
+with a layer for deploying them and managing the bootloader configuration.
+
+The core OSTree model is like git in that it checksums individual files and has
+a content-addressed-object store. It's unlike git in that it "checks out" the
+files via hardlinks, and they should thus be immutable. Therefore, another way
+to think of OSTree is that it's just a more polished version
+of
 [Linux VServer hardlinks](http://linux-vserver.org/index.php?title=util-vserver:Vhashify&oldid=2285).
 
 **Features:**

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.63])
 dnl If incrementing the version here, remember to update libostree.sym too
-AC_INIT([ostree], [2017.1], [walters@verbum.org])
+AC_INIT([libostree], [2017.1], [walters@verbum.org])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -334,7 +334,7 @@ src/libostree/ostree-1.pc
 AC_OUTPUT
 
 echo "
-    OSTree $VERSION
+    libOSTree $VERSION
     ===============
 
 


### PR DESCRIPTION
There are many motivating factors. The biggest is simply that at a practical
level, the command line is not sufficient to build a real system. The docs say
that it's a demo for the library. Let's make that more obvious, so people don't
try to use `ostree admin upgrade` for their real systems, and also don't use
e.g. `ostree commit` on the command line outside of test suites/quick hacking.

This change will also help clarify the role of rpm-ostree, which we will likely
be renamed to "nts". Then use of the term "ostree" will become much clearer. And
similarly for other people writing upgraders, they can say they use libostree.

I didn't try to change all of the docs and code at once, because it's going to
lead to conflicts.

The next big steps are:

  - Rename the github repo (github will inject a redirect)
  - Look at supporting a build where we don't do `ostree admin`, or at least
    it's only built for tests. We may want to split it off as a separate binary
    or so? That way people with their own upgraders don't need to ship it.