### PR TITLE
lib: Prefix GPG errors with the checksum

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4356,8 +4356,8 @@ _ostree_repo_gpg_verify_with_metadata (OstreeRepo          *self,
                                             _OSTREE_METADATA_GPGSIGS_TYPE);
   if (!signaturedata)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "GPG verification enabled, but no signatures found (use gpg-verify=false in remote config to disable)");
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                           "GPG verification enabled, but no signatures found (use gpg-verify=false in remote config to disable)");
       return NULL;
     }
 
@@ -4474,7 +4474,12 @@ ostree_repo_verify_commit (OstreeRepo   *self,
                                           keyringdir, extra_keyring,
                                           cancellable, error);
 
-  return ostree_gpg_verify_result_require_valid_signature (result, error);
+  if (!ostree_gpg_verify_result_require_valid_signature (result, error))
+    {
+      g_prefix_error (error, "Commit %s: ", commit_checksum);
+      return FALSE;
+    }
+  return TRUE;
 }
 
 /**


### PR DESCRIPTION
I was working on https://bugzilla.redhat.com/show_bug.cgi?id=1393545
and it was annoying that I couldn't know what the new (unsigned)
commit has was until verification succeeded.  I could pull it
manually without GPG, but then it'd be sitting in the repo.

Now:

```
Updating from: fedora-atomic:fedora-atomic/25/x86_64/docker-host

Receiving metadata objects: 0/(estimating) -/s 0 bytes
error: Commit 2fb89decd2cb5c3bd73983f0a7b35c7437f23e3aaa91698fab952bb224e46af5: GPG verification enabled, but no signatures found (use gpg-verify=false in remote config to disable)
```