### PR TITLE
travis: Trim flaky distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 sudo: required
 
 env:
-  - ci_distro=ubuntu ci_suite=trusty
+  - ci_distro=ubuntu ci_suite=trusty ci_test=no  # TODO: use libcurl on this
   - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie
-  - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch
+  - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch ci_test=no  # TODO gpgme flake https://github.com/ostreedev/ostree/pull/664#issuecomment-276033383
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 
 script:


### PR DESCRIPTION
I went through the Travis history a bit, and these seem to be
the flaky ones, I'm pretty sure because they don't have the libsoup
patches backported.

As I say in comments, once we have libcurl, I'd like to enable that mostly
everywhere, which should (hopefully) be more reliable.

:phone: @smcv