### PR TITLE
trusted.gpg.d: keep in the same location

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -206,7 +206,7 @@ endif
 pkgconfig_DATA += src/libostree/ostree-1.pc
 
 gpgreadme_DATA = src/libostree/README-gpg
-gpgreadmedir = $(pkgdatadir)/trusted.gpg.d
+gpgreadmedir = $(datadir)/ostree/trusted.gpg.d
 EXTRA_DIST += src/libostree/README-gpg src/libostree/bupsplit.h \
 		src/libostree/ostree-enumtypes.h.template \
 		src/libostree/ostree-enumtypes.c.template \


### PR DESCRIPTION
With the package rename from ostree to libostree, the `trusted.gpg.d/` dir
changed install location from `/usr/share/ostree` to `/usr/share/libostree`.
Let's keep the same dir to remain compatible with existing installations
that may already have keys there.