### PR TITLE
build: Remove .PHONY for Rust shared library

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -24,7 +24,6 @@ noinst_LTLIBRARIES += libostree-kernel-args.la
 
 if ENABLE_RUST
 bupsplitpath = @abs_top_builddir@/target/@RUST_TARGET_SUBDIR@/libbupsplit_rs.a
-.PHONY: $(bupsplitpath)
 BUPSPLIT_RUST_SOURCES = rust/src/bupsplit.rs
 EXTRA_DIST += $(BUPSPLIT_RUST_SOURCES)
 $(bupsplitpath): Makefile $(BUPSPLIT_RUST_SOURCES)


### PR DESCRIPTION
I have no idea why I made the lib `.PHONY` originally; it's clearly wrong, and I
noticed because when I was doing `sudo make install`, we were doing a rebuild,
which in turn triggered other things to be built, and they'd be owned by root.