### PR TITLE
main: Make ostree --version output YAML (and add gitrev)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,8 @@ include Makefile-decls.am
 
 shortened_sysconfdir = $$(echo "$(sysconfdir)" | sed -e 's|^$(prefix)||' -e 's|^/||')
 
+OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -d $(srcdir)/.git; then git describe --abbrev=42 --tags --always HEAD; fi)
+
 ACLOCAL_AMFLAGS = -I buildutil -I libglnx ${ACLOCAL_FLAGS}
 AM_CPPFLAGS += -DDATADIR='"$(datadir)"' -DLIBEXECDIR='"$(libexecdir)"' \
 	-DLOCALEDIR=\"$(datadir)/locale\" -DSYSCONFDIR=\"$(sysconfdir)\" \
@@ -26,6 +28,7 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' -DLIBEXECDIR='"$(libexecdir)"' \
 	-DOSTREE_FEATURES='"$(OSTREE_FEATURES)"' \
 	-DOSTREE_COMPILATION \
 	-DG_LOG_DOMAIN=\"OSTree\" \
+  -DOSTREE_GITREV='"$(OSTREE_GITREV)"' \
 	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40 \
 	-DSOUP_VERSION_MIN_REQUIRED=SOUP_VERSION_2_40 -DSOUP_VERSION_MAX_ALLOWED=SOUP_VERSION_2_48
 AM_CFLAGS += -std=gnu99 $(WARN_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test x$with_curl != xno ], [
     with_soup_default=yes
 ], [with_soup_default=check])
 AM_CONDITIONAL(USE_CURL, test x$with_curl != xno)
-if test x$with_curl = xyes; then OSTREE_FEATURES="$OSTREE_FEATURES +libcurl"; fi
+if test x$with_curl = xyes; then OSTREE_FEATURES="$OSTREE_FEATURES libcurl"; fi
 
 dnl When bumping the libsoup-2.4 dependency, remember to bump
 dnl SOUP_VERSION_MIN_REQUIRED and SOUP_VERSION_MAX_ALLOWED in
@@ -131,7 +131,7 @@ AS_IF([test x$with_soup != xno], [
     with_soup=no
   ])
 ], [ with_soup=no ])
-if test x$with_soup != xno; then OSTREE_FEATURES="$OSTREE_FEATURES +libsoup"; fi
+if test x$with_soup != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libsoup"; fi
 AM_CONDITIONAL(USE_LIBSOUP, test x$with_soup != xno)
 AM_CONDITIONAL(HAVE_LIBSOUP_CLIENT_CERTS, test x$have_libsoup_client_certs = xyes)
 
@@ -158,7 +158,7 @@ PKG_CHECK_MODULES(OT_DEP_GPGME, gpgme-pthread >= $LIBGPGME_DEPENDENCY, have_gpgm
 AS_IF([ test x$have_gpgme = xno ], [
    AC_MSG_ERROR([Need GPGME_PTHREAD version $LIBGPGME_DEPENDENCY or later])
 ])
-OSTREE_FEATURES="$OSTREE_FEATURES +gpgme"
+OSTREE_FEATURES="$OSTREE_FEATURES gpgme"
 
 LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
 # What's in RHEL7.2.
@@ -245,7 +245,7 @@ AS_IF([ test x$with_libarchive != xno ], [
 	with_libarchive=no
     ])
 ], [ with_libarchive=no ])
-if test x$with_libarchive != xno; then OSTREE_FEATURES="$OSTREE_FEATURES +libarchive"; fi
+if test x$with_libarchive != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libarchive"; fi
 AM_CONDITIONAL(USE_LIBARCHIVE, test $with_libarchive != no)
 
 dnl This is what is in RHEL7 anyways
@@ -270,7 +270,7 @@ AS_IF([ test x$with_selinux != xno ], [
 	with_selinux=no
     ])
 ], [ with_selinux=no ])
-if test x$with_selinux != xno; then OSTREE_FEATURES="$OSTREE_FEATURES +selinux"; fi
+if test x$with_selinux != xno; then OSTREE_FEATURES="$OSTREE_FEATURES selinux"; fi
 AM_CONDITIONAL(USE_SELINUX, test $with_selinux != no)
 
 dnl This is what is in RHEL7.2 right now, picking it arbitrarily
@@ -295,7 +295,7 @@ AS_IF([ test x$with_libmount != xno ], [
 	with_libmount=no
     ])
 ], [ with_libmount=no ])
-if test x$with_libmount != xno; then OSTREE_FEATURES="$OSTREE_FEATURES +libmount"; fi
+if test x$with_libmount != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libmount"; fi
 AM_CONDITIONAL(USE_LIBMOUNT, test $with_libmount != no)
 
 # Enabled by default because I think people should use it.

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -241,7 +241,16 @@ ostree_option_context_parse (GOptionContext *context,
 
   if (opt_version)
     {
-      g_print ("%s\n  %s\n", PACKAGE_STRING, OSTREE_FEATURES);
+      /* This should now be YAML, like `docker version`, so it's both nice to read
+       * possible to parse */
+      g_auto(GStrv) features = g_strsplit (OSTREE_FEATURES, " ", -1);
+      g_print ("%s:\n", PACKAGE_NAME);
+      g_print (" Version: %s\n", PACKAGE_VERSION);
+      if (strlen (OSTREE_GITREV) > 0)
+        g_print (" Git: %s\n", OSTREE_GITREV);
+      g_print (" Features:\n");
+      for (char **iter = features; iter && *iter; iter++)
+        g_print ("  - %s\n", *iter);
       exit (EXIT_SUCCESS);
     }
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,11 @@
 
 set -euo pipefail
 
-echo "1..61"
+echo "1..62"
+
+$CMD_PREFIX ostree --version > version.yaml
+python -c 'import yaml; yaml.safe_load(open("version.yaml"))'
+echo "ok yaml version"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -110,6 +110,7 @@ case "$ci_distro" in
             libcurl4-openssl-dev \
             procps \
             zlib1g-dev \
+            python-yaml \
             ${NULL}
 
         if [ "$ci_in_docker" = yes ]; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -538,7 +538,10 @@ skip_without_fuse () {
 }
 
 has_gpgme () {
-    ${CMD_PREFIX} ostree --version | grep -q -e '- gpgme'
+    ostree --version > version.txt
+    assert_file_has_content version.txt '- gpgme'
+    rm -f version.txt
+    true
 }
 
 libtest_cleanup_gpg () {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -538,7 +538,7 @@ skip_without_fuse () {
 }
 
 has_gpgme () {
-    ostree --version > version.txt
+    ${CMD_PREFIX} ostree --version > version.txt
     assert_file_has_content version.txt '- gpgme'
     rm -f version.txt
     true

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -538,7 +538,7 @@ skip_without_fuse () {
 }
 
 has_gpgme () {
-    ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'
+    ${CMD_PREFIX} ostree --version | grep -q -e '- gpgme'
 }
 
 libtest_cleanup_gpg () {

--- a/tests/test-libarchive.sh
+++ b/tests/test-libarchive.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '\+libarchive'; then
+if ! ostree --version | grep -q -e '- libarchive'; then
     echo "1..0 #SKIP no libarchive support compiled in"
     exit 0
 fi


### PR DESCRIPTION
I learned today that `docker version` does this and I really like
the idea.  While we have the patient open, also add the gitrev
with code taken from https://github.com/projectatomic/rpm-ostree/pull/584