### PR TITLE
lib: Ensure an error is set in ensure_unlinked() if errno != ENOENT

### DIFF
--- a/src/libotutil/ot-gio-utils.c
+++ b/src/libotutil/ot-gio-utils.c
@@ -309,7 +309,10 @@ ot_gfile_ensure_unlinked (GFile         *path,
   if (unlink (gs_file_get_path_cached (path)) != 0)
     {
       if (errno != ENOENT)
-        return FALSE;
+        {
+          glnx_set_error_from_errno (error);
+          return FALSE;
+        }
     }
   return TRUE;
 }


### PR DESCRIPTION
We hit this with:
```
27411 unlink("/boot/efi/EFI/fedora/grub.cfg.new") = -1 EROFS (Read-only file system)
```
from the grub2 code.

https://github.com/projectatomic/rpm-ostree/issues/633