### PR TITLE
OSTree + smack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,14 @@ AS_IF([ test x$with_selinux != xno ], [
 if test x$with_selinux != xno; then OSTREE_FEATURES="$OSTREE_FEATURES +selinux"; fi
 AM_CONDITIONAL(USE_SELINUX, test $with_selinux != no)
 
+AC_ARG_WITH(smack,
+AS_HELP_STRING([--with-smack], [Enable smack]),
+:, with_smack=no)
+AS_IF([ test x$with_smack = xyes], [
+  AC_DEFINE([WITH_SMACK], 1, [Define if we have smack.pc])
+])
+AM_CONDITIONAL(USE_SMACK, test $with_smack != no)
+
 dnl This is what is in RHEL7.2 right now, picking it arbitrarily
 LIBMOUNT_DEPENDENCY="mount >= 2.23.0"
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -110,6 +110,30 @@ write_file_metadata_to_xattr (int fd,
   return TRUE;
 }
 
+/* See https://github.com/ostreedev/ostree/pull/698 */
+#ifdef WITH_SMACK
+#define XATTR_NAME_SMACK "security.SMACK64"
+#endif
+
+static void
+ot_security_smack_reset_dfd_name (int dfd, const char *name)
+{
+#ifdef WITH_SMACK
+  char buf[PATH_MAX];
+  /* See glnx-xattrs.c */
+  snprintf (buf, sizeof (buf), "/proc/self/fd/%d/%s", dfd, name);
+  (void) lremovexattr (buf, XATTR_NAME_SMACK);
+#endif
+}
+
+static void
+ot_security_smack_reset_fd (int fd)
+{
+#ifdef WITH_SMACK
+  (void) fremovexattr (fd, XATTR_NAME_SMACK);
+#endif
+}
+
 gboolean
 _ostree_repo_commit_loose_final (OstreeRepo        *self,
                                  const char        *checksum,
@@ -221,6 +245,7 @@ commit_loose_object_trusted (OstreeRepo        *self,
 
       if (xattrs != NULL)
         {
+          ot_security_smack_reset_dfd_name (self->tmp_dir_fd, temp_filename);
           if (!glnx_dfd_name_set_all_xattrs (self->tmp_dir_fd, temp_filename,
                                                xattrs, cancellable, error))
             goto out;
@@ -252,6 +277,7 @@ commit_loose_object_trusted (OstreeRepo        *self,
 
           if (xattrs)
             {
+              ot_security_smack_reset_fd (fd);
               if (!glnx_fd_set_all_xattrs (fd, xattrs, cancellable, error))
                 goto out;
             }


### PR DESCRIPTION
Improves e.g. SMACK support. Motivated by a [bug](https://jira.automotivelinux.org/browse/SPEC-386) in AGL when using Cynara.
Depends on: https://github.com/GNOME/libglnx/pull/34
On RPi causes ENOENT error when temp_filename is NULL (no idea why glnx_dfd_name_set_all_xattrs doesn't give an error under the same conditions). Since temp_filename should not be NULL in this case, I attribute it to some problems with O_TMPFILE on Raspberry Pi and just compile ostree with '-DDISABLE_OTMPFILE'

Signed-off-by: Anton Gerasimov <anton@advancedtelematic.com>