### PR TITLE
pull: Support require-deltas=upgrade

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -181,6 +181,14 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><varname>require-deltas=upgrade</varname></term>
+        <listitem><para>Pull operations will require deltas for upgrades.
+        Ensures that client systems don't fall back to per-object fetch due to
+        server configuration error or badly sync'd data for
+        example.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>unconfigured-state</varname></term>
         <listitem><para>If set, pulls from this remote will fail with the configured text.  This is intended for OS vendors which have a subscription process to access content.</para></listitem>
       </varlistentry>

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -165,13 +165,6 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
   if (opt_untrusted)
     pullflags |= OSTREE_REPO_PULL_FLAGS_UNTRUSTED;
 
-  if (opt_dry_run && !opt_require_static_deltas)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "--dry-run requires --require-static-deltas");
-      goto out;
-    }
-
   if (strchr (argv[1], ':') == NULL)
     {
       remote = g_strdup (argv[1]);


### PR DESCRIPTION
Our general story for "production" repositories is that people use static
deltas. This is part of a story of better supporting that. In this model we
don't want clients to fall back to per-object fetch if due to some
config/systems failure deltas don't exist.

This will also make it easier for us to potentially introduce a "deltas only"
repository format in the future.