### PR TITLE
deltas: Expose the filename parameter

### DIFF
--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -33,6 +33,7 @@ static char *opt_min_fallback_size;
 static char *opt_max_bsdiff_size;
 static char *opt_max_chunk_size;
 static char *opt_endianness;
+static char *opt_filename;
 static gboolean opt_empty;
 static gboolean opt_swap_endianness;
 static gboolean opt_inline;
@@ -71,6 +72,7 @@ static GOptionEntry generate_options[] = {
   { "min-fallback-size", 0, 0, G_OPTION_ARG_STRING, &opt_min_fallback_size, "Minimum uncompressed size in megabytes for individual HTTP request", NULL},
   { "max-bsdiff-size", 0, 0, G_OPTION_ARG_STRING, &opt_max_bsdiff_size, "Maximum size in megabytes to consider bsdiff compression for input files", NULL},
   { "max-chunk-size", 0, 0, G_OPTION_ARG_STRING, &opt_max_chunk_size, "Maximum size of delta chunks in megabytes", NULL},
+  { "filename", 0, 0, G_OPTION_ARG_STRING, &opt_filename, "Write the delta content to PATH (a directory).  If not specified, the OSTree repository is used", "PATH"},
   { NULL }
 };
 
@@ -322,6 +324,9 @@ ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellab
       if (opt_inline)
         g_variant_builder_add (parambuilder, "{sv}",
                                "inline-parts", g_variant_new_boolean (TRUE));
+      if (opt_filename)
+        g_variant_builder_add (parambuilder, "{sv}",
+                               "filename", g_variant_new_bytestring (opt_filename));
 
       g_variant_builder_add (parambuilder, "{sv}", "verbose", g_variant_new_boolean (TRUE));
       if (opt_endianness || opt_swap_endianness)

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -121,8 +121,8 @@ if ${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to
     assert_not_reached "static-delta generate --from=${origrev} --empty unexpectedly succeeded"
 fi
 
-ostree --repo=temp-repo init --mode=archive
-ostree --repo=temp-repo pull-local repo
+${CMD_PREFIX} ostree --repo=temp-repo init --mode=archive
+${CMD_PREFIX} ostree --repo=temp-repo pull-local repo
 ${CMD_PREFIX} ostree --repo=temp-repo static-delta generate --empty --to=${newrev} --filename=some.delta
 assert_has_file some.delta
 ${CMD_PREFIX} ostree --repo=temp-repo static-delta list > delta-list.txt

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -121,6 +121,14 @@ if ${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to
     assert_not_reached "static-delta generate --from=${origrev} --empty unexpectedly succeeded"
 fi
 
+ostree --repo=temp-repo init --mode=archive
+ostree --repo=temp-repo pull-local repo
+${CMD_PREFIX} ostree --repo=temp-repo static-delta generate --empty --to=${newrev} --filename=some.delta
+assert_has_file some.delta
+${CMD_PREFIX} ostree --repo=temp-repo static-delta list > delta-list.txt
+assert_file_has_content delta-list.txt 'No static deltas'
+rm temp-repo -rf
+
 echo 'ok generate'
 
 ${CMD_PREFIX} ostree --repo=repo static-delta show ${origrev}-${newrev} > show.txt


### PR DESCRIPTION
The C API (ostree_repo_static_delta_generate) knows what to do
with it, but this parameter was never exposed via command line
tool.

Closes: https://github.com/ostreedev/ostree/issues/695