### PR TITLE
deploy: Correctly use libmount unref() calls rather than free()

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1692,8 +1692,8 @@ is_ro_mount (const char *path)
 
   fs = mnt_table_find_target(tb, path, MNT_ITER_BACKWARD);
   is_mount = fs && mnt_fs_get_target (fs);
-  mnt_free_cache (cache);
-  mnt_free_table (tb);
+  mnt_unref_cache (cache);
+  mnt_unref_table (tb);
 
   if (!is_mount)
     return FALSE;


### PR DESCRIPTION
We saw a random ostree SEGV start popping up in our CI environment:
https://github.com/projectatomic/rpm-ostree/pull/641#issuecomment-281870424

Looking at this code more and comparing it to what util-linux does, I noticed we
had a write-after-free, since `mnt_unref_table()` will invoke
`mnt_unref_cache()` on its cache, and that function does:

```
	if (cache) {
		cache->rfcount--;
```

unconditionally.

Fix this by using `unref()`.