### PR TITLE
pull: Use all available commits for delta sources

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1903,7 +1903,8 @@ get_best_static_delta_start_for (OtPullData *pull_data,
       if (strcmp (cur_to_rev, to_revision) != 0)
         continue;
 
-      g_ptr_array_add (candidates, g_steal_pointer (&cur_from_rev));
+      if (cur_from_rev)
+        g_ptr_array_add (candidates, g_steal_pointer (&cur_from_rev));
     }
 
   /* Loop over our candidates, find the newest one */

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -26,7 +26,7 @@ skip_without_user_xattrs
 bindatafiles="bash true ostree"
 morebindatafiles="false ls"
 
-echo '1..11'
+echo '1..12'
 
 mkdir repo
 ${CMD_PREFIX} ostree --repo=repo init --mode=archive-z2
@@ -244,6 +244,17 @@ ${CMD_PREFIX} ostree --repo=repo2 ls ${samerev} >/dev/null
 
 echo 'ok pull empty delta part'
 
+# Make a new branch to test "rebase deltas"
+echo otherbranch-content > files/otherbranch-content
+${CMD_PREFIX} ostree --repo=repo commit -b otherbranch --tree=dir=files
+samerev=$(${CMD_PREFIX} ostree --repo=repo rev-parse test)
+${CMD_PREFIX} ostree --repo=repo static-delta generate --from=test --to=otherbranch
+${CMD_PREFIX} ostree --repo=repo summary -u
+${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo otherbranch
+
+echo 'ok rebase deltas'
+
+${CMD_PREFIX} ostree --repo=repo summary -u
 if ${CMD_PREFIX} ostree --repo=repo static-delta show GARBAGE 2> err.txt; then
     assert_not_reached "static-delta show GARBAGE unexpectedly succeeded"
 fi


### PR DESCRIPTION
The previous logic for static deltas was to use as a FROM
revision the current branch tip.  However, we want
to support deltas between branches in an automatic
fashion.

If a summary file is available, we already have an
enumerated list of deltas - so the logic introduced
here is to search it, and find the newest commit
we have locally that matches the TO revision target.

This builds on some thoughts from
https://github.com/ostreedev/ostree/pull/151#issuecomment-232390232

Closes: https://github.com/ostreedev/ostree/pull/151