### PR TITLE
tree-wide: Squash noncritical compiler warnings

### DIFF
--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -520,7 +520,7 @@ run (int argc, char **argv, GCancellable *cancellable, GError **error)
         }
       else
         {
-          g_autoptr(GFile) log_file;
+          g_autoptr(GFile) log_file = NULL;
           GFileOutputStream* log_stream;
 
           log_file = g_file_new_for_path (opt_log);
@@ -601,9 +601,12 @@ run (int argc, char **argv, GCancellable *cancellable, GError **error)
       if (setsid () < 0)
         err (1, "setsid");
       /* Daemonising: close stdout/stderr so $() et al work on us */
-      freopen("/dev/null", "r", stdin);
-      freopen("/dev/null", "w", stdout);
-      freopen("/dev/null", "w", stderr);
+      if (freopen("/dev/null", "r", stdin) == NULL)
+        err (1, "freopen");
+      if (freopen("/dev/null", "w", stdout) == NULL)
+        err (1, "freopen");
+      if (freopen("/dev/null", "w", stderr) == NULL)
+        err (1, "freopen");
     }
   else
     {

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -125,7 +125,7 @@ ostree_builtin_admin (int argc, char **argv, GCancellable *cancellable, GError *
   if (!subcommand->name)
     {
       g_autoptr(GOptionContext) context = NULL;
-      g_autofree char *help;
+      g_autofree char *help = NULL;
 
       context = ostree_admin_option_context_new_with_commands ();
 

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -114,7 +114,7 @@ ostree_builtin_remote (int argc, char **argv, GCancellable *cancellable, GError 
   if (!subcommand->name)
     {
       g_autoptr(GOptionContext) context = NULL;
-      g_autofree char *help;
+      g_autofree char *help = NULL;
 
       context = remote_option_context_new_with_commands ();
 

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -171,7 +171,7 @@ ostree_run (int    argc,
   if (!command->fn)
     {
       g_autoptr(GOptionContext) context = NULL;
-      g_autofree char *help;
+      g_autofree char *help = NULL;
 
       context = ostree_option_context_new_with_commands (commands);
 


### PR DESCRIPTION
Should fix everything from
<https://kojipkgs.fedoraproject.org//packages/ostree/2017.2/3.fc25/data/logs/x86_64/build.log>

Anything that uses autocleanups should *always* be initialized directly I think,
even if a few lines down we directly assign, since this way it's more robust
against refactoring.

And the `freopen()` warnings are right - IMO we should *always* check return
values.