### PR TITLE
deploy/libmount: Fix build with old util-linux 2.23 (CentOS7)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -299,6 +299,10 @@ AS_IF([ test x$with_libmount != xno ], [
         AC_DEFINE([HAVE_LIBMOUNT], 1, [Define if we have libmount.pc])
 	PKG_CHECK_MODULES(OT_DEP_LIBMOUNT, $LIBMOUNT_DEPENDENCY)
 	with_libmount=yes
+  save_LIBS=$LIBS
+  LIBS=$OT_DEP_LIBMOUNT_LIBS
+  AC_CHECK_FUNCS(mnt_unref_cache)
+  LIBS=$save_LIBS
     ], [
 	with_libmount=no
     ])

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1692,8 +1692,13 @@ is_ro_mount (const char *path)
 
   fs = mnt_table_find_target(tb, path, MNT_ITER_BACKWARD);
   is_mount = fs && mnt_fs_get_target (fs);
-  mnt_unref_cache (cache);
+#ifdef HAVE_MNT_UNREF_CACHE
   mnt_unref_table (tb);
+  mnt_unref_cache (cache);
+#else
+  mnt_free_table (tb);
+  mnt_free_cache (cache);
+#endif
 
   if (!is_mount)
     return FALSE;


### PR DESCRIPTION
https://github.com/ostreedev/ostree/pull/705 broke the build
on CentOS 7 which only has util-linux 2.23.

When I was thinking about this, I realized that there must really be a way to
make this safe even for older versions. Looking at that version of util-linux,
all we need to do is invert the order of frees so we `mnt_free_table()` *before*
`mnt_free_cache()`, like util-linux does:

https://github.com/karelzak/util-linux/blob/stable/v2.23/sys-utils/eject.c#L1131

We still use the `_unref()` versions if available.  I also fixed
the ordering there too for double plus redundant safety.