### PR TITLE
pull: don't use static deltas if archive repo

### DIFF
--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -35,7 +35,7 @@ function verify_initial_contents() {
     assert_file_has_content baz/cow '^moo$'
 }
 
-echo "1..14"
+echo "1..15"
 
 # Try both syntaxes
 repo_init
@@ -68,6 +68,16 @@ ${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo fsck
 ${CMD_PREFIX} ostree --repo=mirrorrepo pull --mirror origin main
 ${CMD_PREFIX} ostree --repo=mirrorrepo fsck
 echo "ok pull mirror (should not apply deltas)"
+
+cd ${test_tmpdir}
+if ${CMD_PREFIX} ostree --repo=mirrorrepo \
+     pull origin main --require-static-deltas 2>err.txt; then
+  assert_not_reached "--require-static-deltas unexpectedly succeeded"
+fi
+assert_file_has_content err.txt "Can't use static deltas in an archive repo"
+${CMD_PREFIX} ostree --repo=mirrorrepo pull origin main
+${CMD_PREFIX} ostree --repo=mirrorrepo fsck
+echo "ok pull (refuses deltas)"
 
 cd ${test_tmpdir}
 rm mirrorrepo/refs/remotes/* -rf

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -168,7 +168,7 @@ echo 'ok heuristic endian detection'
 
 ${CMD_PREFIX} ostree --repo=repo summary -u
 
-mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=archive-z2
+mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=bare-user
 ${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${newrev}
 ${CMD_PREFIX} ostree --repo=repo2 fsck
 ${CMD_PREFIX} ostree --repo=repo2 ls ${newrev} >/dev/null
@@ -236,7 +236,7 @@ echo 'ok generate + show empty delta part'
 ${CMD_PREFIX} ostree --repo=repo summary -u
 
 rm -rf repo2
-mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=archive-z2
+mkdir repo2 && ${CMD_PREFIX} ostree --repo=repo2 init --mode=bare-user
 ${CMD_PREFIX} ostree --repo=repo2 pull-local repo ${newrev}
 ${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${samerev}
 ${CMD_PREFIX} ostree --repo=repo2 fsck


### PR DESCRIPTION
In https://github.com/ostreedev/ostree/pull/408, we disabled the use of
static deltas when mirroring. Later,
https://github.com/ostreedev/ostree/pull/506 loosened this up again so
that we could use static deltas when mirroring into bare{-user} repos.

However, the issue which originally spurrred #408 is even more generic
than that: we want to avoid static deltas for any archive repo, not just
when doing a mirror pull. This patch tightens this up, and also
relocates the decision code to make it easier to read.