### PR TITLE
Allow and start using C99 declaration-after-statement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,6 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -Werror=incompatible-pointer-types \
         -Werror=misleading-indentation \
 	-Werror=missing-include-dirs -Werror=aggregate-return \
-	-Werror=declaration-after-statement \
 ])
 AC_SUBST(WARN_CFLAGS)
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4309,16 +4309,14 @@ find_keyring (OstreeRepo          *self,
               OstreeRemote        *remote,
               GCancellable        *cancellable)
 {
-  g_autoptr(GFile) remotes_d = NULL;
-  g_autoptr(GFile) file = NULL;
-  file = g_file_get_child (self->repodir, remote->keyring);
+  g_autoptr(GFile) file = g_file_get_child (self->repodir, remote->keyring);
 
   if (g_file_query_exists (file, cancellable))
     {
       return g_steal_pointer (&file);
     }
 
-  remotes_d = get_remotes_d_dir (self);
+  g_autoptr(GFile) remotes_d = get_remotes_d_dir (self);
   if (remotes_d)
     {
       g_autoptr(GFile) file2 = g_file_get_child (remotes_d, remote->keyring);


### PR DESCRIPTION
I've seen code in a few places that I think on balance is definitely better this
way.  Some of our functions have huge variable declaration sections.
This change includes one small example where we could start using declarations
after statements.

A concern I had was - how does this interact with `__attribute__((cleanup))` and
early returns? I tested it, and AFAICS the behavior is what you'd expect - the
cleanup function isn't called if its variable isn't reachable.