### PR TITLE
build: Fix disabling --enable-man if xsltproc is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,8 +184,9 @@ AS_IF([test "$enable_man" != no], [
       AC_MSG_ERROR([xsltproc is required for --enable-man])
     ])
     enable_man=no
+  ],[
+    enable_man=yes
   ])
-  enable_man=yes
 ])
 AM_CONDITIONAL(ENABLE_MAN, test "$enable_man" != no)
 


### PR DESCRIPTION
If --enable-man=maybe (the default), and xsltproc is not available, the
configuration code would check for it, correctly set enable_man=no, then
incorrectly overwrite that with enable_man=yes, which would result in
later trying to execute $(XSLTPROC) when it’s empty.

Signed-off-by: Philip Withnall <withnall@endlessm.com>