### PR TITLE
Disable "ostree trivial-httpd" by default now

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,14 @@ if test x$with_soup != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libsoup"; fi
 AM_CONDITIONAL(USE_LIBSOUP, test x$with_soup != xno)
 AM_CONDITIONAL(HAVE_LIBSOUP_CLIENT_CERTS, test x$have_libsoup_client_certs = xyes)
 
+AC_ARG_ENABLE(trivial-httpd-cmdline,
+  [AS_HELP_STRING([--enable-trivial-httpd-cmdline],
+  [Continue to support "ostree trivial-httpd" [default=no]])],,
+  enable_trivial_httpd_cmdline=no)
+AS_IF([test x$enable_trivial_httpd_cmdline = xyes],
+  [AC_DEFINE([BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE], 1, [Define if we are enabling ostree trivial-httpd entrypoint])]
+)
+
 AS_IF([test x$with_curl = xyes && test x$with_soup = xno], [
   AC_MSG_ERROR([Curl enabled, but libsoup is not; libsoup is needed for tests])
 ])
@@ -410,6 +418,7 @@ echo "
     Rust (internal oxidation):                    $rust_debug_release
     rofiles-fuse:                                 $enable_rofiles_fuse
     HTTP backend:                                 $fetcher_backend
+    \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
     systemd:                                      $have_libsystemd
     libmount:                                     $with_libmount

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -58,7 +58,7 @@ static OstreeCommand commands[] = {
   { "show", ostree_builtin_show },
   { "static-delta", ostree_builtin_static_delta },
   { "summary", ostree_builtin_summary },
-#ifdef HAVE_LIBSOUP 
+#if defined(HAVE_LIBSOUP) && defined(BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE)
   { "trivial-httpd", ostree_builtin_trivial_httpd },
 #endif
   { NULL }


### PR DESCRIPTION
This goes farther along the path of deprecating it; consumers should
have been ported at this point.  Though probably a lot of people
may still use `rpm-ostree-toolbox`.