### PR TITLE
libostree: add versioning macros

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -36,4 +36,5 @@ libostree_public_headers = \
 	src/libostree/ostree-deployment.h \
 	src/libostree/ostree-bootconfig-parser.h \
 	src/libostree/ostree-repo-deprecated.h \
+	src/libostree/ostree-version.h \
 	$(NULL)

--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -36,5 +36,8 @@ libostree_public_headers = \
 	src/libostree/ostree-deployment.h \
 	src/libostree/ostree-bootconfig-parser.h \
 	src/libostree/ostree-repo-deprecated.h \
-	src/libostree/ostree-version.h \
 	$(NULL)
+
+# This one is generated via configure.ac, and the gtk-doc
+# code hence needs to look in the builddir.
+libostree_public_built_headers = src/libostree/ostree-version.h

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -225,7 +225,8 @@ EXTRA_DIST += src/libostree/README-gpg src/libostree/bupsplit.h \
 		src/libostree/ostree-enumtypes.h.template \
 		src/libostree/ostree-enumtypes.c.template \
 		src/libostree/ostree-deployment-private.h \
-		src/libostree/ostree-repo-deprecated.h
+		src/libostree/ostree-repo-deprecated.h \
+		src/libostree/ostree-version.h
 
 install-mkdir-remotes-d-hook:
 	mkdir -p $(DESTDIR)$(sysconfdir)/ostree/remotes.d

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -44,7 +44,7 @@ libostree_kernel_args_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS)
 lib_LTLIBRARIES += libostree-1.la
 
 libostreeincludedir = $(includedir)/ostree-1
-libostreeinclude_HEADERS = $(libostree_public_headers)
+libostreeinclude_HEADERS = $(libostree_public_headers) $(libostree_public_built_headers)
 
 ENUM_TYPES = $(NULL)
 ENUM_TYPES += $(srcdir)/src/libostree/ostree-fetcher.h

--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -105,7 +105,7 @@ EXTRA_DIST += src/ostree/parse-datetime.y
 CLEANFILES += src/ostree/parse-datetime.c
 
 ostree_bin_shared_cflags = $(AM_CFLAGS) -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree \
-	-I$(srcdir)/src/ostree -I$(srcdir)/libglnx $(OT_INTERNAL_GIO_UNIX_CFLAGS) \
+	-I$(builddir)/src/libostree -I$(srcdir)/src/ostree -I$(srcdir)/libglnx $(OT_INTERNAL_GIO_UNIX_CFLAGS) \
 	-DPKGLIBEXECDIR=\"$(pkglibexecdir)\"
 ostree_bin_shared_ldadd = $(AM_LDFLAGS) libglnx.la libotutil.la libostree-1.la \
 	$(OT_INTERNAL_GIO_UNIX_LIBS)

--- a/apidoc/Makefile.am
+++ b/apidoc/Makefile.am
@@ -60,7 +60,7 @@ FIXXREF_OPTIONS=
 # Used for dependencies. The docs will be rebuilt if any of these change.
 # e.g. HFILE_GLOB=$(top_srcdir)/gtk/*.h
 # e.g. CFILE_GLOB=$(top_srcdir)/gtk/*.c
-HFILE_GLOB=$(addprefix $(top_srcdir)/,$(libostree_public_headers))
+HFILE_GLOB=$(addprefix $(top_srcdir)/,$(libostree_public_headers)) $(addprefix $(top_builddir)/,$(libostree_public_built_headers))
 CFILE_GLOB=$(top_srcdir)/src/libostree/*.c
 
 # Header files to ignore when scanning.

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,10 @@
 AC_PREREQ([2.63])
 dnl If incrementing the version here, remember to update libostree.sym too
-AC_INIT([libostree], [2017.3], [walters@verbum.org])
+m4_define([year_version], [2017])
+m4_define([release_version], [3])
+m4_define([package_version], [year_version.release_version])
+
+AC_INIT([libostree], [package_version], [walters@verbum.org])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -15,6 +19,11 @@ AC_SYS_LARGEFILE
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_YACC
+
+dnl Versioning information
+AC_SUBST([YEAR_VERSION], [year_version])
+AC_SUBST([RELEASE_VERSION], [release_version])
+AC_SUBST([PACKAGE_VERSION], [package_version])
 
 CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -pipe \
@@ -398,6 +407,7 @@ AC_CONFIG_FILES([
 Makefile
 apidoc/Makefile
 src/libostree/ostree-1.pc
+src/libostree/ostree-version.h
 ])
 AC_OUTPUT
 

--- a/src/libostree/ostree-version.h.in
+++ b/src/libostree/ostree-version.h.in
@@ -1,0 +1,82 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+/**
+ * SECTION:ostree-version
+ * @short_description: ostree version checking
+ *
+ * ostree provides macros to check the version of the library
+ * at compile-time
+ */
+
+/**
+ * OSTREE_YEAR_VERSION:
+ *
+ * ostree year version component (e.g. 2017 if %OSTREE_VERSION is 2017.2)
+ */
+#define OSTREE_YEAR_VERSION (@YEAR_VERSION@)
+
+/**
+ * OSTREE_RELEASE_VERSION:
+ *
+ * ostree release version component (e.g. 2 if %OSTREE_VERSION is 2017.2)
+ */
+#define OSTREE_RELEASE_VERSION (@RELEASE_VERSION@)
+
+/**
+ * OSTREE_VERSION
+ *
+ * ostree version.
+ */
+#define OSTREE_VERSION (@VERSION@)
+
+/**
+ * OSTREE_VERSION_S:
+ *
+ * ostree version, encoded as a string, useful for printing and
+ * concatenation.
+ */
+#define OSTREE_VERSION_S "@VERSION@"
+
+#define OSTREE_ENCODE_VERSION(year,release) \
+        ((year) << 16 | (release))
+
+/**
+ * OSTREE_VERSION_HEX:
+ *
+ * ostree version, encoded as an hexadecimal number, useful for
+ * integer comparisons.
+ */
+#define OSTREE_VERSION_HEX \
+        (OSTREE_ENCODE_VERSION (OSTREE_YEAR_VERSION, OSTREE_RELEASE_VERSION))
+
+/**
+ * OSTREE_CHECK_VERSION:
+ * @year: required year version
+ * @release: required release version
+ *
+ * Compile-time version checking. Evaluates to %TRUE if the version
+ * of ostree is equal or greater than the required one.
+ */
+#define OSTREE_CHECK_VERSION(year,release)   \
+        (OSTREE_YEAR_VERSION >= (year) || \
+         (OSTREE_YEAR_VERSION == (year) && OSTREE_RELEASE_VERSION >= (release)))

--- a/src/libostree/ostree.h
+++ b/src/libostree/ostree.h
@@ -33,3 +33,4 @@
 #include <ostree-gpg-verify-result.h>
 
 #include <ostree-autocleanups.h>
+#include <ostree-version.h>


### PR DESCRIPTION
OSTree currently provides no way to inspect the versioning
information at run time, being only available at compile
time through pkg-config.

This is a problem for e.g. Flatpak, that needs to check
whether the 'update-frequency' option is available. Checking
at compile time isn't great since it's not looking for new
symbols, but only if an optional feature is present.

This pull request, then, adds a new header that is generated
at compile time, exposing OSTree's versioning information.