### PR TITLE
Fix includes if built against musl

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -42,6 +42,7 @@
 
 #include <locale.h>
 #include <glib/gstdio.h>
+#include <sys/file.h>
 
 /**
  * SECTION:ostree-repo

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "otutil.h"
+#include <sys/file.h>
 #include <sys/mount.h>
 #include <sys/wait.h>
 


### PR DESCRIPTION
LOCK_* is defined in sys/file.h

http://git.musl-libc.org/cgit/musl/tree/include/sys/file.h