### PR TITLE
core: Add runtime ostree_check_version()

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -133,6 +133,7 @@ ostree_validate_structureof_dirtree
 ostree_validate_structureof_dirmeta
 ostree_commit_get_parent
 ostree_commit_get_timestamp
+ostree_check_version
 </SECTION>
 
 <SECTION>

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -386,12 +386,10 @@ global:
  *                         NOTE NOTE NOTE
  */
 
-/* Stub section for new version, uncomment when the first symbol is added
-LIBOSTREE_2017.$NEWVERSION {
+LIBOSTREE_2017.4 {
 global:
-	someostree_symbol_deleteme;
-} LIBOSTREE_2017.2;
-*/
+  ostree_check_version;
+} LIBOSTREE_2017.3;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2153,3 +2153,16 @@ _ostree_get_default_sysroot_path (void)
 
   return default_sysroot_path;
 }
+
+/**
+ * ostree_check_version:
+ * @required_year: Major/year required
+ * @required_release: Release version required
+ *
+ * Returns: %TRUE if current libostree has at least the requested version, %FALSE otherwise
+ */
+gboolean
+ostree_check_version (guint required_year, guint required_release)
+{
+  return OSTREE_CHECK_VERSION(required_year, required_release);
+}

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -399,4 +399,7 @@ gchar *  ostree_commit_get_parent            (GVariant  *commit_variant);
 _OSTREE_PUBLIC
 guint64  ostree_commit_get_timestamp         (GVariant  *commit_variant);
 
+_OSTREE_PUBLIC
+gboolean ostree_check_version (guint required_year, guint required_release);
+
 G_END_DECLS


### PR DESCRIPTION
[Previously](https://github.com/ostreedev/ostree/pull/728) we added compile-time
checking for versions, but there are use cases for runtime checking as well,
because in a number of API calls we use `GVariant` as an API extension
mechanism.