### PR TITLE
Use OpenSSL for checksums

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -76,10 +76,11 @@ tests:
 inherit: true
 required: true
 
-context: curl
+context: curl-openssl
 
 packages:
   - pkgconfig(libcurl)
+  - pkgconfig(openssl)
 
 build:
     config-opts: >
@@ -88,6 +89,7 @@ build:
       --enable-installed-tests
       --enable-gtk-doc
       --with-curl
+      --with-openssl
 
 tests:
   - make check

--- a/Makefile-otutil.am
+++ b/Makefile-otutil.am
@@ -22,6 +22,8 @@ noinst_LTLIBRARIES += libotutil.la
 libotutil_la_SOURCES = \
 	src/libotutil/ot-checksum-utils.c \
 	src/libotutil/ot-checksum-utils.h \
+	src/libotutil/ot-checksum-instream.c \
+	src/libotutil/ot-checksum-instream.h \
 	src/libotutil/ot-fs-utils.c \
 	src/libotutil/ot-fs-utils.h \
 	src/libotutil/ot-keyfile-utils.c \

--- a/configure.ac
+++ b/configure.ac
@@ -298,6 +298,23 @@ AS_IF([ test x$with_smack = xyes], [
 ])
 AM_CONDITIONAL(USE_SMACK, test $with_smack != no)
 
+dnl begin openssl
+OPENSSL_DEPENDENCY="libselinux >= 1.0.1"
+AC_ARG_WITH(openssl,
+AS_HELP_STRING([--with-openssl], [Enable use of OpenSSL (checksums)]),
+:, with_openssl=no)
+
+AS_IF([ test x$with_openssl != xno ], [
+      PKG_CHECK_MODULES(OT_DEP_OPENSSL, $OPENSSL_DEPENDENCY)
+      AC_DEFINE([HAVE_OPENSSL], 1, [Define if we have openssl])
+      with_openssl=yes
+], [
+      with_openssl=no
+])
+if test x$with_openssl != xno; then OSTREE_FEATURES="$OSTREE_FEATURES openssl"; fi
+AM_CONDITIONAL(USE_OPENSSL, test $with_openssl != no)
+dnl end openssl
+
 dnl This is what is in RHEL7.2 right now, picking it arbitrarily
 LIBMOUNT_DEPENDENCY="mount >= 2.23.0"
 
@@ -430,6 +447,7 @@ echo "
     HTTP backend:                                 $fetcher_backend
     \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
+    OpenSSL (checksums):                          $with_openssl
     systemd:                                      $have_libsystemd
     libmount:                                     $with_libmount
     libarchive (parse tar files directly):        $with_libarchive

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1351,7 +1351,7 @@ void
 ostree_checksum_inplace_from_bytes (const guchar *csum,
                                     char         *buf)
 {
-  ot_bin2hex (buf, csum, OSTREE_SHA256_STRING_LEN);
+  ot_bin2hex (buf, csum, OSTREE_SHA256_DIGEST_LEN);
 }
 
 /**

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1351,16 +1351,7 @@ void
 ostree_checksum_inplace_from_bytes (const guchar *csum,
                                     char         *buf)
 {
-  static const gchar hexchars[] = "0123456789abcdef";
-  guint i, j;
-
-  for (i = 0, j = 0; i < OSTREE_SHA256_DIGEST_LEN; i++, j += 2)
-    {
-      guchar byte = csum[i];
-      buf[j] = hexchars[byte >> 4];
-      buf[j+1] = hexchars[byte & 0xF];
-    }
-  buf[j] = '\0';
+  ot_bin2hex (buf, csum, OSTREE_SHA256_STRING_LEN);
 }
 
 /**

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -889,7 +889,10 @@ write_object (OstreeRepo         *self,
   g_mutex_unlock (&self->txn_stats_lock);
 
   if (checksum_input)
-    ret_csum = ot_checksum_instream_dup_digest (checksum_input, NULL);
+    {
+      g_assert (actual_checksum);
+      ret_csum = ostree_checksum_to_bytes (actual_checksum);
+    }
 
   ret = TRUE;
   ot_transfer_out_value(out_csum, &ret_csum);

--- a/src/libotutil/ot-checksum-instream.c
+++ b/src/libotutil/ot-checksum-instream.c
@@ -167,7 +167,7 @@ ot_checksum_instream_dup_digest (OtChecksumInstream *stream,
 {
 #ifdef HAVE_OPENSSL
   guint len;
-  guchar *ret = g_malloc (EVP_MAX_MD_SIZE);
+  guchar *ret = g_malloc0 (EVP_MAX_MD_SIZE);
   g_assert (EVP_DigestFinal_ex (stream->priv->checksum, ret, &len));
 #else
   gsize len = g_checksum_type_get_length (stream->priv->checksum_type);

--- a/src/libotutil/ot-checksum-instream.c
+++ b/src/libotutil/ot-checksum-instream.c
@@ -22,10 +22,19 @@
 
 #include "ot-checksum-instream.h"
 
+#ifdef HAVE_OPENSSL
+#include <openssl/evp.h>
+#endif
+
 G_DEFINE_TYPE (OtChecksumInstream, ot_checksum_instream, G_TYPE_FILTER_INPUT_STREAM)
 
 struct _OtChecksumInstreamPrivate {
+#ifdef HAVE_OPENSSL
+  EVP_MD_CTX *checksum;
+#else
+  GChecksumType checksum_type;
   GChecksum *checksum;
+#endif
 };
 
 static gssize   ot_checksum_instream_read         (GInputStream         *stream,
@@ -39,7 +48,11 @@ ot_checksum_instream_finalize (GObject *object)
 {
   OtChecksumInstream *self = (OtChecksumInstream*)object;
 
+#ifdef HAVE_OPENSSL
+  EVP_MD_CTX_destroy (self->priv->checksum);
+#else
   g_checksum_free (self->priv->checksum);
+#endif
 
   G_OBJECT_CLASS (ot_checksum_instream_parent_class)->finalize (object);
 }
@@ -60,8 +73,22 @@ static void
 ot_checksum_instream_init (OtChecksumInstream *self)
 {
   self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, OT_TYPE_CHECKSUM_INSTREAM, OtChecksumInstreamPrivate);
-
 }
+
+#ifdef HAVE_OPENSSL
+static const EVP_MD *
+gchecksum_type_to_openssl (GChecksumType checksum_type)
+{
+  switch (checksum_type)
+    {
+    case G_CHECKSUM_SHA256:
+      return EVP_sha256 ();
+    default:
+      /* If there's something else, fill in here */
+      g_assert_not_reached ();
+    }
+}
+#endif
 
 OtChecksumInstream *
 ot_checksum_instream_new (GInputStream    *base,
@@ -74,7 +101,18 @@ ot_checksum_instream_new (GInputStream    *base,
   stream = g_object_new (OT_TYPE_CHECKSUM_INSTREAM,
                          "base-stream", base,
                          NULL);
+
+  /* For now */
+  g_assert (checksum_type == G_CHECKSUM_SHA256);
+
+#ifdef HAVE_OPENSSL
+  stream->priv->checksum = EVP_MD_CTX_create ();
+  g_assert (stream->priv->checksum);
+  g_assert (EVP_DigestInit_ex (stream->priv->checksum, gchecksum_type_to_openssl (checksum_type), NULL));
+#else
   stream->priv->checksum = g_checksum_new (checksum_type);
+  stream->priv->checksum_type = checksum_type;
+#endif
 
   return (OtChecksumInstream*) (stream);
 }
@@ -96,7 +134,13 @@ ot_checksum_instream_read (GInputStream  *stream,
                              cancellable,
                              error);
   if (res > 0)
-    g_checksum_update (self->priv->checksum, buffer, res);
+    {
+#ifdef HAVE_OPENSSL
+      g_assert (EVP_DigestUpdate (self->priv->checksum, buffer, res));
+#else
+      g_checksum_update (self->priv->checksum, buffer, res);
+#endif
+    }
 
   return res;
 }
@@ -106,17 +150,29 @@ ot_checksum_instream_get_digest (OtChecksumInstream *stream,
                                  guint8          *buffer,
                                  gsize           *digest_len)
 {
+#ifdef HAVE_OPENSSL
+  unsigned len;
+  EVP_DigestFinal_ex (stream->priv->checksum, buffer, &len);
+  if (digest_len)
+    *digest_len = len;
+#else
   g_checksum_get_digest (stream->priv->checksum, buffer, digest_len);
+#endif
 }
 
 guint8*
 ot_checksum_instream_dup_digest (OtChecksumInstream *stream,
                                  gsize              *ret_len)
 {
-  gsize len = 32;
+#ifdef HAVE_OPENSSL
+  guint len;
+  guchar *ret = g_malloc (EVP_MAX_MD_SIZE);
+  g_assert (EVP_DigestFinal_ex (stream->priv->checksum, ret, &len));
+#else
+  gsize len = g_checksum_type_get_length (stream->priv->checksum_type);
   guchar *ret = g_malloc (len);
   g_checksum_get_digest (stream->priv->checksum, ret, &len);
-  g_assert (len == 32);
+#endif
   if (ret_len)
     *ret_len = len;
   return ret;
@@ -125,5 +181,14 @@ ot_checksum_instream_dup_digest (OtChecksumInstream *stream,
 char *
 ot_checksum_instream_get_string (OtChecksumInstream *stream)
 {
+#ifdef HAVE_OPENSSL
+  unsigned len;
+  guint8 csum[EVP_MAX_MD_SIZE];
+  g_assert (EVP_DigestFinal_ex (stream->priv->checksum, csum, &len));
+  char *buf = g_malloc (len * 2 + 1);
+  ot_bin2hex (buf, (guint8*)csum, len);
+  return buf;
+#else
   return g_strdup (g_checksum_get_string (stream->priv->checksum));
+#endif
 }

--- a/src/libotutil/ot-checksum-instream.c
+++ b/src/libotutil/ot-checksum-instream.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "ot-checksum-instream.h"
+#include "ot-checksum-utils.h"
 
 #ifdef HAVE_OPENSSL
 #include <openssl/evp.h>

--- a/src/libotutil/ot-checksum-instream.c
+++ b/src/libotutil/ot-checksum-instream.c
@@ -1,0 +1,129 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ * 
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "ot-checksum-instream.h"
+
+G_DEFINE_TYPE (OtChecksumInstream, ot_checksum_instream, G_TYPE_FILTER_INPUT_STREAM)
+
+struct _OtChecksumInstreamPrivate {
+  GChecksum *checksum;
+};
+
+static gssize   ot_checksum_instream_read         (GInputStream         *stream,
+                                                           void                 *buffer,
+                                                           gsize                 count,
+                                                           GCancellable         *cancellable,
+                                                           GError              **error);
+
+static void
+ot_checksum_instream_finalize (GObject *object)
+{
+  OtChecksumInstream *self = (OtChecksumInstream*)object;
+
+  g_checksum_free (self->priv->checksum);
+
+  G_OBJECT_CLASS (ot_checksum_instream_parent_class)->finalize (object);
+}
+
+static void
+ot_checksum_instream_class_init (OtChecksumInstreamClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GInputStreamClass *stream_class = G_INPUT_STREAM_CLASS (klass);
+
+  g_type_class_add_private (klass, sizeof (OtChecksumInstreamPrivate));
+
+  object_class->finalize = ot_checksum_instream_finalize;
+  stream_class->read_fn = ot_checksum_instream_read;
+}
+
+static void
+ot_checksum_instream_init (OtChecksumInstream *self)
+{
+  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, OT_TYPE_CHECKSUM_INSTREAM, OtChecksumInstreamPrivate);
+
+}
+
+OtChecksumInstream *
+ot_checksum_instream_new (GInputStream    *base,
+                          GChecksumType    checksum_type)
+{
+  OtChecksumInstream *stream;
+
+  g_return_val_if_fail (G_IS_INPUT_STREAM (base), NULL);
+
+  stream = g_object_new (OT_TYPE_CHECKSUM_INSTREAM,
+                         "base-stream", base,
+                         NULL);
+  stream->priv->checksum = g_checksum_new (checksum_type);
+
+  return (OtChecksumInstream*) (stream);
+}
+
+static gssize
+ot_checksum_instream_read (GInputStream  *stream,
+                           void          *buffer,
+                           gsize          count,
+                           GCancellable  *cancellable,
+                           GError       **error)
+{
+  OtChecksumInstream *self = (OtChecksumInstream*) stream;
+  GFilterInputStream *fself = (GFilterInputStream*) self;
+  gssize res = -1;
+
+  res = g_input_stream_read (fself->base_stream,
+                             buffer,
+                             count,
+                             cancellable,
+                             error);
+  if (res > 0)
+    g_checksum_update (self->priv->checksum, buffer, res);
+
+  return res;
+}
+
+void
+ot_checksum_instream_get_digest (OtChecksumInstream *stream,
+                                 guint8          *buffer,
+                                 gsize           *digest_len)
+{
+  g_checksum_get_digest (stream->priv->checksum, buffer, digest_len);
+}
+
+guint8*
+ot_checksum_instream_dup_digest (OtChecksumInstream *stream,
+                                 gsize              *ret_len)
+{
+  gsize len = 32;
+  guchar *ret = g_malloc (len);
+  g_checksum_get_digest (stream->priv->checksum, ret, &len);
+  g_assert (len == 32);
+  if (ret_len)
+    *ret_len = len;
+  return ret;
+}
+
+char *
+ot_checksum_instream_get_string (OtChecksumInstream *stream)
+{
+  return g_strdup (g_checksum_get_string (stream->priv->checksum));
+}

--- a/src/libotutil/ot-checksum-instream.h
+++ b/src/libotutil/ot-checksum-instream.h
@@ -1,0 +1,64 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2011 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define OT_TYPE_CHECKSUM_INSTREAM         (ot_checksum_instream_get_type ())
+#define OT_CHECKSUM_INSTREAM(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), OT_TYPE_CHECKSUM_INPUT_STREAM, OtChecksumInstream))
+#define OT_CHECKSUM_INSTREAM_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST((k), OT_TYPE_CHECKSUM_INPUT_STREAM, OtChecksumInstreamClass))
+#define OT_IS_CHECKSUM_INSTREAM(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), OT_TYPE_CHECKSUM_INPUT_STREAM))
+#define OT_IS_CHECKSUM_INSTREAM_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), OT_TYPE_CHECKSUM_INPUT_STREAM))
+#define OT_CHECKSUM_INSTREAM_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), OT_TYPE_CHECKSUM_INPUT_STREAM, OtChecksumInstreamClass))
+
+typedef struct _OtChecksumInstream         OtChecksumInstream;
+typedef struct _OtChecksumInstreamClass    OtChecksumInstreamClass;
+typedef struct _OtChecksumInstreamPrivate  OtChecksumInstreamPrivate;
+
+struct _OtChecksumInstream
+{
+  GFilterInputStream parent_instance;
+
+  /*< private >*/
+  OtChecksumInstreamPrivate *priv;
+};
+
+struct _OtChecksumInstreamClass
+{
+  GFilterInputStreamClass parent_class;
+};
+
+GType          ot_checksum_instream_get_type     (void) G_GNUC_CONST;
+
+OtChecksumInstream * ot_checksum_instream_new          (GInputStream   *stream, GChecksumType   checksum);
+
+void   ot_checksum_instream_get_digest (OtChecksumInstream *stream,
+                                        guint8          *buffer,
+                                        gsize           *digest_len);
+
+guint8* ot_checksum_instream_dup_digest (OtChecksumInstream *stream,
+                                         gsize              *ret_len);
+char * ot_checksum_instream_get_string (OtChecksumInstream *stream);
+
+G_END_DECLS

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -26,6 +26,22 @@
 
 #include <string.h>
 
+
+void
+ot_bin2hex (char *out_buf, const guint8 *inbuf, gsize len)
+{
+  static const gchar hexchars[] = "0123456789abcdef";
+  guint i, j;
+
+  for (i = 0, j = 0; i < len; i++, j += 2)
+    {
+      guchar byte = inbuf[i];
+      out_buf[j] = hexchars[byte >> 4];
+      out_buf[j+1] = hexchars[byte & 0xF];
+    }
+  out_buf[j] = '\0';
+}
+
 guchar *
 ot_csum_from_gchecksum (GChecksum  *checksum)
 {

--- a/src/libotutil/ot-checksum-utils.h
+++ b/src/libotutil/ot-checksum-utils.h
@@ -26,6 +26,8 @@
 
 G_BEGIN_DECLS
 
+void ot_bin2hex (char *out_buf, const guint8 *inbuf, gsize len);
+
 guchar *ot_csum_from_gchecksum (GChecksum *checksum);
 
 gboolean ot_gio_write_update_checksum (GOutputStream  *out,

--- a/src/libotutil/otutil.h
+++ b/src/libotutil/otutil.h
@@ -53,5 +53,6 @@
 #include <ot-checksum-utils.h>
 #include <ot-gpg-utils.h>
 #include <ot-log-utils.h>
+#include <ot-checksum-instream.h>
 
 void ot_ptrarray_add_many (GPtrArray  *a, ...) G_GNUC_NULL_TERMINATED; 


### PR DESCRIPTION
Add an OpenSSL backend to the checksum input stream, which is where we do a lot
of checksumming (object commit, static deltas).

The raw OpenSSL performance is
[approximately double](https://gist.github.com/cgwalters/169349fd1c06fd4fb4d3a7ce33303222) on
my laptop; not only does OpenSSL have e.g. hand-tuned x86_64 assembly, the
current implementation uses the
[Intel SHA extensions](https://en.wikipedia.org/wiki/Intel_SHA_extensions).

Another reason to do this is I was idly thinking about adding
[Curve25519](https://en.wikipedia.org/wiki/Curve25519) signatures (like e.g.
Alpine does) instead of/in addition to GPG.  The rationale for that is
that GPG is pretty heavyweight, both in code footprint and the simple
fact that EC keys are way smaller.

I didn't benchmark ostree with this; we have bigger performance problems
really like the fact we just malloc way too much.  But, it's a step
in the right direction I think in combination with the libcurl work
where we're linking to openssl anyways.