### PR TITLE
sysroot: Have writing non-default deployments go after booted

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1572,10 +1572,10 @@ ostree_sysroot_simple_write_deployment (OstreeSysroot      *sysroot,
   for (i = 0; i < deployments->len; i++)
     {
       OstreeDeployment *deployment = deployments->pdata[i];
-      const gboolean is_merge_or_booted = 
-        ostree_deployment_equal (deployment, booted_deployment) ||
+      const gboolean is_booted = ostree_deployment_equal (deployment, booted_deployment);
+      const gboolean is_merge_or_booted = is_booted ||
         ostree_deployment_equal (deployment, merge_deployment);
-      
+
       /* Keep deployments with different osnames, as well as the
        * booted and merge deployments
        */
@@ -1586,16 +1586,16 @@ ostree_sysroot_simple_write_deployment (OstreeSysroot      *sysroot,
           g_ptr_array_add (new_deployments, g_object_ref (deployment));
         }
 
-      if (!added_new)
+      /* Insert new non-default right after the booted, if we have a booted deployment */
+      if (!make_default && is_booted)
         {
           g_ptr_array_add (new_deployments, g_object_ref (new_deployment));
           added_new = TRUE;
         }
     }
 
-  /* In this non-default case , an improvement in the future would be
-   * to put the new deployment right after the current default in the
-   * order.
+  /* If we're operating on a non-booted osname, arbitrarily insert the new
+   * non-default last.
    */
   if (!added_new)
     {


### PR DESCRIPTION
When I added this API, I hadn't considered the case where we
have a "pending" deployment.  the `_NOT_DEFAULT` case worked
fine without that.

However for `rpm-ostree ex livefs`, we want to push a rollback target which is
the snapshot of the current deployment before mutating.