### PR TITLE
sysroot: Prep refactoring of cleanup logic

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1730,14 +1730,13 @@ ostree_sysroot_write_deployments (OstreeSysroot     *self,
                                   GError           **error)
 {
   return _ostree_sysroot_write_deployments_internal (self, new_deployments,
-                                                     OSTREE_SYSROOT_CLEANUP_ALL,
-                                                     cancellable, error);
+                                                     TRUE, cancellable, error);
 }
 
 gboolean
 _ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
                                             GPtrArray         *new_deployments,
-                                            OstreeSysrootCleanupFlags cleanup_flags,
+                                            gboolean           do_clean,
                                             GCancellable      *cancellable,
                                             GError           **error)
 {
@@ -1965,11 +1964,13 @@ _ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
 
   /* And finally, cleanup of any leftover data.
    */
-  if (!_ostree_sysroot_piecemeal_cleanup (self, cleanup_flags,
-                                          cancellable, error))
+  if (do_clean)
     {
-      g_prefix_error (error, "Performing final cleanup: ");
-      goto out;
+      if (!ostree_sysroot_cleanup (self, cancellable, error))
+        {
+          g_prefix_error (error, "Performing final cleanup: ");
+          goto out;
+        }
     }
 
   ret = TRUE;

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -109,21 +109,14 @@ gboolean _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
 gboolean _ostree_sysroot_bump_mtime (OstreeSysroot *sysroot,
                                      GError       **error);
 
-typedef enum {
-  OSTREE_SYSROOT_CLEANUP_BOOTVERSIONS = 1 << 0,
-  OSTREE_SYSROOT_CLEANUP_DEPLOYMENTS  = 1 << 1,
-  OSTREE_SYSROOT_CLEANUP_PRUNE_REPO   = 1 << 2,
-  OSTREE_SYSROOT_CLEANUP_ALL          = 0xffff
-} OstreeSysrootCleanupFlags;
-
-gboolean _ostree_sysroot_piecemeal_cleanup (OstreeSysroot *sysroot,
-                                            OstreeSysrootCleanupFlags flags,
-                                            GCancellable *cancellable,
-                                            GError **error);
+gboolean _ostree_sysroot_cleanup_internal (OstreeSysroot *sysroot,
+                                           gboolean       prune_repo,
+                                           GCancellable  *cancellable,
+                                           GError       **error);
 
 gboolean _ostree_sysroot_write_deployments_internal (OstreeSysroot     *self,
                                                      GPtrArray         *new_deployments,
-                                                     OstreeSysrootCleanupFlags cleanup_flags,
+                                                     gboolean           do_clean,
                                                      GCancellable      *cancellable,
                                                      GError           **error);
 

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1604,8 +1604,7 @@ ostree_sysroot_simple_write_deployment (OstreeSysroot      *sysroot,
     }
 
   if (!_ostree_sysroot_write_deployments_internal (sysroot, new_deployments,
-                                                   postclean ? OSTREE_SYSROOT_CLEANUP_ALL : 0,
-                                                   cancellable, error))
+                                                   postclean, cancellable, error))
     goto out;
 
   ret = TRUE;


### PR DESCRIPTION
For future work I'm going to tweak how we handle cleanup, and
the private cleanup flags didn't really end up being used - we
only specify "prune repo or not".  So fold that into a boolean for now.

The sysroot deploy logic then has a single "do_postclean" boolean, which is all
I want to expose as public API.