### PR TITLE
Bump libglnx, port a few callers to new error API

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1798,13 +1798,9 @@ ostree_validate_structureof_objtype (guchar    objtype,
                                      GError   **error)
 {
   OstreeObjectType objtype_v = (OstreeObjectType) objtype;
-  if (objtype_v < OSTREE_OBJECT_TYPE_FILE 
+  if (objtype_v < OSTREE_OBJECT_TYPE_FILE
       || objtype_v > OSTREE_OBJECT_TYPE_COMMIT)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Invalid object type '%u'", objtype);
-      return FALSE;
-    }
+    return glnx_throw (error, "Invalid object type '%u'", objtype);
   return TRUE;
 }
 
@@ -1837,11 +1833,7 @@ ostree_validate_structureof_checksum_string (const char *checksum,
   size_t len = strlen (checksum);
 
   if (len != OSTREE_SHA256_STRING_LEN)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Invalid rev '%s'", checksum);
-      return FALSE;
-    }
+    return glnx_throw (error, "Invalid rev '%s'", checksum);
 
   for (i = 0; i < len; i++)
     {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1831,10 +1831,7 @@ ostree_repo_create (OstreeRepo     *self,
   if (mkdir (repopath, 0755) != 0)
     {
       if (G_UNLIKELY (errno != EEXIST))
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno (error);
     }
 
   if (!glnx_opendirat (AT_FDCWD, repopath, TRUE, &dfd, error))
@@ -1858,10 +1855,7 @@ ostree_repo_create (OstreeRepo     *self,
             return FALSE;
         }
       else
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno (error);
     }
 
   for (guint i = 0; i < G_N_ELEMENTS (state_dirs); i++)
@@ -1870,10 +1864,7 @@ ostree_repo_create (OstreeRepo     *self,
       if (mkdirat (dfd, elt, 0755) == -1)
         {
           if (G_UNLIKELY (errno != EEXIST))
-            {
-              glnx_set_error_from_errno (error);
-              return FALSE;
-            }
+            return glnx_throw_errno (error);
         }
     }
 


### PR DESCRIPTION
Testing out the waters here. I think we should roll this into any future code
cleanup reworking we do.

Depends: https://github.com/GNOME/libglnx/pull/38