### PR TITLE
Add bare-user-only mode that works on non-xattrs filesystems

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -46,6 +46,7 @@ dist_uninstalled_test_scripts = tests/test-symbols.sh
 dist_test_scripts = \
 	tests/test-basic.sh \
 	tests/test-basic-user.sh \
+	tests/test-basic-user-only.sh \
 	tests/test-pull-subpath.sh \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \

--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -139,6 +139,14 @@ _ostree_loose_path (char              *buf,
 #define _OSTREE_METADATA_GPGSIGS_NAME "ostree.gpgsigs"
 #define _OSTREE_METADATA_GPGSIGS_TYPE G_VARIANT_TYPE ("aay")
 
+static inline gboolean
+_ostree_repo_mode_is_bare (OstreeRepoMode mode)
+{
+  return
+    mode == OSTREE_REPO_MODE_BARE ||
+    mode == OSTREE_REPO_MODE_BARE_USER;
+}
+
 GVariant *
 _ostree_detached_metadata_append_gpg_sig (GVariant   *existing_metadata,
                                           GBytes     *signature_bytes);

--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -144,7 +144,8 @@ _ostree_repo_mode_is_bare (OstreeRepoMode mode)
 {
   return
     mode == OSTREE_REPO_MODE_BARE ||
-    mode == OSTREE_REPO_MODE_BARE_USER;
+    mode == OSTREE_REPO_MODE_BARE_USER ||
+    mode == OSTREE_REPO_MODE_BARE_USER_ONLY;
 }
 
 GVariant *

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -179,6 +179,7 @@ typedef enum {
  * @OSTREE_REPO_MODE_BARE: Files are stored as themselves; checkouts are hardlinks; can only be written as root
  * @OSTREE_REPO_MODE_ARCHIVE_Z2: Files are compressed, should be owned by non-root.  Can be served via HTTP
  * @OSTREE_REPO_MODE_BARE_USER: Files are stored as themselves, except ownership; can be written by user. Hardlinks work only in user checkouts.
+ * @OSTREE_REPO_MODE_BARE_USER_ONLY: Same as BARE_USER, but all metadata is not stored, so it can only be used for user checkouts. Does not need xattrs.
  *
  * See the documentation of #OstreeRepo for more information about the
  * possible modes.
@@ -186,7 +187,8 @@ typedef enum {
 typedef enum {
   OSTREE_REPO_MODE_BARE,
   OSTREE_REPO_MODE_ARCHIVE_Z2,
-  OSTREE_REPO_MODE_BARE_USER
+  OSTREE_REPO_MODE_BARE_USER,
+  OSTREE_REPO_MODE_BARE_USER_ONLY,
 } OstreeRepoMode;
 
 _OSTREE_PUBLIC

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -363,7 +363,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
                         GError                             **error)
 {
   HardlinkResult ret_result = HARDLINK_RESULT_NOT_SUPPORTED;
-  int srcfd = (self->mode == OSTREE_REPO_MODE_BARE || self->mode == OSTREE_REPO_MODE_BARE_USER) ?
+  int srcfd = _ostree_repo_mode_is_bare (self->mode) ?
     self->objects_dir_fd : self->uncompressed_objects_dir_fd;
 
  again:

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -306,8 +306,7 @@ commit_loose_object_trusted (OstreeRepo        *self,
             goto out;
         }
 
-      if (objtype == OSTREE_OBJECT_TYPE_FILE && (self->mode == OSTREE_REPO_MODE_BARE ||
-                                                 self->mode == OSTREE_REPO_MODE_BARE_USER))
+      if (objtype == OSTREE_OBJECT_TYPE_FILE && _ostree_repo_mode_is_bare (self->mode))
         {
           /* To satisfy tools such as guile which compare mtimes
            * to determine whether or not source files need to be compiled,
@@ -700,7 +699,7 @@ write_object (OstreeRepo         *self,
        * binary with trailing garbage, creating a window on the local
        * system where a malicious setuid binary exists.
        */
-      if ((repo_mode == OSTREE_REPO_MODE_BARE || repo_mode == OSTREE_REPO_MODE_BARE_USER) && temp_file_is_regular)
+      if ((_ostree_repo_mode_is_bare (repo_mode)) && temp_file_is_regular)
         {
           guint64 size = g_file_info_get_size (file_info);
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2472,7 +2472,7 @@ list_loose_objects_at (OstreeRepo             *self,
 
       if ((self->mode == OSTREE_REPO_MODE_ARCHIVE_Z2
            && strcmp (dot, ".filez") == 0) ||
-          ((self->mode == OSTREE_REPO_MODE_BARE || self->mode == OSTREE_REPO_MODE_BARE_USER)
+          ((_ostree_repo_mode_is_bare (self->mode))
            && strcmp (dot, ".file") == 0))
         objtype = OSTREE_OBJECT_TYPE_FILE;
       else if (strcmp (dot, ".dirtree") == 0)
@@ -2743,8 +2743,7 @@ _ostree_repo_read_bare_fd (OstreeRepo           *self,
 {
   char loose_path_buf[_OSTREE_LOOSE_PATH_MAX];
 
-  g_assert (self->mode == OSTREE_REPO_MODE_BARE ||
-            self->mode == OSTREE_REPO_MODE_BARE_USER);
+  g_assert (_ostree_repo_mode_is_bare (self->mode));
 
   _ostree_loose_path (loose_path_buf, checksum, OSTREE_OBJECT_TYPE_FILE, self->mode);
 

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -536,11 +536,13 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo    *r
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE: No special flags
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS: Do not process extended attributes
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES: Generate size information.
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS: Canonicalize permissions for bare-user-only mode.
  */
 typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE = 0,
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS = (1 << 0),
-  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES = (1 << 1)
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES = (1 << 1),
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS = (1 << 2),
 } OstreeRepoCommitModifierFlags;
 
 /**

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -45,6 +45,7 @@ static gboolean opt_link_checkout_speedup;
 static gboolean opt_skip_if_unchanged;
 static gboolean opt_tar_autocreate_parents;
 static gboolean opt_no_xattrs;
+static gboolean opt_canonical_permissions;
 static char **opt_trees;
 static gint opt_owner_uid = -1;
 static gint opt_owner_gid = -1;
@@ -84,6 +85,7 @@ static GOptionEntry options[] = {
   { "add-detached-metadata-string", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_detached_metadata_strings, "Add a key/value pair to detached metadata", "KEY=VALUE" },
   { "owner-uid", 0, 0, G_OPTION_ARG_INT, &opt_owner_uid, "Set file ownership user id", "UID" },
   { "owner-gid", 0, 0, G_OPTION_ARG_INT, &opt_owner_gid, "Set file ownership group id", "GID" },
+  { "canonical-permissions", 0, 0, G_OPTION_ARG_NONE, &opt_canonical_permissions, "Canonicalize permissions in the same way bare-user does for hardlinked files", NULL },
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Do not import extended attributes", NULL },
   { "link-checkout-speedup", 0, 0, G_OPTION_ARG_NONE, &opt_link_checkout_speedup, "Optimize for commits of trees composed of hardlinks into the repository", NULL },
   { "tar-autocreate-parents", 0, 0, G_OPTION_ARG_NONE, &opt_tar_autocreate_parents, "When loading tar archives, automatically create parent directories as needed", NULL },
@@ -399,6 +401,8 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
 
   if (opt_no_xattrs)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS;
+  if (opt_canonical_permissions)
+    flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS;
   if (opt_generate_sizes)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES;
   if (opt_disable_fsync)

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -206,6 +206,11 @@ setup_test_repository () {
 
     oldpwd=`pwd`
 
+    COMMIT_ARGS=""
+    if [ $mode == "bare-user-only" ] ; then
+       COMMIT_ARGS="--owner-uid=0 --owner-gid=0 --no-xattrs --canonical-permissions"
+    fi
+
     cd ${test_tmpdir}
     if test -n "${mode}"; then
         ostree_repo_init repo --mode=${mode}
@@ -224,7 +229,7 @@ setup_test_repository () {
     echo first > firstfile
 
     cd ${test_tmpdir}/files
-    $OSTREE commit -b test2 -s "Test Commit 1" -m "Commit body first"
+    $OSTREE commit ${COMMIT_ARGS}  -b test2 -s "Test Commit 1" -m "Commit body first"
 
     mkdir baz
     echo moo > baz/cow
@@ -236,7 +241,7 @@ setup_test_repository () {
     echo x > baz/another/y
 
     cd ${test_tmpdir}/files
-    $OSTREE commit -b test2 -s "Test Commit 2" -m "Commit body second"
+    $OSTREE commit ${COMMIT_ARGS}  -b test2 -s "Test Commit 2" -m "Commit body second"
     $OSTREE fsck -q
 
     cd $oldpwd

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_test_repository "bare-user-only"
+. $(dirname $0)/basic-test.sh


### PR DESCRIPTION
This mode is similar to bare-user, but does not store the permission,
ownership (uid/gid) and xattrs in an xattr on the file objects in the
repo. Additionally it stores symlinks as symlinks rather than as
regular files+xattrs, like the bare mode. The later is needed because
we can't store the is-symlink in the xattr.
    
This means that some metadata is lost, such as the uid. When reading a
repo like this we always report uid, gid as 0, and no xattrs, so
unless this is true in the commit the resulting repository will
not fsck correctly.
    
However, it the main usecase of the repository is to check out with
--user-mode, then no information is lost, and the repository can
work on filesystems without xattrs (such as tmpfs).
