### PR TITLE
Add Coccinelle 🐞 usage: one for blacklisting, one for patch collection

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install -y \
         fuse \
         gjs \
         parallel \
+        coccinelle \
         clang \
         libubsan \
         libasan \

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -10,6 +10,7 @@ container:
 
 packages:
   - libasan
+  - coccinelle
 
 env:
     CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address'

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -28,6 +28,7 @@ EXTRA_DIST += \
 # include the builddir in $PATH so we find our just-built ostree
 # binary.
 TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
+  OSTREE_UNINSTALLED_SRCDIR=$(abs_top_srcdir) \
 	OSTREE_UNINSTALLED=$(abs_top_builddir) \
 	G_DEBUG=fatal-warnings \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
@@ -98,6 +99,7 @@ dist_test_scripts = \
 	tests/test-switchroot.sh \
 	tests/test-pull-contenturl.sh \
 	tests/test-pull-mirrorlist.sh \
+	tests/coccinelle.sh \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/coccinelle/README.md
+++ b/coccinelle/README.md
@@ -1,0 +1,6 @@
+This is a directory of semantic patches
+to apply with coccinelle, like the collection in systemd:
+https://github.com/systemd/systemd/tree/29f32655842a0712e8db482bcefc4da8908460c8/coccinelle
+
+See also the tests/coccinelle directory which
+has spatches which detect errors.

--- a/coccinelle/glnx-errors.cocci
+++ b/coccinelle/glnx-errors.cocci
@@ -1,0 +1,6 @@
+@@
+expression p;
+@@
+- glnx_set_error_from_errno (p);
+- goto out;
++ return  glnx_throw_errno (p);

--- a/coccinelle/glnx-errors.cocci
+++ b/coccinelle/glnx-errors.cocci
@@ -1,6 +1,0 @@
-@@
-expression p;
-@@
-- glnx_set_error_from_errno (p);
-- goto out;
-+ return  glnx_throw_errno (p);

--- a/coccinelle/newstyle.cocci
+++ b/coccinelle/newstyle.cocci
@@ -1,0 +1,22 @@
+@@
+expression p;
+@@
+- glnx_set_error_from_errno (p);
+- goto out;
++ return glnx_throw_errno (p);
+@@
+expression p;
+@@
+- if (!p)
+-   goto out;
++ if (!p)
++   return FALSE;
+@@
+expression p;
+@@
+- gboolean ret = FALSE;
+...
+- ret = TRUE;
+- out:
+- return ret;
++ return TRUE;

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -68,7 +68,7 @@ int
 main (int    argc,
       char **argv)
 {
-  GError *error = NULL;
+  g_autoptr(GError) error = NULL;
   int ret;
 
   setlocale (LC_ALL, "");
@@ -88,7 +88,6 @@ main (int    argc,
           suffix = "\x1b[22m\x1b[0m"; /* bold off, color reset */
         }
       g_printerr ("%serror: %s%s\n", prefix, suffix, error->message);
-      g_error_free (error);
     }
 
   return ret;

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -259,7 +259,7 @@ ostree_option_context_parse (GOptionContext *context,
 
   if (opt_repo == NULL && !(flags & OSTREE_BUILTIN_FLAG_NO_REPO))
     {
-      GError *local_error = NULL;
+      g_autoptr(GError) local_error = NULL;
 
       repo = ostree_repo_new_default ();
       if (!ostree_repo_open (repo, cancellable, &local_error))
@@ -270,14 +270,13 @@ ostree_option_context_parse (GOptionContext *context,
 
               g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                                    "Command requires a --repo argument");
-              g_error_free (local_error);
 
               help = g_option_context_get_help (context, FALSE, NULL);
               g_printerr ("%s", help);
             }
           else
             {
-              g_propagate_error (error, local_error);
+              g_propagate_error (error, g_steal_pointer (&local_error));
             }
           goto out;
         }

--- a/tests/coccinelle.sh
+++ b/tests/coccinelle.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! spatch --version 2>/dev/null; then
+    skip "no spatch; get it from http://coccinelle.lip6.fr/"
+fi
+
+if test -z "${OSTREE_UNINSTALLED_SRCDIR:-}"; then
+    skip "running installed?"
+fi
+
+. $(dirname $0)/libtest.sh
+
+coccitests=$(ls $(dirname $0)/coccinelle/*.cocci)
+echo "1.."$(echo ${coccitests} | wc -l)
+
+for cocci in $(dirname $0)/coccinelle/*.cocci; do
+    echo "Running: ${cocci}"
+    spatch --very-quiet --dir ${OSTREE_UNINSTALLED_SRCDIR} ${cocci} > cocci.out
+    if test -s cocci.out; then
+        sed -e 's/^/# /' < cocci.out >&2
+        fatal "Failed semantic patch: ${cocci}"
+    fi
+    echo ok ${cocci}
+done

--- a/tests/coccinelle.sh
+++ b/tests/coccinelle.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
+# Run the .cocci files in the tests directory; these act
+# as a blacklist.
+
 set -euo pipefail
+
+. $(dirname $0)/libtest.sh
 
 if ! spatch --version 2>/dev/null; then
     skip "no spatch; get it from http://coccinelle.lip6.fr/"
@@ -9,8 +14,6 @@ fi
 if test -z "${OSTREE_UNINSTALLED_SRCDIR:-}"; then
     skip "running installed?"
 fi
-
-. $(dirname $0)/libtest.sh
 
 coccitests=$(ls $(dirname $0)/coccinelle/*.cocci)
 echo "1.."$(echo ${coccitests} | wc -l)

--- a/tests/coccinelle/README.md
+++ b/tests/coccinelle/README.md
@@ -1,0 +1,2 @@
+Add patches here which should never match in the code; i.e. the suggested
+replacement may be junk.

--- a/tests/coccinelle/raw-free.cocci
+++ b/tests/coccinelle/raw-free.cocci
@@ -1,0 +1,5 @@
+@@
+expression p;
+@@
+- g_error_free (p);
++ g_clear_error (&p);

--- a/tests/test-rollsum-cli.c
+++ b/tests/test-rollsum-cli.c
@@ -22,6 +22,8 @@
 
 #include "ostree-rollsum.h"
 
+#include "libglnx.h"
+
 int
 main (int argc, char **argv)
 {

--- a/tests/test-rollsum-cli.c
+++ b/tests/test-rollsum-cli.c
@@ -25,7 +25,7 @@
 int
 main (int argc, char **argv)
 {
-  GError *local_error = NULL;
+  g_autoptr(GError) local_error = NULL;
   GError **error = &local_error;
   GBytes *from_bytes = NULL;
   GBytes *to_bytes = NULL;
@@ -64,7 +64,6 @@ main (int argc, char **argv)
   if (local_error)
     {
       g_printerr ("%s\n", local_error->message);
-      g_error_free (local_error);
       return 1;
     }
   return 0;


### PR DESCRIPTION
This is inspired by the [Coccinelle](http://coccinelle.lip6.fr/) usage
in systemd.  I also took it a bit further and added infrastructure
to have spatches which should never apply.  This acts as a blacklist.

The reason to do the latter is that coccinelle is *way* more powerful than the
regular expresssions we have in `make syntax-check`.

I started with blacklisting `g_error_free()` directly. The reason that's bad is
it leaves a dangling pointer.