### PR TITLE
build: Dist ostree-sepolicy-private.h

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -31,6 +31,7 @@ libostree_public_headers = \
 	src/libostree/ostree-diff.h \
 	src/libostree/ostree-gpg-verify-result.h \
 	src/libostree/ostree-sepolicy.h \
+	src/libostree/ostree-sepolicy-private.h \
 	src/libostree/ostree-sysroot.h \
 	src/libostree/ostree-sysroot-upgrader.h \
 	src/libostree/ostree-deployment.h \

--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -31,7 +31,6 @@ libostree_public_headers = \
 	src/libostree/ostree-diff.h \
 	src/libostree/ostree-gpg-verify-result.h \
 	src/libostree/ostree-sepolicy.h \
-	src/libostree/ostree-sepolicy-private.h \
 	src/libostree/ostree-sysroot.h \
 	src/libostree/ostree-sysroot-upgrader.h \
 	src/libostree/ostree-deployment.h \

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -107,6 +107,7 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-repo-file-enumerator.c \
 	src/libostree/ostree-repo-file-enumerator.h \
 	src/libostree/ostree-sepolicy.c \
+	src/libostree/ostree-sepolicy-private.h \
 	src/libostree/ostree-sysroot-private.h \
 	src/libostree/ostree-sysroot.c \
 	src/libostree/ostree-sysroot-cleanup.c \


### PR DESCRIPTION
Should fix the Travis builds which actually generate a legacy tarball via
Automake.