### PR TITLE
build: Expose autocleanups ⎚ unconditionally, start using them

### DIFF
--- a/src/libostree/ostree-autocleanups.h
+++ b/src/libostree/ostree-autocleanups.h
@@ -26,14 +26,10 @@
 
 G_BEGIN_DECLS
 
-#ifndef OSTREE_WITH_AUTOCLEANUPS
-#define OSTREE_WITH_AUTOCLEANUPS 0
-#endif
-
 /* ostree can use g_autoptr backports from libglnx when glib is too
  * old, but still avoid exposing them to users that also have an old
  * glib */
-#if defined(OSTREE_COMPILATION) || (OSTREE_WITH_AUTOCLEANUPS && GLIB_CHECK_VERSION(2, 44, 0))
+#if defined(OSTREE_COMPILATION) || GLIB_CHECK_VERSION(2, 44, 0)
 
 /*
  * The following types have no specific clear/free/unref functions, so

--- a/src/ostree/ot-remote-builtin-add-cookie.c
+++ b/src/ostree/ot-remote-builtin-add-cookie.c
@@ -37,7 +37,7 @@ gboolean
 ot_remote_builtin_add_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   const char *domain;
   const char *path;

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -45,7 +45,7 @@ gboolean
 ot_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   const char *remote_url;
   char **iter;

--- a/src/ostree/ot-remote-builtin-delete-cookie.c
+++ b/src/ostree/ot-remote-builtin-delete-cookie.c
@@ -37,7 +37,7 @@ gboolean
 ot_remote_builtin_delete_cookie (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   const char *domain;
   const char *path;

--- a/src/ostree/ot-remote-builtin-delete.c
+++ b/src/ostree/ot-remote-builtin-delete.c
@@ -36,7 +36,7 @@ gboolean
 ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   gboolean ret = FALSE;
 

--- a/src/ostree/ot-remote-builtin-gpg-import.c
+++ b/src/ostree/ot-remote-builtin-gpg-import.c
@@ -94,7 +94,7 @@ gboolean
 ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autoptr(GInputStream) source_stream = NULL;
   const char *remote_name;
   const char * const *key_ids;

--- a/src/ostree/ot-remote-builtin-list-cookies.c
+++ b/src/ostree/ot-remote-builtin-list-cookies.c
@@ -36,7 +36,7 @@ gboolean
 ot_remote_builtin_list_cookies (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   g_autofree char *jar_path = NULL;
   g_autofree char *cookie_file = NULL;

--- a/src/ostree/ot-remote-builtin-list.c
+++ b/src/ostree/ot-remote-builtin-list.c
@@ -34,7 +34,7 @@ gboolean
 ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_auto(GStrv) remotes = NULL;
   guint ii, n_remotes = 0;
   gboolean ret = FALSE;

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -36,7 +36,7 @@ gboolean
 ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   gboolean ret = FALSE;
   g_autoptr(GHashTable) refs = NULL;

--- a/src/ostree/ot-remote-builtin-show-url.c
+++ b/src/ostree/ot-remote-builtin-show-url.c
@@ -33,7 +33,7 @@ gboolean
 ot_remote_builtin_show_url (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   g_autofree char *remote_url = NULL;
   gboolean ret = FALSE;

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -40,7 +40,7 @@ gboolean
 ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *remote_name;
   g_autoptr(GBytes) summary_bytes = NULL;
   g_autoptr(GBytes) signature_bytes = NULL;


### PR DESCRIPTION
I'd like to do this in rpm-ostree at least. Originally I was looking at porting
to `G_DECLARE_FINAL_TYPE` but eh, this is easier for now and won't bump our GLib
dependency which might matter for our embedded users.

For now I just did a few replacements in the `remote` command line. A full port
can come as we do other code cleanups.

This will actually break the flatpak build right now, but
that's easy to fix.  And we concluded in e.g.
https://bugs.freedesktop.org/show_bug.cgi?id=95065#c5
it's a bug for downstream projects to do that.