### PR TITLE
sysroot: Don't cache sepolicy

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -756,7 +756,7 @@ selinux_relabel_var_if_needed (OstreeSysroot                 *sysroot,
       { g_auto(OstreeSepolicyFsCreatecon) con = { 0, };
         const char *selabeled_abspath = glnx_strjoina ("/", selabeled);
 
-        if (!_ostree_sepolicy_preparefscreatecon (&con, sysroot->sepolicy,
+        if (!_ostree_sepolicy_preparefscreatecon (&con, sepolicy,
                                                   selabeled_abspath,
                                                   0644, error))
           return FALSE;
@@ -2128,9 +2128,6 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
       return FALSE;
     }
 
-  g_clear_object (&self->sepolicy);
-  self->sepolicy = g_object_ref (sepolicy);
-
   if (!selinux_relabel_var_if_needed (self, sepolicy, os_deploy_dfd,
                                       cancellable, error))
     return FALSE;
@@ -2144,7 +2141,7 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
 
   { g_auto(OstreeSepolicyFsCreatecon) con = { 0, };
 
-    if (!_ostree_sepolicy_preparefscreatecon (&con, self->sepolicy,
+    if (!_ostree_sepolicy_preparefscreatecon (&con, sepolicy,
                                               "/etc/ostree/remotes.d/dummy.conf",
                                               0644, error))
       return FALSE;

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -49,8 +49,6 @@ struct OstreeSysroot {
 
   gboolean loaded;
   
-  OstreeSePolicy *sepolicy;
-  
   GPtrArray *deployments;
   int bootversion;
   int subbootversion;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -72,7 +72,6 @@ ostree_sysroot_finalize (GObject *object)
   OstreeSysroot *self = OSTREE_SYSROOT (object);
 
   g_clear_object (&self->path);
-  g_clear_object (&self->sepolicy);
   g_clear_object (&self->repo);
   g_clear_pointer (&self->deployments, g_ptr_array_unref);
   g_clear_object (&self->booted_deployment);


### PR DESCRIPTION
In [this commit](https://github.com/ostreedev/ostree/commit/6ce80f9685e6273dbcb4731d6650a10976ea220a)
for some reason I added a `sepolicy` member to the sysroot.  I
have no idea why I did that, and it's conceptually wrong
since the policy is specific to a *deployment*.

This bit me when I was working on [a pull request](https://github.com/ostreedev/ostree/pull/763)
elsewhere, since at that point it was `NULL`.

We already pass around the sepolicy in the deployment code, so just stop caching
it.