### PR TITLE
ci: Enable -Werror=unused-result with -Wp,-D_FORTIFY_SOURCE=2

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -4,6 +4,7 @@ branches:
     - try
 
 required: true
+context: f25-sanitizer
 
 container:
     image: projectatomic/ostree-tester
@@ -12,7 +13,7 @@ packages:
   - libasan
 
 env:
-    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address'
+    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
     # TODO when we're doing leak checks: G_SLICE: "always-malloc"
 
@@ -38,7 +39,7 @@ artifacts:
 inherit: true
 required: true
 
-context: Clang
+context: f25-clang
 
 env:
     CC: 'clang'
@@ -76,7 +77,7 @@ tests:
 inherit: true
 required: true
 
-context: curl-openssl
+context: f25-curl-openssl
 
 packages:
   - pkgconfig(libcurl)

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -Werror=incompatible-pointer-types \
         -Werror=misleading-indentation \
 	-Werror=missing-include-dirs -Werror=aggregate-return \
+  -Werror=unused-result \
 ])
 AC_SUBST(WARN_CFLAGS)
 


### PR DESCRIPTION
(Also rename the other CI contexts to be more consistent)

We pass this right now. I just noticed an instance of this in bwrap, and I think
we should be trying to match the RPM build baseline.