### PR TITLE
lib: Fix OSTREE_CHECK_VERSION()

### DIFF
--- a/src/libostree/ostree-version.h.in
+++ b/src/libostree/ostree-version.h.in
@@ -78,5 +78,5 @@
  * of ostree is equal or greater than the required one.
  */
 #define OSTREE_CHECK_VERSION(year,release)   \
-        (OSTREE_YEAR_VERSION >= (year) || \
+        (OSTREE_YEAR_VERSION > (year) || \
          (OSTREE_YEAR_VERSION == (year) && OSTREE_RELEASE_VERSION >= (release)))


### PR DESCRIPTION
Actually trying to use this in rpm-ostree, it kept returning successfully when I
didn't expect it to... The first conditional was always succeeding even when I
was asking for a newer minor.