### PR TITLE
ci: Run ⊂ of rpm-ostree's vmcheck

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -181,3 +181,39 @@ tests:
 
 artifacts:
   - test-suite.log
+
+---
+
+# Run rpm-ostree's vmcheck.  This is a temporary hack until
+# we share more code. https://github.com/projectatomic/rpm-ostree/issues/662
+inherit: false
+
+branches:
+    - master
+    - auto
+    - try
+
+context: f27-rpmostree
+required: true
+
+cluster:
+  hosts:
+    - name: vmcheck
+      distro: fedora/27/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:27
+
+env:
+  HOSTS: vmcheck
+  # This should roughly match the Fedora spec file, although right now we don't
+  # explicitly enable gtk-doc because we don't really need it
+  CONFIGOPTS: '--with-selinux --with-dracut=yesbutnoconf --with-curl --with-openssl'
+
+tests:
+  - ./ci/rpmostree.sh
+
+artifacts:
+  - test-suite.log
+  - vmcheck
+
+timeout: 60m

--- a/ci/rpmostree.sh
+++ b/ci/rpmostree.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Build and run rpm-ostree's unit tests using the just-built ostree for this PR.
+
+set -xeuo pipefail
+
+# Frozen to a tag for now to help predictability; it's
+# also useful to test building *older* versions since
+# that must work.
+RPMOSTREE_TAG=v2017.11
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
+codedir=$(pwd)
+
+pkg_upgrade
+pkg_install_builddeps ostree
+pkg_install_builddeps rpm-ostree
+pkg_install rpm-ostree && rpm -e rpm-ostree
+
+# Duplicate of deps from build.sh in rpm-ostree for tests
+pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
+            libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
+            selinux-policy-devel selinux-policy-targeted
+# This one is in the papr.yml
+pkg_install rsync
+
+# build+install ostree
+cd ${codedir}
+build ${CONFIGOPTS:-}
+make install
+
+tmpd=$(mktemp -d)
+cd ${tmpd}
+git clone --recursive --depth=1 -b ${RPMOSTREE_TAG} https://github.com/projectatomic/rpm-ostree
+cd rpm-ostree
+build
+# We want to capture automake results
+cleanup() {
+    mv test-suite.log ${codedir} || true
+}
+trap cleanup EXIT
+make -j 8 check
+# Basic sanity test of rpm-ostree+new ostree by restarting rpm-ostreed
+if ! make vmsync; then
+    ssh -o User=root vmcheck 'journalctl --no-pager | tail -1000'
+    fatal "vmsync failed"
+fi
+# Now run tests; just a subset ⊂ for now to avoid CI overload
+make vmcheck TESTS="basic layering-basic"


### PR DESCRIPTION
This is a quick hack to get us more than unit testing, albeit indirectly.

See: https://github.com/projectatomic/rpm-ostree/issues/662