### PR TITLE
core: Fix default value of disable_xattrs

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2075,7 +2075,7 @@ reload_core_config (OstreeRepo          *self,
 
   /* See https://github.com/ostreedev/ostree/issues/758 */
   if (!ot_keyfile_get_boolean_with_default (self->config, "core", "disable-xattrs",
-                                            TRUE, &self->disable_xattrs, error))
+                                            FALSE, &self->disable_xattrs, error))
     return FALSE;
 
   { g_autofree char *tmp_expiry_seconds = NULL;

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -30,7 +30,7 @@ echo "1..4"
 
 cd ${test_tmpdir}
 mkdir repo
-${OSTREE} init
+ostree_repo_init repo
 
 #----------------------------------------------
 # Test synchronicity of keyring file and remote


### PR DESCRIPTION
Sigh.  Rather awful regression from https://github.com/ostreedev/ostree/pull/759