### PR TITLE
pull: Support deltas 𝚫 for explicit commits

### DIFF
--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -169,9 +169,9 @@ echo 'ok heuristic endian detection'
 ${CMD_PREFIX} ostree --repo=repo summary -u
 
 mkdir repo2 && ostree_repo_init repo2 --mode=bare-user
-${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${newrev}
+${CMD_PREFIX} ostree --repo=repo2 pull-local --require-static-deltas repo ${origrev}
 ${CMD_PREFIX} ostree --repo=repo2 fsck
-${CMD_PREFIX} ostree --repo=repo2 ls ${newrev} >/dev/null
+${CMD_PREFIX} ostree --repo=repo2 ls ${origrev} >/dev/null
 
 echo 'ok pull delta'
 


### PR DESCRIPTION
I think the majority of OSTree usage calls pull with refs, not
explicit commits.  We even added special "override syntax" with
`@` (e.g. `ostree pull foo@ab12c34`) as a hybrid.

However, some users may want to still pull explicit commits
for whatever reason.  The old static delta logic looked at
the previous commit of the ref.  However, in #710
we enhanced the logic to look at all local commits.

It's now a lot more natural to teach the delta logic
to support revisions, e.g. `ostree pull someorigin ab12c34`.

This also fixes the problem that before, `--require-static-deltas`
was completely ignored when processing revisions.

This is a nontrivial refactoring of the logic, but the end
result feels a lot more readable to me.

Closes: #783