### PR TITLE
Rename "osname" → "stateroot"

### DIFF
--- a/docs/manual/atomic-upgrades.md
+++ b/docs/manual/atomic-upgrades.md
@@ -55,7 +55,7 @@ checking it back out of the repo into a deployment.
 ## Assembling a new deployment directory
 
 Given a commit to deploy, OSTree first allocates a directory for
-it.  This is of the form `/boot/loader/entries/ostree-$osname-$checksum.$serial.conf`.
+it.  This is of the form `/boot/loader/entries/ostree-$stateroot-$checksum.$serial.conf`.
 The `$serial` is normally `0`, but if a
 given commit is deployed more than once, it will be incremented.
 This is supported because the previous deployment may have

--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -8,23 +8,24 @@ operating systems (accessible via `ostree admin`).  The core content of these op
 are treated as read-only, but they transparently share storage.
 
 A deployment is physically located at a path of the form
-`/ostree/deploy/$osname/deploy/$checksum`.
+`/ostree/deploy/$stateroot/deploy/$checksum`.
 OSTree is designed to boot directly into exactly one deployment
 at a time; each deployment is intended to be a target for
 `chroot()` or equivalent.
 
-### "osname": Group of deployments that share /var
+### "stateroot" (AKA "osname"): Group of deployments that share /var
 
-Each deployment is grouped in exactly one "osname".  From above, you
-can see that an osname is physically represented in the
-`/ostree/deploy/$osname` directory.  For example, OSTree can allow
-parallel installing Debian in `/ostree/deploy/debian` and Red Hat
-Enterprise Linux in `/ostree/deploy/rhel` (subject to operating system
-support, present released versions of these operating systems may not
-support this).
+Each deployment is grouped in exactly one "stateroot" (also known as an "osname");
+the former term is preferred.
 
-Each osname has exactly one copy of the traditional Unix `/var`,
-stored physically in `/ostree/deploy/$osname/var`.  OSTree provides
+From above, you can see that an stateroot is physically represented in the
+`/ostree/deploy/$stateroot` directory. For example, OSTree can allow parallel
+installing Debian in `/ostree/deploy/debian` and Red Hat Enterprise Linux in
+`/ostree/deploy/rhel` (subject to operating system support, present released
+versions of these operating systems may not support this).
+
+Each stateroot has exactly one copy of the traditional Unix `/var`,
+stored physically in `/ostree/deploy/$stateroot/var`.  OSTree provides
 support tools for `systemd` to create a Linux bind mount that ensures
 the booted deployment sees the shared copy of `/var`.
 
@@ -81,7 +82,7 @@ files.
 
 When a tree is deployed, it will have a configuration file generated
 of the form
-`/boot/loader/entries/ostree-$osname-$checksum.$serial.conf`.  This
+`/boot/loader/entries/ostree-$stateroot-$checksum.$serial.conf`.  This
 configuration file will include a special `ostree=` kernel argument
 that allows the initramfs to find (and `chroot()` into) the specified
 deployment.

--- a/docs/manual/introduction.md
+++ b/docs/manual/introduction.md
@@ -97,7 +97,7 @@ parallel install inside an existing OS or distribution
 occupying the physical `/` root.
 
 On each client machine, there is an OSTree repository stored
-in `/ostree/repo`, and a set of "deployments" stored in `/ostree/deploy/$OSNAME/$CHECKSUM`.
+in `/ostree/repo`, and a set of "deployments" stored in `/ostree/deploy/$STATEROOT/$CHECKSUM`.
 Each deployment is primarily composed of a set of hardlinks
 into the repository.  This means each version is deduplicated;
 an upgrade process only costs disk space proportional to the

--- a/man/ostree-admin-config-diff.xml
+++ b/man/ostree-admin-config-diff.xml
@@ -66,10 +66,10 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
-                <term><option>--os</option>="OSNAME"</term>
+                <term><option>--os</option>="STATEROOT"</term>
 
                 <listitem><para>
-                    Use a different operating system root than the current one.
+                    Use a different operating system stateroot than the current one.
                 </para></listitem>
             </varlistentry>
         </variablelist>

--- a/man/ostree-admin-deploy.xml
+++ b/man/ostree-admin-deploy.xml
@@ -66,7 +66,7 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
-                <term><option>--os</option>="OSNAME"</term>
+                <term><option>--os</option>="STATEROOT"</term>
 
                 <listitem><para>
                     Use a different operating system root than the current one.

--- a/man/ostree-admin-os-init.xml
+++ b/man/ostree-admin-os-init.xml
@@ -49,7 +49,7 @@ Boston, MA 02111-1307, USA.
 
     <refsynopsisdiv>
             <cmdsynopsis>
-                <command>ostree admin os-init</command> <arg choice="req">OSNAME</arg>
+                <command>ostree admin os-init</command> <arg choice="req">STATEROOT</arg>
             </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -57,15 +57,19 @@ Boston, MA 02111-1307, USA.
         <title>Description</title>
 
         <para>
-            Initializes an new state for an operating system.  Ensures that the core subdirectories of /var (/tmp, /lib, /run, and /lock) exist and initialize the given OSNAME as OSTree root.  Each deployment location is comprised of a single shared <filename>var</filename> and a set of deployments (chroots).
+            Initializes an new stateroot (AKA "osname") for an operating system.
+            Ensures that the core subdirectories of /var (/tmp, /lib, /run, and
+            /lock) exist and initialize the given STATEROOT as OSTree stateroot.
+            Each deployment location is comprised of a single shared
+            <filename>var</filename> and a set of deployments (chroots).
         </para>
     </refsect1>
 
     <refsect1>
         <title>Example</title>
-        <para><command>$ ostree admin os-init gnome-ostree</command></para>
+        <para><command>$ ostree admin os-init exampleos</command></para>
     <programlisting>
-        ostree/deploy/gnome-ostree initialized as OSTree root
+        ostree/deploy/exampleos initialized as OSTree root
     </programlisting>
     </refsect1>
 </refentry>

--- a/man/ostree-admin-switch.xml
+++ b/man/ostree-admin-switch.xml
@@ -66,7 +66,7 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
-                <term><option>--os</option>="OSNAME"</term>
+                <term><option>--os</option>="STATEROOT"</term>
 
                 <listitem><para>
                     Use a different operating system root than the current one.

--- a/man/ostree-admin-upgrade.xml
+++ b/man/ostree-admin-upgrade.xml
@@ -69,7 +69,7 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
-                <term><option>--os</option>="OSNAME"</term>
+                <term><option>--os</option>="STATEROOT"</term>
 
                 <listitem><para>
                     Use a different operating system root than the current one.

--- a/man/ostree.xml
+++ b/man/ostree.xml
@@ -65,8 +65,9 @@ Boston, MA 02111-1307, USA.
             Instead, they parallel install to the new toplevel
             <filename>/ostree</filename> directory.  Each
             installed system gets its own
-            <filename>/ostree/deploy/<replaceable>osname</replaceable></filename>
-            directory.
+            <filename>/ostree/deploy/<replaceable>stateroot</replaceable></filename>
+            directory.  (<literal>stateroot</literal> is the
+            newer term for <literal>osname</literal>).
         </para>
         <para>
             Unlike <literal>rpm</literal> or

--- a/src/libostree/ostree-deployment.c
+++ b/src/libostree/ostree-deployment.c
@@ -39,6 +39,12 @@ ostree_deployment_get_bootcsum (OstreeDeployment *self)
   return self->bootcsum;
 }
 
+/*
+ * ostree_deployment_get_osname:
+ * @self: Deployemnt
+ *
+ * Returns: The "stateroot" name, also known as an "osname"
+ */
 const char *
 ostree_deployment_get_osname (OstreeDeployment *self)
 {


### PR DESCRIPTION
I never really liked the term "osname". I feel "stateroot" is a *lot* clearer,
since the osname/stateroot mostly just holds `/var`. Further it avoids the `os`
prefix which is already overloaded.

Some of the existing docs already talked about "operating system state", which
further reinforces this.

There's *lot* more things than this which reference the term "osname", but I
don't want to change *everything* yet in this patch in case we decide to do
something different - this just gets the highlights.