### PR TITLE
 checkout: Add force_copy+SELinux options for checkout, use in deploy

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -775,7 +775,9 @@ typedef struct {
   OstreeRepoDevInoCache *devino_to_csum_cache;
 
   int unused_ints[6];
-  gpointer unused_ptrs[7];
+  gpointer unused_ptrs[5];
+  OstreeSePolicy *sepolicy; /* Since: 2017.6 */
+  const char *sepolicy_prefix;
 } OstreeRepoCheckoutAtOptions;
 
 _OSTREE_PUBLIC

--- a/src/libostree/ostree-sepolicy-private.h
+++ b/src/libostree/ostree-sepolicy-private.h
@@ -37,5 +37,6 @@ gboolean _ostree_sepolicy_preparefscreatecon (OstreeSepolicyFsCreatecon *con,
                                               guint32           mode,
                                               GError          **error);
 
+GVariant *_ostree_filter_selinux_xattr (GVariant *xattrs);
 
 G_END_DECLS

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -407,6 +407,9 @@ EOF
     mkdir sysroot
     export OSTREE_SYSROOT=sysroot
     ${CMD_PREFIX} ostree admin init-fs sysroot
+    if test -n "${OSTREE_NO_XATTRS:-}"; then
+        echo -e 'disable-xattrs=true\n' >> sysroot/ostree/repo/config
+    fi
     ${CMD_PREFIX} ostree admin os-init testos
 
     case $bootmode in


### PR DESCRIPTION
This is a variant of the efforts in #741
Working on `rpm-ostree livefs`, I realized though I needed to just
check out *new* files directly into the live `/etc` (and possibly
delete obsolete files).

The way the current `/etc` merge works is fundamentally different from
that.  So my plan currently is to probably do something like:

 - Compute diff
 - Check out each *new* file individually (as a copy)
 - Optionally delete obsolete files

Also, a few other things become more important - in the current deploy code, we
copy all of the files, then relabel them. But we shouldn't expose to *live*
systems the race conditions of doing that, plus we should only relabel files we
checked out.

By converting the deploy's /etc code to use this, we fix the same TODO item
there around atomically having the label set up as we create files. And further,
if we kill the `/var` relabeling which I think is unnecessary since Anaconda
does it, we could delete large chunks of code there.