### PR TITLE
Release 2017.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.63])
 dnl If incrementing the version here, remember to update libostree.sym too
 m4_define([year_version], [2017])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 
 AC_INIT([libostree], [package_version], [walters@verbum.org])


### PR DESCRIPTION
This is a bugfix release for 2017.4 to fix a regression
that broke flatpak: https://github.com/ostreedev/ostree/issues/798