### PR TITLE
repo: Add a "force copy" flag to checkout

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -895,6 +895,8 @@ ostree_repo_checkout_at (OstreeRepo                        *self,
   if (ostree_repo_get_mode (self) == OSTREE_REPO_MODE_BARE_USER_ONLY)
     options->mode = OSTREE_REPO_CHECKOUT_MODE_USER;
 
+  g_return_val_if_fail (!(options->force_copy && options->no_copy_fallback), FALSE);
+
   g_autoptr(GFile) commit_root = (GFile*) _ostree_repo_file_new_for_commit (self, commit, error);
   if (!commit_root)
     return FALSE;

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -403,7 +403,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
 
       need_copy = FALSE;
     }
-  else
+  else if (!options->force_copy)
     {
       HardlinkResult hardlink_res = HARDLINK_RESULT_NOT_SUPPORTED;
       /* Try to do a hardlink first, if it's a regular file.  This also

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -767,7 +767,8 @@ typedef struct {
   gboolean enable_fsync;  /* Deprecated */
   gboolean process_whiteouts;
   gboolean no_copy_fallback;
-  gboolean unused_bools[7];
+  gboolean force_copy; /* Since: 2017.6 */
+  gboolean unused_bools[6];
 
   const char *subpath;
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -28,7 +28,7 @@ echo "ok yaml version"
 CHECKOUT_U_ARG=""
 COMMIT_ARGS=""
 DIFF_ARGS=""
-if grep bare-user-only repo/config; then
+if grep -q bare-user-only repo/config; then
     # In bare-user-only repos we can only represent files with uid/gid 0, no
     # xattrs and canonical permissions, so we need to commit them as such, or
     # we end up with repos that don't pass fsck
@@ -41,7 +41,6 @@ fi
 validate_checkout_basic() {
     (cd $1;
      assert_has_file firstfile
-     assert_not_streq $(stat -c '%h' firstfile) 1
      assert_has_file baz/cow
      assert_file_has_content baz/cow moo
      assert_has_file baz/deeper/ohyeah
@@ -51,11 +50,14 @@ validate_checkout_basic() {
 
 $OSTREE checkout test2 checkout-test2
 validate_checkout_basic checkout-test2
+if grep -q 'mode=bare$' repo/config; then
+    assert_not_streq $(stat -c '%h' checkout-test2/firstfile) 1
+fi
 echo "ok checkout"
 
 # Note this tests bare-user *and* bare-user-only
 rm checkout-test2 -rf
-if grep bare-user repo/config; then
+if grep -q bare-user repo/config; then
     $OSTREE checkout -U -H test2 checkout-test2
 else
     $OSTREE checkout -H test2 checkout-test2

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..65"
+echo "1..66"
 
 $CMD_PREFIX ostree --version > version.yaml
 python -c 'import yaml; yaml.safe_load(open("version.yaml"))'
@@ -41,6 +41,7 @@ fi
 validate_checkout_basic() {
     (cd $1;
      assert_has_file firstfile
+     assert_not_streq $(stat -c '%h' firstfile) 1
      assert_has_file baz/cow
      assert_file_has_content baz/cow moo
      assert_has_file baz/deeper/ohyeah
@@ -77,6 +78,14 @@ else
 fi
 fi
 echo "ok checkout -H"
+
+rm checkout-test2 -rf
+$OSTREE checkout -C test2 checkout-test2
+for file in firstfile baz/cow baz/alink; do
+    assert_streq $(stat -c '%h' checkout-test2/$file) 1
+done
+
+echo "ok checkout -C"
 
 $OSTREE rev-parse test2
 $OSTREE rev-parse 'test2^'


### PR DESCRIPTION
This is intended to be used for copying `/usr/etc` → `/etc` for
deployments.

A TODO here is to use `glnx_file_copy_at()` if the repo mode allows
it - then we'd use reflinks if available.