### PR TITLE
tests/installed: New installed, privileged tests using Fedora AH

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -101,3 +101,41 @@ tests:
 
 artifacts:
   - test-suite.log
+
+---
+
+inherit: false
+branches:
+    - master
+    - auto
+    - try
+
+context: f25ah-insttest
+required: false
+
+cluster:
+  hosts:
+    - name: vmcheck
+      distro: fedora/25/atomic
+  container:
+    image: projectatomic/ostree-tester
+
+build:
+    config-opts: >
+      --prefix=/usr
+      --libdir=/usr/lib64
+      --enable-installed-tests
+      --enable-gtk-doc
+      --with-curl
+      --with-openssl
+
+# Copy the build from the container to the host; ideally down the line
+# this is installing an RPM via https://github.com/jlebon/redhat-ci/issues/10
+tests:
+  - make install DESTDIR=$(pwd)/insttree
+  - rsync -rl -e 'ssh -o User=root -F ssh-config' . vmcheck:ostree/
+  - ssh -o User=root -F ssh-config vmcheck 'ostree admin unlock && rsync -rlv ostree/insttree/usr/ /usr/'
+  - ssh -o User=root -F ssh-config vmcheck ./ostree/tests/installed/run.sh
+
+artifacts:
+  - test-suite.log

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -130,9 +130,8 @@ build:
 # this is installing an RPM via https://github.com/jlebon/redhat-ci/issues/10
 tests:
   - make install DESTDIR=$(pwd)/insttree
-  - rsync -rl -e 'ssh -o User=root -F ssh-config' . vmcheck:ostree/
-  - ssh -o User=root -F ssh-config vmcheck 'ostree admin unlock && rsync -rlv ostree/insttree/usr/ /usr/'
-  - ssh -o User=root -F ssh-config vmcheck ./ostree/tests/installed/run.sh
+  - rsync -rl -e 'ssh -o User=root' . vmcheck:ostree/
+  - ssh root@vmcheck 'ostree admin unlock && rsync -rlv ./ostree/insttree/usr/ /usr/ && ./ostree/tests/installed/run.sh'
 
 artifacts:
   - test-suite.log

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -124,10 +124,7 @@ build:
     config-opts: >
       --prefix=/usr
       --libdir=/usr/lib64
-      --enable-installed-tests
       --enable-gtk-doc
-      --with-curl
-      --with-openssl
 
 # Copy the build from the container to the host; ideally down the line
 # this is installing an RPM via https://github.com/jlebon/redhat-ci/issues/10

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -129,7 +129,7 @@ dist_installed_test_data = tests/archive-test.sh \
 	tests/pre-endian-deltas-repo-little.tar.xz \
 	$(NULL)
 
-EXTRA_DIST += tests/libtest.sh 
+EXTRA_DIST += tests/libtest.sh tests/libtest-core.sh
 
 dist_test_extra_scripts = \
 	tests/bootloader-entries-crosscheck.py \

--- a/maint.mk
+++ b/maint.mk
@@ -1123,7 +1123,7 @@ sc_copyright_check:
 sc_missing_cmd_prefix:
 	@prohibit='^ostree '						\
 	halt='found missing ${CMD_PREFIX}'				\
-	in_vc_files='$tests/.*\.sh$$'					\
+	in_vc_files='$tests/[^/]*\.sh$$'					\
 	  $(_sc_search_regexp)
 
 # If tests/help-version exists and seems to be new enough, assume that its

--- a/tests/installed/README.md
+++ b/tests/installed/README.md
@@ -1,0 +1,2 @@
+This suite of tests is currently run from redhat-ci;
+they're intended to run as root.

--- a/tests/installed/libinsttest.sh
+++ b/tests/installed/libinsttest.sh
@@ -1,0 +1,48 @@
+# Common definitions for installed, privileged tests
+#
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+dn=$(dirname $0)
+. ${dn}/libtest-core.sh
+
+# Determine our origin refspec - we'll use this as a test base
+rpmostree=$(which rpm-ostree 2>/dev/null)
+if test -z "${rpmostree}"; then
+    skip "no rpm-ostree, at some point point this to raw ostree too"
+fi
+
+# We need to be root
+assert_streq $(id -u) 0
+
+PYTHON=
+for PYTHON in /usr/bin/python3 /usr/bin/python; do
+    if ! test -x ${PYTHON}; then continue; fi
+    export PYTHON
+    break
+done
+if test -z "${PYTHON}"; then
+    fatal "no python found"
+fi
+
+rpmostree_query_json() {
+    query=$1
+    rpm-ostree status --json | $PYTHON -c 'import json,sys; v=json.load(sys.stdin); print(v'${query}')'
+}
+host_refspec=$(rpmostree_query_json '["deployments"][0]["origin"]')
+host_commit=$(rpmostree_query_json '["deployments"][0]["checksum"]')
+host_osname=$(rpmostree_query_json '["deployments"][0]["osname"]')

--- a/tests/installed/libinsttest.sh
+++ b/tests/installed/libinsttest.sh
@@ -30,9 +30,9 @@ fi
 assert_streq $(id -u) 0
 
 PYTHON=
-for PYTHON in /usr/bin/python3 /usr/bin/python; do
-    if ! test -x ${PYTHON}; then continue; fi
-    export PYTHON
+for py in /usr/bin/python3 /usr/bin/python; do
+    if ! test -x ${py}; then continue; fi
+    export PYTHON=${py}
     break
 done
 if test -z "${PYTHON}"; then

--- a/tests/installed/libtest-core.sh
+++ b/tests/installed/libtest-core.sh
@@ -1,0 +1,1 @@
+../libtest-core.sh

--- a/tests/installed/run.sh
+++ b/tests/installed/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+for tn in ${dn}/test-*.sh; do
+    echo Executing: ${tn}
+    ${tn}
+done

--- a/tests/installed/test-bare-root.sh
+++ b/tests/installed/test-bare-root.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Tests of the "raw ostree" functionality using the host's ostree repo as uid 0.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+echo "1..2"
+
+cd /ostree/repo/tmp
+rm co -rf
+rm co-testref -rf
+ostree refs --delete testref
+ostree checkout -H ${host_refspec} co
+victim_symlink=/usr/bin/gtar  # Seems likely to stick around
+# Copy the link to avoid corrupting it
+cp co/${victim_symlink}{,.tmp}
+mv co/${victim_symlink}{.tmp,}
+# Add another xattr to a symlink and a directory, since otherwise this is unusual
+setfattr -n security.biometric -v iris co/${victim_symlink}
+setfattr -n security.crunchy -v withketchup co/usr/bin
+csum=$(ostree commit -b testref --link-checkout-speedup --tree=dir=co)
+ostree fsck
+ostree ls -X testref ${victim_symlink} > ls.txt
+assert_file_has_content ls.txt 'security.biometric'
+ostree ls -X ${host_refspec} ${victim_symlink} > ls.txt
+assert_not_file_has_content ls.txt security.biometric
+ostree ls -X testref usr/bin > ls.txt
+assert_file_has_content ls.txt 'security.crunchy'
+
+ostree checkout -H testref co-testref
+getfattr -n security.biometric co-testref/${victim_symlink} > xattr.txt
+assert_file_has_content xattr.txt 'security.biometric="iris"'
+getfattr -n security.crunchy co-testref/usr/bin > xattr.txt
+assert_file_has_content xattr.txt 'security.crunchy="withketchup"'
+
+rm co -rf
+rm co-testref -rf
+
+echo "ok xattrs"

--- a/tests/installed/test-deploy-selinux.sh
+++ b/tests/installed/test-deploy-selinux.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Verify our /etc merge works with selinux
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+# Create a new deployment
+ostree admin deploy --karg-proc-cmdline ${host_refspec}
+new_deployment_path=/ostree/deploy/${host_osname}/deploy/${host_commit}.1
+
+# A set of files that have a variety of security contexts
+for file in fstab passwd exports hostname sysctl.conf; do
+    current=$(cd /etc && ls -Z ${file})
+    new=$(cd ${new_deployment_path}/etc && ls -Z ${file})
+    assert_streq "${current}" "${new}"
+done
+
+ostree admin undeploy 0

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -1,0 +1,111 @@
+# Core source library for shell script tests
+#
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+fatal() {
+    echo $@ 1>&2; exit 1
+}
+# fatal() is shorter to type, but retain this alias
+assert_not_reached () {
+    fatal "$@"
+}
+
+# Some tests look for specific English strings. Use a UTF-8 version
+# of the C (POSIX) locale if we have one, or fall back to POSIX
+# (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
+if locale -a | grep C.UTF-8 >/dev/null; then
+    export LC_ALL=C.UTF-8
+else
+    export LC_ALL=C
+fi
+
+# This should really be the default IMO
+export G_DEBUG=fatal-warnings
+assert_streq () {
+    test "$1" = "$2" || fatal "$1 != $2"
+}
+
+assert_str_match () {
+    if ! echo "$1" | grep -E -q "$2"; then
+	      fatal "$1 does not match regexp $2"
+    fi
+}
+
+assert_not_streq () {
+    (! test "$1" = "$2") || fatal "$1 == $2"
+}
+
+assert_has_file () {
+    test -f "$1" || fatal "Couldn't find '$1'"
+}
+
+assert_has_dir () {
+    test -d "$1" || fatal "Couldn't find '$1'"
+}
+
+assert_not_has_file () {
+    if test -f "$1"; then
+        sed -e 's/^/# /' < "$1" >&2
+        fatal "File '$1' exists"
+    fi
+}
+
+assert_not_file_has_content () {
+    if grep -q -e "$2" "$1"; then
+        sed -e 's/^/# /' < "$1" >&2
+        fatal "File '$1' incorrectly matches regexp '$2'"
+    fi
+}
+
+assert_not_has_dir () {
+    if test -d "$1"; then
+	      fatal "Directory '$1' exists"
+    fi
+}
+
+assert_file_has_content () {
+    if ! grep -q -e "$2" "$1"; then
+        sed -e 's/^/# /' < "$1" >&2
+        fatal "File '$1' doesn't match regexp '$2'"
+    fi
+}
+
+assert_symlink_has_content () {
+    if ! test -L "$1"; then
+        echo 1>&2 "File '$1' is not a symbolic link"
+        exit 1
+    fi
+    if ! readlink "$1" | grep -q -e "$2"; then
+        sed -e 's/^/# /' < "$1" >&2
+        echo 1>&2 "Symbolic link '$1' doesn't match regexp '$2'"
+        exit 1
+    fi
+}
+
+assert_file_empty() {
+    if test -s "$1"; then
+        sed -e 's/^/# /' < "$1" >&2
+        fatal "File '$1' is not empty"
+    fi
+}
+
+# Use to skip all of these tests
+skip() {
+    echo "1..0 # SKIP" "$@"
+    exit 0
+}

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -18,7 +18,6 @@
 # Boston, MA 02111-1307, USA.
 
 dn=$(dirname $0)
-. ${dn}/libtest-core.sh
 
 if [ -n "${G_TEST_SRCDIR:-}" ]; then
   test_srcdir="${G_TEST_SRCDIR}/tests"
@@ -31,6 +30,7 @@ if [ -n "${G_TEST_BUILDDIR:-}" ]; then
 else
   test_builddir=$(dirname $0)
 fi
+. ${test_srcdir}/libtest-core.sh
 
 test_tmpdir=$(pwd)
 


### PR DESCRIPTION
Our container-driven tests can't e.g. test SELinux sanely, and
have to support being run as root *and* non-root too.

Use redhat-ci to provision a VM and run tests directly there. These are
installed tests too.