### PR TITLE
lib/util: Delete some leftover pre-libglnx directory opening functions

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2465,7 +2465,7 @@ list_loose_objects (OstreeRepo                     *self,
       buf[0] = hexchars[c >> 4];
       buf[1] = hexchars[c & 0xF];
       buf[2] = '\0';
-      dfd = ot_opendirat (self->objects_dir_fd, buf, FALSE);
+      dfd = glnx_opendirat_with_errno (self->objects_dir_fd, buf, FALSE);
       if (dfd == -1)
         {
           if (errno == ENOENT)

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -255,7 +255,7 @@ ensure_directory_from_template (int                 orig_etc_fd,
   g_assert (path != NULL);
   g_assert (*path != '/' && *path != '\0');
 
-  if (!ot_gopendirat (modified_etc_fd, path, TRUE, &src_dfd, error))
+  if (!glnx_opendirat (modified_etc_fd, path, TRUE, &src_dfd, error))
     goto out;
 
   /* Create with mode 0700, we'll fchmod/fchown later */
@@ -293,7 +293,7 @@ ensure_directory_from_template (int                 orig_etc_fd,
         }
     }
 
-  if (!ot_gopendirat (new_etc_fd, path, TRUE, &target_dfd, error))
+  if (!glnx_opendirat (new_etc_fd, path, TRUE, &target_dfd, error))
     goto out;
 
   if (!dirfd_copy_attributes_and_xattrs (modified_etc_fd, path, src_dfd, target_dfd,

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -35,32 +35,6 @@ ot_fdrel_to_gfile (int dfd, const char *path)
   return g_file_new_for_path (abspath);
 }
 
-int
-ot_opendirat (int dfd, const char *path, gboolean follow)
-{
-  int flags = O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY;
-  if (!follow)
-    flags |= O_NOFOLLOW;
-  return openat (dfd, path, flags);
-}
-
-gboolean
-ot_gopendirat (int             dfd,
-               const char     *path,
-               gboolean        follow,
-               int            *out_fd,
-               GError        **error)
-{
-  int ret = ot_opendirat (dfd, path, follow);
-  if (ret == -1)
-    {
-      glnx_set_error_from_errno (error);
-      return FALSE;
-    }
-  *out_fd = ret;
-  return TRUE;
-}
-
 gboolean
 ot_readlinkat_gfile_info (int             dfd,
                           const char     *path,

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -26,13 +26,6 @@ G_BEGIN_DECLS
 
 GFile * ot_fdrel_to_gfile (int dfd, const char *path);
 
-int ot_opendirat (int dfd, const char *path, gboolean follow);
-gboolean ot_gopendirat (int             dfd,
-                        const char     *path,
-                        gboolean        follow,
-                        int            *out_fd,
-                        GError        **error);
-
 gboolean ot_readlinkat_gfile_info (int             dfd,
                                    const char     *path,
                                    GFileInfo      *target_info,


### PR DESCRIPTION
These were migrated into libglnx; port the few callers to use that.