### PR TITLE
repo: Fix incorrect use of errno() error throwing

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2631,7 +2631,7 @@ query_info_for_bare_content_object (OstreeRepo      *self,
         return FALSE;
     }
   else
-    return glnx_throw_errno_prefix (error, "Not a regular file or symlink: %s", loose_path_buf);
+    return glnx_throw (error, "Not a regular file or symlink: %s", loose_path_buf);
 
   ot_transfer_out_value (out_info, &ret_info);
   return TRUE;


### PR DESCRIPTION
I happened to glance at the top of my most recent patch and
noticed that I used an `throw_errno()` function in a non-errno place.
I scanned the patch for other instances of this but didn't find one.