### PR TITLE
checkout/commit: Use glnx_regfile_copy_bytes() if possible

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -459,29 +459,19 @@ add_size_index_to_metadata (OstreeRepo        *self,
 }
 
 static gboolean
-fallocate_stream (GFileDescriptorBased      *stream,
-                  goffset                    size,
-                  GCancellable              *cancellable,
-                  GError                   **error)
+ot_fallocate (int fd, goffset size, GError **error)
 {
-  gboolean ret = FALSE;
-  int fd = g_file_descriptor_based_get_fd (stream);
+  if (size == 0)
+    return TRUE;
 
-  if (size > 0)
+  int r = posix_fallocate (fd, 0, size);
+  if (r != 0)
     {
-      int r = posix_fallocate (fd, 0, size);
-      if (r != 0)
-        {
-          /* posix_fallocate is a weird deviation from errno standards */
-          errno = r;
-          glnx_set_error_from_errno (error);
-          goto out;
-        }
+      /* posix_fallocate is a weird deviation from errno standards */
+      errno = r;
+      return glnx_throw_errno_prefix (error, "fallocate");
     }
-
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }
 
 gboolean
@@ -511,11 +501,10 @@ _ostree_repo_open_content_bare (OstreeRepo          *self,
                                           &fd, &temp_filename, error))
         goto out;
 
-      ret_stream = g_unix_output_stream_new (fd, TRUE);
-      
-      if (!fallocate_stream ((GFileDescriptorBased*)ret_stream, content_len,
-                             cancellable, error))
+      if (!ot_fallocate (fd, content_len, error))
         goto out;
+
+      ret_stream = g_unix_output_stream_new (fd, TRUE);
     }
 
   ret = TRUE;
@@ -570,7 +559,6 @@ create_regular_tmpfile_linkable_with_content (OstreeRepo *self,
                                               GCancellable *cancellable,
                                               GError **error)
 {
-  g_autoptr(GOutputStream) temp_out = NULL;
   glnx_fd_close int temp_fd = -1;
   g_autofree char *temp_filename = NULL;
 
@@ -578,20 +566,27 @@ create_regular_tmpfile_linkable_with_content (OstreeRepo *self,
                                       &temp_fd, &temp_filename,
                                       error))
     return FALSE;
-  temp_out = g_unix_output_stream_new (temp_fd, FALSE);
 
-  if (!fallocate_stream ((GFileDescriptorBased*)temp_out, length,
-                         cancellable, error))
+  if (!ot_fallocate (temp_fd, length, error))
     return FALSE;
 
-  if (g_output_stream_splice (temp_out, input, 0,
-                              cancellable, error) < 0)
-    return FALSE;
-  if (fchmod (temp_fd, 0644) < 0)
+  if (G_IS_FILE_DESCRIPTOR_BASED (input))
     {
-      glnx_set_error_from_errno (error);
-      return FALSE;
+      int infd = g_file_descriptor_based_get_fd ((GFileDescriptorBased*) input);
+      if (glnx_regfile_copy_bytes (infd, temp_fd, (off_t)length, TRUE) < 0)
+        return glnx_throw_errno_prefix (error, "regfile copy");
     }
+  else
+    {
+      g_autoptr(GOutputStream) temp_out = g_unix_output_stream_new (temp_fd, FALSE);
+      if (g_output_stream_splice (temp_out, input, 0,
+                                  cancellable, error) < 0)
+        return FALSE;
+    }
+
+  if (fchmod (temp_fd, 0644) < 0)
+    return glnx_throw_errno_prefix (error, "fchmod");
+
   *out_fd = temp_fd; temp_fd = -1;
   *out_path = g_steal_pointer (&temp_filename);
   return TRUE;

--- a/tests/ci-commitmessage-submodules.sh
+++ b/tests/ci-commitmessage-submodules.sh
@@ -40,6 +40,7 @@ git log --pretty=oneline origin/master.. | while read logline; do
             echo "Commit $commit modifies submodule: $submodule"
             expected_match="Update submodule: $submodule"
             if ! grep -q -e "$expected_match" ${tmpd}/log.txt; then
+                sed -e 's,^,# ,' < ${tmpd}/log.txt
                 echo "error: Commit message for ${commit} changes a submodule, but does not match regex ${expected_match}"
                 exit 1
             fi


### PR DESCRIPTION
Rather than `g_output_stream_splice()`, where the input is a regular
file.

See https://github.com/GNOME/libglnx/pull/44 for some more information.

I didn't try to measure the performance difference, but seeing the
read()/write() to/from userspace mixed in with the pointless `poll()` annoyed me
when reading strace.

As a bonus, we will again start using reflinks (if available) for `/etc`,
which is a regression from the https://github.com/ostreedev/ostree/pull/797
changes (which before used `glnx_file_copy_at()`).

Also, for the first time we'll use reflinks when doing commits from file-backed
content. This happens in `rpm-ostree compose tree` today for example.