### PR TITLE
ci: Add a context for testing flatpak

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -155,3 +155,6 @@ host:
 
 tests:
   - docker run --rm --privileged -v $(pwd):/srv/code registry.fedoraproject.org/fedora:25 /bin/sh -c "cd /srv/code && ./ci/flatpak.sh"
+
+artifacts:
+  - test-suite.log

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -135,3 +135,23 @@ tests:
 
 artifacts:
   - test-suite.log
+
+---
+
+inherit: false
+branches:
+    - master
+    - auto
+    - try
+
+context: f25-flatpak
+required: false
+
+# This test case wants an "unprivileged container with bubblewrap",
+# which we don't have right now; so just provision a VM and do a
+# docker --privileged run.
+host:
+  distro: fedora/25/atomic
+
+tests:
+  - docker run --rm --privileged -v $(pwd):/srv/code registry.fedoraproject.org/fedora:25 /bin/sh -c "cd /srv/code && ./ci/flatpak.sh"

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -9,6 +9,8 @@ build() {
     make -j 8
 }
 
+codedir=$(pwd)
+
 # Core prep
 dnf -y install dnf-plugins-core
 dnf install -y @buildsys-build
@@ -24,5 +26,13 @@ cd ${tmpd}
 git clone --recursive --depth=1 -b 0.9.3 https://github.com/flatpak/flatpak
 cd flatpak
 dnf builddep -y flatpak
+# And runtime deps
+dnf install -y flatpak && rpm -e flatpak
+dnf install which attr fuse parallel # for the test suite
 build
+# We want to capture automake results from flatpak
+cleanup() {
+    mv test-suite.log ${codedir} || true
+}
+trap cleanup EXIT
 make -j 8 check

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -17,7 +17,7 @@ dnf install -y 'dnf-command(builddep)'
 # build+install ostree
 dnf builddep -y ostree
 build
-sudo make install
+make install
 tmpd=$(mktemp -d)
 cd ${tmpd}
 # Frozen to a tag for now on general principle

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -9,7 +9,13 @@ build() {
     make -j 8
 }
 
+# Core prep
+dnf -y install dnf-plugins-core
+dnf install -y @buildsys-build
+dnf install -y 'dnf-command(builddep)'
+
 # build+install ostree
+dnf builddep -y ostree
 build
 sudo make install
 tmpd=$(mktemp -d)

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -4,7 +4,7 @@
 set -xeuo pipefail
 
 build() {
-    env NOCONFIGURE=1./autogen.sh
+    env NOCONFIGURE=1 ./autogen.sh
     ./configure --prefix=/usr --libdir=/usr/lib64 "$@"
     make -j 8
 }

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build and run flatpak's unit tests using the just-built ostree for this PR.
+
+set -xeuo pipefail
+
+build() {
+    env NOCONFIGURE=1./autogen.sh
+    ./configure --prefix=/usr --libdir=/usr/lib64 "$@"
+    make -j 8
+}
+
+# build+install ostree
+build
+sudo make install
+tmpd=$(mktemp -d)
+cd ${tmpd}
+# Frozen to a tag for now on general principle
+git clone --recursive --depth=1 -b 0.9.3 https://github.com/flatpak/flatpak
+cd flatpak
+dnf builddep -y flatpak
+build
+make -j 8 check


### PR DESCRIPTION
This was part of the philosophy behind https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests -
libraries like libostree don't need to replicate everything in unit tests, we
can use the tests from our dependencies directly too.

We'll also get API break coverage testing too.