### PR TITLE
repo: Delete the last use of GFile tmp_dir

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -116,7 +116,7 @@ _ostree_gpg_verifier_check_signature (OstreeGpgVerifier  *self,
   if (result == NULL)
     goto out;
 
-  if (!ot_gpgme_ctx_tmp_home_dir (result->context, NULL,
+  if (!ot_gpgme_ctx_tmp_home_dir (result->context,
                                   &tmp_dir, &target_stream,
                                   cancellable, error))
     goto out;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -78,7 +78,6 @@ struct OstreeRepo {
 
   GFile *repodir;
   int    repo_dir_fd;
-  GFile *tmp_dir;
   int    tmp_dir_fd;
   int    cache_dir_fd;
   char  *cache_dir;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -517,7 +517,6 @@ ostree_repo_finalize (GObject *object)
     (void) close (self->commit_stagedir_fd);
   g_free (self->commit_stagedir_name);
   glnx_release_lock_file (&self->commit_stagedir_lock);
-  g_clear_object (&self->tmp_dir);
   if (self->tmp_dir_fd != -1)
     (void) close (self->tmp_dir_fd);
   if (self->cache_dir_fd != -1)
@@ -604,8 +603,6 @@ ostree_repo_constructed (GObject *object)
   OstreeRepo *self = OSTREE_REPO (object);
 
   g_assert (self->repodir != NULL);
-
-  self->tmp_dir = g_file_resolve_relative_path (self->repodir, "tmp");
 
   /* Ensure the "sysroot-path" property is set. */
   if (self->sysroot_dir == NULL)
@@ -1401,7 +1398,6 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
   ot_auto_gpgme_data gpgme_data_t data_buffer = NULL;
   gpgme_import_result_t import_result;
   gpgme_import_status_t import_status;
-  const char *tmp_dir = NULL;
   g_autofree char *source_tmp_dir = NULL;
   g_autofree char *target_tmp_dir = NULL;
   glnx_fd_close int target_temp_fd = -1;
@@ -1419,17 +1415,6 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
   if (remote == NULL)
     goto out;
 
-  /* Use OstreeRepo's "tmp" directory so the keyring files remain
-   * under one mount point.  Necessary for renameat() below. */
-
-  /* XXX This produces a path under "/proc/self/fd/" which won't
-   *     work in a child process so I had to resort to the GFile.
-   *     I was trying to avoid the GFile so we can get rid of it.
-   *
-   *     tmp_dir = glnx_fdrel_abspath (self->repo_dir_fd, "tmp");
-   */
-  tmp_dir = gs_file_get_path_cached (self->tmp_dir);
-
   /* Prepare the source GPGME context.  If reading GPG keys from an input
    * stream, point the OpenPGP engine at a temporary directory and import
    * the keys to a new pubring.gpg file.  If the key data format is ASCII
@@ -1443,7 +1428,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
     {
       data_buffer = ot_gpgme_data_input (source_stream);
 
-      if (!ot_gpgme_ctx_tmp_home_dir (source_context, tmp_dir, &source_tmp_dir,
+      if (!ot_gpgme_ctx_tmp_home_dir (source_context, &source_tmp_dir,
                                       NULL, cancellable, error))
         {
           g_prefix_error (error, "Unable to configure context: ");
@@ -1526,7 +1511,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
     goto out;
 
   /* No need for an output stream since we copy in a pubring.gpg. */
-  if (!ot_gpgme_ctx_tmp_home_dir (target_context, tmp_dir, &target_tmp_dir,
+  if (!ot_gpgme_ctx_tmp_home_dir (target_context, &target_tmp_dir,
                                   NULL, cancellable, error))
     {
       g_prefix_error (error, "Unable to configure context: ");
@@ -1626,13 +1611,11 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
 
   /* Import successful; replace the remote's old keyring with the
    * updated keyring in the target context's temporary directory. */
-
-  if (renameat (target_temp_fd, "pubring.gpg",
-                self->repo_dir_fd, remote->keyring) == -1)
-    {
-      glnx_set_prefix_error_from_errno (error, "%s", "Unable to rename keyring");
-      goto out;
-    }
+  if (!glnx_file_copy_at (target_temp_fd, "pubring.gpg", NULL,
+                          self->repo_dir_fd, remote->keyring,
+                          GLNX_FILE_COPY_OVERWRITE,
+                          cancellable, error))
+    goto out;
 
   if (out_imported != NULL)
     *out_imported = (guint) import_result->imported;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1405,6 +1405,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
   struct stat stbuf;
   gpgme_error_t gpg_error;
   gboolean ret = FALSE;
+  const GLnxFileCopyFlags copyflags = self->disable_xattrs ? GLNX_FILE_COPY_NOXATTRS : 0;
 
   g_return_val_if_fail (OSTREE_IS_REPO (self), FALSE);
   g_return_val_if_fail (name != NULL, FALSE);
@@ -1526,10 +1527,9 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
 
   if (fstatat (self->repo_dir_fd, remote->keyring, &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
     {
-      GLnxFileCopyFlags copyflags = self->disable_xattrs ? GLNX_FILE_COPY_NOXATTRS : 0;
       if (!glnx_file_copy_at (self->repo_dir_fd, remote->keyring,
-                              &stbuf, target_temp_fd, "pubring.gpg", copyflags,
-                              cancellable, error))
+                              &stbuf, target_temp_fd, "pubring.gpg",
+                              copyflags, cancellable, error))
         {
           g_prefix_error (error, "Unable to copy remote's keyring: ");
           goto out;
@@ -1613,7 +1613,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
    * updated keyring in the target context's temporary directory. */
   if (!glnx_file_copy_at (target_temp_fd, "pubring.gpg", NULL,
                           self->repo_dir_fd, remote->keyring,
-                          GLNX_FILE_COPY_OVERWRITE,
+                          copyflags | GLNX_FILE_COPY_OVERWRITE,
                           cancellable, error))
     goto out;
 

--- a/src/libotutil/ot-gpg-utils.c
+++ b/src/libotutil/ot-gpg-utils.c
@@ -67,7 +67,6 @@ ot_gpgme_error_to_gio_error (gpgme_error_t   gpg_error,
 
 gboolean
 ot_gpgme_ctx_tmp_home_dir (gpgme_ctx_t     gpgme_ctx,
-                           const char     *tmp_dir,
                            char          **out_tmp_home_dir,
                            GOutputStream **out_pubring_stream,
                            GCancellable   *cancellable,
@@ -85,10 +84,7 @@ ot_gpgme_ctx_tmp_home_dir (gpgme_ctx_t     gpgme_ctx,
    * and hand the caller an open output stream to concatenate necessary
    * keyring files. */
 
-  if (tmp_dir == NULL)
-    tmp_dir = g_get_tmp_dir ();
-
-  tmp_home_dir = g_build_filename (tmp_dir, "ostree-gpg-XXXXXX", NULL);
+  tmp_home_dir = g_build_filename (g_get_tmp_dir (), "ostree-gpg-XXXXXX", NULL);
 
   if (mkdtemp (tmp_home_dir) == NULL)
     {

--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -34,7 +34,6 @@ GLNX_DEFINE_CLEANUP_FUNCTION0(gpgme_ctx_t, ot_cleanup_gpgme_ctx, gpgme_release)
 void ot_gpgme_error_to_gio_error (gpgme_error_t gpg_error, GError **error);
 
 gboolean ot_gpgme_ctx_tmp_home_dir (gpgme_ctx_t     gpgme_ctx,
-                                    const char     *tmp_dir,
                                     char          **out_tmp_home_dir,
                                     GOutputStream **out_pubring_stream,
                                     GCancellable   *cancellable,


### PR DESCRIPTION
The keyring isn't large, so let's just fall back to copying it
rather than requiring `renameat()`.

Prep for `ostree_repo_open_at()`.