### PR TITLE
ci: More flatpak ci fixes

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -153,6 +153,8 @@ required: false
 # docker --privileged run.
 host:
   distro: fedora/25/atomic
+  specs:
+    ram: 4096  # build-bundle is a static delta, which needs RAM right now
 
 tests:
   - docker run --rm --privileged -v $(pwd):/srv/code registry.fedoraproject.org/fedora:25 /bin/sh -c "cd /srv/code && ./ci/flatpak.sh"

--- a/ci/0001-tests-Fix-race-condition-in-tmp-webserver.patch
+++ b/ci/0001-tests-Fix-race-condition-in-tmp-webserver.patch
@@ -1,0 +1,44 @@
+From 6197e6922e3ba3c8881733a6a3253e8ae12eb538 Mon Sep 17 00:00:00 2001
+From: Colin Walters <walters@verbum.org>
+Date: Fri, 5 May 2017 16:36:04 -0400
+Subject: [PATCH] tests: Fix race condition in tmp webserver
+
+I was seeing this when trying to run flatpak's tests in ostree's CI:
+https://github.com/ostreedev/ostree/pull/824
+
+The race here is that the python process can still be writing to the output
+while sed is reading it, and hence we'll find a difference on the next line.
+Fix this by making a tmp copy of the file, which then both sed and cmp will
+read consistently.
+
+I'm not *entirely* sure this will fix the problem as I couldn't easily reproduce
+the race locally, but I believe it at least fixes *a* race.
+---
+ tests/test-webserver.sh | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/tests/test-webserver.sh b/tests/test-webserver.sh
+index 3291b06..2964ce9 100755
+--- a/tests/test-webserver.sh
++++ b/tests/test-webserver.sh
+@@ -10,9 +10,15 @@ env PYTHONUNBUFFERED=1 setsid python -m SimpleHTTPServer 0 >${test_tmpdir}/httpd
+ child_pid=$!
+ 
+ for x in $(seq 50); do
+-    sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) \.\.\.,\1,' < ${test_tmpdir}/httpd-output > ${test_tmpdir}/httpd-port
+-    if ! cmp ${test_tmpdir}/httpd-output ${test_tmpdir}/httpd-port 1>/dev/null; then
+-        break
++    # Snapshot the output
++    cp ${test_tmpdir}/httpd-output{,.tmp}
++    # If it's non-empty, see whether it matches our regexp
++    if test -s ${test_tmpdir}/httpd-output.tmp; then
++        sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) \.\.\.,\1,' < ${test_tmpdir}/httpd-output.tmp > ${test_tmpdir}/httpd-port
++        if ! cmp ${test_tmpdir}/httpd-output.tmp ${test_tmpdir}/httpd-port 1>/dev/null; then
++            # If so, we've successfully extracted the port
++            break
++        fi
+     fi
+     sleep 0.1
+ done
+-- 
+2.9.3


### PR DESCRIPTION
We need our `make install` to override the ostree RPM, so do it all in one txn.
This sort of thing is where a more rigorous model like rdgo/gcontinuous use
becomes better, but we'll hack it with shell for now.