### PR TITLE
libostree: Add missing checks for invalid timestamps

### DIFF
--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -562,6 +562,14 @@ ostree_gpg_verify_result_describe_variant (GVariant *variant,
   key_id = (len > 16) ? fingerprint + len - 16 : fingerprint;
 
   date_time_utc = g_date_time_new_from_unix_utc (timestamp);
+  if (date_time_utc == NULL)
+    {
+      g_string_append_printf (output_buffer,
+                              "Can't check signature: timestamp %" G_GINT64_FORMAT " is invalid\n",
+                              timestamp);
+      return;
+    }
+
   date_time_local = g_date_time_to_local (date_time_utc);
   formatted_date_time = g_date_time_format (date_time_local, "%c");
 
@@ -606,6 +614,14 @@ ostree_gpg_verify_result_describe_variant (GVariant *variant,
   if (exp_timestamp > 0)
     {
       date_time_utc = g_date_time_new_from_unix_utc (exp_timestamp);
+      if (date_time_utc == NULL)
+        {
+          g_string_append_printf (output_buffer,
+                                  "Signature expiry timestamp (%" G_GINT64_FORMAT ") is invalid\n",
+                                  exp_timestamp);
+          return;
+        }
+
       date_time_local = g_date_time_to_local (date_time_utc);
       formatted_date_time = g_date_time_format (date_time_local, "%c");
 

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -470,8 +470,15 @@ ostree_sysroot_upgrader_check_timestamps (OstreeRepo     *repo,
       g_autofree char *old_ts_str = NULL;
       g_autofree char *new_ts_str = NULL;
 
-      g_assert (old_ts);
-      g_assert (new_ts);
+      if (old_ts == NULL || new_ts == NULL)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Upgrade target revision '%s' timestamp (%" G_GINT64_FORMAT ") or current revision '%s' timestamp (%" G_GINT64_FORMAT ") is invalid",
+                       to_rev, ostree_commit_get_timestamp (new_commit),
+                       from_rev, ostree_commit_get_timestamp (old_commit));
+          goto out;
+        }
+
       old_ts_str = g_date_time_format (old_ts, "%c");
       new_ts_str = g_date_time_format (new_ts, "%c");
       g_date_time_unref (old_ts);

--- a/src/ostree/ot-remote-cookie-util.c
+++ b/src/ostree/ot-remote-cookie-util.c
@@ -298,14 +298,18 @@ ot_list_cookies_at (int dfd, const char *jar_path, GError **error)
   while (ot_parse_cookies_next (parser))
     {
       g_autoptr(GDateTime) expires = g_date_time_new_from_unix_utc (parser->expiration);
-      g_autofree char *expires_str = g_date_time_format (expires, "%Y-%m-%d %H:%M:%S +0000");
+      g_autofree char *expires_str = NULL;
+
+      if (expires != NULL)
+        expires_str = g_date_time_format (expires, "%Y-%m-%d %H:%M:%S +0000");
 
       g_print ("--\n");
       g_print ("Domain: %s\n", parser->domain);
       g_print ("Path: %s\n", parser->path);
       g_print ("Name: %s\n", parser->name);
       g_print ("Secure: %s\n", parser->secure);
-      g_print ("Expires: %s\n", expires_str);
+      if (expires_str != NULL)
+        g_print ("Expires: %s\n", expires_str);
       g_print ("Value: %s\n", parser->value);
     }
 #else


### PR DESCRIPTION
g_date_time_new_from_unix_utc() will not always return a valid GDateTime
— if the input timestamp is too big, GDateTime cannot represent it, and
the constructor returns NULL.

Add some missing checks for these situations. We don’t ever expect
timestamps to be this big, but they could be as a result of corruption
or a malicious repository.

Signed-off-by: Philip Withnall <withnall@endlessm.com>