### PR TITLE
libostree: Add some additional metadata to the summary file

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -101,6 +101,7 @@ dist_test_scripts = \
 	tests/test-switchroot.sh \
 	tests/test-pull-contenturl.sh \
 	tests/test-pull-mirrorlist.sh \
+	tests/test-summary-view.sh \
 	tests/coccinelle.sh \
 	$(NULL)
 

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -158,6 +158,17 @@ typedef enum {
  * - a(s(taya{sv})) - Map of ref name -> (latest commit size, latest commit checksum, additional metadata), sorted by ref name
  * - a{sv} - Additional metadata, at the current time the following are defined:
  *   - key: "ostree.static-deltas", value: a{sv}, static delta name -> 32 bytes of checksum
+ *   - key: "ostree.summary.last-modified", value: t, timestamp (seconds since
+ *     the Unix epoch in UTC, big-endian) when the summary was last regenerated
+ *     (similar to the HTTP `Last-Modified` header)
+ *   - key: "ostree.summary.expires", value: t, timestamp (seconds since the
+ *     Unix epoch in UTC, big-endian) after which the summary is considered
+ *     stale and should be re-downloaded if possible (similar to the HTTP
+ *     `Expires` header)
+ *
+ * The currently defined keys for the `a{sv}` of additional metadata for each commit are:
+ *  - key: `ostree.commit.timestamp`, value: `t`, timestamp (seconds since the
+ *    Unix epoch in UTC, big-endian) when the commit was committed
  */
 #define OSTREE_SUMMARY_GVARIANT_STRING "(a(s(taya{sv}))a{sv})"
 #define OSTREE_SUMMARY_GVARIANT_FORMAT G_VARIANT_TYPE (OSTREE_SUMMARY_GVARIANT_STRING)

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -104,9 +104,9 @@ typedef enum {
 /**
  * OSTREE_DIRMETA_GVARIANT_FORMAT:
  *
- * - u - uid
- * - u - gid
- * - u - mode
+ * - u - uid (big-endian)
+ * - u - gid (big-endian)
+ * - u - mode (big-endian)
  * - a(ayay) - xattrs
  */
 #define OSTREE_DIRMETA_GVARIANT_STRING "(uuua(ayay))"
@@ -120,9 +120,9 @@ typedef enum {
  * can't store in the real filesystem but we can still use a regular .file object
  * that we can hardlink to in the case of a user-mode checkout.
  *
- * - u - uid
- * - u - gid
- * - u - mode
+ * - u - uid (big-endian)
+ * - u - gid (big-endian)
+ * - u - mode (big-endian)
  * - a(ayay) - xattrs
  */
 #define OSTREE_FILEMETA_GVARIANT_STRING "(uuua(ayay))"
@@ -145,7 +145,7 @@ typedef enum {
  * - a(say) - Related objects
  * - s - subject
  * - s - body
- * - t - Timestamp in seconds since the epoch (UTC)
+ * - t - Timestamp in seconds since the epoch (UTC, big-endian)
  * - ay - Root tree contents
  * - ay - Root tree metadata
  */

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -43,6 +43,14 @@ G_BEGIN_DECLS
  * */
 #define _OSTREE_MAX_OUTSTANDING_WRITE_REQUESTS 16
 
+/* Well-known keys for the additional metadata field in a summary file. */
+#define OSTREE_SUMMARY_LAST_MODIFIED "ostree.summary.last-modified"
+#define OSTREE_SUMMARY_EXPIRES "ostree.summary.expires"
+
+/* Well-known keys for the additional metadata field in a commit in a ref entry
+ * in a summary file. */
+#define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
+
 typedef enum {
   OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0)
 } OstreeRepoTestErrorFlags;

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -26,6 +26,7 @@
 #include "ot-builtins.h"
 #include "ostree.h"
 #include "otutil.h"
+#include "ostree-core-private.h"
 
 static gboolean opt_delete;
 static char *opt_gpg_homedir;
@@ -85,7 +86,7 @@ delete_signatures (OstreeRepo *repo,
   g_variant_dict_init (&metadata_dict, old_metadata);
 
   signature_data = g_variant_dict_lookup_value (&metadata_dict,
-                                                "ostree.gpgsigs",
+                                                _OSTREE_METADATA_GPGSIGS_NAME,
                                                 G_VARIANT_TYPE ("aay"));
 
   /* Taking the approach of deleting whatever matches we find for the
@@ -154,7 +155,7 @@ delete_signatures (OstreeRepo *repo,
   /* Update the metadata dictionary. */
   if (g_queue_is_empty (&signatures))
     {
-      g_variant_dict_remove (&metadata_dict, "ostree.gpgsigs");
+      g_variant_dict_remove (&metadata_dict, _OSTREE_METADATA_GPGSIGS_NAME);
     }
   else
     {
@@ -170,7 +171,7 @@ delete_signatures (OstreeRepo *repo,
         }
 
       g_variant_dict_insert_value (&metadata_dict,
-                                   "ostree.gpgsigs",
+                                   _OSTREE_METADATA_GPGSIGS_NAME,
                                    g_variant_builder_end (&signature_builder));
     }
 

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -20,17 +20,21 @@
 
 #include "config.h"
 
+#include "ostree-repo-private.h"
+#include "ot-dump.h"
 #include "ot-main.h"
 #include "ot-builtins.h"
 #include "ostree.h"
 #include "otutil.h"
 
-static gboolean opt_update;
+static gboolean opt_update, opt_view, opt_raw;
 static char **opt_key_ids;
 static char *opt_gpg_homedir;
 
 static GOptionEntry options[] = {
   { "update", 'u', 0, G_OPTION_ARG_NONE, &opt_update, "Update the summary", NULL },
+  { "view", 'v', 0, G_OPTION_ARG_NONE, &opt_view, "View the local summary file", NULL },
+  { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "View the raw bytes of the summary file", NULL },
   { "gpg-sign", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_key_ids, "GPG Key ID to sign the summary with", "KEY-ID"},
   { "gpg-homedir", 0, 0, G_OPTION_ARG_FILENAME, &opt_gpg_homedir, "GPG Homedir to use when looking for keyrings", "HOMEDIR"},
   { NULL }
@@ -42,6 +46,7 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object OstreeRepo *repo = NULL;
+  OstreeDumpFlags flags = OSTREE_DUMP_NONE;
 
   context = g_option_context_new ("Manage summary metadata");
 
@@ -65,6 +70,19 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
                                                       error))
             goto out;
         }
+    }
+  else if (opt_view)
+    {
+      g_autoptr(GBytes) summary_data = NULL;
+
+      if (opt_raw)
+        flags |= OSTREE_DUMP_RAW;
+
+      summary_data = ot_file_mapat_bytes (repo->repo_dir_fd, "summary", error);
+      if (!summary_data)
+        goto out;
+
+      ot_dump_summary_bytes (summary_data, flags);
     }
   else
     {

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -26,6 +26,8 @@
 
 #include <err.h>
 
+#include "ostree-repo-private.h"
+#include "ostree-repo-static-delta-private.h"
 #include "ot-dump.h"
 #include "otutil.h"
 #include "ot-admin-functions.h"
@@ -268,17 +270,17 @@ ot_dump_summary_bytes (GBytes          *summary_bytes,
       g_autofree gchar *value_str = NULL;
       const gchar *pretty_key = NULL;
 
-      if (g_strcmp0 (key, "ostree.static-deltas") == 0)
+      if (g_strcmp0 (key, OSTREE_SUMMARY_STATIC_DELTAS) == 0)
         {
           pretty_key = "Static Deltas";
           value_str = g_variant_print (value, FALSE);
         }
-      else if (g_strcmp0 (key, "ostree.summary.last-modified") == 0)
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_LAST_MODIFIED) == 0)
         {
           pretty_key = "Last-Modified";
           value_str = uint64_secs_to_iso8601 (GUINT64_FROM_BE (g_variant_get_uint64 (value)));
         }
-      else if (g_strcmp0 (key, "ostree.summary.expires") == 0)
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_EXPIRES) == 0)
         {
           pretty_key = "Expires";
           value_str = uint64_secs_to_iso8601 (GUINT64_FROM_BE (g_variant_get_uint64 (value)));

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Authors:
+#  - Philip Withnall <withnall@endlessm.com>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..2"
+
+COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
+setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+
+# Set up a second branch.
+mkdir ${test_tmpdir}/ostree-srv/other-files
+cd ${test_tmpdir}/ostree-srv/other-files
+echo 'hello world some object' > hello-world
+${CMD_PREFIX} ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit ${COMMIT_SIGN} -b other -s "A commit" -m "Example commit body"
+
+# Generate the summary file.
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
+
+# Check out the repository.
+prev_dir=`pwd`
+cd ${test_tmpdir}
+ostree_repo_init repo --mode=archive-z2
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
+${CMD_PREFIX} ostree --repo=repo pull --mirror origin
+
+# Check the summary file exists in the checkout, and can be viewed.
+assert_has_file repo/summary
+output=$(${OSTREE} summary --view)
+echo "$output" | sed -e 's/^/# /'
+echo "$output" | grep --quiet --no-messages "* main"
+echo "$output" | grep --quiet --no-messages "* other"
+echo "$output" | grep --quiet --no-messages "ostree.summary.last-modified"
+echo "$output" | grep --quiet --no-messages "Static Deltas (ostree.static-deltas): {}"
+echo "ok view summary"
+
+# Check the summary can be viewed raw too.
+raw_output=$(${OSTREE} summary --view --raw)
+echo "$raw_output" | sed -e 's/^/# /'
+echo "$raw_output" | grep --quiet --no-messages "('main', ("
+echo "$raw_output" | grep --quiet --no-messages "('other', ("
+echo "$raw_output" | grep --quiet --no-messages "{'ostree.summary.last-modified': <uint64"
+echo "ok view summary raw"
+
+libtest_cleanup_gpg


### PR DESCRIPTION
 • Commit timestamps, so it’s easy to work out whether a given commit is
   newer than the one we have locally
 • Summary file timestamp, so it’s easy to work out whether the summary
   file is more up to date than another summary file
 • Summary file expiry time, so clients can work out when they should
   expect the summary file to next be updated, and hence can query for
   it at roughly the right time

The expiry time requires input from the user, so is currently never set
automatically. Programs using libostree can set it if they wish.

Signed-off-by: Philip Withnall <withnall@endlessm.com>