### PR TITLE
repo/commit: Fix memory leak

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -608,7 +608,8 @@ write_object (OstreeRepo         *self,
               GError            **error)
 {
   gboolean ret = FALSE;
-  g_autofree char *actual_checksum = NULL;
+  const char *actual_checksum = NULL;
+  g_autofree char *actual_checksum_owned = NULL;
   gboolean do_commit;
   OstreeRepoMode repo_mode;
   g_autofree char *temp_filename = NULL;
@@ -770,10 +771,10 @@ write_object (OstreeRepo         *self,
     }
 
   if (!checksum_input)
-    actual_checksum = g_strdup (expected_checksum);
+    actual_checksum = expected_checksum;
   else
     {
-      actual_checksum = ot_checksum_instream_get_string (checksum_input);
+      actual_checksum = actual_checksum_owned = ot_checksum_instream_get_string (checksum_input);
       if (expected_checksum && strcmp (actual_checksum, expected_checksum) != 0)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -608,7 +608,7 @@ write_object (OstreeRepo         *self,
               GError            **error)
 {
   gboolean ret = FALSE;
-  const char *actual_checksum;
+  g_autofree char *actual_checksum = NULL;
   gboolean do_commit;
   OstreeRepoMode repo_mode;
   g_autofree char *temp_filename = NULL;
@@ -770,7 +770,7 @@ write_object (OstreeRepo         *self,
     }
 
   if (!checksum_input)
-    actual_checksum = expected_checksum;
+    actual_checksum = g_strdup (expected_checksum);
   else
     {
       actual_checksum = ot_checksum_instream_get_string (checksum_input);


### PR DESCRIPTION
While running the testsuite under valgrind a small memory leak showed up:

==16487== 65 bytes in 1 blocks are definitely lost in loss record 773 of 1,123
==16487==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==16487==    by 0x6048E08: g_malloc (gmem.c:94)
==16487==    by 0x6062EAE: g_strdup (gstrfuncs.c:363)
==16487==    by 0x54CE3E6: write_object (ostree-repo-commit.c:776)
==16487==    by 0x54CF2D4: ostree_repo_write_metadata (ostree-repo-commit.c:1528)
==16487==    by 0x54CF505: _ostree_repo_write_directory_meta (ostree-repo-commit.c:1712)
==16487==    by 0x54D0AB4: write_dfd_iter_to_mtree_internal (ostree-repo-commit.c:2650)
==16487==    by 0x54D0E2D: ostree_repo_write_dfd_to_mtree (ostree-repo-commit.c:2793)
==16487==    by 0x1190C4: ostree_builtin_commit (ot-builtin-commit.c:474)
==16487==    by 0x11F2EE: ostree_run (ot-main.c:200)
==16487==    by 0x116F32: main (main.c:78)

The reason for this is that ot_checksum_instream_get_string returns a chunk of newly allocated memory which never got freed.

Make actual_checksum something that gets autocleanend and own the memory
assigned to it in all cases.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>