### PR TITLE
pull: Fix crash specifying override URL in summary fetch

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2459,7 +2459,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
   g_autoptr(GMainContext) mainctx = NULL;
   gboolean ret = FALSE;
   gboolean from_cache = FALSE;
-  g_autofree char *url_override = NULL;
+  const char *url_override = NULL;
   g_autoptr(GPtrArray) mirrorlist = NULL;
 
   if (options)


### PR DESCRIPTION
The summary URL override is looked up with "&s", which directly
exchanges the data to a pointer without allocation. This was causing a
segfault calling ostree_repo_remote_fetch_summary_with_options from
pygobject.