### PR TITLE
libostree: Make OstreeRemote a public and internal API

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -38,6 +38,12 @@ libostree_public_headers = \
 	src/libostree/ostree-repo-deprecated.h \
 	$(NULL)
 
+if ENABLE_EXPERIMENTAL_API
+libostree_public_headers += \
+	src/libostree/ostree-remote.h \
+	$(NULL)
+endif
+
 # This one is generated via configure.ac, and the gtk-doc
 # code hence needs to look in the builddir.
 libostree_public_built_headers = src/libostree/ostree-version.h

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -94,6 +94,8 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-linuxfsutil.c \
 	src/libostree/ostree-diff.c \
 	src/libostree/ostree-mutable-tree.c \
+	src/libostree/ostree-remote.c \
+	src/libostree/ostree-remote-private.h \
 	src/libostree/ostree-repo.c \
 	src/libostree/ostree-repo-checkout.c \
 	src/libostree/ostree-repo-commit.c \
@@ -144,6 +146,11 @@ if HAVE_LIBSOUP_CLIENT_CERTS
 libostree_1_la_SOURCES += \
 	src/libostree/ostree-tls-cert-interaction.c \
 	src/libostree/ostree-tls-cert-interaction.h \
+	$(NULL)
+endif
+if !ENABLE_EXPERIMENTAL_API
+libostree_1_la_SOURCES += \
+	src/libostree/ostree-remote.h \
 	$(NULL)
 endif
 

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -156,7 +156,15 @@ libostree_1_la_LIBADD = libotutil.la libglnx.la libbsdiff.la libostree-kernel-ar
 libostree_1_la_LIBADD += $(bupsplitpath)
 EXTRA_libostree_1_la_DEPENDENCIES = $(top_srcdir)/src/libostree/libostree.sym
 
-EXTRA_DIST += src/libostree/libostree.sym
+EXTRA_DIST += \
+	src/libostree/libostree.sym \
+	src/libostree/libostree-experimental.sym \
+	$(NULL)
+
+if ENABLE_EXPERIMENTAL_API
+libostree_1_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/src/libostree/libostree-experimental.sym
+EXTRA_libostree_1_la_DEPENDENCIES += $(top_srcdir)/src/libostree/libostree-experimental.sym
+endif
 
 if USE_LIBARCHIVE
 libostree_1_la_CFLAGS += $(OT_DEP_LIBARCHIVE_CFLAGS)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -34,6 +34,7 @@ TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$${LD_LIBRARY_PATH}} \
 	PATH=$$(cd $(top_builddir)/tests && pwd):$${PATH} \
+	OSTREE_FEATURES="$(OSTREE_FEATURES)" \
 	$(NULL)
 if BUILDOPT_ASAN
 TESTS_ENVIRONMENT += OT_SKIP_READDIR_RAND=1 G_SLICE=always-malloc

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ include Makefile-decls.am
 
 shortened_sysconfdir = $$(echo "$(sysconfdir)" | sed -e 's|^$(prefix)||' -e 's|^/||')
 
-OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -d $(srcdir)/.git; then git describe --abbrev=42 --tags --always HEAD; fi)
+OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -d $(srcdir)/.git; then git -C $(srcdir) describe --abbrev=42 --tags --always HEAD; fi)
 
 ACLOCAL_AMFLAGS = -I buildutil -I libglnx ${ACLOCAL_FLAGS}
 AM_CPPFLAGS += -DDATADIR='"$(datadir)"' -DLIBEXECDIR='"$(libexecdir)"' \
@@ -113,11 +113,11 @@ include Makefile-boot.am
 include Makefile-man.am
 
 release-tag:
-	git tag -m "Release $(VERSION)" v$(VERSION)
+	git -C $(srcdir) tag -m "Release $(VERSION)" v$(VERSION)
 
 embed_dependency=tar -C $(srcdir) --append --exclude='.git/*' --transform="s,^embedded-dependencies/,ostree-embeddeps-$${GITVERSION}/embedded-dependencies/," --file=$${TARFILE_TMP}
 
-git_version_rpm = $$(git describe | sed -e 's,-,\.,g' -e 's,^v,,')
+git_version_rpm = $$(git -C $(srcdir) describe | sed -e 's,-,\.,g' -e 's,^v,,')
 
 release-tarball-embedded:
 	set -x; \

--- a/apidoc/Makefile.am
+++ b/apidoc/Makefile.am
@@ -120,6 +120,7 @@ include $(top_srcdir)/gtk-doc.make
 EXTRA_DIST += \
 	version.xml \
 	ostree-sections.txt \
+	ostree-experimental-sections.txt \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -1,0 +1,6 @@
+<SECTION>
+<FILE>ostree-remote</FILE>
+OstreeRemote
+ostree_remote_ref
+ostree_remote_unref
+</SECTION>

--- a/configure.ac
+++ b/configure.ac
@@ -429,6 +429,22 @@ AS_IF([test "x$found_introspection" = xyes && test x$using_asan != xyes], [
 ], [have_gjs=no])
 AM_CONDITIONAL(BUILDOPT_GJS, test x$have_gjs = xyes)
 
+# Do we enable building experimental (non-stable) API?
+# The OSTREE_ENABLE_EXPERIMENTAL_API #define is used internally and in public
+# headers, so any consumer of libostree who wants to use experimental API must
+#    #define OSTREE_ENABLE_EXPERIMENTAL_API 1
+# before including libostree headers. This means the name in the AC_DEFINE below
+# is public API.
+AC_ARG_ENABLE([experimental-api],
+  [AS_HELP_STRING([--enable-experimental-api],
+                  [Enable unstable experimental API in libostree [default=no]])],,
+  [enable_experimental_api=no])
+AS_IF([test x$enable_experimental_api = xyes],
+  [AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if experimental API should be enabled])
+   OSTREE_FEATURES="$OSTREE_FEATURES experimental"]
+)
+AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API],[test x$enable_experimental_api = xyes])
+
 AC_CONFIG_FILES([
 Makefile
 apidoc/Makefile
@@ -460,7 +476,8 @@ echo "
     gjs-based tests:                              $have_gjs
     dracut:                                       $with_dracut
     mkinitcpio:                                   $with_mkinitcpio
-    Static compiler for ostree-prepare-root:      $with_static_compiler"
+    Static compiler for ostree-prepare-root:      $with_static_compiler
+    Experimental API                              $enable_experimental_api"
 AS_IF([test x$with_builtin_grub2_mkconfig = xyes], [
     echo "    builtin grub2-mkconfig (instead of system):   $with_builtin_grub2_mkconfig"
 ], [

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -24,9 +24,8 @@
  * --enable-experimental-api. They are not stable or officially supported, and
  * might disappear or change in future releases. */
 
-/*
 LIBOSTREE_2017.6_EXPERIMENTAL {
 global:
-  some_symbol;
+  ostree_remote_ref;
+  ostree_remote_unref;
 } LIBOSTREE_2017.6;
-*/

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+/* Symbols in this file are added to the build if OSTree is configured with
+ * --enable-experimental-api. They are not stable or officially supported, and
+ * might disappear or change in future releases. */
+
+/*
+LIBOSTREE_2017.6_EXPERIMENTAL {
+global:
+  some_symbol;
+} LIBOSTREE_2017.6;
+*/

--- a/src/libostree/ostree-1.pc.in
+++ b/src/libostree/ostree-1.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+features=@OSTREE_FEATURES@
 
 Name: OSTree
 Description: Git for operating system binaries

--- a/src/libostree/ostree-autocleanups.h
+++ b/src/libostree/ostree-autocleanups.h
@@ -59,6 +59,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSysrootUpgrader, g_object_unref)
 
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (OstreeRepoCommitTraverseIter, ostree_repo_commit_traverse_iter_clear)
 
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRemote, ostree_remote_unref)
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
+
 #endif
 
 G_END_DECLS

--- a/src/libostree/ostree-remote-private.h
+++ b/src/libostree/ostree-remote-private.h
@@ -1,0 +1,59 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2011 Colin Walters <walters@verbum.org>
+ * Copyright © 2015 Red Hat, Inc.
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Colin Walters <walters@verbum.org>
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include "libglnx.h"
+#include "ostree-remote.h"
+#include "ostree-types.h"
+
+G_BEGIN_DECLS
+
+struct OstreeRemote {
+  volatile int ref_count;
+  char *name;
+  char *group;   /* group name in options */
+  char *keyring; /* keyring name (NAME.trustedkeys.gpg) */
+  GFile *file;   /* NULL if remote defined in repo/config */
+  GKeyFile *options;
+};
+
+G_GNUC_INTERNAL
+OstreeRemote *ostree_remote_new (void);
+
+G_GNUC_INTERNAL
+OstreeRemote *ostree_remote_new_from_keyfile (GKeyFile    *keyfile,
+                                              const gchar *group);
+
+#if (defined(OSTREE_COMPILATION) || GLIB_CHECK_VERSION(2, 44, 0)) && !defined(OSTREE_ENABLE_EXPERIMENTAL_API)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRemote, ostree_remote_unref)
+#endif
+
+G_END_DECLS

--- a/src/libostree/ostree-remote.c
+++ b/src/libostree/ostree-remote.c
@@ -1,0 +1,144 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2011 Colin Walters <walters@verbum.org>
+ * Copyright © 2015 Red Hat, Inc.
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Colin Walters <walters@verbum.org>
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ostree-remote.h"
+#include "ostree-remote-private.h"
+#include "ot-keyfile-utils.h"
+
+/**
+ * SECTION:remote
+ *
+ * The #OstreeRemote structure represents the configuration for a single remote
+ * repository. Currently, all configuration is handled internally, and
+ * #OstreeRemote objects are represented by their textual name handle, or by an
+ * opaque pointer (which can be reference counted if needed).
+ *
+ * #OstreeRemote provides configuration for accessing a remote, but does not
+ * provide the results of accessing a remote, such as information about what
+ * refs are currently on a remote, or the commits they currently point to. Use
+ * #OstreeRepo in combination with an #OstreeRemote to query that information.
+ *
+ * Since: 2017.6
+ */
+
+OstreeRemote *
+ostree_remote_new (void)
+{
+  OstreeRemote *remote;
+
+  remote = g_slice_new0 (OstreeRemote);
+  remote->ref_count = 1;
+  remote->options = g_key_file_new ();
+
+  return remote;
+}
+
+OstreeRemote *
+ostree_remote_new_from_keyfile (GKeyFile    *keyfile,
+                                const gchar *group)
+{
+  g_autoptr(GMatchInfo) match = NULL;
+  OstreeRemote *remote;
+
+  static gsize regex_initialized;
+  static GRegex *regex;
+
+  if (g_once_init_enter (&regex_initialized))
+    {
+      regex = g_regex_new ("^remote \"(.+)\"$", 0, 0, NULL);
+      g_assert (regex);
+      g_once_init_leave (&regex_initialized, 1);
+    }
+
+  /* Sanity check */
+  g_return_val_if_fail (g_key_file_has_group (keyfile, group), NULL);
+
+  /* If group name doesn't fit the pattern, fail. */
+  if (!g_regex_match (regex, group, 0, &match))
+    return NULL;
+
+  remote = ostree_remote_new ();
+  remote->name = g_match_info_fetch (match, 1);
+  remote->group = g_strdup (group);
+  remote->keyring = g_strdup_printf ("%s.trustedkeys.gpg", remote->name);
+
+  ot_keyfile_copy_group (keyfile, remote->options, group);
+
+  return remote;
+}
+
+/**
+ * ostree_remote_ref:
+ * @remote: an #OstreeRemote
+ *
+ * Increase the reference count on the given @remote.
+ *
+ * Returns: (transfer full): a copy of @remote, for convenience
+ * Since: 2017.6
+ */
+OstreeRemote *
+ostree_remote_ref (OstreeRemote *remote)
+{
+  gint refcount;
+  g_return_val_if_fail (remote != NULL, NULL);
+  refcount = g_atomic_int_add (&remote->ref_count, 1);
+  g_assert (refcount > 0);
+  return remote;
+}
+
+/**
+ * ostree_remote_unref:
+ * @remote: (transfer full): an #OstreeRemote
+ *
+ * Decrease the reference count on the given @remote and free it if the
+ * reference count reaches 0.
+ *
+ * Since: 2017.6
+ */
+void
+ostree_remote_unref (OstreeRemote *remote)
+{
+  g_return_if_fail (remote != NULL);
+  g_return_if_fail (remote->ref_count > 0);
+
+  if (g_atomic_int_dec_and_test (&remote->ref_count))
+    {
+      g_clear_pointer (&remote->name, g_free);
+      g_clear_pointer (&remote->group, g_free);
+      g_clear_pointer (&remote->keyring, g_free);
+      g_clear_object (&remote->file);
+      g_clear_pointer (&remote->options, g_key_file_free);
+      g_slice_free (OstreeRemote, remote);
+    }
+}

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -1,6 +1,8 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
  *
- * Copyright (C) 2011 Colin Walters <walters@verbum.org>
+ * Copyright © 2011 Colin Walters <walters@verbum.org>
+ * Copyright © 2015 Red Hat, Inc.
+ * Copyright © 2017 Endless Mobile, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,29 +19,38 @@
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  *
- * Author: Colin Walters <walters@verbum.org>
+ * Authors:
+ *  - Colin Walters <walters@verbum.org>
+ *  - Philip Withnall <withnall@endlessm.com>
  */
 
 #pragma once
 
 #include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
 
-#ifndef _OSTREE_PUBLIC
-#define _OSTREE_PUBLIC extern
-#endif
+#include "ostree-types.h"
 
 G_BEGIN_DECLS
 
-typedef struct OstreeRepo OstreeRepo;
-typedef struct OstreeRepoDevInoCache OstreeRepoDevInoCache;
-typedef struct OstreeSePolicy OstreeSePolicy;
-typedef struct OstreeSysroot OstreeSysroot;
-typedef struct OstreeSysrootUpgrader OstreeSysrootUpgrader;
-typedef struct OstreeMutableTree OstreeMutableTree;
-typedef struct OstreeRepoFile OstreeRepoFile;
-
-#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+/**
+ * OstreeRemote:
+ *
+ * This represents the configuration for a single remote repository. Currently,
+ * remotes can only be passed around as (reference counted) opaque handles. In
+ * future, more API may be added to create and interrogate them.
+ *
+ * Since: 2016.7
+ */
+#ifndef OSTREE_ENABLE_EXPERIMENTAL_API
+/* This is in ostree-types.h otherwise */
 typedef struct OstreeRemote OstreeRemote;
 #endif
+
+_OSTREE_PUBLIC
+OstreeRemote *ostree_remote_ref (OstreeRemote *remote);
+_OSTREE_PUBLIC
+void ostree_remote_unref (OstreeRemote *remote);
 
 G_END_DECLS

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ostree-repo.h"
+#include "ostree-remote-private.h"
 #include "libglnx.h"
 
 G_BEGIN_DECLS
@@ -349,5 +350,17 @@ _ostree_repo_read_bare_fd (OstreeRepo           *self,
 gboolean
 _ostree_repo_update_mtime (OstreeRepo        *self,
                            GError           **error);
+
+void
+_ostree_repo_add_remote (OstreeRepo   *self,
+                         OstreeRemote *remote);
+OstreeRemote *
+_ostree_repo_get_remote (OstreeRepo  *self,
+                         const char  *name,
+                         GError     **error);
+OstreeRemote *
+_ostree_repo_get_remote_inherited (OstreeRepo  *self,
+                                   const char  *name,
+                                   GError     **error);
 
 G_END_DECLS

--- a/src/libostree/ostree.h
+++ b/src/libostree/ostree.h
@@ -24,6 +24,9 @@
 #include <ostree-core.h>
 #include <ostree-repo.h>
 #include <ostree-mutable-tree.h>
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+#include <ostree-remote.h>
+#endif
 #include <ostree-repo-file.h>
 #include <ostree-sysroot.h>
 #include <ostree-sysroot-upgrader.h>

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -21,9 +21,17 @@ set -euo pipefail
 
 echo '1..2'
 
+if echo "$OSTREE_FEATURES" | grep --quiet --no-messages "experimental"; then
+  experimental_sym="${G_TEST_SRCDIR}/src/libostree/libostree-experimental.sym"
+  experimental_sections="${G_TEST_SRCDIR}/apidoc/ostree-experimental-sections.txt"
+else
+  experimental_sym=""
+  experimental_sections=""
+fi
+
 echo "Verifying all expected symbols are actually exported..."
-grep ' ostree_[A-Za-z0-9_]*;' ${G_TEST_SRCDIR}/src/libostree/libostree.sym | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
-eu-readelf -a ${G_TEST_BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9_.]*,\1,' |sort -u > found-symbols.txt
+grep --no-filename ' ostree_[A-Za-z0-9_]*;' ${G_TEST_SRCDIR}/src/libostree/libostree.sym $experimental_sym | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
+eu-readelf -a ${G_TEST_BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9A-Z_.]*,\1,' |sort -u > found-symbols.txt
 diff -u expected-symbols.txt found-symbols.txt
 echo "ok exports"
 
@@ -31,7 +39,7 @@ echo "ok exports"
 grep -E -v '(ostree_cmd__private__)|(ostree_fetcher_config_flags_get_type)' found-symbols.txt > expected-documented.txt
 
 echo "Verifying all public symbols are documented:"
-grep '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt |sort -u > found-documented.txt
+grep '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt $experimental_sections |sort -u > found-documented.txt
 diff -u expected-documented.txt found-documented.txt
 
 echo 'ok documented symbols'


### PR DESCRIPTION
Previously it was static to ostree-repo.c. Make it usable throughout
libostree so it can be used by an upcoming commit, but also expose the
typedef and reference counting functions so that opaque OstreeRemote
pointers can be used by user code, in anticipation of exposing more of
its API publicly in future.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

This also includes a commit to introduce an `--enable-experimental-api` configure option, which the changes to the remotes API are hidden behind.

It also includes all the commits from PR #826 because I can’t figure out a way to make one PR depend on the other on GitHub.