### PR TITLE
Mark ostree_repo_transaction_set_ref* checksums nullable

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1306,7 +1306,7 @@ ensure_txn_refs (OstreeRepo *self)
  * ostree_repo_transaction_set_refspec:
  * @self: An #OstreeRepo
  * @refspec: The refspec to write
- * @checksum: The checksum to point it to
+ * @checksum: (nullable): The checksum to point it to
  *
  * Like ostree_repo_transaction_set_ref(), but takes concatenated
  * @refspec format as input instead of separate remote and name
@@ -1329,7 +1329,7 @@ ostree_repo_transaction_set_refspec (OstreeRepo *self,
  * @self: An #OstreeRepo
  * @remote: (allow-none): A remote for the ref
  * @ref: The ref to write
- * @checksum: The checksum to point it to
+ * @checksum: (nullable): The checksum to point it to
  *
  * If @checksum is not %NULL, then record it as the target of ref named
  * @ref; if @remote is provided, the ref will appear to originate from that

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -52,4 +52,18 @@ let child = root.get_child('some-file');
 let info = child.query_info("standard::name,standard::type,standard::size", 0, null);
 assertEquals(info.get_size(), 12);
 
+// Write a ref and read it back
+repo.prepare_transaction(null);
+repo.transaction_set_refspec('someref', commit);
+repo.commit_transaction(null, null);
+let [,readCommit] = repo.resolve_rev('someref', false);
+assertEquals(readCommit, commit);
+
+// Delete a ref
+repo.prepare_transaction(null);
+repo.transaction_set_refspec('someref', null);
+repo.commit_transaction(null, null);
+[,readCommit] = repo.resolve_rev('someref', true);
+assertEquals(readCommit, null);
+
 print("test-core complete");


### PR DESCRIPTION
So you can delete refs in a transaction from GI bindings. In order to test this, I added it to the JS tests, which only run installed. Which led me down the rabbit hole of why the installed tests were failing horribly.