### PR TITLE
tree-wide: Convert to using autoptr(GString) vs g_string_free(...,TRUE)

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -148,7 +148,7 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
                                           GError                       **error)
 {
   gboolean ret = FALSE;
-  GString *output = g_string_new ("");
+  g_autoptr(GString) output = g_string_new ("");
   g_autoptr(GOutputStream) out_stream = NULL;
   g_autoptr(GPtrArray) loader_configs = NULL;
   guint i;
@@ -260,8 +260,6 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
 
   ret = TRUE;
  out:
-  if (output)
-    g_string_free (output, TRUE);
   return ret;
 }
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -433,7 +433,7 @@ add_size_index_to_metadata (OstreeRepo        *self,
         {
           guint8 csum[OSTREE_SHA256_DIGEST_LEN];
           const char *e_checksum = sorted_keys->pdata[i];
-          GString *buffer = g_string_new (NULL);
+          g_autoptr(GString) buffer = g_string_new (NULL);
 
           ostree_checksum_inplace_to_bytes (e_checksum, csum);
           g_string_append_len (buffer, (char*)csum, sizeof (csum));
@@ -444,7 +444,6 @@ add_size_index_to_metadata (OstreeRepo        *self,
 
           g_variant_builder_add (&index_builder, "@ay",
                                  ot_gvariant_new_bytearray ((guint8*)buffer->str, buffer->len));
-          g_string_free (buffer, TRUE);
         }
       
       g_variant_builder_add (builder, "{sv}", "ostree.sizes",

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3474,8 +3474,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   bytes_transferred = _ostree_fetcher_bytes_transferred (pull_data->fetcher);
   if (bytes_transferred > 0 && pull_data->progress)
     {
-      guint shift; 
-      GString *buf = g_string_new ("");
+      guint shift;
+      g_autoptr(GString) buf = g_string_new ("");
 
       if (bytes_transferred < 1024)
         shift = 1;
@@ -3496,7 +3496,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                               (guint) ((end_time - pull_data->start_time) / G_USEC_PER_SEC));
 
       ostree_async_progress_set_status (pull_data->progress, buf->str);
-      g_string_free (buf, TRUE);
     }
 
   /* iterate over commits fetched and delete any commitpartial files */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3717,7 +3717,6 @@ void
 ostree_repo_pull_default_console_progress_changed (OstreeAsyncProgress *progress,
                                                    gpointer             user_data)
 {
-  GString *buf;
   g_autofree char *status = NULL;
   gboolean scanning;
   guint outstanding_fetches;
@@ -3729,7 +3728,7 @@ ostree_repo_pull_default_console_progress_changed (OstreeAsyncProgress *progress
   guint fetched_delta_part_fallbacks;
   guint total_delta_part_fallbacks;
 
-  buf = g_string_new ("");
+  g_autoptr(GString) buf = g_string_new ("");
 
   ostree_async_progress_get (progress,
                              "outstanding-fetches", "u", &outstanding_fetches,
@@ -3838,8 +3837,6 @@ ostree_repo_pull_default_console_progress_changed (OstreeAsyncProgress *progress
     }
 
   glnx_console_text (buf->str);
-
-  g_string_free (buf, TRUE);
 }
 
 /**

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -47,12 +47,9 @@ static GOptionContext *
 ostree_admin_instutil_option_context_new_with_commands (void)
 {
   OstreeAdminInstUtilCommand *command = admin_instutil_subcommands;
-  GOptionContext *context;
-  GString *summary;
+  GOptionContext *context = g_option_context_new ("COMMAND");
 
-  context = g_option_context_new ("COMMAND");
-
-  summary = g_string_new ("Builtin \"admin instutil\" Commands:");
+  g_autoptr(GString) summary = g_string_new ("Builtin \"admin instutil\" Commands:");
 
   while (command->name != NULL)
     {
@@ -61,8 +58,6 @@ ostree_admin_instutil_option_context_new_with_commands (void)
     }
 
   g_option_context_set_summary (context, summary->str);
-
-  g_string_free (summary, TRUE);
 
   return context;
 }

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -124,7 +124,6 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
           OstreeDeploymentUnlockedState unlocked = ostree_deployment_get_unlocked (deployment);
           g_autofree char *version = version_of_commit (repo, ref);
           glnx_unref_object OstreeGpgVerifyResult *result = NULL;
-          GString *output_buffer;
           guint jj, n_signatures;
           GError *local_error = NULL;
 
@@ -159,6 +158,7 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
 
           if (deployment_get_gpg_verify (deployment, repo))
             {
+              g_autoptr(GString) output_buffer = g_string_sized_new (256);
               /* Print any digital signatures on this commit. */
 
               result = ostree_repo_verify_commit_ext (repo, ref, NULL, NULL,
@@ -176,7 +176,6 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
                   goto out;
                 }
 
-              output_buffer = g_string_sized_new (256);
               n_signatures = ostree_gpg_verify_result_count_all (result);
 
               for (jj = 0; jj < n_signatures; jj++)
@@ -186,7 +185,6 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
                 }
 
               g_print ("%s", output_buffer->str);
-              g_string_free (output_buffer, TRUE);
             }
         }
     }

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -56,12 +56,9 @@ static GOptionContext *
 ostree_admin_option_context_new_with_commands (void)
 {
   OstreeAdminCommand *command = admin_subcommands;
-  GOptionContext *context;
-  GString *summary;
+  GOptionContext *context = g_option_context_new ("--print-current-dir|COMMAND");
 
-  context = g_option_context_new ("--print-current-dir|COMMAND");
-
-  summary = g_string_new ("Builtin \"admin\" Commands:");
+  g_autoptr(GString) summary = g_string_new ("Builtin \"admin\" Commands:");
 
   while (command->name != NULL)
     {
@@ -70,8 +67,6 @@ ostree_admin_option_context_new_with_commands (void)
     }
 
   g_option_context_set_summary (context, summary->str);
-
-  g_string_free (summary, TRUE);
 
   return context;
 }

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -218,7 +218,7 @@ commit_editor (OstreeRepo     *repo,
   g_autofree char *input = NULL;
   g_autofree char *output = NULL;
   gboolean ret = FALSE;
-  GString *bodybuf = NULL;
+  g_autoptr(GString) bodybuf = NULL;
   char **lines = NULL;
   int i;
 
@@ -288,8 +288,6 @@ commit_editor (OstreeRepo     *repo,
 
 out:
   g_strfreev (lines);
-  if (bodybuf)
-    g_string_free (bodybuf, TRUE);
   return ret;
 }
 

--- a/src/ostree/ot-builtin-ls.c
+++ b/src/ostree/ot-builtin-ls.c
@@ -47,15 +47,13 @@ static void
 print_one_file_text (GFile     *f,
                      GFileInfo *file_info)
 {
-  GString *buf = NULL;
+  g_autoptr(GString) buf = g_string_new ("");
   char type_c;
   guint32 mode;
   guint32 type;
 
   if (!ostree_repo_file_ensure_resolved ((OstreeRepoFile*)f, NULL))
     g_assert_not_reached ();
-  
-  buf = g_string_new ("");
 
   type_c = '?';
   mode = g_file_info_get_attribute_uint32 (file_info, "unix::mode");
@@ -119,8 +117,6 @@ print_one_file_text (GFile     *f,
     g_string_append_printf (buf, " -> %s", g_file_info_get_attribute_byte_string (file_info, "standard::symlink-target"));
       
   g_print ("%s\n", buf->str);
-
-  g_string_free (buf, TRUE);
 }
 
 static void

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -84,7 +84,6 @@ dry_run_console_progress_changed (OstreeAsyncProgress *progress,
   guint fetched_delta_parts, total_delta_parts;
   guint fetched_delta_part_fallbacks, total_delta_part_fallbacks;
   guint64 fetched_delta_part_size, total_delta_part_size, total_delta_part_usize;
-  GString *buf;
 
   g_assert (!printed_console_progress);
   printed_console_progress = TRUE;
@@ -107,7 +106,7 @@ dry_run_console_progress_changed (OstreeAsyncProgress *progress,
   fetched_delta_parts += fetched_delta_part_fallbacks;
   total_delta_parts += total_delta_part_fallbacks;
 
-  buf = g_string_new ("");
+  g_autoptr(GString) buf = g_string_new ("");
 
   { g_autofree char *formatted_fetched =
       g_format_size (fetched_delta_part_size);
@@ -122,7 +121,6 @@ dry_run_console_progress_changed (OstreeAsyncProgress *progress,
                             formatted_usize);
   }
   g_print ("%s\n", buf->str);
-  g_string_free (buf, TRUE);
 }
 
 gboolean

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -51,12 +51,9 @@ static GOptionContext *
 remote_option_context_new_with_commands (void)
 {
   OstreeRemoteCommand *subcommand = remote_subcommands;
-  GOptionContext *context;
-  GString *summary;
+  GOptionContext *context = g_option_context_new ("COMMAND");
 
-  context = g_option_context_new ("COMMAND");
-
-  summary = g_string_new ("Builtin \"remote\" Commands:");
+  g_autoptr(GString) summary = g_string_new ("Builtin \"remote\" Commands:");
 
   while (subcommand->name != NULL)
     {
@@ -65,8 +62,6 @@ remote_option_context_new_with_commands (void)
     }
 
   g_option_context_set_summary (context, summary->str);
-
-  g_string_free (summary, TRUE);
 
   return context;
 }

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -59,12 +59,9 @@ static GOptionEntry global_admin_entries[] = {
 static GOptionContext *
 ostree_option_context_new_with_commands (OstreeCommand *commands)
 {
-  GOptionContext *context;
-  GString *summary;
+  GOptionContext *context = g_option_context_new ("COMMAND");
 
-  context = g_option_context_new ("COMMAND");
-
-  summary = g_string_new ("Builtin Commands:");
+  g_autoptr(GString) summary = g_string_new ("Builtin Commands:");
 
   while (commands->name != NULL)
     {
@@ -73,8 +70,6 @@ ostree_option_context_new_with_commands (OstreeCommand *commands)
     }
 
   g_option_context_set_summary (context, summary->str);
-
-  g_string_free (summary, TRUE);
 
   return context;
 }
@@ -389,18 +384,15 @@ ostree_ensure_repo_writable (OstreeRepo *repo,
 void
 ostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
 {
-  GString *buffer;
-  guint n_sigs, ii;
-
-  n_sigs = ostree_gpg_verify_result_count_all (result);
+  guint n_sigs = ostree_gpg_verify_result_count_all (result);
 
   /* XXX If we ever add internationalization, use ngettext() here. */
   g_print ("GPG: Verification enabled, found %u signature%s:\n",
            n_sigs, n_sigs == 1 ? "" : "s");
 
-  buffer = g_string_sized_new (256);
+  g_autoptr(GString) buffer = g_string_sized_new (256);
 
-  for (ii = 0; ii < n_sigs; ii++)
+  for (guint ii = 0; ii < n_sigs; ii++)
     {
       g_string_append_c (buffer, '\n');
       ostree_gpg_verify_result_describe (result, ii, buffer, "  ",
@@ -408,7 +400,6 @@ ostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
     }
 
   g_print ("%s", buffer->str);
-  g_string_free (buffer, TRUE);
 }
 
 gboolean

--- a/tests/test-gpg-verify-result.c
+++ b/tests/test-gpg-verify-result.c
@@ -28,11 +28,10 @@
 #define assert_no_gpg_error(err, filename) \
   G_STMT_START { \
     if (err != GPG_ERR_NO_ERROR) { \
-      GString *string = g_string_new ("assertion failed "); \
+      g_autoptr(GString) string = g_string_new ("assertion failed ");  \
       g_string_append_printf (string, "%s: %s ", gpgme_strsource (err), gpgme_strerror (err)); \
       g_string_append (string, filename ? filename : ""); \
       g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, string->str); \
-      g_string_free (string, TRUE); \
     } \
   } G_STMT_END
 


### PR DESCRIPTION
If we're freeing the segment, it's basically always better to use
`autoptr()`.  Fewer lines, more reliable, etc.

Noticed an instance of this in the pull code while reviewing a different PR,
decided to do a grep for it and fix it tree wide.