### PR TITLE
tests: Fix regex escaping in test-summary-view.sh

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -85,6 +85,13 @@ assert_file_has_content () {
     fi
 }
 
+assert_file_has_content_literal () {
+    if ! grep -q -F -e "$2" "$1"; then
+        sed -e 's/^/# /' < "$1" >&2
+        fatal "File '$1' doesn't match fixed string list '$2'"
+    fi
+}
+
 assert_symlink_has_content () {
     if ! test -L "$1"; then
         echo 1>&2 "File '$1' is not a symbolic link"

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -47,20 +47,18 @@ ${CMD_PREFIX} ostree --repo=repo pull --mirror origin
 
 # Check the summary file exists in the checkout, and can be viewed.
 assert_has_file repo/summary
-output=$(${OSTREE} summary --view)
-echo "$output" | sed -e 's/^/# /'
-echo "$output" | grep --quiet --no-messages "* main"
-echo "$output" | grep --quiet --no-messages "* other"
-echo "$output" | grep --quiet --no-messages "ostree.summary.last-modified"
-echo "$output" | grep --quiet --no-messages "Static Deltas (ostree.static-deltas): {}"
+${OSTREE} summary --view > summary.txt
+assert_file_has_content_literal summary.txt "* main"
+assert_file_has_content_literal summary.txt "* other"
+assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
+assert_file_has_content_literal summary.txt "Static Deltas (ostree.static-deltas): {}"
 echo "ok view summary"
 
 # Check the summary can be viewed raw too.
-raw_output=$(${OSTREE} summary --view --raw)
-echo "$raw_output" | sed -e 's/^/# /'
-echo "$raw_output" | grep --quiet --no-messages "('main', ("
-echo "$raw_output" | grep --quiet --no-messages "('other', ("
-echo "$raw_output" | grep --quiet --no-messages "{'ostree.summary.last-modified': <uint64"
+${OSTREE} summary --view --raw > raw-summary.txt
+assert_file_has_content_literal raw-summary.txt "('main', ("
+assert_file_has_content_literal raw-summary.txt "('other', ("
+assert_file_has_content_literal raw-summary.txt "{'ostree.summary.last-modified': <uint64"
 echo "ok view summary raw"
 
 libtest_cleanup_gpg


### PR DESCRIPTION
There were some regex special characters in the pattern strings, which I
think were causing the test to fail on some Travis builds due to using
an invalid regex.

Fix that by matching using fixed strings instead. We don’t need regexes
here.

Signed-off-by: Philip Withnall <withnall@endlessm.com>