### PR TITLE
ci: Move travis scripts from tests/ → ci/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 
 script:
-  - tests/ci-install.sh
-  - ci_parallel=2 ci_sudo=yes tests/ci-build.sh
+  - ci/travis-install.sh
+  - ci_parallel=2 ci_sudo=yes ci/travis-build.sh
 
 notifications:
   email: false

--- a/ci/travis-Dockerfile.in
+++ b/ci/travis-Dockerfile.in
@@ -1,8 +1,8 @@
 FROM @ci_docker@
 ENV container docker
 
-ADD tests/ci-install.sh /ci-install.sh
-RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /ci-install.sh
+ADD ci/travis-install.sh /travis-install.sh
+RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /travis-install.sh
 
 ADD . /home/user/ostree
 RUN chown -R user:user /home/user/ostree

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -28,7 +28,7 @@ set -x
 NULL=
 
 # ci_docker:
-# If non-empty, this is the name of a Docker image. ci-install.sh will
+# If non-empty, this is the name of a Docker image. travis-install.sh will
 # fetch it with "docker pull" and use it as a base for a new Docker image
 # named "ci-image" in which we will do our testing.
 #
@@ -66,7 +66,7 @@ if [ -n "$ci_docker" ]; then
         --env=ci_configopts="${ci_configopts}" \
         --privileged \
         ci-image \
-        tests/ci-build.sh
+        ci/travis-build.sh
 fi
 
 maybe_fail_tests () {

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -33,13 +33,13 @@ NULL=
 : "${ci_distro:=debian}"
 
 # ci_docker:
-# If non-empty, this is the name of a Docker image. ci-install.sh will
+# If non-empty, this is the name of a Docker image. travis-install.sh will
 # fetch it with "docker pull" and use it as a base for a new Docker image
 # named "ci-image" in which we will do our testing.
 : "${ci_docker:=}"
 
 # ci_in_docker:
-# Used internally by ci-install.sh. If yes, we are inside the Docker image
+# Used internally by travis-install.sh. If yes, we are inside the Docker image
 # (ci_docker is empty in this case).
 : "${ci_in_docker:=no}"
 
@@ -64,7 +64,7 @@ if [ -n "$ci_docker" ]; then
         -e "s/@ci_distro@/${ci_distro}/" \
         -e "s/@ci_docker@/${ci_docker}/" \
         -e "s/@ci_suite@/${ci_suite}/" \
-        < tests/ci-Dockerfile.in > Dockerfile
+        < ci/travis-Dockerfile.in > Dockerfile
     exec docker build -t ci-image .
 fi
 


### PR DESCRIPTION
I think tests/ should be just that, ci/ is separate.  Also rename
the files to include "travis" since that's what we use them
for right now.