### PR TITLE
tree-wide: Switch tabs ⭾ in various files over to spaces ␠

### DIFF
--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -457,10 +457,10 @@ httpd_callback (SoupServer *server, SoupMessage *msg,
 
 static void
 on_dir_changed (GFileMonitor  *mon,
-		GFile *file,
-		GFile *other,
-		GFileMonitorEvent  event,
-		gpointer user_data)
+                GFile *file,
+                GFile *other,
+                GFileMonitorEvent  event,
+                gpointer user_data)
 {
   OtTrivialHttpd *self = user_data;
 

--- a/src/rofiles-fuse/main.c
+++ b/src/rofiles-fuse/main.c
@@ -85,7 +85,7 @@ callback_readlink (const char *path, char *buf, size_t size)
 
 static int
 callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
-      off_t offset, struct fuse_file_info *fi)
+                  off_t offset, struct fuse_file_info *fi)
 {
   DIR *dp;
   struct dirent *de;
@@ -366,7 +366,7 @@ callback_read_buf (const char *path, struct fuse_bufvec **bufp,
 
 static int
 callback_read (const char *path, char *buf, size_t size, off_t offset,
-         struct fuse_file_info *finfo)
+               struct fuse_file_info *finfo)
 {
   int r;
   r = pread (finfo->fh, buf, size, offset);
@@ -390,7 +390,7 @@ callback_write_buf (const char *path, struct fuse_bufvec *buf, off_t offset,
 
 static int
 callback_write (const char *path, const char *buf, size_t size, off_t offset,
-    struct fuse_file_info *finfo)
+                struct fuse_file_info *finfo)
 {
   int r;
   r = pwrite (finfo->fh, buf, size, offset);
@@ -438,7 +438,7 @@ callback_access (const char *path, int mode)
 
 static int
 callback_setxattr (const char *path, const char *name, const char *value,
-       size_t size, int flags)
+                   size_t size, int flags)
 {
   return -ENOTSUP;
 }
@@ -513,19 +513,19 @@ static void
 usage (const char *progname)
 {
   fprintf (stdout,
-     "usage: %s basepath mountpoint [options]\n"
-     "\n"
-     "   Makes basepath visible at mountpoint such that files are read-only, directories are writable\n"
-     "\n"
-     "general options:\n"
-     "   -o opt,[opt...]     mount options\n"
-     "   -h  --help          print help\n"
-     "\n", progname);
+           "usage: %s basepath mountpoint [options]\n"
+           "\n"
+           "   Makes basepath visible at mountpoint such that files are read-only, directories are writable\n"
+           "\n"
+           "general options:\n"
+           "   -o opt,[opt...]     mount options\n"
+           "   -h  --help          print help\n"
+           "\n", progname);
 }
 
 static int
 rofs_parse_opt (void *data, const char *arg, int key,
-    struct fuse_args *outargs)
+                struct fuse_args *outargs)
 {
   (void) data;
 

--- a/src/rofiles-fuse/main.c
+++ b/src/rofiles-fuse/main.c
@@ -56,12 +56,12 @@ callback_getattr (const char *path, struct stat *st_data)
   if (!*path)
     {
       if (fstat (basefd, st_data) == -1)
-	return -errno;
+        return -errno;
     }
   else
     {
       if (fstatat (basefd, path, st_data, AT_SYMLINK_NOFOLLOW) == -1)
-	return -errno;
+        return -errno;
     }
   return 0;
 }
@@ -85,7 +85,7 @@ callback_readlink (const char *path, char *buf, size_t size)
 
 static int
 callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
-		  off_t offset, struct fuse_file_info *fi)
+      off_t offset, struct fuse_file_info *fi)
 {
   DIR *dp;
   struct dirent *de;
@@ -102,7 +102,7 @@ callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
     {
       dfd = openat (basefd, path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
       if (dfd == -1)
-	return -errno;
+        return -errno;
     }
 
   /* Transfers ownership of fd */
@@ -117,7 +117,7 @@ callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
       st.st_ino = de->d_ino;
       st.st_mode = de->d_type << 12;
       if (filler (buf, de->d_name, &st, 0))
-	break;
+        break;
     }
 
   (void) closedir (dp);
@@ -170,7 +170,7 @@ callback_symlink (const char *from, const char *to)
   if (fstatat (basefd, to, &stbuf, AT_SYMLINK_NOFOLLOW) == -1)
     {
       fprintf (stderr, "Failed to find newly created symlink '%s': %s\n",
-	       to, g_strerror (errno));
+               to, g_strerror (errno));
       exit (EXIT_FAILURE);
     }
   return 0;
@@ -209,9 +209,9 @@ can_write (const char *path)
   if (fstatat (basefd, path, &stbuf, 0) == -1)
     {
       if (errno == ENOENT)
-	return 0;
+        return 0;
       else
-	return -errno;
+        return -errno;
     }
   if (stbuf_is_regfile_hardlinked (&stbuf))
     return -EROFS;
@@ -366,7 +366,7 @@ callback_read_buf (const char *path, struct fuse_bufvec **bufp,
 
 static int
 callback_read (const char *path, char *buf, size_t size, off_t offset,
-	       struct fuse_file_info *finfo)
+         struct fuse_file_info *finfo)
 {
   int r;
   r = pread (finfo->fh, buf, size, offset);
@@ -390,7 +390,7 @@ callback_write_buf (const char *path, struct fuse_bufvec *buf, off_t offset,
 
 static int
 callback_write (const char *path, const char *buf, size_t size, off_t offset,
-		struct fuse_file_info *finfo)
+    struct fuse_file_info *finfo)
 {
   int r;
   r = pwrite (finfo->fh, buf, size, offset);
@@ -426,7 +426,7 @@ static int
 callback_access (const char *path, int mode)
 {
   path = ENSURE_RELPATH (path);
-  
+
   /* Apparently at least GNU coreutils rm calls `faccessat(W_OK)`
    * before trying to do an unlink.  So...we'll just lie about
    * writable access here.
@@ -438,14 +438,14 @@ callback_access (const char *path, int mode)
 
 static int
 callback_setxattr (const char *path, const char *name, const char *value,
-		   size_t size, int flags)
+       size_t size, int flags)
 {
   return -ENOTSUP;
 }
 
 static int
 callback_getxattr (const char *path, const char *name, char *value,
-		   size_t size)
+       size_t size)
 {
   return -ENOTSUP;
 }
@@ -513,19 +513,19 @@ static void
 usage (const char *progname)
 {
   fprintf (stdout,
-	   "usage: %s basepath mountpoint [options]\n"
-	   "\n"
-	   "   Makes basepath visible at mountpoint such that files are read-only, directories are writable\n"
-	   "\n"
-	   "general options:\n"
-	   "   -o opt,[opt...]     mount options\n"
-	   "   -h  --help          print help\n"
-	   "\n", progname);
+     "usage: %s basepath mountpoint [options]\n"
+     "\n"
+     "   Makes basepath visible at mountpoint such that files are read-only, directories are writable\n"
+     "\n"
+     "general options:\n"
+     "   -o opt,[opt...]     mount options\n"
+     "   -h  --help          print help\n"
+     "\n", progname);
 }
 
 static int
 rofs_parse_opt (void *data, const char *arg, int key,
-		struct fuse_args *outargs)
+    struct fuse_args *outargs)
 {
   (void) data;
 
@@ -533,19 +533,19 @@ rofs_parse_opt (void *data, const char *arg, int key,
     {
     case FUSE_OPT_KEY_NONOPT:
       if (basefd == -1)
-	{
-	  basefd = openat (AT_FDCWD, arg, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
-	  if (basefd == -1)
-	    {
-	      perror ("openat");
-	      exit (EXIT_FAILURE);
-	    }
-	  return 0;
-	}
+        {
+          basefd = openat (AT_FDCWD, arg, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+          if (basefd == -1)
+            {
+              perror ("openat");
+              exit (EXIT_FAILURE);
+            }
+          return 0;
+        }
       else
-	{
-	  return 1;
-	}
+        {
+          return 1;
+        }
     case FUSE_OPT_KEY_OPT:
       return 1;
     case KEY_HELP:

--- a/src/rofiles-fuse/main.c
+++ b/src/rofiles-fuse/main.c
@@ -218,10 +218,10 @@ can_write (const char *path)
   return 0;
 }
 
-#define VERIFY_WRITE(path) do { \
-  int r = can_write (path); \
-  if (r != 0) \
-    return r; \
+#define VERIFY_WRITE(path) do {                 \
+    int r = can_write (path);                   \
+    if (r != 0)                                 \
+      return r;                                 \
   } while (0)
 
 static int
@@ -445,7 +445,7 @@ callback_setxattr (const char *path, const char *name, const char *value,
 
 static int
 callback_getxattr (const char *path, const char *name, char *value,
-       size_t size)
+                   size_t size)
 {
   return -ENOTSUP;
 }
@@ -503,8 +503,7 @@ struct fuse_operations callback_oper = {
   .removexattr = callback_removexattr
 };
 
-enum
-{
+enum {
   KEY_HELP,
   KEY_VERSION,
 };

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -1,13 +1,13 @@
 /* -*- c-file-style: "gnu" -*-
  * Switch to new root directory and start init.
- * 
+ *
  * Copyright 2011,2012,2013 Colin Walters <walters@verbum.org>
  *
- * Based on code from util-linux/sys-utils/switch_root.c, 
+ * Based on code from util-linux/sys-utils/switch_root.c,
  * Copyright 2002-2009 Red Hat, Inc.  All rights reserved.
  * Authors:
- *	Peter Jones <pjones@redhat.com>
- *	Jeremy Katz <katzj@redhat.com>
+ *  Peter Jones <pjones@redhat.com>
+ *  Jeremy Katz <katzj@redhat.com>
  *
  * Relicensed with permission to LGPLv2+.
  *
@@ -91,15 +91,15 @@ parse_ostree_cmdline (void)
       const char *next = strchr (iter, ' ');
       const char *next_nonspc = next;
       while (next_nonspc && *next_nonspc == ' ')
-	next_nonspc += 1;
+        next_nonspc += 1;
       if (strncmp (iter, "ostree=", strlen ("ostree=")) == 0)
         {
-	  const char *start = iter + strlen ("ostree=");
-	  if (next)
-	    ret = strndup (start, next - start);
-	  else
-	    ret = strdup (start);
-	  break;
+          const char *start = iter + strlen ("ostree=");
+          if (next)
+            ret = strndup (start, next - start);
+          else
+            ret = strdup (start);
+          break;
         }
       iter = next_nonspc;
     }
@@ -115,7 +115,7 @@ static void
 touch_run_ostree (void)
 {
   int fd;
-  
+
   fd = open ("/run/ostree-booted", O_CREAT | O_WRONLY | O_NOCTTY, 0640);
   /* We ignore failures here in case /run isn't mounted...not much we
    * can do about that, but we don't want to fail.
@@ -239,10 +239,10 @@ main(int argc, char *argv[])
        * later boot and `systemd-remount-fs.service`.
        */
       if (path_is_on_readonly_fs ("."))
-	{
-	  if (mount (".", ".", NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
-	    err (EXIT_FAILURE, "failed to remount rootfs writable (for overlayfs)");
-	}
+  {
+    if (mount (".", ".", NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
+      err (EXIT_FAILURE, "failed to remount rootfs writable (for overlayfs)");
+  }
       
       if (mount ("overlay", "usr", "overlay", 0, usr_ovl_options) < 0)
         err (EXIT_FAILURE, "failed to mount /usr overlayfs");

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -239,11 +239,11 @@ main(int argc, char *argv[])
        * later boot and `systemd-remount-fs.service`.
        */
       if (path_is_on_readonly_fs ("."))
-  {
-    if (mount (".", ".", NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
-      err (EXIT_FAILURE, "failed to remount rootfs writable (for overlayfs)");
-  }
-      
+        {
+          if (mount (".", ".", NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
+            err (EXIT_FAILURE, "failed to remount rootfs writable (for overlayfs)");
+        }
+
       if (mount ("overlay", "usr", "overlay", 0, usr_ovl_options) < 0)
         err (EXIT_FAILURE, "failed to mount /usr overlayfs");
     }

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -85,13 +85,13 @@ main(int argc, char *argv[])
       if (S_ISLNK (stbuf.st_mode))
         continue;
       if (mount (target, target, NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
-	{
+        {
           /* Also ignore ENINVAL - if the target isn't a mountpoint
            * already, then assume things are OK.
            */
           if (errno != EINVAL)
             err (EXIT_FAILURE, "failed to remount %s", target);
-	}
+        }
     }
 
   maybe_mount_tmpfs_on_var ();

--- a/tests/readdir-rand.c
+++ b/tests/readdir-rand.c
@@ -83,7 +83,7 @@ readdir (DIR *dirp)
   struct dirent *(*real_readdir)(DIR *dirp) = dlsym (RTLD_NEXT, READDIR);
   struct dirent *ret;
   gboolean cache_another = TRUE;
-  
+
   ensure_initialized ();
 
   /* The core idea here is that each time through the loop, we read a
@@ -101,40 +101,40 @@ readdir (DIR *dirp)
       errno = 0;
       ret = real_readdir (dirp);
       if (ret == NULL && errno != 0)
-	goto out;
+        goto out;
 
       g_mutex_lock (&direntcache_lock);
       de = g_hash_table_lookup (direntcache, dirp);
       if (ret)
-	{
-	  if (g_random_boolean ())
-	    {
-	      struct dirent *copy;
-	      if (!de)
-		{
-		  de = dir_entries_new ();
-		  g_hash_table_insert (direntcache, dirp, de);
-		}
-	      copy = g_memdup (ret, sizeof (struct dirent));
-	      g_ptr_array_add (de->entries, copy);
-	    }
-	  else
-	    {
-	      cache_another = FALSE;
-	    }
-	}
+        {
+          if (g_random_boolean ())
+            {
+              struct dirent *copy;
+              if (!de)
+                {
+                  de = dir_entries_new ();
+                  g_hash_table_insert (direntcache, dirp, de);
+                }
+              copy = g_memdup (ret, sizeof (struct dirent));
+              g_ptr_array_add (de->entries, copy);
+            }
+          else
+            {
+              cache_another = FALSE;
+            }
+        }
       else
-	{
-	  if (de && de->offset < de->entries->len)
-	    {
-	      ret = de->entries->pdata[de->offset];
-	      de->offset++;
-	    }
-	  cache_another = FALSE;
-	}
+        {
+          if (de && de->offset < de->entries->len)
+            {
+              ret = de->entries->pdata[de->offset];
+              de->offset++;
+            }
+          cache_another = FALSE;
+        }
       g_mutex_unlock (&direntcache_lock);
     }
-  
+
  out:
   return ret;
 }
@@ -145,7 +145,7 @@ closedir (DIR *dirp)
   int (*real_closedir)(DIR *dirp) = dlsym (RTLD_NEXT, "closedir");
 
   ensure_initialized ();
-  
+
   g_mutex_lock (&direntcache_lock);
   g_hash_table_remove (direntcache, dirp);
   g_mutex_unlock (&direntcache_lock);
@@ -170,7 +170,7 @@ seekdir (DIR *dirp, long loc)
 
   ensure_initialized ();
 
-  /* For now, crash if seekdir is called when we have cached entries. 
+  /* For now, crash if seekdir is called when we have cached entries.
    * If some app wants to use this and seekdir() we can implement it.
    */
   assert_no_cached_entries (dirp);

--- a/tests/test-rollsum.c
+++ b/tests/test-rollsum.c
@@ -152,7 +152,7 @@ test_bupsplit_sum(void)
     sum1a = bupsplit_sum(buf, 0, BUP_SELFTEST_SIZE);
     sum1b = bupsplit_sum(buf, 1, BUP_SELFTEST_SIZE);
     sum2a = bupsplit_sum(buf, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE*5/2,
-			BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
+                         BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
     sum2b = bupsplit_sum(buf, 0, BUP_SELFTEST_SIZE - BUP_WINDOWSIZE);
     sum3a = bupsplit_sum(buf, 0, BUP_WINDOWSIZE+3);
     sum3b = bupsplit_sum(buf, 3, BUP_WINDOWSIZE+3);


### PR DESCRIPTION
As $DEITY intended.

I was reading the `prepare-root.c` code and the indentation damage was
distracting. Squash tabs that have leaked into various places in the code. I
didn't yet touch the `src/libostree` bits as that has higher potential for
conflict.