### PR TITLE
remount: Drop support for auto-tmpfs-on-var; use systemd.volatile=state

### DIFF
--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -38,24 +38,6 @@
 
 #include "ostree-mount-util.h"
 
-/* Having a writeable /var is necessary for full system functioning.
- * If /var isn't writeable, we mount tmpfs over it. While this is
- * somewhat outside of ostree's scope, having all /var twiddling
- * in one place will make future maintenance easier.
- */
-static void
-maybe_mount_tmpfs_on_var (void)
-{
-  if (!path_is_on_readonly_fs ("/var"))
-    return;
-
-  if (umount ("/var") < 0 && errno != EINVAL)
-    warn ("failed to unmount /var prior to mounting tmpfs, mounting over");
-
-  if (mount ("tmpfs", "/var", "tmpfs", 0, NULL) < 0)
-    err (EXIT_FAILURE, "failed to mount tmpfs on /var");
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -68,8 +50,6 @@ main(int argc, char *argv[])
       /* If / isn't writable, don't do any remounts; we don't want
        * to clear the readonly flag in that case.
        */
-
-      maybe_mount_tmpfs_on_var ();
 
       exit (EXIT_SUCCESS);
     }
@@ -93,8 +73,6 @@ main(int argc, char *argv[])
             err (EXIT_FAILURE, "failed to remount %s", target);
         }
     }
-
-  maybe_mount_tmpfs_on_var ();
 
   exit (EXIT_SUCCESS);
 }


### PR DESCRIPTION
In current systemd, there is:
[systemd-volatile-root](https://www.freedesktop.org/software/systemd/man/systemd-volatile-root.service.html)
which was introduced by [this commit](https://github.com/systemd/systemd/commit/91214a37ef4eb8042d2598aa89bae52b410d11a7).

I'd like to make further changes to how we handle `/var`, and I don't
want to reason about the interaction of our "tmpfs var" with too many
other things.

The comment about having "all /var handling in one place" was always inaccurate
given that we rely on systemd for mounting. And in general, I don't want to
duplicate too many things systemd does - it does them well, documents them, etc.

As far as I know, it was basically just Owen who was using this for the GNOME
hardware testing effort, and I'm sure he could easily switch over to
`systemd.volatile=state`.