### PR TITLE
lib/remote: Box OstreeRemote if experimental-api

### DIFF
--- a/src/libostree/ostree-remote.c
+++ b/src/libostree/ostree-remote.c
@@ -142,3 +142,9 @@ ostree_remote_unref (OstreeRemote *remote)
       g_slice_free (OstreeRemote, remote);
     }
 }
+
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+G_DEFINE_BOXED_TYPE(OstreeRemote, ostree_remote,
+                    ostree_remote_ref,
+                    ostree_remote_unref);
+#endif

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -48,9 +48,16 @@ G_BEGIN_DECLS
 typedef struct OstreeRemote OstreeRemote;
 #endif
 
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+_OSTREE_PUBLIC
+GType ostree_remote_get_type (void) G_GNUC_CONST;
+#else
+#ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 OstreeRemote *ostree_remote_ref (OstreeRemote *remote);
 _OSTREE_PUBLIC
 void ostree_remote_unref (OstreeRemote *remote);
+#endif /* GI_SCANNER */
+#endif
 
 G_END_DECLS


### PR DESCRIPTION
To avoid an introspection warning.  Otherwise, don't box it.