### PR TITLE
 Switch to using a systemd generator for /var

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -115,6 +115,7 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-sysroot-cleanup.c \
 	src/libostree/ostree-sysroot-deploy.c \
 	src/libostree/ostree-sysroot-upgrader.c \
+	src/libostree/ostree-impl-system-generator.c \
 	src/libostree/ostree-bootconfig-parser.c \
 	src/libostree/ostree-deployment.c \
 	src/libostree/ostree-bootloader.h \

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -27,6 +27,7 @@ ostree_prepare_root_SOURCES = \
     src/switchroot/ostree-mount-util.h \
     src/switchroot/ostree-prepare-root.c \
     $(NULL)
+ostree_prepare_root_CPPFLAGS = $(AM_CPPFLAGS)
 
 if BUILDOPT_USE_STATIC_COMPILER
 # ostree-prepare-root can be used as init in a system without a populated /lib.
@@ -45,7 +46,6 @@ ostree-prepare-root : $(ostree_prepare_root_SOURCES)
 	$(STATIC_COMPILER) -o $@ -static $(ostree_prepare_root_SOURCES) $(AM_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
-
 ostree_prepare_root_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot
 endif
 
@@ -53,4 +53,19 @@ ostree_remount_SOURCES = \
     src/switchroot/ostree-mount-util.h \
     src/switchroot/ostree-remount.c \
     $(NULL)
-ostree_remount_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot
+ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) -Isrc/switchroot
+
+# This is the "new mode" of using a generator for /var; see
+# https://github.com/ostreedev/ostree/issues/855
+if BUILDOPT_SYSTEMD_AND_LIBMOUNT
+ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD_AND_LIBMOUNT=1
+ostree_remount_CPPFLAGS += -DHAVE_SYSTEMD_AND_LIBMOUNT=1
+
+systemdsystemgenerator_PROGRAMS = ostree-system-generator
+GITIGNOREFILES += $(systemdsystemgenerator_PROGRAMS)
+ostree_system_generator_SOURCES = src/switchroot/ostree-mount-util.h \
+                                  src/switchroot/ostree-system-generator.c
+ostree_system_generator_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libostree
+ostree_system_generator_CFLAGS = $(AM_CFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS)
+ostree_system_generator_LDADD = $(AM_LDFLAGS) libglnx.la libostree-1.la $(OT_INTERNAL_GIO_UNIX_LIBS)
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -378,10 +378,7 @@ dnl We have separate checks for libsystemd and the unit dir for historical reaso
 PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [have_libsystemd=yes], [have_libsystemd=no])
 AM_CONDITIONAL(BUILDOPT_LIBSYSTEMD, test x$have_libsystemd = xyes)
 AM_COND_IF(BUILDOPT_LIBSYSTEMD,
-           AC_DEFINE([HAVE_LIBSYSTEMD], 1, [Define if we have libsystemd])
-           systemdsystemgeneratordir=$($PKG_CONFIG --variable=systemdsystemgeneratordir systemd)
-           AC_SUBST(systemdsystemgeneratordir)
-           )
+           AC_DEFINE([HAVE_LIBSYSTEMD], 1, [Define if we have libsystemd]))
 
 AS_IF([test "x$have_libsystemd" = "xyes"], [
   with_systemd=yes
@@ -391,6 +388,13 @@ AS_IF([test "x$have_libsystemd" = "xyes"], [
               [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
   AS_IF([test "x$with_systemdsystemunitdir" != "xno"], [
     AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+  ])
+  AC_ARG_WITH([systemdsystemgeneratordir],
+              AS_HELP_STRING([--with-systemdsystemgeneratordir=DIR], [Directory for systemd generators]),
+              [],
+              [with_systemdsystemgeneratordir=$($PKG_CONFIG --variable=systemdsystemgeneratordir systemd)])
+  AS_IF([test "x$with_systemdsystemgeneratordir" != "xno"], [
+    AC_SUBST([systemdsystemgeneratordir], [$with_systemdsystemgeneratordir])
   ])
 ])
 AM_CONDITIONAL(BUILDOPT_SYSTEMD, test x$with_systemd = xyes)

--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,10 @@ dnl We have separate checks for libsystemd and the unit dir for historical reaso
 PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [have_libsystemd=yes], [have_libsystemd=no])
 AM_CONDITIONAL(BUILDOPT_LIBSYSTEMD, test x$have_libsystemd = xyes)
 AM_COND_IF(BUILDOPT_LIBSYSTEMD,
-           AC_DEFINE([HAVE_LIBSYSTEMD], 1, [Define if we have libsystemd]))
+           AC_DEFINE([HAVE_LIBSYSTEMD], 1, [Define if we have libsystemd])
+           systemdsystemgeneratordir=$($PKG_CONFIG --variable=systemdsystemgeneratordir systemd)
+           AC_SUBST(systemdsystemgeneratordir)
+           )
 
 AS_IF([test "x$have_libsystemd" = "xyes"], [
   with_systemd=yes
@@ -391,6 +394,10 @@ AS_IF([test "x$have_libsystemd" = "xyes"], [
   ])
 ])
 AM_CONDITIONAL(BUILDOPT_SYSTEMD, test x$with_systemd = xyes)
+dnl If we have both, we use the "new /var" model with ostree-system-generator
+AM_CONDITIONAL(BUILDOPT_SYSTEMD_AND_LIBMOUNT,[test x$with_systemd = xyes && test x$with_libmount = xyes])
+AM_COND_IF(BUILDOPT_SYSTEMD_AND_LIBMOUNT,
+  AC_DEFINE([BUILDOPT_LIBSYSTEMD_AND_LIBMOUNT], 1, [Define if systemd and libmount]))
 
 AC_ARG_WITH(builtin-grub2-mkconfig,
             AS_HELP_STRING([--with-builtin-grub2-mkconfig],

--- a/src/libostree/ostree-cmdprivate.c
+++ b/src/libostree/ostree-cmdprivate.c
@@ -45,6 +45,7 @@ const OstreeCmdPrivateVTable *
 ostree_cmd__private__ (void)
 {
   static OstreeCmdPrivateVTable table = {
+    _ostree_impl_system_generator,
     impl_ostree_generate_grub2_config,
     _ostree_repo_static_delta_dump,
     _ostree_repo_static_delta_query_exists,

--- a/src/libostree/ostree-cmdprivate.h
+++ b/src/libostree/ostree-cmdprivate.h
@@ -24,7 +24,10 @@
 
 G_BEGIN_DECLS
 
+gboolean _ostree_impl_system_generator (const char *ostree_cmdline, const char *normal_dir, const char *early_dir, const char *late_dir, GError **error);
+
 typedef struct {
+  gboolean (* ostree_system_generator) (const char *ostree_cmdline, const char *normal_dir, const char *early_dir, const char *late_dir, GError **error);
   gboolean (* ostree_generate_grub2_config) (OstreeSysroot *sysroot, int bootversion, int target_fd, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_dump) (OstreeRepo *repo, const char *delta_id, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_query_exists) (OstreeRepo *repo, const char *delta_id, gboolean *out_exists, GCancellable *cancellable, GError **error);

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -23,7 +23,10 @@
 #include <glib-unix.h>
 #include <gio/gunixoutputstream.h>
 #include <errno.h>
+#include <stdio.h>
+#ifdef HAVE_LIBMOUNT
 #include <libmount.h>
+#endif
 #include <stdbool.h>
 
 #include "ostree.h"
@@ -32,6 +35,7 @@
 
 #include "libglnx.h"
 
+#ifdef HAVE_LIBMOUNT
 typedef FILE OtLibMountFile;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtLibMountFile, endmntent);
 
@@ -106,6 +110,7 @@ stateroot_from_ostree_cmdline (const char *ostree_cmdline,
 
   return g_match_info_fetch (match, 1);
 }
+#endif
 
 /* Implementation of ostree-system-generator */
 gboolean
@@ -115,6 +120,7 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
                                const char *late_dir,
                                GError    **error)
 {
+#ifdef HAVE_LIBMOUNT
   /* Not currently cancellable, but define a var in case we care later */
   GCancellable *cancellable = NULL;
   /* Some path constants to avoid typos */
@@ -207,4 +213,7 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
     return FALSE;
 
   return TRUE;
+#else
+  return glnx_throw (error, "Not implemented");
+#endif
 }

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -28,12 +28,11 @@
 #include <libmount.h>
 #endif
 #include <stdbool.h>
+#include "otutil.h"
 
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-cmdprivate.h"
-
-#include "libglnx.h"
 
 #ifdef HAVE_LIBMOUNT
 typedef FILE OtLibMountFile;

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -1,0 +1,210 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <glib-unix.h>
+#include <gio/gunixoutputstream.h>
+#include <errno.h>
+#include <libmount.h>
+#include <stdbool.h>
+
+#include "ostree.h"
+#include "ostree-core-private.h"
+#include "ostree-cmdprivate.h"
+
+#include "libglnx.h"
+
+typedef FILE OtLibMountFile;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtLibMountFile, endmntent);
+
+/* Taken from systemd path-util.c */
+static bool
+is_path (const char *p)
+{
+  return !!strchr (p, '/');
+}
+
+/* Taken from systemd path-util.c */
+static char*
+path_kill_slashes (char *path)
+{
+  char *f, *t;
+  bool slash = false;
+
+  /* Removes redundant inner and trailing slashes. Modifies the
+   * passed string in-place.
+   *
+   * For example: ///foo///bar/ becomes /foo/bar
+   */
+
+  for (f = path, t = path; *f; f++)
+    {
+      if (*f == '/')
+        {
+          slash = true;
+          continue;
+        }
+
+      if (slash)
+        {
+          slash = false;
+          *(t++) = '/';
+        }
+
+      *(t++) = *f;
+    }
+
+  /* Special rule, if we are talking of the root directory, a
+     trailing slash is good */
+
+  if (t == path && slash)
+    *(t++) = '/';
+
+  *t = 0;
+  return path;
+}
+
+/* Written by ostree-sysroot-deploy.c. We parse out the stateroot here since we
+ * need to know it to mount /var. Unfortunately we can't easily use the
+ * libostree API to find the booted deployment since /boot might not have been
+ * mounted yet.
+ */
+static char *
+stateroot_from_ostree_cmdline (const char *ostree_cmdline,
+                               GError **error)
+{
+  static GRegex *regex;
+  static gsize regex_initialized;
+  if (g_once_init_enter (&regex_initialized))
+    {
+      regex = g_regex_new ("^/ostree/boot.[01]/([^/]+)/", 0, 0, NULL);
+      g_assert (regex);
+      g_once_init_leave (&regex_initialized, 1);
+    }
+
+  g_autoptr(GMatchInfo) match = NULL;
+  if (!g_regex_match (regex, ostree_cmdline, 0, &match))
+    return glnx_null_throw (error, "Failed to parse %s", ostree_cmdline);
+
+  return g_match_info_fetch (match, 1);
+}
+
+/* Implementation of ostree-system-generator */
+gboolean
+_ostree_impl_system_generator (const char *ostree_cmdline,
+                               const char *normal_dir,
+                               const char *early_dir,
+                               const char *late_dir,
+                               GError    **error)
+{
+  /* Not currently cancellable, but define a var in case we care later */
+  GCancellable *cancellable = NULL;
+  /* Some path constants to avoid typos */
+  static const char fstab_path[] = "/etc/fstab";
+  static const char var_path[] = "/var";
+
+  /* ostree-prepare-root was patched to write the stateroot to this file */
+  g_autofree char *stateroot = stateroot_from_ostree_cmdline (ostree_cmdline, error);
+  if (!stateroot)
+    return FALSE;
+
+  /* Load /etc/fstab if it exists, and look for a /var mount */
+  g_autoptr(OtLibMountFile) fstab = setmntent (fstab_path, "re");
+  gboolean found_var_mnt = FALSE;
+  if (!fstab)
+    {
+      if (errno != ENOENT)
+        return glnx_throw_errno_prefix (error, "Reading %s", fstab_path);
+    }
+  else
+    {
+      /* Parse it */
+      struct mntent *me;
+      while ((me = getmntent (fstab)))
+        {
+          g_autofree char *where = g_strdup (me->mnt_dir);
+          if (is_path (where))
+            path_kill_slashes (where);
+
+          /* We're only looking for /var here */
+          if (strcmp (where, var_path) != 0)
+            continue;
+
+          found_var_mnt = TRUE;
+          break;
+        }
+    }
+
+  /* If we found /var, we're done */
+  if (found_var_mnt)
+    return TRUE;
+
+  /* Prepare to write to the output unit dir; we use the "normal" dir
+   * that overrides /usr, but not /etc.
+   */
+  glnx_fd_close int normal_dir_dfd = -1;
+  if (!glnx_opendirat (AT_FDCWD, normal_dir, TRUE, &normal_dir_dfd, error))
+    return FALSE;
+
+  /* Generate our bind mount unit */
+  const char *stateroot_var_path = glnx_strjoina ("/sysroot/ostree/deploy/", stateroot, "/var");
+
+  glnx_fd_close int tmpfd = -1;
+  g_autofree char *tmppath = NULL;
+  if (!glnx_open_tmpfile_linkable_at (normal_dir_dfd, ".", O_WRONLY,
+                                      &tmpfd, &tmppath, error))
+    return FALSE;
+  g_autoptr(GOutputStream) outstream = g_unix_output_stream_new (tmpfd, FALSE);
+  gsize bytes_written;
+  /* This code is inspired by systemd's fstab-generator.c.
+   *
+   * Note that our unit doesn't run if systemd.volatile is enabled;
+   * see https://github.com/ostreedev/ostree/pull/856
+   */
+  if (!g_output_stream_printf (outstream, &bytes_written, cancellable, error,
+                               "##\n# Automatically generated by ostree-system-generator\n##\n\n"
+                               "[Unit]\n"
+                               "Documentation=man:ostree(1)\n"
+                               "ConditionKernelCommandLine=!systemd.volatile\n"
+                               /* We need /sysroot mounted writable first */
+                               "After=ostree-remount.service\n"
+                               "\n"
+                               "[Mount]\n"
+                               "Where=%s\n"
+                               "What=%s\n"
+                               "Options=bind\n",
+                               var_path,
+                               stateroot_var_path))
+    return FALSE;
+  if (!g_output_stream_flush (outstream, cancellable, error))
+    return FALSE;
+  g_clear_object (&outstream);
+  /* It should be readable */
+  if (fchmod (tmpfd, 0644) < 0)
+    return glnx_throw_errno_prefix (error, "fchmod");
+  /* Error out if somehow it already exists, that'll help us debug conflicts */
+  if (!glnx_link_tmpfile_at (normal_dir_dfd, GLNX_LINK_TMPFILE_NOREPLACE,
+                             tmpfd, tmppath, normal_dir_dfd,
+                             "var.mount", error))
+    return FALSE;
+
+  return TRUE;
+}

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -191,6 +191,7 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
                                "ConditionKernelCommandLine=!systemd.volatile\n"
                                /* We need /sysroot mounted writable first */
                                "After=ostree-remount.service\n"
+                               "Before=local-fs.target\n"
                                "\n"
                                "[Mount]\n"
                                "Where=%s\n"

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1379,6 +1379,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
 
   val = ostree_bootconfig_parser_get (bootconfig, "options");
 
+  /* Note this is parsed in ostree-impl-system-generator.c */
   g_autofree char *ostree_kernel_arg = g_strdup_printf ("ostree=/ostree/boot.%d/%s/%s/%d",
                                        new_bootversion, osname, bootcsum,
                                        ostree_deployment_get_bootserial (deployment));

--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -25,6 +25,10 @@
 #include <err.h>
 #include <stdlib.h>
 #include <sys/statvfs.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
 
 static inline int
 path_is_on_readonly_fs (char *path)
@@ -35,6 +39,68 @@ path_is_on_readonly_fs (char *path)
     err (EXIT_FAILURE, "statvfs(%s)", path);
 
   return (stvfsbuf.f_flag & ST_RDONLY) != 0;
+}
+
+static inline char *
+read_proc_cmdline (void)
+{
+  FILE *f = fopen("/proc/cmdline", "r");
+  char *cmdline = NULL;
+  size_t len;
+
+  if (!f)
+    goto out;
+
+  /* Note that /proc/cmdline will not end in a newline, so getline
+   * will fail unelss we provide a length.
+   */
+  if (getline (&cmdline, &len, f) < 0)
+    goto out;
+  /* ... but the length will be the size of the malloc buffer, not
+   * strlen().  Fix that.
+   */
+  len = strlen (cmdline);
+
+  if (cmdline[len-1] == '\n')
+    cmdline[len-1] = '\0';
+out:
+  if (f)
+    fclose (f);
+  return cmdline;
+}
+
+static inline char *
+read_proc_cmdline_ostree (void)
+{
+  char *cmdline = NULL;
+  const char *iter;
+  char *ret = NULL;
+
+  cmdline = read_proc_cmdline ();
+  if (!cmdline)
+    err (EXIT_FAILURE, "failed to read /proc/cmdline");
+
+  iter = cmdline;
+  while (iter != NULL)
+    {
+      const char *next = strchr (iter, ' ');
+      const char *next_nonspc = next;
+      while (next_nonspc && *next_nonspc == ' ')
+        next_nonspc += 1;
+      if (strncmp (iter, "ostree=", strlen ("ostree=")) == 0)
+        {
+          const char *start = iter + strlen ("ostree=");
+          if (next)
+            ret = strndup (start, next - start);
+          else
+            ret = strdup (start);
+          break;
+        }
+      iter = next_nonspc;
+    }
+
+  free (cmdline);
+  return ret;
 }
 
 #endif /* __OSTREE_MOUNT_UTIL_H_ */

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -59,7 +59,7 @@ maybe_mount_tmpfs_on_var (void)
 int
 main(int argc, char *argv[])
 {
-  const char *remounts[] = { "/sysroot", "/etc", "/home", "/root", "/tmp", "/var", NULL };
+  const char *remounts[] = { "/sysroot", "/var", NULL };
   struct stat stbuf;
   int i;
 

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -100,7 +100,8 @@ main(int argc, char *argv[])
           if (errno != EINVAL)
             err (EXIT_FAILURE, "failed to remount %s", target);
         }
-      printf ("Remounted: %s\n", target);
+      else
+        printf ("Remounted: %s\n", target);
     }
 
   maybe_mount_tmpfs_on_var ();

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -84,6 +84,14 @@ main(int argc, char *argv[])
        */
       if (S_ISLNK (stbuf.st_mode))
         continue;
+      /* If not a mountpoint, skip it */
+      struct statvfs stvfsbuf;
+      if (statvfs (target, &stvfsbuf) == -1)
+        continue;
+      /* If no read-only flag, skip it */
+      if ((stvfsbuf.f_flag & ST_RDONLY) == 0)
+        continue;
+      /* It's a mounted, read-only fs; remount it */
       if (mount (target, target, NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
         {
           /* Also ignore ENINVAL - if the target isn't a mountpoint
@@ -92,6 +100,7 @@ main(int argc, char *argv[])
           if (errno != EINVAL)
             err (EXIT_FAILURE, "failed to remount %s", target);
         }
+      printf ("Remounted: %s\n", target);
     }
 
   maybe_mount_tmpfs_on_var ();

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -1,0 +1,67 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <err.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+
+#include "ostree-cmdprivate.h"
+#include "ostree-mount-util.h"
+
+static const char *arg_dest = "/tmp";
+static const char *arg_dest_late = "/tmp";
+
+/* This program is a simple stub that calls the implementation that
+ * lives inside libostree.
+ */
+int
+main(int argc, char *argv[])
+{
+  /* Important: if this isn't an ostree-booted system, do nothing; people could
+   * have the package installed as a dependency for flatpak or whatever.
+   */
+  { struct stat stbuf;
+    if (fstatat (AT_FDCWD, "/run/ostree-booted", &stbuf, 0) < 0)
+      exit (EXIT_SUCCESS);
+  }
+
+  if (argc > 1 && argc != 4)
+    errx (EXIT_FAILURE, "This program takes three or no arguments");
+
+  if (argc > 1)
+    arg_dest = argv[1];
+  if (argc > 3)
+    arg_dest_late = argv[3];
+
+  char *ostree_cmdline = read_proc_cmdline_ostree ();
+  if (!ostree_cmdline)
+    errx (EXIT_FAILURE, "Failed to find ostree= kernel argument");
+
+  { g_autoptr(GError) local_error = NULL;
+    if (!ostree_cmd__private__()->ostree_system_generator (ostree_cmdline, arg_dest, NULL, arg_dest_late, &local_error))
+      errx (EXIT_FAILURE, "%s", local_error->message);
+  }
+
+  exit (EXIT_SUCCESS);
+}


### PR DESCRIPTION

If one wants to set up a mount for `/var` in `/etc/fstab`, it
won't be mounted since `ostree-prepare-root` set up a bind mount for
`/var` to `/sysroot/ostree/$stateroot/var`, and systemd will take
the already extant mount over what's in `/etc/fstab`.

There are a few options to fix this, but what I settled on is parsing
`/etc/fstab` in a generator (exactly like `systemd-fstab-generator` does),
except here we look for an explicit mount for `/var`, and if one *isn't* found,
synthesize the default ostree mount to the stateroot. Another nice property is
that if an admin creates a `var.mount` unit in `/etc` for example, that will
also override our mount.

Note that today ostree doesn't hard depend on systemd, so this behavior only
kicks in if we're built with systemd *and* libmount support (for parsing
`/etc/fstab`).  I didn't really test that case though.

Initially I started writing this as a "pure libc" program, but at one point
decided to use `libostree.so` to find the booted deployment. That didn't work
out because `/boot` wasn't necessarily mounted and hence we couldn't find the
bootloader config. A leftover artifact from this is that the generator code
calls into libostree via the "cmd private" infrastructure. But it's an easy way
to share code, and doesn't hurt.