### PR TITLE
 Update libglnx, port to new GLnxTmpfile

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -60,13 +60,11 @@ checkout_object_for_uncompressed_cache (OstreeRepo      *self,
   guint32 file_mode = g_file_info_get_attribute_uint32 (src_info, "unix::mode");
   file_mode &= ~(S_ISUID|S_ISGID);
 
-  glnx_fd_close int fd = -1;
-  g_autofree char *temp_filename = NULL;
+  g_auto(GLnxTmpfile) tmpf = GLNX_TMPFILE_INIT;
   if (!glnx_open_tmpfile_linkable_at (self->tmp_dir_fd, ".", O_WRONLY | O_CLOEXEC,
-                                      &fd, &temp_filename,
-                                      error))
+                                      &tmpf, error))
     return FALSE;
-  g_autoptr(GOutputStream) temp_out = g_unix_output_stream_new (fd, FALSE);
+  g_autoptr(GOutputStream) temp_out = g_unix_output_stream_new (tmpf.fd, FALSE);
 
   if (g_output_stream_splice (temp_out, content, 0, cancellable, error) < 0)
     return FALSE;
@@ -76,14 +74,14 @@ checkout_object_for_uncompressed_cache (OstreeRepo      *self,
 
   if (!self->disable_fsync)
     {
-      if (TEMP_FAILURE_RETRY (fsync (fd)) < 0)
+      if (TEMP_FAILURE_RETRY (fsync (tmpf.fd)) < 0)
         return glnx_throw_errno (error);
     }
 
   if (!g_output_stream_close (temp_out, cancellable, error))
     return FALSE;
 
-  if (fchmod (fd, file_mode) < 0)
+  if (fchmod (tmpf.fd, file_mode) < 0)
     return glnx_throw_errno (error);
 
   if (!_ostree_repo_ensure_loose_objdir_at (self->uncompressed_objects_dir_fd,
@@ -91,8 +89,7 @@ checkout_object_for_uncompressed_cache (OstreeRepo      *self,
                                             cancellable, error))
     return FALSE;
 
-  if (!glnx_link_tmpfile_at (self->tmp_dir_fd, GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST,
-                             fd, temp_filename,
+  if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST,
                              self->uncompressed_objects_dir_fd, loose_path,
                              error))
     return FALSE;
@@ -185,7 +182,6 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
                                 GCancellable   *cancellable,
                                 GError        **error)
 {
-  g_autofree char *temp_filename = NULL;
   const gboolean union_mode = options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
   const gboolean add_mode = options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES;
   const gboolean sepolicy_enabled = options->sepolicy && !repo->disable_xattrs;
@@ -252,7 +248,6 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
     }
   else if (g_file_info_get_file_type (file_info) == G_FILE_TYPE_REGULAR)
     {
-      glnx_fd_close int temp_fd = -1;
       guint32 file_mode;
       GLnxLinkTmpfileReplaceMode replace_mode;
 
@@ -261,9 +256,9 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
       if (options->mode == OSTREE_REPO_CHECKOUT_MODE_USER)
         file_mode &= ~(S_ISUID|S_ISGID);
 
+      g_auto(GLnxTmpfile) tmpf = GLNX_TMPFILE_INIT;
       if (!glnx_open_tmpfile_linkable_at (destination_dfd, ".", O_WRONLY | O_CLOEXEC,
-                                          &temp_fd, &temp_filename,
-                                          error))
+                                          &tmpf, error))
         return FALSE;
 
       if (sepolicy_enabled)
@@ -274,11 +269,11 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
                                           g_file_info_get_attribute_uint32 (file_info, "unix::mode"),
                                           &label, cancellable, error))
             return FALSE;
-          if (fsetxattr (temp_fd, "security.selinux", label, strlen (label), 0) < 0)
+          if (fsetxattr (tmpf.fd, "security.selinux", label, strlen (label), 0) < 0)
             return glnx_throw_errno_prefix (error, "Setting security.selinux");
         }
 
-      if (!write_regular_file_content (repo, options, temp_fd, file_info, xattrs, input,
+      if (!write_regular_file_content (repo, options, tmpf.fd, file_info, xattrs, input,
                                        cancellable, error))
         return FALSE;
 
@@ -290,9 +285,8 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
       else
         replace_mode = GLNX_LINK_TMPFILE_NOREPLACE;
 
-      if (!glnx_link_tmpfile_at (destination_dfd, replace_mode,
-                                 temp_fd, temp_filename, destination_dfd,
-                                 destination_name,
+      if (!glnx_link_tmpfile_at (&tmpf, replace_mode,
+                                 destination_dfd, destination_name,
                                  error))
         return FALSE;
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3804,8 +3804,7 @@ sign_data (OstreeRepo     *self,
            GError        **error)
 {
   gboolean ret = FALSE;
-  glnx_fd_close int tmp_fd = -1;
-  g_autofree char *tmp_path = NULL;
+  g_auto(GLnxTmpfile) tmpf = GLNX_TMPFILE_INIT;
   g_autoptr(GOutputStream) tmp_signature_output = NULL;
   gpgme_ctx_t context = NULL;
   g_autoptr(GBytes) ret_signature = NULL;
@@ -3814,11 +3813,11 @@ sign_data (OstreeRepo     *self,
   gpgme_data_t commit_buffer = NULL;
   gpgme_data_t signature_buffer = NULL;
   g_autoptr(GMappedFile) signature_file = NULL;
-  
+
   if (!glnx_open_tmpfile_linkable_at (self->tmp_dir_fd, ".", O_RDWR | O_CLOEXEC,
-                                      &tmp_fd, &tmp_path, error))
+                                      &tmpf, error))
     goto out;
-  tmp_signature_output = g_unix_output_stream_new (tmp_fd, FALSE);
+  tmp_signature_output = g_unix_output_stream_new (tmpf.fd, FALSE);
 
   context = ot_gpgme_new_ctx (homedir, error);
   if (!context)
@@ -3872,7 +3871,7 @@ sign_data (OstreeRepo     *self,
   if (!g_output_stream_close (tmp_signature_output, cancellable, error))
     goto out;
   
-  signature_file = g_mapped_file_new_from_fd (tmp_fd, FALSE, error);
+  signature_file = g_mapped_file_new_from_fd (tmpf.fd, FALSE, error);
   if (!signature_file)
     goto out;
   ret_signature = g_mapped_file_get_bytes (signature_file);

--- a/src/ostree/ot-remote-cookie-util.c
+++ b/src/ostree/ot-remote-cookie-util.c
@@ -279,20 +279,9 @@ gboolean
 ot_list_cookies_at (int dfd, const char *jar_path, GError **error)
 {
 #ifdef HAVE_LIBCURL
-  glnx_fd_close int tempfile_fd = -1;
-  g_autofree char *tempfile_path = NULL;
-  g_autofree char *dnbuf = NULL;
-  const char *dn = NULL;
   g_autoptr(OtCookieParser) parser = NULL;
 
   if (!ot_parse_cookies_at (AT_FDCWD, jar_path, &parser, NULL, error))
-    return FALSE;
-
-  dnbuf = dirname (g_strdup (jar_path));
-  dn = dnbuf;
-  if (!glnx_open_tmpfile_linkable_at (AT_FDCWD, dn, O_WRONLY | O_CLOEXEC,
-                                      &tempfile_fd, &tempfile_path,
-                                      error))
     return FALSE;
 
   while (ot_parse_cookies_next (parser))


### PR DESCRIPTION

See the rationale in: GNOME/libglnx#46
Basically we should now start unlinking the tmpfile in the non-`O_TMPFILE`
case in more places in the code.

Parts of the commit path get uglier though, but a refactoring there is
a bit overdue; the code is overly complex.

Update submodule: libglnx