### PR TITLE
lib/repo: Fix double close()

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2283,6 +2283,7 @@ list_loose_objects_at (OstreeRepo             *self,
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
   if (!glnx_dirfd_iterator_init_take_fd (target_dfd, &dfd_iter, error))
     return FALSE;
+  target_dfd = -1; /* Transferred */
 
   while (TRUE)
     {


### PR DESCRIPTION
Should probably change `_take_fd()` to take a pointer and set to `-1`
at some point.

Regression from 8d58ab1002cbc4a1ecafe3d1a80984f8a60f41e9