### PR TITLE
 lib: Add "open dfd iter handling noent" helper, port tree-wide

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -73,99 +73,88 @@ ostree_repo_list_static_delta_names (OstreeRepo                  *self,
                                      GCancellable                *cancellable,
                                      GError                     **error)
 {
-  g_autoptr(GPtrArray) ret_deltas = NULL;
-  glnx_fd_close int dfd = -1;
+  g_autoptr(GPtrArray) ret_deltas = g_ptr_array_new_with_free_func (g_free);
 
-  ret_deltas = g_ptr_array_new_with_free_func (g_free);
-
-  dfd = glnx_opendirat_with_errno (self->repo_dir_fd, "deltas", TRUE);
-  if (dfd < 0)
+  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  gboolean exists;
+  if (!ot_dfd_iter_init_allow_noent (self->repo_dir_fd, "deltas", &dfd_iter,
+                                     &exists, error))
+    return FALSE;
+  if (!exists)
     {
-      if (errno != ENOENT)
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+      ot_transfer_out_value (out_deltas, &ret_deltas);
+      return TRUE;
     }
-  else
-    {
-      g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
 
-      if (!glnx_dirfd_iterator_init_take_fd (dfd, &dfd_iter, error))
+  while (TRUE)
+    {
+      g_auto(GLnxDirFdIterator) sub_dfd_iter = { 0, };
+      struct dirent *dent;
+
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
         return FALSE;
-      dfd = -1;
+      if (dent == NULL)
+        break;
+      if (dent->d_type != DT_DIR)
+        continue;
+
+      if (!glnx_dirfd_iterator_init_at (dfd_iter.fd, dent->d_name, FALSE,
+                                        &sub_dfd_iter, error))
+        return FALSE;
 
       while (TRUE)
         {
-          g_auto(GLnxDirFdIterator) sub_dfd_iter = { 0, };
-          struct dirent *dent;
+          struct dirent *sub_dent;
+          const char *name1;
+          const char *name2;
+          g_autofree char *superblock_subpath = NULL;
+          struct stat stbuf;
 
-          if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
+          if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&sub_dfd_iter, &sub_dent,
+                                                           cancellable, error))
             return FALSE;
-          if (dent == NULL)
+          if (sub_dent == NULL)
             break;
           if (dent->d_type != DT_DIR)
             continue;
 
-          if (!glnx_dirfd_iterator_init_at (dfd_iter.fd, dent->d_name, FALSE,
-                                            &sub_dfd_iter, error))
-            return FALSE;
+          name1 = dent->d_name;
+          name2 = sub_dent->d_name;
 
-          while (TRUE)
+          superblock_subpath = g_strconcat (name2, "/superblock", NULL);
+          if (fstatat (sub_dfd_iter.fd, superblock_subpath, &stbuf, 0) < 0)
             {
-              struct dirent *sub_dent;
-              const char *name1;
-              const char *name2;
-              g_autofree char *superblock_subpath = NULL;
-              struct stat stbuf;
-
-              if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&sub_dfd_iter, &sub_dent,
-                                                               cancellable, error))
-                return FALSE;
-              if (sub_dent == NULL)
-                break;
-              if (dent->d_type != DT_DIR)
-                continue;
-
-              name1 = dent->d_name;
-              name2 = sub_dent->d_name;
-
-              superblock_subpath = g_strconcat (name2, "/superblock", NULL);
-              if (fstatat (sub_dfd_iter.fd, superblock_subpath, &stbuf, 0) < 0)
+              if (errno != ENOENT)
                 {
-                  if (errno != ENOENT)
-                    {
-                      glnx_set_error_from_errno (error);
-                      return FALSE;
-                    }
+                  glnx_set_error_from_errno (error);
+                  return FALSE;
                 }
-              else
-                {
-                  g_autofree char *buf = g_strconcat (name1, name2, NULL);
-                  GString *out = g_string_new ("");
-                  char checksum[OSTREE_SHA256_STRING_LEN+1];
-                  guchar csum[OSTREE_SHA256_DIGEST_LEN];
-                  const char *dash = strchr (buf, '-');
+            }
+          else
+            {
+              g_autofree char *buf = g_strconcat (name1, name2, NULL);
+              GString *out = g_string_new ("");
+              char checksum[OSTREE_SHA256_STRING_LEN+1];
+              guchar csum[OSTREE_SHA256_DIGEST_LEN];
+              const char *dash = strchr (buf, '-');
 
-                  ostree_checksum_b64_inplace_to_bytes (buf, csum);
+              ostree_checksum_b64_inplace_to_bytes (buf, csum);
+              ostree_checksum_inplace_from_bytes (csum, checksum);
+              g_string_append (out, checksum);
+              if (dash)
+                {
+                  g_string_append_c (out, '-');
+                  ostree_checksum_b64_inplace_to_bytes (dash+1, csum);
                   ostree_checksum_inplace_from_bytes (csum, checksum);
                   g_string_append (out, checksum);
-                  if (dash)
-                    {
-                      g_string_append_c (out, '-');
-                      ostree_checksum_b64_inplace_to_bytes (dash+1, csum);
-                      ostree_checksum_inplace_from_bytes (csum, checksum);
-                      g_string_append (out, checksum);
-                    }
-
-                  g_ptr_array_add (ret_deltas, g_string_free (out, FALSE));
                 }
+
+              g_ptr_array_add (ret_deltas, g_string_free (out, FALSE));
             }
         }
     }
 
-  if (out_deltas)
-    *out_deltas = g_steal_pointer (&ret_deltas);
+  ot_transfer_out_value (out_deltas, &ret_deltas);
   return TRUE;
 }
 

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -82,6 +82,7 @@ ostree_repo_list_static_delta_names (OstreeRepo                  *self,
     return FALSE;
   if (!exists)
     {
+      /* Note early return */
       ot_transfer_out_value (out_deltas, &ret_deltas);
       return TRUE;
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2272,18 +2272,13 @@ list_loose_objects_at (OstreeRepo             *self,
 {
   GVariant *key, *value;
 
-  glnx_fd_close int target_dfd = glnx_opendirat_with_errno (dfd, prefix, FALSE);
-  if (target_dfd < 0)
-    {
-      /* Nothing to do if this dir doesn't exist */
-      if (errno == ENOENT)
-        return TRUE;
-      return glnx_throw_errno (error);
-    }
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
-  if (!glnx_dirfd_iterator_init_take_fd (target_dfd, &dfd_iter, error))
+  gboolean exists;
+  if (!ot_dfd_iter_init_allow_noent (dfd, prefix, &dfd_iter, &exists, error))
     return FALSE;
-  target_dfd = -1; /* Transferred */
+  /* Note early return */
+  if (!exists)
+    return TRUE;
 
   while (TRUE)
     {

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -186,7 +186,7 @@ ot_dfd_iter_init_allow_noent (int dfd,
   if (fd < 0)
     {
       if (errno != ENOENT)
-        return glnx_throw_errno (error);
+        return glnx_throw_errno_prefix (error, "opendirat");
       *out_exists = FALSE;
       return TRUE;
     }

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -172,6 +172,31 @@ ot_openat_ignore_enoent (int dfd,
   return ret;
 }
 
+/* Like glnx_dirfd_iterator_init_at(), but if %ENOENT, then set
+ * @out_exists to %FALSE, and return successfully.
+ */
+gboolean
+ot_dfd_iter_init_allow_noent (int dfd,
+                              const char *path,
+                              GLnxDirFdIterator *dfd_iter,
+                              gboolean *out_exists,
+                              GError **error)
+{
+  glnx_fd_close int fd = glnx_opendirat_with_errno (dfd, path, TRUE);
+  if (fd < 0)
+    {
+      if (errno != ENOENT)
+        return glnx_throw_errno (error);
+      *out_exists = FALSE;
+      return TRUE;
+    }
+  if (!glnx_dirfd_iterator_init_take_fd (fd, dfd_iter, error))
+    return FALSE;
+  fd = -1;
+  *out_exists = TRUE;
+  return TRUE;
+}
+
 GBytes *
 ot_file_mapat_bytes (int dfd,
                      const char *path,

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ot-unix-utils.h"
+#include "libglnx.h"
 
 G_BEGIN_DECLS
 
@@ -52,6 +53,12 @@ gboolean ot_openat_ignore_enoent (int dfd,
                                   const char *path,
                                   int *out_fd,
                                   GError **error);
+
+gboolean ot_dfd_iter_init_allow_noent (int dfd,
+                                       const char *path,
+                                       GLnxDirFdIterator *dfd_iter,
+                                       gboolean *out_exists,
+                                       GError **error);
 
 GBytes *ot_file_mapat_bytes (int dfd,
                              const char *path,


### PR DESCRIPTION

Follow up to a previous patch that addressed a double-close; I
realized we already had a helper for doing "open dfd iter, do nothing
if we get ENOENT".  Raise it to libotuil, and port all consumers.