### PR TITLE
Release 2017.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.63])
 dnl If incrementing the version here, remember to update libostree.sym too
 m4_define([year_version], [2017])
-m4_define([release_version], [5])
+m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 
 AC_INIT([libostree], [package_version], [walters@verbum.org])

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -389,11 +389,6 @@ global:
   ostree_sysroot_write_deployments_with_options;
 } LIBOSTREE_2017.3;
 
-/*                         NOTE NOTE NOTE
- * Versions above here are released.  Only add symbols below this line.
- *                         NOTE NOTE NOTE
- */
-
 LIBOSTREE_2017.6 {
 global:
   ostree_async_progress_get;
@@ -401,6 +396,16 @@ global:
   ostree_async_progress_get_variant;
   ostree_async_progress_set_variant;
 } LIBOSTREE_2017.4;
+
+/*                         NOTE NOTE NOTE
+ * Versions above here are released.  Only add symbols below this line.
+ *                         NOTE NOTE NOTE
+ */
+
+LIBOSTREE_2017.$NEWVERSION {
+global:
+	someostree_symbol_deleteme;
+} LIBOSTREE_2017.6;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -402,10 +402,12 @@ global:
  *                         NOTE NOTE NOTE
  */
 
+/*
 LIBOSTREE_2017.$NEWVERSION {
 global:
 	someostree_symbol_deleteme;
 } LIBOSTREE_2017.6;
+*/
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste


### PR DESCRIPTION
There's already a lot queued.  In particular this brings some API
additions that rpm-ostree depends on.