### PR TITLE
tree-wide: Add a few missing O_CLOEXEC

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -272,7 +272,7 @@ ensure_tmpfile (FetcherRequest *req, GError **error)
   if (req->out_tmpfile_fd == -1)
     {
       if (!glnx_open_tmpfile_linkable_at (req->fetcher->tmpdir_dfd, ".",
-                                          O_WRONLY, &req->out_tmpfile_fd,
+                                          O_WRONLY | O_CLOEXEC, &req->out_tmpfile_fd,
                                           &req->out_tmpfile,
                                           error))
         return FALSE;

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -174,7 +174,7 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
 
   glnx_fd_close int tmpfd = -1;
   g_autofree char *tmppath = NULL;
-  if (!glnx_open_tmpfile_linkable_at (normal_dir_dfd, ".", O_WRONLY,
+  if (!glnx_open_tmpfile_linkable_at (normal_dir_dfd, ".", O_WRONLY | O_CLOEXEC,
                                       &tmpfd, &tmppath, error))
     return FALSE;
   g_autoptr(GOutputStream) outstream = g_unix_output_stream_new (tmpfd, FALSE);

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -54,7 +54,7 @@ touch_run_ostree (void)
 {
   int fd;
 
-  fd = open ("/run/ostree-booted", O_CREAT | O_WRONLY | O_NOCTTY, 0640);
+  fd = open ("/run/ostree-booted", O_CREAT | O_WRONLY | O_NOCTTY | O_CLOEXEC, 0640);
   /* We ignore failures here in case /run isn't mounted...not much we
    * can do about that, but we don't want to fail.
    */


### PR DESCRIPTION
I noticed an instance of this while working on https://github.com/ostreedev/ostree/pull/861
Which apparently I cargo-culted into the new system generator bits.
Let's break this out as a small concise change.