### PR TITLE
 Add stub for new libglnx tmpfile API, port simpler callers to it

### DIFF
--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -25,6 +25,61 @@
 #include <sys/xattr.h>
 #include <gio/gunixinputstream.h>
 
+/* Before https://github.com/GNOME/libglnx/commit/9929adc, the libglnx
+ * tmpfile API made it hard to clean up tmpfiles in failure cases.
+ * it's API breaking. Carry the fix here until we're ready to fully port.
+ */
+void
+ot_tmpfile_clear (OtTmpfile *tmpf)
+{
+  if (!tmpf->initialized)
+    return;
+  if (tmpf->fd == -1)
+    return;
+  (void) close (tmpf->fd);
+  /* If ->path is set, we're likely aborting due to an error. Clean it up */
+  if (tmpf->path)
+    {
+      (void) unlinkat (tmpf->src_dfd, tmpf->path, 0);
+      g_free (tmpf->path);
+    }
+}
+
+gboolean
+ot_open_tmpfile_linkable_at (int dfd,
+                             const char *subpath,
+                             int flags,
+                             OtTmpfile *out_tmpf,
+                             GError **error)
+{
+  if (!glnx_open_tmpfile_linkable_at (dfd, subpath, flags, &out_tmpf->fd, &out_tmpf->path, error))
+    return FALSE;
+  out_tmpf->initialized = TRUE;
+  out_tmpf->src_dfd = dfd;
+  return TRUE;
+}
+
+gboolean
+ot_link_tmpfile_at (OtTmpfile *tmpf,
+                    GLnxLinkTmpfileReplaceMode mode,
+                    int target_dfd,
+                    const char *target,
+                    GError **error)
+{
+  g_return_val_if_fail (tmpf->initialized, FALSE);
+  glnx_fd_close int fd = glnx_steal_fd (&tmpf->fd);
+  if (!glnx_link_tmpfile_at (tmpf->src_dfd, mode, fd, tmpf->path,
+                             target_dfd, target, error))
+    {
+      if (tmpf->path)
+        (void) unlinkat (tmpf->src_dfd, tmpf->path, 0);
+      tmpf->initialized = FALSE;
+      return FALSE;
+    }
+  tmpf->initialized = FALSE;
+  return TRUE;
+}
+
 /* Convert a fd-relative path to a GFile* - use
  * for legacy code.
  */

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -25,6 +25,30 @@
 
 G_BEGIN_DECLS
 
+/* This is a copy of https://github.com/GNOME/libglnx/pull/46 until we
+ * can do a full port; see https://github.com/ostreedev/ostree/pull/861 */
+typedef struct {
+  gboolean initialized;
+  int src_dfd;
+  int fd;
+  char *path;
+} OtTmpfile;
+void ot_tmpfile_clear (OtTmpfile *tmpf);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OtTmpfile, ot_tmpfile_clear);
+
+gboolean
+ot_open_tmpfile_linkable_at (int dfd,
+                             const char *subpath,
+                             int flags,
+                             OtTmpfile *out_tmpf,
+                             GError **error);
+gboolean
+ot_link_tmpfile_at (OtTmpfile *tmpf,
+                    GLnxLinkTmpfileReplaceMode flags,
+                    int target_dfd,
+                    const char *target,
+                    GError **error);
+
 GFile * ot_fdrel_to_gfile (int dfd, const char *path);
 
 gboolean ot_readlinkat_gfile_info (int             dfd,

--- a/src/ostree/ot-remote-cookie-util.c
+++ b/src/ostree/ot-remote-cookie-util.c
@@ -279,20 +279,9 @@ gboolean
 ot_list_cookies_at (int dfd, const char *jar_path, GError **error)
 {
 #ifdef HAVE_LIBCURL
-  glnx_fd_close int tempfile_fd = -1;
-  g_autofree char *tempfile_path = NULL;
-  g_autofree char *dnbuf = NULL;
-  const char *dn = NULL;
   g_autoptr(OtCookieParser) parser = NULL;
 
   if (!ot_parse_cookies_at (AT_FDCWD, jar_path, &parser, NULL, error))
-    return FALSE;
-
-  dnbuf = dirname (g_strdup (jar_path));
-  dn = dnbuf;
-  if (!glnx_open_tmpfile_linkable_at (AT_FDCWD, dn, O_WRONLY | O_CLOEXEC,
-                                      &tempfile_fd, &tempfile_path,
-                                      error))
     return FALSE;
 
   while (ot_parse_cookies_next (parser))


### PR DESCRIPTION

It's hard right now to do a full port to the new libglnx tmpfile
API since there are complex cases in the commit path which deal
with symlinks as well.

Let's make things more gradual by introducing the important part (struct with
autocleanup) here in libotutil, port what we can. This will make a future
complete port easier.