### PR TITLE
A few tweaks to the OstreeRemote API

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -79,6 +79,26 @@ tests:
 ---
 
 inherit: true
+
+context: f25-experimental-api
+
+build:
+    config-opts: >
+      --prefix=/usr
+      --libdir=/usr/lib64
+      --enable-gtk-doc
+      --enable-experimental-api
+
+env:
+    CC: 'gcc'
+
+tests:
+    - make check
+    - /bin/sh -c 'gnome-desktop-testing-runner -p 0 --timeout $((10 * 60)) libostree/'
+
+---
+
+inherit: true
 required: true
 
 context: f25-curl-openssl

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -76,6 +76,8 @@ env:
 tests:
     - make check TESTS=tests/test-rollsum
 
+artifacts:
+  - test-suite.log
 ---
 
 inherit: true
@@ -96,6 +98,8 @@ tests:
     - make check
     - /bin/sh -c 'gnome-desktop-testing-runner -p 0 --timeout $((10 * 60)) libostree/'
 
+artifacts:
+  - test-suite.log
 ---
 
 inherit: true

--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -3,4 +3,5 @@
 OstreeRemote
 ostree_remote_ref
 ostree_remote_unref
+ostree_remote_get_name
 </SECTION>

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -29,3 +29,8 @@ global:
   ostree_remote_ref;
   ostree_remote_unref;
 } LIBOSTREE_2017.6;
+
+LIBOSTREE_2016.7_EXPERIMENTAL {
+global:
+  ostree_remote_get_name;
+} LIBOSTREE_2017.6_EXPERIMENTAL;

--- a/src/libostree/ostree-remote-private.h
+++ b/src/libostree/ostree-remote-private.h
@@ -38,9 +38,9 @@ G_BEGIN_DECLS
 
 struct OstreeRemote {
   volatile int ref_count;
-  char *name;
-  char *group;   /* group name in options */
-  char *keyring; /* keyring name (NAME.trustedkeys.gpg) */
+  char *name;  /* (not nullable) */
+  char *group;   /* group name in options (not nullable) */
+  char *keyring; /* keyring name (NAME.trustedkeys.gpg) (not nullable) */
   GFile *file;   /* NULL if remote defined in repo/config */
   GKeyFile *options;
 };

--- a/src/libostree/ostree-remote-private.h
+++ b/src/libostree/ostree-remote-private.h
@@ -46,7 +46,7 @@ struct OstreeRemote {
 };
 
 G_GNUC_INTERNAL
-OstreeRemote *ostree_remote_new (void);
+OstreeRemote *ostree_remote_new (const gchar *name);
 
 G_GNUC_INTERNAL
 OstreeRemote *ostree_remote_new_from_keyfile (GKeyFile    *keyfile,

--- a/src/libostree/ostree-remote.c
+++ b/src/libostree/ostree-remote.c
@@ -148,3 +148,23 @@ G_DEFINE_BOXED_TYPE(OstreeRemote, ostree_remote,
                     ostree_remote_ref,
                     ostree_remote_unref);
 #endif
+
+/**
+ * ostree_remote_get_name:
+ * @remote: an #OstreeRemote
+ *
+ * Get the human-readable name of the remote. This is what the user configured,
+ * if the remote was explicitly configured; and will otherwise be a stable,
+ * arbitrary, string.
+ *
+ * Returns: remote’s name
+ * Since: 2017.7
+ */
+const gchar *
+ostree_remote_get_name (OstreeRemote *remote)
+{
+  g_return_val_if_fail (remote != NULL, NULL);
+  g_return_val_if_fail (remote->ref_count > 0, NULL);
+
+  return remote->name;
+}

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -48,17 +48,14 @@ G_BEGIN_DECLS
 typedef struct OstreeRemote OstreeRemote;
 #endif
 
-#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+#ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 GType ostree_remote_get_type (void) G_GNUC_CONST;
-#else
-#ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 OstreeRemote *ostree_remote_ref (OstreeRemote *remote);
 _OSTREE_PUBLIC
 void ostree_remote_unref (OstreeRemote *remote);
 #endif /* GI_SCANNER */
-#endif
 
 _OSTREE_PUBLIC
 const gchar *ostree_remote_get_name (OstreeRemote *remote);

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -60,4 +60,7 @@ void ostree_remote_unref (OstreeRemote *remote);
 #endif /* GI_SCANNER */
 #endif
 
+_OSTREE_PUBLIC
+const gchar *ostree_remote_get_name (OstreeRemote *remote);
+
 G_END_DECLS

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -354,6 +354,9 @@ _ostree_repo_update_mtime (OstreeRepo        *self,
 gboolean
 _ostree_repo_add_remote (OstreeRepo   *self,
                          OstreeRemote *remote);
+gboolean
+_ostree_repo_remove_remote (OstreeRepo   *self,
+                            OstreeRemote *remote);
 OstreeRemote *
 _ostree_repo_get_remote (OstreeRepo  *self,
                          const char  *name,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -351,7 +351,7 @@ gboolean
 _ostree_repo_update_mtime (OstreeRepo        *self,
                            GError           **error);
 
-void
+gboolean
 _ostree_repo_add_remote (OstreeRepo   *self,
                          OstreeRemote *remote);
 OstreeRemote *

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -150,19 +150,23 @@ _ostree_repo_get_remote_inherited (OstreeRepo  *self,
   return g_steal_pointer (&remote);
 }
 
-void
+gboolean
 _ostree_repo_add_remote (OstreeRepo   *self,
                          OstreeRemote *remote)
 {
-  g_return_if_fail (self != NULL);
-  g_return_if_fail (remote != NULL);
-  g_return_if_fail (remote->name != NULL);
+  gboolean already_existed;
+
+  g_return_val_if_fail (self != NULL, FALSE);
+  g_return_val_if_fail (remote != NULL, FALSE);
+  g_return_val_if_fail (remote->name != NULL, FALSE);
 
   g_mutex_lock (&self->remotes_lock);
 
-  g_hash_table_replace (self->remotes, remote->name, ostree_remote_ref (remote));
+  already_existed = g_hash_table_replace (self->remotes, remote->name, ostree_remote_ref (remote));
 
   g_mutex_unlock (&self->remotes_lock);
+
+  return already_existed;
 }
 
 static gboolean

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -882,10 +882,7 @@ impl_repo_remote_add (OstreeRepo     *self,
                          name, remote->file ? gs_file_get_path_cached (remote->file) : "(in config)");
     }
 
-  remote = ostree_remote_new ();
-  remote->name = g_strdup (name);
-  remote->group = g_strdup_printf ("remote \"%s\"", name);
-  remote->keyring = g_strdup_printf ("%s.trustedkeys.gpg", name);
+  remote = ostree_remote_new (name);
 
   /* The OstreeRepo maintains its own internal system root path,
    * so we need to not only check if a "sysroot" argument was given

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -169,9 +169,9 @@ _ostree_repo_add_remote (OstreeRepo   *self,
   return already_existed;
 }
 
-static gboolean
-ost_repo_remove_remote (OstreeRepo   *self,
-                        OstreeRemote *remote)
+gboolean
+_ostree_repo_remove_remote (OstreeRepo   *self,
+                            OstreeRemote *remote)
 {
   gboolean removed;
 
@@ -1040,7 +1040,7 @@ impl_repo_remote_delete (OstreeRepo     *self,
   if (!ot_ensure_unlinked_at (self->repo_dir_fd, remote->keyring, error))
     return FALSE;
 
-  ost_repo_remove_remote (self, remote);
+  _ostree_repo_remove_remote (self, remote);
 
   return TRUE;
 }

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -39,7 +39,7 @@ echo "ok exports"
 grep -E -v '(ostree_cmd__private__)|(ostree_fetcher_config_flags_get_type)' found-symbols.txt > expected-documented.txt
 
 echo "Verifying all public symbols are documented:"
-grep '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt $experimental_sections |sort -u > found-documented.txt
+grep --no-filename '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt $experimental_sections |sort -u > found-documented.txt
 diff -u expected-documented.txt found-documented.txt
 
 echo 'ok documented symbols'


### PR DESCRIPTION
These are some more groundwork for https://github.com/pwithnall/ostree/tree/lan-and-usb. They’re mostly internal changes, apart from the addition of a new `ostree_remote_get_name()` public API (currently hidden behind `--enable--experimental-api`).