### PR TITLE
build: Use AM_TESTS_ENVIRONMENT rather than TESTS_ENVIRONMENT

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -27,7 +27,7 @@ EXTRA_DIST += \
 # We should probably consider flipping the default for DEBUG.  Also,
 # include the builddir in $PATH so we find our just-built ostree
 # binary.
-TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
+AM_TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
   OSTREE_UNINSTALLED_SRCDIR=$(abs_top_srcdir) \
 	OSTREE_UNINSTALLED=$(abs_top_builddir) \
 	G_DEBUG=fatal-warnings \
@@ -37,7 +37,7 @@ TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	OSTREE_FEATURES="$(OSTREE_FEATURES)" \
 	$(NULL)
 if BUILDOPT_ASAN
-TESTS_ENVIRONMENT += OT_SKIP_READDIR_RAND=1 G_SLICE=always-malloc
+AM_TESTS_ENVIRONMENT += OT_SKIP_READDIR_RAND=1 G_SLICE=always-malloc
 endif
 
 uninstalled_test_data = tests/ostree-symlink-stamp tests/ostree-prepare-root-symlink-stamp \

--- a/buildutil/glib-tap.mk
+++ b/buildutil/glib-tap.mk
@@ -1,6 +1,6 @@
 # GLIB - Library of useful C routines
 
-TESTS_ENVIRONMENT= \
+AM_TESTS_ENVIRONMENT= \
 	G_TEST_SRCDIR="$(abs_srcdir)" 		\
 	G_TEST_BUILDDIR="$(abs_builddir)" 	\
 	UNINSTALLEDTESTS=1                      \


### PR DESCRIPTION
TESTS_ENVIRONMENT is reserved for the user to be able to set when
running the tests. AM_TESTS_ENVIRONMENT is for the tests’ Makefile to
set itself.

https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html

Signed-off-by: Philip Withnall <withnall@endlessm.com>