### PR TITLE
lib/repo: Delete unused private prototypes

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -321,28 +321,6 @@ _ostree_repo_commit_trusted_content_bare (OstreeRepo          *self,
                                           GError             **error);
 
 gboolean
-_ostree_repo_open_untrusted_content_bare (OstreeRepo          *self,
-                                          const char          *expected_checksum,
-                                          guint64              content_len,
-                                          OstreeRepoContentBareCommit *out_state,
-                                          GOutputStream      **out_stream,
-                                          gboolean            *out_have_object,
-                                          GCancellable        *cancellable,
-                                          GError             **error);
-
-gboolean
-_ostree_repo_commit_untrusted_content_bare (OstreeRepo          *self,
-                                            const char          *expected_checksum,
-                                            OstreeRepoContentBareCommit *state,
-                                            guint32              uid,
-                                            guint32              gid,
-                                            guint32              mode,
-                                            GVariant            *xattrs,
-                                            GCancellable        *cancellable,
-                                            GError             **error);
-
-
-gboolean
 _ostree_repo_read_bare_fd (OstreeRepo           *self,
                            const char           *checksum,
                            int                  *out_fd,


### PR DESCRIPTION
The implementations were removed in: 6ffcb24d227eae5a479caf45adb8037eceb6ae33
I noticed this while looking at the commit code.