### PR TITLE
checkout: also chmod in the user checkout case

### DIFF
--- a/docs/manual/repo.md
+++ b/docs/manual/repo.md
@@ -81,11 +81,11 @@ The `bare-user` mode is useful for build systems that run as non-root
 but want to generate root-owned content, as well as non-root container
 systems.
 
-There is a variant to the `bare-user` mode called `bare-user-only` mode. Unlike
-`bare-user` modes, neither ownership nor extended attributes are stored. These
-repos are meant to to be checked out in user mode (with the `-U` flag), where
-this information is not applied anyway. The main advantage of `bare-user-only`
-is that repos can be stored on filesystems which do not support extended
+There is a variant to the `bare-user` mode called `bare-user-only`. Unlike
+`bare-user`, neither ownership nor extended attributes are stored. These repos
+are meant to to be checked out in user mode (with the `-U` flag), where this
+information is not applied anyway. The main advantage of `bare-user-only` is
+that repos can be stored on filesystems which do not support extended
 attributes, such as tmpfs.
 
 In contrast, the `archive-z2` mode is designed for serving via plain

--- a/docs/manual/repo.md
+++ b/docs/manual/repo.md
@@ -81,6 +81,13 @@ The `bare-user` mode is useful for build systems that run as non-root
 but want to generate root-owned content, as well as non-root container
 systems.
 
+There is a variant to the `bare-user` mode called `bare-user-only` mode. Unlike
+`bare-user` modes, neither ownership nor extended attributes are stored. These
+repos are meant to to be checked out in user mode (with the `-U` flag), where
+this information is not applied anyway. The main advantage of `bare-user-only`
+is that repos can be stored on filesystems which do not support extended
+attributes, such as tmpfs.
+
 In contrast, the `archive-z2` mode is designed for serving via plain
 HTTP.  Like tar files, it can be read/written by non-root users.
 

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -261,14 +261,14 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
                                         &tmpf, error))
         return FALSE;
 
-      if (sepolicy_enabled)
+      if (sepolicy_enabled && options->mode != OSTREE_REPO_CHECKOUT_MODE_USER)
         {
           g_autofree char *label = NULL;
-          if (!ostree_sepolicy_get_label (options->sepolicy,
-                                          state->selabel_path_buf->str,
+          if (!ostree_sepolicy_get_label (options->sepolicy, state->selabel_path_buf->str,
                                           g_file_info_get_attribute_uint32 (file_info, "unix::mode"),
                                           &label, cancellable, error))
             return FALSE;
+
           if (fsetxattr (tmpf.fd, "security.selinux", label, strlen (label), 0) < 0)
             return glnx_throw_errno_prefix (error, "Setting security.selinux");
         }

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -557,6 +557,8 @@ ${CMD_PREFIX} ostree --repo=repo2 pull-local repo
 rm -rf test2-checkout
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U --disable-cache test2 test2-checkout
 if test -d repo2/uncompressed-objects-cache; then
+    assert_file_has_mode test2-checkout/baz/cowro 600
+    assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
     ls repo2/uncompressed-objects-cache > ls.txt
     if test -s ls.txt; then
 	assert_not_reached "repo has uncompressed objects"
@@ -566,6 +568,8 @@ rm test2-checkout -rf
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U test2 test2-checkout
 assert_file_has_content test2-checkout/baz/cow moo
 assert_has_dir repo2/uncompressed-objects-cache
+assert_file_has_mode test2-checkout/baz/cowro 600
+assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
 echo "ok disable cache checkout"
 
 cd ${test_tmpdir}

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -566,6 +566,10 @@ rm test2-checkout -rf
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U test2 test2-checkout
 assert_file_has_content test2-checkout/baz/cow moo
 assert_has_dir repo2/uncompressed-objects-cache
+ls repo2/uncompressed-objects-cache > ls.txt
+if ! test -s ls.txt; then
+    assert_not_reached "repo didn't cache uncompressed objects"
+fi
 # we're in archive mode, but the repo we pull-local from might be
 # bare-user-only, in which case, we skip these checks since bare-user-only
 # doesn't store permission bits

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -559,7 +559,7 @@ ${CMD_PREFIX} ostree --repo=repo2 checkout -U --disable-cache test2 test2-checko
 if test -d repo2/uncompressed-objects-cache; then
     # we're in archive mode, but the repo we pull-local from might be
     # bare-user-only, in which case, we skip these checks since bare-user-only
-    # doesn't apply permission bits
+    # doesn't store permission bits
     if ! is_bare_user_only_repo repo; then
         assert_file_has_mode test2-checkout/baz/cowro 600
         assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -28,7 +28,7 @@ echo "ok yaml version"
 CHECKOUT_U_ARG=""
 COMMIT_ARGS=""
 DIFF_ARGS=""
-if grep -q bare-user-only repo/config; then
+if is_bare_user_only_repo repo; then
     # In bare-user-only repos we can only represent files with uid/gid 0, no
     # xattrs and canonical permissions, so we need to commit them as such, or
     # we end up with repos that don't pass fsck
@@ -66,7 +66,7 @@ validate_checkout_basic checkout-test2
 rm checkout-test2 -rf
 # Only do these tests on bare-user/bare, not bare-user-only
 # since the latter automatically synthesizes -U if it's not passed.
-if ! grep -q bare-user-only repo/config; then
+if ! is_bare_user_only_repo repo; then
 if grep -q bare-user repo/config; then
     if $OSTREE checkout -H test2 checkout-test2 2>err.txt; then
         assert_not_reached "checkout -H worked?"
@@ -557,8 +557,13 @@ ${CMD_PREFIX} ostree --repo=repo2 pull-local repo
 rm -rf test2-checkout
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U --disable-cache test2 test2-checkout
 if test -d repo2/uncompressed-objects-cache; then
-    assert_file_has_mode test2-checkout/baz/cowro 600
-    assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
+    # we're in archive mode, but the repo we pull-local from might be
+    # bare-user-only, in which case, we skip these checks since bare-user-only
+    # doesn't apply permission bits
+    if ! is_bare_user_only_repo repo; then
+        assert_file_has_mode test2-checkout/baz/cowro 600
+        assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
+    fi
     ls repo2/uncompressed-objects-cache > ls.txt
     if test -s ls.txt; then
 	assert_not_reached "repo has uncompressed objects"
@@ -568,8 +573,10 @@ rm test2-checkout -rf
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U test2 test2-checkout
 assert_file_has_content test2-checkout/baz/cow moo
 assert_has_dir repo2/uncompressed-objects-cache
-assert_file_has_mode test2-checkout/baz/cowro 600
-assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
+if ! is_bare_user_only_repo repo; then # see comment above
+    assert_file_has_mode test2-checkout/baz/cowro 600
+    assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
+fi
 echo "ok disable cache checkout"
 
 cd ${test_tmpdir}

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -557,13 +557,6 @@ ${CMD_PREFIX} ostree --repo=repo2 pull-local repo
 rm -rf test2-checkout
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U --disable-cache test2 test2-checkout
 if test -d repo2/uncompressed-objects-cache; then
-    # we're in archive mode, but the repo we pull-local from might be
-    # bare-user-only, in which case, we skip these checks since bare-user-only
-    # doesn't store permission bits
-    if ! is_bare_user_only_repo repo; then
-        assert_file_has_mode test2-checkout/baz/cowro 600
-        assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
-    fi
     ls repo2/uncompressed-objects-cache > ls.txt
     if test -s ls.txt; then
 	assert_not_reached "repo has uncompressed objects"
@@ -573,7 +566,10 @@ rm test2-checkout -rf
 ${CMD_PREFIX} ostree --repo=repo2 checkout -U test2 test2-checkout
 assert_file_has_content test2-checkout/baz/cow moo
 assert_has_dir repo2/uncompressed-objects-cache
-if ! is_bare_user_only_repo repo; then # see comment above
+# we're in archive mode, but the repo we pull-local from might be
+# bare-user-only, in which case, we skip these checks since bare-user-only
+# doesn't store permission bits
+if ! is_bare_user_only_repo repo; then
     assert_file_has_mode test2-checkout/baz/cowro 600
     assert_file_has_mode test2-checkout/baz/deeper/ohyeahx 755
 fi

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -110,6 +110,13 @@ assert_file_has_content_literal () {
     fi
 }
 
+assert_file_has_mode () {
+    mode=$(stat -c '%a' $1)
+    if [ "$mode" != "$2" ]; then
+        fatal "File '$1' has wrong mode: expected $2, but got $mode"
+    fi
+}
+
 assert_symlink_has_content () {
     if ! test -L "$1"; then
         fatal "File '$1' is not a symbolic link"

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -157,9 +157,13 @@ setup_test_repository () {
 
     mkdir baz
     echo moo > baz/cow
+    echo mooro > baz/cowro
+    chmod 600 baz/cowro
     echo alien > baz/saucer
     mkdir baz/deeper
     echo hi > baz/deeper/ohyeah
+    echo hix > baz/deeper/ohyeahx
+    chmod 755 baz/deeper/ohyeahx
     ln -s nonexistent baz/alink
     mkdir baz/another/
     echo x > baz/another/y

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -499,3 +499,7 @@ has_gpgme () {
 libtest_cleanup_gpg () {
     gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye || true
 }
+
+is_bare_user_only_repo () {
+  grep -q 'mode=bare-user-only' $1/config
+}


### PR DESCRIPTION
When falling back to copying, we previously would only chmod checked out
files in the non-user-checkout mode. Fix this by always doing chmod.
The file_mode was being prepared but never actually applied.

Add a basic test in the archive-z2 --> usermode checkout case in which
we're guaranteed to always fall back to copy mode.

Closes: #633