### PR TITLE
Don't install trivial-httpd man page if not enabled

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -29,7 +29,10 @@ ostree-commit.1 ostree-export.1 ostree-gpg-sign.1 ostree-config.1	\
 ostree-diff.1 ostree-fsck.1 ostree-init.1 ostree-log.1 ostree-ls.1	\
 ostree-prune.1 ostree-pull-local.1 ostree-pull.1 ostree-refs.1		\
 ostree-remote.1 ostree-reset.1 ostree-rev-parse.1 ostree-show.1		\
-ostree-summary.1 ostree-static-delta.1 ostree-trivial-httpd.1
+ostree-summary.1 ostree-static-delta.1
+if BUILDOPT_TRIVIAL_HTTPD
+man1_files += ostree-trivial-httpd.1
+endif
 
 if BUILDOPT_FUSE
 man1_files += rofiles-fuse.1

--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,8 @@ AC_ARG_ENABLE(trivial-httpd-cmdline,
   [AS_HELP_STRING([--enable-trivial-httpd-cmdline],
   [Continue to support "ostree trivial-httpd" [default=no]])],,
   enable_trivial_httpd_cmdline=no)
-AS_IF([test x$enable_trivial_httpd_cmdline = xyes],
+AM_CONDITIONAL(BUILDOPT_TRIVIAL_HTTPD, test x$enable_trivial_httpd_cmdline = xyes)
+AM_COND_IF(BUILDOPT_TRIVIAL_HTTPD,
   [AC_DEFINE([BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE], 1, [Define if we are enabling ostree trivial-httpd entrypoint])]
 )
 


### PR DESCRIPTION
I just noticed this scroll by in a file listing.