### PR TITLE
lib/repo: For bare-user, make repo modes mirror checkout user-mode

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..66"
+echo "1..$((66 + ${extra_basic_tests:-0}))"
 
 $CMD_PREFIX ostree --version > version.yaml
 python -c 'import yaml; yaml.safe_load(open("version.yaml"))'

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -503,3 +503,21 @@ libtest_cleanup_gpg () {
 is_bare_user_only_repo () {
   grep -q 'mode=bare-user-only' $1/config
 }
+
+# Given a path to a file in a repo for a ref, print its checksum
+ostree_file_path_to_checksum() {
+    repo=$1
+    ref=$2
+    path=$3
+    $CMD_PREFIX ostree --repo=$repo ls -C $ref $path | awk '{ print $5 }'
+}
+
+# Given a path to a file in a repo for a ref, print the path to its object
+ostree_file_path_to_object_path() {
+   repo=$1
+   ref=$2
+   path=$3
+   checksum=$(ostree_file_path_to_checksum $repo $ref $path)
+   test -n "${checksum}"
+   echo ${repo}/objects/${checksum:0:2}/${checksum:2}.file
+}

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -25,4 +25,39 @@ skip_without_user_xattrs
 
 setup_test_repository "bare-user"
 
+extra_basic_tests=3
 . $(dirname $0)/basic-test.sh
+
+# Reset things so we don't inherit a lot of state from earlier tests
+rm repo files -rf
+setup_test_repository "bare-user"
+
+cd ${test_tmpdir}
+objpath_nonexec=$(ostree_file_path_to_object_path repo test2 baz/cow)
+# This actually depends on umask, that's going to be a pain
+assert_file_has_mode ${objpath_nonexec} 664
+objpath_ro=$(ostree_file_path_to_object_path repo test2 baz/cowro)
+assert_file_has_mode ${objpath_ro} 600
+objpath_exec=$(ostree_file_path_to_object_path repo test2 baz/deeper/ohyeahx)
+assert_file_has_mode ${objpath_exec} 755
+echo "ok bare-user committed modes"
+
+rm test2-checkout -rf
+$OSTREE checkout -U -H test2 test2-checkout
+cd test2-checkout
+assert_file_has_mode baz/cow 664
+assert_file_has_mode baz/cowro 600
+assert_file_has_mode baz/deeper/ohyeahx 755
+echo "ok bare-user checkout modes"
+
+rm test2-checkout -rf
+$OSTREE checkout -U -H test2 test2-checkout
+touch test2-checkout/unreadable
+chmod 0400 test2-checkout/unreadable
+$OSTREE commit -b test2-unreadable --tree=dir=test2-checkout
+chmod 0600 test2-checkout/unreadable
+rm test2-checkout -rf
+$OSTREE checkout -U -H test2-unreadable test2-checkout
+cd test2-checkout
+assert_file_has_mode unreadable 400
+echo "ok bare-user unreadable"

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -52,12 +52,12 @@ echo "ok bare-user checkout modes"
 
 rm test2-checkout -rf
 $OSTREE checkout -U -H test2 test2-checkout
-touch test2-checkout/unreadable
-chmod 0400 test2-checkout/unreadable
-$OSTREE commit -b test2-unreadable --tree=dir=test2-checkout
-chmod 0600 test2-checkout/unreadable
+touch test2-checkout/unwritable
+chmod 0400 test2-checkout/unwritable
+$OSTREE commit -b test2-unwritable --tree=dir=test2-checkout
+chmod 0600 test2-checkout/unwritable
 rm test2-checkout -rf
-$OSTREE checkout -U -H test2-unreadable test2-checkout
+$OSTREE checkout -U -H test2-unwritable test2-checkout
 cd test2-checkout
-assert_file_has_mode unreadable 400
-echo "ok bare-user unreadable"
+assert_file_has_mode unwritable 400
+echo "ok bare-user unwritable"

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -34,8 +34,11 @@ setup_test_repository "bare-user"
 
 cd ${test_tmpdir}
 objpath_nonexec=$(ostree_file_path_to_object_path repo test2 baz/cow)
-# This actually depends on umask, that's going to be a pain
-assert_file_has_mode ${objpath_nonexec} 664
+# Sigh, umask
+touch testfile
+default_mode=$(stat -c '%a' testfile)
+rm testfile
+assert_file_has_mode ${objpath_nonexec} ${default_mode}
 objpath_ro=$(ostree_file_path_to_object_path repo test2 baz/cowro)
 assert_file_has_mode ${objpath_ro} 600
 objpath_exec=$(ostree_file_path_to_object_path repo test2 baz/deeper/ohyeahx)
@@ -45,7 +48,7 @@ echo "ok bare-user committed modes"
 rm test2-checkout -rf
 $OSTREE checkout -U -H test2 test2-checkout
 cd test2-checkout
-assert_file_has_mode baz/cow 664
+assert_file_has_mode baz/cow ${default_mode}
 assert_file_has_mode baz/cowro 600
 assert_file_has_mode baz/deeper/ohyeahx 755
 echo "ok bare-user checkout modes"


### PR DESCRIPTION
Having every object in a bare-user repo (and checkouts) be executable
is ugly.  I can't think of a good reason to do that.  So make
the committed mode semantics mirror that for user-mode checkouts; we
strip suid/sgid bits.

However, we also do ensure that the written files are read/writable by the
owning user, since otherwise we couldn't do anything to them. I'm not aware of
any real use cases for non-readable/non-writable by owner files in ostree.

Closes: https://github.com/ostreedev/ostree/issues/907