### PR TITLE
Canonicalize bare-user-only perms with 0755 mask

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -312,8 +312,13 @@ cd ${test_tmpdir}/checkout-test2-4
 $OSTREE commit ${COMMIT_ARGS} -b test2-override -s "with statoverride" --statoverride=../test-statoverride.txt
 cd ${test_tmpdir}
 $OSTREE checkout test2-override checkout-test2-override
-test -g checkout-test2-override/a/nested/2
-test -u checkout-test2-override/a/nested/3
+if ! is_bare_user_only_repo repo; then
+    test -g checkout-test2-override/a/nested/2
+    test -u checkout-test2-override/a/nested/3
+else
+    test '!' -g checkout-test2-override/a/nested/2
+    test '!' -u checkout-test2-override/a/nested/3
+fi
 echo "ok commit statoverride"
 
 cd ${test_tmpdir}


### PR DESCRIPTION
For the flatpak use case where bare-user-only was introduced, we actually
don't want to support s{u,g} id files in particular.

Actually, I can't think of a reason to have anything outside of the
`0755 i.e. (u=rwx,g=rx,o=rx)` mask, so that's what we do here.

This will have the effect of treating existing `bare-user-only` repositories as
corrupted if they have files outside of that mask, but I think we should do this
now; most of the flatpak users will still be on `bare-user`, and we haven't
changed the semantics of that mode yet.

Note that in this patch we will also *reject* file content that doesn't
match this.  This is somewhat asymmetric, since we aren't similarly rejecting
e.g. directory metadata.  But, this will close off the biggest source
of the problem for flatpak (setuid binaries).

See: https://github.com/ostreedev/ostree/pull/908
See: https://github.com/flatpak/flatpak/pull/837