### PR TITLE
lib/repo: Don't copy xattrs when manipulating the GPG keyring

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1329,7 +1329,6 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
   struct stat stbuf;
   gpgme_error_t gpg_error;
   gboolean ret = FALSE;
-  const GLnxFileCopyFlags copyflags = self->disable_xattrs ? GLNX_FILE_COPY_NOXATTRS : 0;
 
   g_return_val_if_fail (OSTREE_IS_REPO (self), FALSE);
   g_return_val_if_fail (name != NULL, FALSE);
@@ -1453,7 +1452,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
     {
       if (!glnx_file_copy_at (self->repo_dir_fd, remote->keyring,
                               &stbuf, target_temp_fd, "pubring.gpg",
-                              copyflags, cancellable, error))
+                              GLNX_FILE_COPY_NOXATTRS, cancellable, error))
         {
           g_prefix_error (error, "Unable to copy remote's keyring: ");
           goto out;
@@ -1537,7 +1536,7 @@ ostree_repo_remote_gpg_import (OstreeRepo         *self,
    * updated keyring in the target context's temporary directory. */
   if (!glnx_file_copy_at (target_temp_fd, "pubring.gpg", NULL,
                           self->repo_dir_fd, remote->keyring,
-                          copyflags | GLNX_FILE_COPY_OVERWRITE,
+                          GLNX_FILE_COPY_NOXATTRS | GLNX_FILE_COPY_OVERWRITE,
                           cancellable, error))
     goto out;
 


### PR DESCRIPTION
Copying xattrs when manipulating the GPG keyring for a repository
causes errors when the underlying filesystem doesn't support writing
xattrs - overlayfs is a common example. It also causes the selinux
attributes of the keyring files to be copied from the temporary
location instead of properly inherited from the destination directory
(ending up, for example, as unconfined_u:object_r:user_tmp_t:s0, rather
than unconfined_u:object_r:data_home_t:s0)

NOTE: The probably with the selinux contexts could potentially considered that libglnx is not sophisticated enough about copying attrs - coreutils cp, when instructed to copy xattrs with 'cp --preserve=xattr' or 'cp -a' uses libattr routines to honor /etc/xattr.conf and has special handling of selinux - but in the end, I don't think there's any reason to believe that preserving xattrs is important in this location. 