### PR TITLE
Minor fixes

### DIFF
--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -46,6 +46,8 @@ struct OstreeFetcherClass
   GObjectClass parent_class;
 };
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OstreeFetcher, g_object_unref)
+
 typedef enum {
   OSTREE_FETCHER_FLAGS_NONE = 0,
   OSTREE_FETCHER_FLAGS_TLS_PERMISSIVE = (1 << 0),

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2690,7 +2690,7 @@ initiate_request (OtPullData *pull_data,
  *   * override-commit-ids (as): Array of specific commit IDs to fetch for refs
  *   * dry-run (b): Only print information on what will be downloaded (requires static deltas)
  *   * override-url (s): Fetch objects from this URL if remote specifies no metalink in options
- *   * inherit-transaction (b): Don't initiate, finish or abort a transaction, usefult to do multiple pulls in one transaction.
+ *   * inherit-transaction (b): Don't initiate, finish or abort a transaction, useful to do multiple pulls in one transaction.
  *   * http-headers (a(ss)): Additional headers to add to all HTTP requests
  *   * update-frequency (u): Frequency to call the async progress callback in milliseconds, if any; only values higher than 0 are valid
  */

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3174,8 +3174,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     if (pull_data->summary)
       {
         refs = g_variant_get_child_value (pull_data->summary, 0);
-        n = g_variant_n_children (refs);
-        for (i = 0; i < n; i++)
+        for (i = 0, n = g_variant_n_children (refs); i < n; i++)
           {
             const char *refname;
             g_autoptr(GVariant) ref = g_variant_get_child_value (refs, i);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3479,15 +3479,16 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           if (!ot_ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
             goto out;
         }
-        g_hash_table_iter_init (&hash_iter, commits_to_fetch);
-        while (g_hash_table_iter_next (&hash_iter, &key, &value))
-          {
-            const char *commit = value;
-            g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (commit);
 
-            if (!ot_ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
-              goto out;
-          }
+      g_hash_table_iter_init (&hash_iter, commits_to_fetch);
+      while (g_hash_table_iter_next (&hash_iter, &key, &value))
+        {
+          const char *commit = value;
+          g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (commit);
+
+          if (!ot_ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
+            goto out;
+        }
     }
 
   ret = TRUE;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3241,7 +3241,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
               char *commitid = commitid_strviter ? g_strdup (*commitid_strviter) : NULL;
               g_hash_table_insert (requested_refs_to_fetch, g_strdup (branch), commitid);
             }
-          
+
           strviter++;
           if (commitid_strviter)
             commitid_strviter++;
@@ -3377,7 +3377,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       ret = TRUE;
       goto out;
     }
-  
+
   g_assert_cmpint (pull_data->n_outstanding_metadata_fetches, ==, 0);
   g_assert_cmpint (pull_data->n_outstanding_metadata_write_requests, ==, 0);
   g_assert_cmpint (pull_data->n_outstanding_content_fetches, ==, 0);
@@ -3390,7 +3390,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       const char *checksum = value;
       g_autofree char *remote_ref = NULL;
       g_autofree char *original_rev = NULL;
-          
+
       if (pull_data->remote_name)
         remote_ref = g_strdup_printf ("%s/%s", pull_data->remote_name, ref);
       else

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4561,7 +4561,8 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
         g_variant_dict_insert_value (&deltas_builder, delta_names->pdata[i], ot_gvariant_new_bytearray (csum, 32));
       }
 
-    g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_STATIC_DELTAS, g_variant_dict_end (&deltas_builder));
+    if (delta_names->len > 0)
+      g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_STATIC_DELTAS, g_variant_dict_end (&deltas_builder));
   }
 
   {

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -52,6 +52,7 @@ assert_file_has_content_literal summary.txt "* main"
 assert_file_has_content_literal summary.txt "* other"
 assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
 assert_file_has_content_literal summary.txt "Static Deltas (ostree.static-deltas): {}"
+assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp): "
 echo "ok view summary"
 
 # Check the summary can be viewed raw too.

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -51,7 +51,6 @@ ${OSTREE} summary --view > summary.txt
 assert_file_has_content_literal summary.txt "* main"
 assert_file_has_content_literal summary.txt "* other"
 assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
-assert_file_has_content_literal summary.txt "Static Deltas (ostree.static-deltas): {}"
 assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp): "
 echo "ok view summary"
 


### PR DESCRIPTION
Various minor fixes: typo fixes, whitespace fixes, a minor optimisation in the `summary` file, and improvements in formatting for `ostree summary -v`.