### PR TITLE
lib/pull: Fix construction of a refspec to use the correct separator

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3393,7 +3393,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       g_autofree char *original_rev = NULL;
           
       if (pull_data->remote_name)
-        remote_ref = g_strdup_printf ("%s/%s", pull_data->remote_name, ref);
+        remote_ref = g_strdup_printf ("%s:%s", pull_data->remote_name, ref);
       else
         remote_ref = g_strdup (ref);
 


### PR DESCRIPTION
This code looks like it was supposed to build a refspec, but it used a
slash as a separator rather than a colon. The following code does
recover by supporting prefix matching with slashes, but it seems like
this was perhaps not the intention.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

Split out from PR #911.