### PR TITLE
 repo/commit: Support group-writable files for bare-user-only

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -301,10 +301,10 @@ commit_loose_object_trusted (OstreeRepo        *self,
                self->mode == OSTREE_REPO_MODE_BARE_USER_ONLY
                && !object_is_symlink)
         {
-          guint32 invalid_modebits = (mode & ~S_IFMT) & ~0755;
+          guint32 invalid_modebits = (mode & ~S_IFMT) & ~0775;
           if (invalid_modebits > 0)
             return glnx_throw (error, "Invalid mode 0%04o with bits 0%04o in bare-user-only repository",
-                                   mode, invalid_modebits);
+                               mode, invalid_modebits);
 
           if (fchmod (fd, mode) < 0)
             return glnx_throw_errno_prefix (error, "fchmod");

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..66"
+echo "1..$((66 + ${extra_basic_tests:-0}))"
 
 $CMD_PREFIX ostree --version > version.yaml
 python -c 'import yaml; yaml.safe_load(open("version.yaml"))'

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 setup_test_repository "bare-user-only"
-extra_basic_tests=1
+extra_basic_tests=2
 . $(dirname $0)/basic-test.sh
 
 # Reset things so we don't inherit a lot of state from earlier tests
@@ -47,3 +47,15 @@ if $CMD_PREFIX ostree pull-local --repo=repo repo-input 2>err.txt; then
 fi
 assert_file_has_content err.txt "Invalid mode.*with bits 040.*in bare-user-only"
 echo "ok failed to commit suid"
+
+cd ${test_tmpdir}
+rm repo-input -rf
+ostree --repo=repo-input init --mode=archive
+rm files -rf && mkdir files
+echo "a group writable file" > files/some-group-writable
+chmod 0664 files/some-group-writable
+$CMD_PREFIX ostree --repo=repo-input commit -b content-with-group-writable --tree=dir=files
+$CMD_PREFIX ostree pull-local --repo=repo repo-input
+$CMD_PREFIX ostree --repo=repo checkout -U -H content-with-group-writable groupwritable-co
+assert_file_has_mode groupwritable-co/some-group-writable 664
+echo "ok supported group writable"

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -50,7 +50,7 @@ echo "ok failed to commit suid"
 
 cd ${test_tmpdir}
 rm repo-input -rf
-ostree --repo=repo-input init --mode=archive
+ostree_repo_init repo-input init --mode=archive
 rm files -rf && mkdir files
 echo "a group writable file" > files/some-group-writable
 chmod 0664 files/some-group-writable

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -28,12 +28,12 @@ extra_basic_tests=2
 # Reset things so we don't inherit a lot of state from earlier tests
 cd ${test_tmpdir}
 rm repo files -rf
-ostree --repo=repo init --mode=bare-user-only
+ostree_repo_init repo init --mode=bare-user-only
 
 # Init an archive repo where we'll store content that can't go into bare-user
 cd ${test_tmpdir}
 rm repo-input -rf
-ostree --repo=repo-input init --mode=archive
+ostree_repo_init repo-input init --mode=archive
 cd ${test_tmpdir}
 cat > statoverride.txt <<EOF
 2048 /some-setuid

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -22,4 +22,28 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 setup_test_repository "bare-user-only"
+extra_basic_tests=1
 . $(dirname $0)/basic-test.sh
+
+# Reset things so we don't inherit a lot of state from earlier tests
+cd ${test_tmpdir}
+rm repo files -rf
+ostree --repo=repo init --mode=bare-user-only
+
+# Init an archive repo where we'll store content that can't go into bare-user
+cd ${test_tmpdir}
+rm repo-input -rf
+ostree --repo=repo-input init --mode=archive
+cd ${test_tmpdir}
+cat > statoverride.txt <<EOF
+2048 /some-setuid
+EOF
+mkdir -p files/
+echo "a setuid file" > files/some-setuid
+chmod 0644 files/some-setuid
+$CMD_PREFIX ostree --repo=repo-input commit -b content-with-suid --statoverride=statoverride.txt --tree=dir=files
+if $CMD_PREFIX ostree pull-local --repo=repo repo-input 2>err.txt; then
+    assert_not_reached "copying suid file into bare-user worked?"
+fi
+assert_file_has_content err.txt "Invalid mode.*with bits 040.*in bare-user-only"
+echo "ok failed to commit suid"


### PR DESCRIPTION

These exist in the wild for flatpak, and aren't really a problem.
The canonical permissions are still `0{6,7}44`, we just support
the additional writable bit for the group now to avoid breaking
some flatpak content.