### PR TITLE
 lib/checkout: Ignore world-writable dirs for bare-user-only checkout

### DIFF
--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 setup_test_repository "bare-user-only"
-extra_basic_tests=2
+extra_basic_tests=3
 . $(dirname $0)/basic-test.sh
 
 # Reset things so we don't inherit a lot of state from earlier tests
@@ -59,3 +59,15 @@ $CMD_PREFIX ostree pull-local --repo=repo repo-input
 $CMD_PREFIX ostree --repo=repo checkout -U -H content-with-group-writable groupwritable-co
 assert_file_has_mode groupwritable-co/some-group-writable 664
 echo "ok supported group writable"
+
+cd ${test_tmpdir}
+rm repo-input -rf
+ostree_repo_init repo-input init --mode=archive
+rm files -rf && mkdir files
+mkdir files/worldwritable-dir
+chmod a+w files/worldwritable-dir
+$CMD_PREFIX ostree --repo=repo-input commit -b content-with-dir-world-writable --tree=dir=files
+$CMD_PREFIX ostree pull-local --repo=repo repo-input
+$CMD_PREFIX ostree --repo=repo checkout -U -H content-with-dir-world-writable dir-co
+assert_file_has_mode dir-co/worldwritable-dir 775
+echo "ok didn't make world-writable dir"


### PR DESCRIPTION

See #909 for more information on the
rationale. Basically there's no reason for flatpak (which uses `bare-user-only`)
to have world-writable dirs. Particularly with the presence of the system
helper.

An approach I considered instead was to parse and validate directory metadata
objects at commit time. We still may do that in addition; for file objects we *had*
to do it that way because the actual files would be laid down suid.  But directories
live only as inert `.dirmeta` objects until we do a checkout (i.e. `mkdir()`), so
we can solve the problem at checkout time.