### PR TITLE
lib/pull: Add OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1015,12 +1015,14 @@ gboolean ostree_repo_prune_from_reachable (OstreeRepo             *self,
  * @OSTREE_REPO_PULL_FLAGS_MIRROR: Write out refs suitable for mirrors
  * @OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY: Fetch only the commit metadata
  * @OSTREE_REPO_PULL_FLAGS_UNTRUSTED: Don't trust local remote
+ * @OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES: Since 2017.7.  Reject writes of content objects with modes outside of 0775.
  */
 typedef enum {
   OSTREE_REPO_PULL_FLAGS_NONE,
   OSTREE_REPO_PULL_FLAGS_MIRROR = (1 << 0),
   OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY = (1 << 1),
-  OSTREE_REPO_PULL_FLAGS_UNTRUSTED = (1 << 2)
+  OSTREE_REPO_PULL_FLAGS_UNTRUSTED = (1 << 2),
+  OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES = (1 << 3)
 } OstreeRepoPullFlags;
 
 _OSTREE_PUBLIC

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -33,6 +33,7 @@
 static char *opt_remote;
 static gboolean opt_disable_fsync;
 static gboolean opt_untrusted;
+static gboolean opt_bareuseronly_files;
 static gboolean opt_require_static_deltas;
 static gboolean opt_gpg_verify;
 static gboolean opt_gpg_verify_summary;
@@ -42,6 +43,7 @@ static GOptionEntry options[] = {
   { "remote", 0, 0, G_OPTION_ARG_STRING, &opt_remote, "Add REMOTE to refspec", "REMOTE" },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
   { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Do not trust source", NULL },
+  { "bareuseronly-files", 0, 0, G_OPTION_ARG_NONE, &opt_bareuseronly_files, "Reject regular files with mode outside of 0775 (world writable, suid, etc.)", NULL },
   { "require-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_require_static_deltas, "Require static deltas", NULL },
   { "gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify, "GPG verify commits (must specify --remote)", NULL },
   { "gpg-verify-summary", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify_summary, "GPG verify summary (must specify --remote)", NULL },
@@ -92,6 +94,8 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (opt_untrusted)
     pullflags |= OSTREE_REPO_PULL_FLAGS_UNTRUSTED;
+  if (opt_bareuseronly_files)
+    pullflags |= OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES;
 
   if (opt_disable_fsync)
     ostree_repo_set_disable_fsync (repo, TRUE);

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -34,6 +34,7 @@ static gboolean opt_dry_run;
 static gboolean opt_disable_static_deltas;
 static gboolean opt_require_static_deltas;
 static gboolean opt_untrusted;
+static gboolean opt_bareuseronly_files;
 static char** opt_subpaths;
 static char** opt_http_headers;
 static char* opt_cache_dir;
@@ -50,6 +51,7 @@ static GOptionEntry options[] = {
    { "mirror", 0, 0, G_OPTION_ARG_NONE, &opt_mirror, "Write refs suitable for a mirror", NULL },
    { "subpath", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_subpaths, "Only pull the provided subpath(s)", NULL },
    { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Do not trust (local) sources", NULL },
+   { "bareuseronly-files", 0, 0, G_OPTION_ARG_NONE, &opt_bareuseronly_files, "Reject regular files with mode outside of 0775 (world writable, suid, etc.)", NULL },
    { "dry-run", 0, 0, G_OPTION_ARG_NONE, &opt_dry_run, "Only print information on what will be downloaded (requires static deltas)", NULL },
    { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
    { "url", 0, 0, G_OPTION_ARG_STRING, &opt_url, "Pull objects from this URL instead of the one from the remote config", NULL },
@@ -167,6 +169,8 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
   if (opt_untrusted)
     pullflags |= OSTREE_REPO_PULL_FLAGS_UNTRUSTED;
+  if (opt_bareuseronly_files)
+    pullflags |= OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES;
 
   if (opt_dry_run && !opt_require_static_deltas)
     {

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -35,7 +35,7 @@ function verify_initial_contents() {
     assert_file_has_content baz/cow '^moo$'
 }
 
-echo "1..20"
+echo "1..21"
 
 # Try both syntaxes
 repo_init --no-gpg-verify
@@ -78,6 +78,13 @@ assert_file_has_content err.txt "Can't use static deltas in an archive repo"
 ${CMD_PREFIX} ostree --repo=mirrorrepo pull origin main
 ${CMD_PREFIX} ostree --repo=mirrorrepo fsck
 echo "ok pull (refuses deltas)"
+
+if ${CMD_PREFIX} ostree --repo=mirrorrepo \
+                 pull origin main --bareuseronly-files 2>err.txt; then
+    assert_not_reached "--bareuseronly-files unexpectedly succeeded"
+fi
+assert_file_has_content err.txt 'bareuseronly-files with non-local'
+echo "ok pull (refuses bareuseronly)"
 
 cd ${test_tmpdir}
 rm mirrorrepo/refs/remotes/* -rf


### PR DESCRIPTION
This is an option which is intended mostly for flatpak;
see: https://github.com/flatpak/flatpak/issues/845

We're adding an option for pulling into *all*
repo modes that has an effect similar to the `bare-user-only`
change from https://github.com/ostreedev/ostree/pull/909

This way one can pull content into e.g. a root-owned `bare` repository and
ensure that there aren't any setuid or world-writable files.