### PR TITLE
ostreee-version.h.in: Added Since: version annotations

### DIFF
--- a/src/libostree/ostree-version.h.in
+++ b/src/libostree/ostree-version.h.in
@@ -32,6 +32,8 @@
  * OSTREE_YEAR_VERSION:
  *
  * ostree year version component (e.g. 2017 if %OSTREE_VERSION is 2017.2)
+ *
+ * Since: 2017.4
  */
 #define OSTREE_YEAR_VERSION (@YEAR_VERSION@)
 
@@ -39,6 +41,8 @@
  * OSTREE_RELEASE_VERSION:
  *
  * ostree release version component (e.g. 2 if %OSTREE_VERSION is 2017.2)
+ *
+ * Since: 2017.4
  */
 #define OSTREE_RELEASE_VERSION (@RELEASE_VERSION@)
 
@@ -46,6 +50,8 @@
  * OSTREE_VERSION
  *
  * ostree version.
+ *
+ * Since: 2017.4
  */
 #define OSTREE_VERSION (@VERSION@)
 
@@ -54,6 +60,8 @@
  *
  * ostree version, encoded as a string, useful for printing and
  * concatenation.
+ *
+ * Since: 2017.4
  */
 #define OSTREE_VERSION_S "@VERSION@"
 
@@ -65,6 +73,8 @@
  *
  * ostree version, encoded as an hexadecimal number, useful for
  * integer comparisons.
+ *
+ * Since: 2017.4
  */
 #define OSTREE_VERSION_HEX \
         (OSTREE_ENCODE_VERSION (OSTREE_YEAR_VERSION, OSTREE_RELEASE_VERSION))
@@ -76,6 +86,8 @@
  *
  * Compile-time version checking. Evaluates to %TRUE if the version
  * of ostree is equal or greater than the required one.
+ *
+ * Since: 2017.4
  */
 #define OSTREE_CHECK_VERSION(year,release)   \
         (OSTREE_YEAR_VERSION > (year) || \


### PR DESCRIPTION
This is especially interesting for the versioning symbols themselves,
as it is an indicator of when applications using introspection information
can start to use a symbol in the library to check if they have a
recent enough version of OSTree to use.