### PR TITLE
lib/repo: Fix annotations for out parameters

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2618,9 +2618,9 @@ _ostree_repo_read_bare_fd (OstreeRepo           *self,
  * ostree_repo_load_file:
  * @self: Repo
  * @checksum: ASCII SHA256 checksum
- * @out_input: (out) (allow-none): File content
- * @out_file_info: (out) (allow-none): File information
- * @out_xattrs: (out) (allow-none): Extended attributes
+ * @out_input: (out) (optional) (nullable): File content
+ * @out_file_info: (out) (optional) (nullable): File information
+ * @out_xattrs: (out) (optional) (nullable): Extended attributes
  * @cancellable: Cancellable
  * @error: Error
  *


### PR DESCRIPTION
Change the annotation of the out parameters on ostree_repo_load_file
from `(allow-none)` to `(optional) (nullable)`. `allow-none` is
ambiguous, since these parameters can be both NULL on input and set to
NULL on return.

This issue was encountered using the Haskell bindings, see https://github.com/haskell-gi/haskell-gi/issues/106