### PR TITLE
static delta apply: Work on bare-user-only repos

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -690,7 +690,8 @@ dispatch_open (OstreeRepo                 *repo,
   if (!state->stats_only)
     {
       g_assert (repo->mode == OSTREE_REPO_MODE_BARE ||
-                repo->mode == OSTREE_REPO_MODE_BARE_USER);
+                repo->mode == OSTREE_REPO_MODE_BARE_USER ||
+                repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY);
     }
   
   if (!open_output_target (state, cancellable, error))


### PR DESCRIPTION
Flatpak make check is failing when applying a static delta
to a bare-user-only repo due to an assert. The fix is to add
bare-user-only to the assert check.