### PR TITLE
 Repouninit warning

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -12,7 +12,9 @@ packages:
   - git
 
 env:
-    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
+    # Enable all the sanitizers for this primary build.
+    # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
+    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2 -Werror=maybe-uninitialized'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
     # TODO when we're doing leak checks: G_SLICE: "always-malloc"
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2683,7 +2683,7 @@ ostree_repo_load_file (OstreeRepo         *self,
     }
   else
     {
-      int objdir_fd; /* referenced */
+      int objdir_fd = -1; /* referenced */
       if (!stat_bare_content_object (self, loose_path_buf,
                                      &objdir_fd,
                                      &ret_file_info,


### PR DESCRIPTION
It's spurious, but unfortunately GCC doesn't currently understand that it will
always be set.