### PR TITLE
Support verifying inline summary signatures

### DIFF
--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -28,6 +28,7 @@ ostree_repo_find_remotes_finish
 ostree_repo_pull_from_remotes_async
 ostree_repo_pull_from_remotes_finish
 ostree_repo_resolve_keyring_for_collection
+OSTREE_REPO_METADATA_REF
 </SECTION>
 
 <SECTION>

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1244,6 +1244,32 @@ gboolean ostree_repo_regenerate_summary (OstreeRepo     *self,
                                          GCancellable   *cancellable,
                                          GError        **error);
 
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+
+/**
+ * OSTREE_REPO_METADATA_REF:
+ *
+ * The name of a ref which is used to store metadata for the entire repository,
+ * such as its expected update time (`ostree.summary.expires`), name, or new
+ * GPG keys. Metadata is stored on contentless commits in the ref, and hence is
+ * signed with the commits.
+ *
+ * This supersedes the additional metadata dictionary in the `summary` file
+ * (see ostree_repo_regenerate_summary()), as the use of a ref means that the
+ * metadata for multiple upstream repositories can be included in a single mirror
+ * repository, disambiguating the refs using collection IDs. In order to support
+ * peer to peer redistribution of repository metadata, repositories must set a
+ * collection ID (ostree_repo_set_collection_id()).
+ *
+ * Users of OSTree may place arbitrary metadata in commits on this ref, but the
+ * keys must be namespaced by product or developer. For example,
+ * `exampleos.end-of-life`. The `ostree.` prefix is reserved.
+ *
+ * Since: 2017.8
+ */
+#define OSTREE_REPO_METADATA_REF "ostree-metadata"
+
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
 
 G_END_DECLS
 


### PR DESCRIPTION
This adds support for verifying inline signatures in `summary` files, including defining two new keys for containing such inline signatures (`OSTREE_SUMMARY_REFS_SIGNATURES` and `OSTREE_SUMMARY_ADDITIONAL_SIGNATURES`). It does not add support for generating inline signatures yet — the current plan is to modify `ostree_repo_add_gpg_signature_summary()` to read in, sign, and rewrite, the `summary` file. However, I wanted to get the schema of additional metadata keys sorted before implementing that.

Thoughts about the approach? This code is ready to merge apart from the fact it’s based on the lan-and-usb branch, which is still under review. Hence, please only look at the top 7 commits. Please also think about whether having `ostree_repo_add_gpg_signature_summary()` transparently rewrite the `summary` file to include inline signatures is your preferred approach for the write side of things.

Additional tests need to be added for the inline signature support, but they can only be added once libostree supports writing inline signatures; so they will be added with that. All the existing tests (for external `summary.sig` files) still pass.

---

This is based on the lan-and-usb branch and can’t be merged until that one is, as it depends on some of the new summary fields it introduces. The top 7 commits are relevant here.