### PR TITLE
build: Always include ostree-trivial-httpd.xml in tarballs

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -32,6 +32,9 @@ ostree-remote.1 ostree-reset.1 ostree-rev-parse.1 ostree-show.1		\
 ostree-summary.1 ostree-static-delta.1
 if BUILDOPT_TRIVIAL_HTTPD
 man1_files += ostree-trivial-httpd.1
+else
+# We still want to distribute the source, even if we are not building it
+EXTRA_DIST += man/ostree-trivial-httpd.xml
 endif
 
 if BUILDOPT_FUSE


### PR DESCRIPTION
If we `make dist` after configuring with `--disable-trivial-httpd-cmdline` (the default, as was done for 2017.7), the resulting tarball would not include the source code for this man page, making it fail to build from source when subsequently configured with `--enable-trivial-httpd-cmdline`.

(This could be detected by using `--enable-trivial-httpd-cmdline` in the `AM_DISTCHECK_CONFIGURE_FLAGS`, but I can't test that yet, because distcheck has other failures for me at the moment.)