### PR TITLE
lib/core: Fix ‘Since’ line for ostree_validate_remote_name()

### DIFF
--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -30,7 +30,7 @@ global:
   ostree_remote_unref;
 } LIBOSTREE_2017.6;
 
-LIBOSTREE_2016.7_EXPERIMENTAL {
+LIBOSTREE_2017.7_EXPERIMENTAL {
 global:
   ostree_remote_get_name;
 } LIBOSTREE_2017.6_EXPERIMENTAL;

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -187,7 +187,7 @@ ostree_validate_rev (const char *rev,
  * @error: Error
  *
  * Returns: %TRUE if @remote_name is a valid remote name
- * Since: 2017.7
+ * Since: 2017.8
  */
 gboolean
 ostree_validate_remote_name (const char  *remote_name,

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
  * remotes can only be passed around as (reference counted) opaque handles. In
  * future, more API may be added to create and interrogate them.
  *
- * Since: 2016.7
+ * Since: 2017.6
  */
 #ifndef OSTREE_ENABLE_EXPERIMENTAL_API
 /* This is in ostree-types.h otherwise */


### PR DESCRIPTION
This was missed when cherry-picking it out of
https://github.com/ostreedev/ostree/pull/924#discussion_r123097919.

Signed-off-by: Philip Withnall <withnall@endlessm.com>