### PR TITLE
 lib/repo: Split archive/bare file parsing

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -644,7 +644,7 @@ ostree_content_stream_parse (gboolean                compressed,
   if (compressed)
     {
       if (!zlib_file_header_parse (file_header,
-                                   out_file_info ? &ret_file_info : NULL,
+                                   &ret_file_info,
                                    out_xattrs ? &ret_xattrs : NULL,
                                    error))
         return FALSE;
@@ -652,12 +652,11 @@ ostree_content_stream_parse (gboolean                compressed,
   else
     {
       if (!file_header_parse (file_header,
-                              out_file_info ? &ret_file_info : NULL,
+                              &ret_file_info,
                               out_xattrs ? &ret_xattrs : NULL,
                               error))
         return FALSE;
-      if (ret_file_info)
-        g_file_info_set_size (ret_file_info, input_length - archive_header_size - 8);
+      g_file_info_set_size (ret_file_info, input_length - archive_header_size - 8);
     }
 
   g_autoptr(GInputStream) ret_input = NULL;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2650,20 +2650,17 @@ repo_load_file_archive (OstreeRepo *self,
                                           out_input, out_file_info, out_xattrs,
                                           cancellable, error);
     }
+  else if (self->parent_repo)
+    {
+      return ostree_repo_load_file (self->parent_repo, checksum,
+                                    out_input, out_file_info, out_xattrs,
+                                    cancellable, error);
+    }
   else
     {
-      if (self->parent_repo)
-        {
-          return ostree_repo_load_file (self->parent_repo, checksum,
-                                        out_input, out_file_info, out_xattrs,
-                                        cancellable, error);
-        }
-      else
-        {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                       "Couldn't find file object '%s'", checksum);
-          return FALSE;
-        }
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "Couldn't find file object '%s'", checksum);
+      return FALSE;
     }
 }
 


### PR DESCRIPTION

Prep for future cleanup patches (in particular I want an internal-only
version at first that uses a fd+`struct stat`) to avoid allocations.

The new version avoids lots of deep nesting of conditionals as well
by hoisting the "not found" handling to an early return.

There's a bit of code duplication between the two cases but it's
quite worth the result.