### PR TITLE
lib/repo: More cleanup of load_file() internals

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -321,11 +321,14 @@ _ostree_repo_commit_trusted_content_bare (OstreeRepo          *self,
                                           GError             **error);
 
 gboolean
-_ostree_repo_read_bare_fd (OstreeRepo           *self,
-                           const char           *checksum,
-                           int                  *out_fd,
-                           GCancellable        *cancellable,
-                           GError             **error);
+_ostree_repo_load_file_bare (OstreeRepo         *self,
+                             const char         *checksum,
+                             int                *out_fd,
+                             struct stat        *out_stbuf,
+                             char              **out_symlink,
+                             GVariant          **out_xattrs,
+                             GCancellable       *cancellable,
+                             GError            **error);
 
 gboolean
 _ostree_repo_update_mtime (OstreeRepo        *self,

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -830,11 +830,13 @@ dispatch_set_read_source (OstreeRepo                 *repo,
 
   g_free (state->read_source_object);
   state->read_source_object = ostree_checksum_from_bytes (state->payload_data + source_offset);
-  
-  if (!_ostree_repo_read_bare_fd (repo, state->read_source_object, &state->read_source_fd,
-                                  cancellable, error))
+
+  if (!_ostree_repo_load_file_bare (repo, state->read_source_object,
+                                    &state->read_source_fd,
+                                    NULL, NULL, NULL,
+                                    cancellable, error))
     goto out;
-  
+
   ret = TRUE;
  out:
   if (!ret)


### PR DESCRIPTION
This is followon work from previous cleanups.  Basically
`stat_bare_content_object()` was the `fstatat()` logic
and `ostree_repo_read_bare_fd()` was the `openat()` implementation;
they duplicated some bits to find the object in staging, recurse
into parent etc.

Further, I wanted an internal-only version of this API which didn't allocate
`GFileInfo`/`GInputStream` but used a plain `fd` and `struct stat` to avoid
mallocs.

The end version here I think looks a lot nicer, since we deduplicate the various
`open()` calls in the different cases for example.