### PR TITLE
tests: add a syntax-check rule for glnx_prefix_error()

### DIFF
--- a/cfg.mk
+++ b/cfg.mk
@@ -23,6 +23,10 @@ local-checks-to-skip = \
     sc_prohibit_path_max_allocation \
     sc_trailing_blank \
 
+sc_glnx_prefix_error_colon:
+	@prohibit='\<glnx_prefix_error *\(.*: ",' halt="don't add trailing : for glnx_prefix_error"	\
+	  $(_sc_search_regexp)
+
 sc_glnx_errno_prefix_colon:
 	@prohibit='\<glnx_throw_errno_prefix *\(.*: ",' halt="don't add trailing : for glnx_throw_errno_prefix"	\
 	  $(_sc_search_regexp)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -762,7 +762,7 @@ write_content_object (OstreeRepo         *self,
                                     uid, gid, mode,
                                     xattrs, temp_fd,
                                     cancellable, error))
-    return glnx_prefix_error (error, "Writing object %s.%s: ", actual_checksum,
+    return glnx_prefix_error (error, "Writing object %s.%s", actual_checksum,
                               ostree_object_type_to_string (OSTREE_OBJECT_TYPE_FILE));
   /* Clear the unlinker path, it was consumed */
   tmp_unlinker.path = NULL;


### PR DESCRIPTION
Same as the errno variant; the colon-space `: ` thing got me in a different
patch.