### PR TITLE
Summary signature cleanups

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -108,6 +108,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-switchroot.sh \
 	tests/test-pull-contenturl.sh \
 	tests/test-pull-mirrorlist.sh \
+	tests/test-summary-update.sh \
 	tests/test-summary-view.sh \
 	$(NULL)
 

--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -73,7 +73,14 @@ Boston, MA 02111-1307, USA.
                 <term><option>-u</option></term>
 
                 <listitem><para>
-		  Update the summary file.
+                  Update the summary file.
+                </para><para>
+                  Any additional arguments to the command
+                  are treated as additional key–value pairs to be added to the
+                  summary file as additional metadata. They must be in the format
+                  <command><replaceable>KEY</replaceable>=<replaceable>VALUE</replaceable></command>
+                  or as two separate arguments. The values must be in GVariant
+                  text format.
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -79,8 +79,10 @@ Boston, MA 02111-1307, USA.
                   are treated as additional key–value pairs to be added to the
                   summary file as additional metadata. They must be in the format
                   <command><replaceable>KEY</replaceable>=<replaceable>VALUE</replaceable></command>
-                  or as two separate arguments. The values must be in GVariant
-                  text format.
+                  or as two separate arguments. The keys must be namespaced for
+                  your organisation or repository using a dot prefix. The values
+                  must be in GVariant text format. For example,
+                  <command>exampleos.end-of-life "@t 1445385600"</command>.
                 </para></listitem>
             </varlistentry>
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3322,7 +3322,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (pull_data->gpg_verify_summary && bytes_summary && bytes_sig)
       {
-        glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+        g_autoptr(OstreeGpgVerifyResult) result = NULL;
 
         result = ostree_repo_verify_summary (self, pull_data->remote_name,
                                              bytes_summary, bytes_sig,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3343,6 +3343,20 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         pull_data->summary_data = g_bytes_ref (bytes_summary);
         pull_data->summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT, bytes_summary, FALSE);
 
+        if (!g_variant_is_normal_form (pull_data->summary))
+          {
+            g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                 "Not normal form");
+            goto out;
+          }
+        if (!g_variant_is_of_type (pull_data->summary, OSTREE_SUMMARY_GVARIANT_FORMAT))
+          {
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "Doesn't match variant type '%s'",
+                         (char *)OSTREE_SUMMARY_GVARIANT_FORMAT);
+            goto out;
+          }
+
         if (bytes_sig)
           pull_data->summary_data_sig = g_bytes_ref (bytes_sig);
       }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3322,18 +3322,11 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (pull_data->gpg_verify_summary && bytes_summary && bytes_sig)
       {
-        g_autoptr(GVariant) sig_variant = NULL;
         glnx_unref_object OstreeGpgVerifyResult *result = NULL;
 
-        sig_variant = g_variant_new_from_bytes (OSTREE_SUMMARY_SIG_GVARIANT_FORMAT, bytes_sig, FALSE);
-        result = _ostree_repo_gpg_verify_with_metadata (self,
-                                                        bytes_summary,
-                                                        sig_variant,
-                                                        pull_data->remote_name,
-                                                        NULL,
-                                                        NULL,
-                                                        cancellable,
-                                                        error);
+        result = ostree_repo_verify_summary (self, pull_data->remote_name,
+                                             bytes_summary, bytes_sig,
+                                             cancellable, error);
         if (!ostree_gpg_verify_result_require_valid_signature (result, error))
           goto out;
       }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3320,28 +3320,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         goto out;
       }
 
-    if (bytes_summary)
-      {
-        pull_data->summary_data = g_bytes_ref (bytes_summary);
-        pull_data->summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT, bytes_summary, FALSE);
-
-        if (bytes_sig)
-          pull_data->summary_data_sig = g_bytes_ref (bytes_sig);
-      }
-
-
-    if (!summary_from_cache && bytes_summary && bytes_sig)
-      {
-        if (!pull_data->remote_repo_local &&
-            !_ostree_repo_cache_summary (self,
-                                         remote_name_or_baseurl,
-                                         bytes_summary,
-                                         bytes_sig,
-                                         cancellable,
-                                         error))
-          goto out;
-      }
-
     if (pull_data->gpg_verify_summary && bytes_summary && bytes_sig)
       {
         g_autoptr(GVariant) sig_variant = NULL;
@@ -3357,6 +3335,27 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                                         cancellable,
                                                         error);
         if (!ostree_gpg_verify_result_require_valid_signature (result, error))
+          goto out;
+      }
+
+    if (bytes_summary)
+      {
+        pull_data->summary_data = g_bytes_ref (bytes_summary);
+        pull_data->summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT, bytes_summary, FALSE);
+
+        if (bytes_sig)
+          pull_data->summary_data_sig = g_bytes_ref (bytes_sig);
+      }
+
+    if (!summary_from_cache && bytes_summary && bytes_sig)
+      {
+        if (!pull_data->remote_repo_local &&
+            !_ostree_repo_cache_summary (self,
+                                         remote_name_or_baseurl,
+                                         bytes_summary,
+                                         bytes_sig,
+                                         cancellable,
+                                         error))
           goto out;
       }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4064,7 +4064,7 @@ ostree_repo_sign_delta (OstreeRepo     *self,
  * @cancellable: A #GCancellable
  * @error: a #GError
  *
- * Add a GPG signature to a static delta.
+ * Add a GPG signature to a summary file.
  */
 gboolean
 ostree_repo_add_gpg_signature_summary (OstreeRepo     *self,

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -50,51 +50,48 @@ argv_to_additional_metadata (int      *argc,
 {
   g_autoptr(GVariantBuilder) builder = NULL;
   int i;
+  char **args = *argv;
 
   builder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
 
   for (i = 1; i < *argc; i++)
     {
-      const gchar *equals = strchr ((*argv)[i], '=');
+      const gchar *equals = strchr (args[i], '=');
       g_autofree gchar *key = NULL;
       const gchar *value_str;
       g_autoptr(GVariant) value = NULL;
 
       if (equals != NULL)
         {
-          key = g_strndup ((*argv)[i], equals - (*argv)[i]);
+          key = g_strndup (args[i], equals - args[i]);
           value_str = equals + 1;
         }
       else
         {
-          key = g_strdup ((*argv)[i]);
+          key = g_strdup (args[i]);
 
           if (i + 1 >= *argc)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Invalid additional metadata list: not an even number of arguments");
-              return NULL;
-            }
+            return glnx_null_throw (error,
+                                    "Invalid additional metadata list: not an even number of arguments");
 
-          value_str = (*argv)[i + 1];
+          value_str = args[i + 1];
           i++;
         }
 
       value = g_variant_parse (NULL, value_str, NULL, NULL, error);
       if (value == NULL)
-        {
-          g_prefix_error (error, "Error parsing variant ‘%s’: ", value_str);
-          return NULL;
-        }
+        return glnx_prefix_error_null (error, "Error parsing variant ‘%s’: ", value_str);
 
       g_variant_builder_add (builder, "{sv}", key, value);
     }
 
   /* Update the argument list. */
   for (; i > 1; i--)
-    (*argv)[i] = NULL;
+    args[i] = NULL;
 
-  return g_variant_builder_end (builder);
+  *argv = args;
+
+  return g_variant_ref_sink (g_variant_builder_end (builder));
 }
 
 gboolean

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -84,13 +84,13 @@ if ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-sum
     assert_not_reached "GPG summary verification with no summary unexpectedly succeeded"
 fi
 
-${OSTREE} summary -u update
+${OSTREE} summary --update
 
 if ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-summary repo test2 2>&1; then
     assert_not_reached "GPG summary verification with signed no summary unexpectedly succeeded"
 fi
 
-${OSTREE} summary -u update --gpg-sign=${TEST_GPG_KEYID_1} --gpg-homedir=${TEST_GPG_KEYHOME}
+${OSTREE} summary --update --gpg-sign=${TEST_GPG_KEYID_1} --gpg-homedir=${TEST_GPG_KEYHOME}
 
 ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-summary repo test2 2>&1
 

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -46,9 +46,9 @@ ${CMD_PREFIX} ostree --repo=repo summary --update
 ${CMD_PREFIX} ostree --repo=repo summary --update --gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}
 
 # Try various ways of adding additional data.
-${CMD_PREFIX} ostree --repo=repo summary --update key="'value'" key2 true
-${CMD_PREFIX} ostree --repo=repo summary --update some-int '@t 123'
-${CMD_PREFIX} ostree --repo=repo summary --update map='@a{sv} {}'
+${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata key="'value'" --add-metadata=key2=true
+${CMD_PREFIX} ostree --repo=repo summary --update -m some-int='@t 123'
+${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata=map='@a{sv} {}'
 
 # Check the additional metadata turns up in the output.
 ${CMD_PREFIX} ostree --repo=repo summary --view > summary
@@ -83,9 +83,9 @@ ${CMD_PREFIX} ostree --repo=repo summary --update
 ${CMD_PREFIX} ostree --repo=repo summary --update --gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}
 
 # Try various ways of adding additional data.
-${CMD_PREFIX} ostree --repo=repo summary --update key="'value'" key2 true
-${CMD_PREFIX} ostree --repo=repo summary --update some-int '@t 123'
-${CMD_PREFIX} ostree --repo=repo summary --update map='@a{sv} {}'
+${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata key="'value'" --add-metadata=key2=true
+${CMD_PREFIX} ostree --repo=repo summary --update -m some-int='@t 123'
+${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata=map='@a{sv} {}'
 
 # Check the additional metadata turns up in the output.
 ${CMD_PREFIX} ostree --repo=repo summary --view > summary

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Authors:
+#  - Philip Withnall <withnall@endlessm.com>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..1"
+
+cd ${test_tmpdir}
+mkdir repo
+ostree_repo_init repo --collection-id org.example.Collection1
+
+mkdir -p tree/root
+touch tree/root/a
+
+# Add a few commits
+seq 5 | while read i; do
+    echo a >> tree/root/a
+    ${CMD_PREFIX} ostree --repo=repo commit --branch=test-$i -m test -s test tree
+    ${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collection2:test-$i test-$i
+done
+
+# Generate a plain summary file.
+${CMD_PREFIX} ostree --repo=repo summary --update
+
+# Generate a signed summary file.
+${CMD_PREFIX} ostree --repo=repo summary --update --gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}
+
+# Try various ways of adding additional data.
+${CMD_PREFIX} ostree --repo=repo summary --update key="'value'" key2 true
+${CMD_PREFIX} ostree --repo=repo summary --update some-int '@t 123'
+${CMD_PREFIX} ostree --repo=repo summary --update map='@a{sv} {}'
+
+# Check the additional metadata turns up in the output.
+${CMD_PREFIX} ostree --repo=repo summary --view > summary
+assert_file_has_content summary "^map: {}$"
+
+echo "ok 1 update summary"


### PR DESCRIPTION
Various cleanups to the `summary.sig` code paths, split out from #946. These should be suitable to apply to master without needing discussion about the design.