### PR TITLE
 lib/ref: Suppress more collection ref methods from introspection

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -15,6 +15,8 @@ env:
     # Enable all the sanitizers for this primary build.
     # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
     CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2 -Werror=maybe-uninitialized'
+    # Only for CI with a known g-ir-scanner
+    GI_SCANNERFLAGS: '--warn-error'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
     # TODO when we're doing leak checks: G_SLICE: "always-malloc"
 

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -256,7 +256,7 @@ OSTree_1_0_gir_EXPORT_PACKAGES = ostree-1
 OSTree_1_0_gir_INCLUDES = Gio-2.0
 OSTree_1_0_gir_CFLAGS = $(libostree_1_la_CFLAGS)
 OSTree_1_0_gir_LIBS = libostree-1.la
-OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree
+OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree $(GI_SCANNERFLAGS)
 OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h %/ostree-repo-finder.h %/ostree-repo-finder-avahi.h %/ostree-repo-finder-config.h %/ostree-repo-finder-mount.h,$(libostree_1_la_SOURCES))
 INTROSPECTION_GIRS += OSTree-1.0.gir
 gir_DATA += OSTree-1.0.gir

--- a/src/libostree/ostree-ref.h
+++ b/src/libostree/ostree-ref.h
@@ -52,7 +52,6 @@ typedef struct
 #ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 GType ostree_collection_ref_get_type (void);
-#endif
 
 _OSTREE_PUBLIC
 OstreeCollectionRef *ostree_collection_ref_new (const gchar *collection_id,
@@ -61,6 +60,7 @@ _OSTREE_PUBLIC
 OstreeCollectionRef *ostree_collection_ref_dup (const OstreeCollectionRef *ref);
 _OSTREE_PUBLIC
 void ostree_collection_ref_free (OstreeCollectionRef *ref);
+#endif
 
 _OSTREE_PUBLIC
 guint ostree_collection_ref_hash (gconstpointer ref);


### PR DESCRIPTION

This squashes some warnings.