### PR TITLE
build: Don't scan ostree-remote.h for introspection if !experimental-api

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -150,8 +150,7 @@ libostree_1_la_SOURCES += \
 	src/libostree/ostree-tls-cert-interaction.h \
 	$(NULL)
 endif
-if !ENABLE_EXPERIMENTAL_API
-libostree_1_la_SOURCES += \
+libostree_experimental_headers = \
 	src/libostree/ostree-ref.h \
 	src/libostree/ostree-remote.h \
 	src/libostree/ostree-repo-finder.h \
@@ -159,6 +158,8 @@ libostree_1_la_SOURCES += \
 	src/libostree/ostree-repo-finder-config.h \
 	src/libostree/ostree-repo-finder-mount.h \
 	$(NULL)
+if !ENABLE_EXPERIMENTAL_API
+libostree_1_la_SOURCES += $(libostree_experimental_headers)
 else # if ENABLE_EXPERIMENTAL_API
 libostree_1_la_SOURCES += \
 	src/libostree/ostree-bloom.c \
@@ -257,7 +258,7 @@ OSTree_1_0_gir_INCLUDES = Gio-2.0
 OSTree_1_0_gir_CFLAGS = $(libostree_1_la_CFLAGS)
 OSTree_1_0_gir_LIBS = libostree-1.la
 OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree $(GI_SCANNERFLAGS)
-OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h %/ostree-repo-finder.h %/ostree-repo-finder-avahi.h %/ostree-repo-finder-config.h %/ostree-repo-finder-mount.h,$(libostree_1_la_SOURCES))
+OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h $(libostree_experimental_headers),$(libostree_1_la_SOURCES))
 INTROSPECTION_GIRS += OSTree-1.0.gir
 gir_DATA += OSTree-1.0.gir
 typelib_DATA += OSTree-1.0.typelib


### PR DESCRIPTION
It's a bit unfortunate that the scanner doesn't error on this, but
anyways

Closes: https://github.com/ostreedev/ostree/issues/966