### PR TITLE
papr: build and test on c7

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -31,18 +31,22 @@ artifacts:
   - test-suite.log
 ---
 
-context: c7-build
+context: c7-primary
 inherit: true
 required: true
 
-container:
-  image: registry.centos.org/centos/centos:7
+packages:
+
+host:
+  distro: centos/7/atomic
 
 env:
     CFLAGS: ''
 
 tests:
-  - ci/build-check.sh
+  - docker run --privileged -v $PWD:$PWD --workdir $PWD
+    registry.centos.org/centos/centos:7 sh -c
+    'yum install -y git && ci/build-check.sh'
 
 ---
 

--- a/tests/test-switchroot.sh
+++ b/tests/test-switchroot.sh
@@ -127,6 +127,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	. $(dirname $0)/libtest.sh
 	unshare -m true || \
 	    skip "this test needs to set up mount namespaces, rerun as root"
+	[ -f /bin/busybox ] || \
+	    skip "this test needs busybox"
 
 	echo "1..3"
 	test_that_prepare_root_sets_sysroot_up_correctly_with_initrd


### PR DESCRIPTION
Start testing on CentOS 7 as well to cover kernel differences (e.g.
`O_TMPFILE` support).