### PR TITLE
codebase: start using GLNX_HASH_TABLE_FOREACH macros

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -14,7 +14,7 @@ packages:
 env:
     # Enable all the sanitizers for this primary build.
     # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
-    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2 -Werror=maybe-uninitialized'
+    CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
     # Only for CI with a known g-ir-scanner
     GI_SCANNERFLAGS: '--warn-error'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -20,6 +20,5 @@ if test -x /usr/bin/clang; then
     # job than gcc for vars with cleanups; perhaps in the future these could
     # parallelize
     export CC=clang
-    export CFLAGS='-Werror=unused-variable'
     build
 fi

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -16,8 +16,9 @@ fi
 
 if test -x /usr/bin/clang; then
     git clean -dfx && git submodule foreach git clean -dfx
-    # And now a clang build to find unused variables; perhaps
-    # in the future these could parallelize
+    # And now a clang build to find unused variables because it does a better
+    # job than gcc for vars with cleanups; perhaps in the future these could
+    # parallelize
     export CC=clang
     export CFLAGS='-Werror=unused-variable'
     build

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -12,6 +12,9 @@ pkg_install sudo which attr fuse \
     elfutils
 pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang
 
+# always fail on warnings; https://github.com/ostreedev/ostree/pull/971
+export CFLAGS="-Werror ${CFLAGS:-}"
+
 DETECTED_CONFIGOPTS=
 if test -x /usr/bin/gnome-desktop-testing-runner; then
     DETECTED_CONFIGOPTS="${DETECTED_CONFIGOPTS} --enable-installed-tests=exclusive"

--- a/src/libostree/ostree-bootconfig-parser.c
+++ b/src/libostree/ostree-bootconfig-parser.c
@@ -48,15 +48,11 @@ OstreeBootconfigParser *
 ostree_bootconfig_parser_clone (OstreeBootconfigParser *self)
 {
   OstreeBootconfigParser *parser = ostree_bootconfig_parser_new ();
-  guint i;
-  GHashTableIter hashiter;
-  gpointer k, v;
 
-  for (i = 0; i < self->lines->len; i++)
+  for (guint i = 0; i < self->lines->len; i++)
     g_ptr_array_add (parser->lines, g_variant_ref (self->lines->pdata[i]));
 
-  g_hash_table_iter_init (&hashiter, self->options);
-  while (g_hash_table_iter_next (&hashiter, &k, &v))
+  GLNX_HASH_TABLE_FOREACH_KV (self->options, const char*, k, const char*, v)
     g_hash_table_replace (parser->options, g_strdup (k), g_strdup (v));
 
   return parser;
@@ -183,14 +179,11 @@ ostree_bootconfig_parser_write_at (OstreeBootconfigParser   *self,
         }
     }
 
-  GHashTableIter hashiter;
-  gpointer hashkey, hashvalue;
-  g_hash_table_iter_init (&hashiter, self->options);
-  while (g_hash_table_iter_next (&hashiter, &hashkey, &hashvalue))
+  GLNX_HASH_TABLE_FOREACH_KV (self->options, const char*, k, const char*, v)
     {
-      if (g_hash_table_lookup (written_overrides, hashkey))
+      if (g_hash_table_lookup (written_overrides, k))
         continue;
-      write_key (self, buf, hashkey, hashvalue);
+      write_key (self, buf, k, v);
     }
 
   if (!glnx_file_replace_contents_at (dfd, path, (guint8*)buf->str, buf->len,

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -690,9 +690,6 @@ static void
 adopt_steal_mainctx (OstreeFetcher *self,
                      GMainContext *mainctx)
 {
-  GHashTableIter hiter;
-  gpointer key, value;
-
   g_assert (self->mainctx == NULL);
   self->mainctx = mainctx; /* Transfer */
 
@@ -706,12 +703,8 @@ adopt_steal_mainctx (OstreeFetcher *self,
       update_timeout_cb (self->multi, timeout_micros / 1000, self);
     }
 
-  g_hash_table_iter_init (&hiter, self->sockets);
-  while (g_hash_table_iter_next (&hiter, &key, &value))
-    {
-      SockInfo *fdp = key;
-      setsock (fdp, fdp->sockfd, fdp->action, self);
-    }
+  GLNX_HASH_TABLE_FOREACH (self->sockets, SockInfo*, fdp)
+    setsock (fdp, fdp->sockfd, fdp->action, self);
 }
 
 static void

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1323,24 +1323,18 @@ _ostree_fetcher_request_to_membuf_finish (OstreeFetcher *self,
 guint64
 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self)
 {
-  GHashTableIter hiter;
-  gpointer key, value;
-  guint64 ret;
-
   g_return_val_if_fail (OSTREE_IS_FETCHER (self), 0);
 
   g_mutex_lock (&self->thread_closure->output_stream_set_lock);
 
-  ret = self->thread_closure->total_downloaded;
+  guint64 ret = self->thread_closure->total_downloaded;
 
-  g_hash_table_iter_init (&hiter, self->thread_closure->output_stream_set);
-  while (g_hash_table_iter_next (&hiter, &key, &value))
+  GLNX_HASH_TABLE_FOREACH (self->thread_closure->output_stream_set,
+                           GFileOutputStream*, stream)
     {
-      GFileOutputStream *stream = key;
-      struct stat stbuf;
-      
       if (G_IS_FILE_DESCRIPTOR_BASED (stream))
         {
+          struct stat stbuf;
           if (glnx_stream_fstat ((GFileDescriptorBased*)stream, &stbuf, NULL))
             ret += stbuf.st_size;
         }

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -114,9 +114,6 @@ ostree_mutable_tree_set_contents_checksum (OstreeMutableTree *self,
 const char *
 ostree_mutable_tree_get_contents_checksum (OstreeMutableTree *self)
 {
-  GHashTableIter iter;
-  gpointer key, value;
-
   if (!self->contents_checksum)
     return NULL;
 
@@ -127,10 +124,8 @@ ostree_mutable_tree_get_contents_checksum (OstreeMutableTree *self)
    *
    * However, we only call this function once right now.
    */
-  g_hash_table_iter_init (&iter, self->subdirs);
-  while (g_hash_table_iter_next (&iter, &key, &value))
+  GLNX_HASH_TABLE_FOREACH_V (self->subdirs, OstreeMutableTree*, subdir)
     {
-      OstreeMutableTree *subdir = value;
       if (!ostree_mutable_tree_get_contents_checksum (subdir))
         {
           g_free (self->contents_checksum);

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1088,13 +1088,12 @@ ostree_repo_checkout_gc (OstreeRepo        *self,
   self->updated_uncompressed_dirs = g_hash_table_new (NULL, NULL);
   g_mutex_unlock (&self->cache_lock);
 
-  GHashTableIter iter;
-  gpointer key, value;
-  if (to_clean_dirs)
-    g_hash_table_iter_init (&iter, to_clean_dirs);
-  while (to_clean_dirs && g_hash_table_iter_next (&iter, &key, &value))
+  if (!to_clean_dirs)
+    return TRUE; /* Note early return */
+
+  GLNX_HASH_TABLE_FOREACH (to_clean_dirs, guint, prefix)
     {
-      g_autofree char *objdir_name = g_strdup_printf ("%02x", GPOINTER_TO_UINT (key));
+      g_autofree char *objdir_name = g_strdup_printf ("%02x", prefix);
       g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
 
       if (!glnx_dirfd_iterator_init_at (self->uncompressed_objects_dir_fd, objdir_name, FALSE,

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -773,14 +773,11 @@ aic_import_deferred_hardlinks (OstreeRepoArchiveImportContext *ctx,
                                GCancellable  *cancellable,
                                GError       **error)
 {
-  GHashTableIter iter;
-  gpointer key, value;
-
-  g_hash_table_iter_init (&iter, ctx->deferred_hardlinks);
-  while (g_hash_table_iter_next (&iter, &key, &value))
-    if (!aic_import_deferred_hardlinks_for (ctx, key, value, error))
-      return FALSE;
-
+  GLNX_HASH_TABLE_FOREACH_KV (ctx->deferred_hardlinks, const char*, target, GSList*, links)
+    {
+      if (!aic_import_deferred_hardlinks_for (ctx, target, links, error))
+        return FALSE;
+    }
   return TRUE;
 }
 


### PR DESCRIPTION
Use the new macros introduced recently in libglnx to make iterating over
hash tables cleaner. This is just a start, it does not migrate the whole
tree.

Update submodule: libglnx

Requires: https://github.com/GNOME/libglnx/pull/58