### PR TITLE
collection ref in commit metadata

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -122,6 +122,7 @@ _installed_or_uninstalled_test_scripts += \
 	tests/test-refs-collections.sh \
 	tests/test-remote-add-collections.sh \
 	tests/test-summary-collections.sh \
+	tests/test-pull-collections.sh \
 	$(NULL)
 endif
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -56,6 +56,10 @@ G_BEGIN_DECLS
  * in a summary file. */
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
 
+/* Well-known keys for the commit metadata */
+#define OSTREE_REF_BINDING "ostree.ref-binding"
+#define OSTREE_COLLECTION_BINDING "ostree.collection-binding"
+
 typedef enum {
   OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0)
 } OstreeRepoTestErrorFlags;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1369,6 +1369,141 @@ commitstate_is_partial (OtPullData   *pull_data,
     || (commitstate & OSTREE_REPO_COMMIT_STATE_PARTIAL) > 0;
 }
 
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+/* Reads the collection-id of a given remote from the repo
+ * configuration.
+ */
+static char *
+get_real_remote_repo_collection_id (OstreeRepo  *repo,
+                                    const gchar *remote_name)
+{
+  g_autofree gchar *remote_collection_id = NULL;
+  if (!ostree_repo_get_remote_option (repo, remote_name, "collection-id", NULL,
+                                      &remote_collection_id, NULL) ||
+      (remote_collection_id == NULL) ||
+      (remote_collection_id[0] == '\0'))
+    return NULL;
+
+  return g_steal_pointer (&remote_collection_id);
+}
+
+/* Reads the collection-id of the remote repo. Where it will be read
+ * from depends on whether we pull from the "local" remote repo (the
+ * "file://" URL) or "remote" remote repo (likely the "http(s)://"
+ * URL).
+ */
+static char *
+get_remote_repo_collection_id (OtPullData *pull_data)
+{
+  if (pull_data->remote_repo_local != NULL)
+    {
+      const char *remote_collection_id =
+        ostree_repo_get_collection_id (pull_data->remote_repo_local);
+      if ((remote_collection_id == NULL) ||
+          (remote_collection_id[0] == '\0'))
+        return NULL;
+      return g_strdup (remote_collection_id);
+    }
+
+  return get_real_remote_repo_collection_id (pull_data->repo,
+                                             pull_data->remote_name);
+}
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
+
+/* Verify the ref and collection bindings.
+ *
+ * The ref binding is verified only if it exists. But if we have the
+ * collection ID specified in the remote configuration then the ref
+ * binding must exist, otherwise the verification will fail. Parts of
+ * the verification can be skipped by passing NULL to requested_ref or
+ * checksum parameters.
+ *
+ * The collection binding is verified only when we have collection ID
+ * specified in the remote configuration. If it is specified, then the
+ * binding must exist and must be equal to the remote repository
+ * collection ID.
+ */
+static gboolean
+verify_bindings (OtPullData                 *pull_data,
+                 GVariant                   *commit,
+                 const OstreeCollectionRef  *requested_ref,
+                 GError                    **error)
+{
+  g_autofree char *remote_collection_id = NULL;
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+  remote_collection_id = get_remote_repo_collection_id (pull_data);
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
+  g_autoptr(GVariant) metadata = g_variant_get_child_value (commit, 0);
+  g_autofree const char **refs = NULL;
+  if (!g_variant_lookup (metadata,
+                         OSTREE_REF_BINDING,
+                         "^a&s",
+                         &refs))
+    {
+      /* Early return here - if the remote collection ID is NULL, then
+       * we certainly will verify the collection binding in the
+       * commit.
+       */
+      if (remote_collection_id == NULL)
+        return TRUE;
+
+      return glnx_throw (error,
+                         "expected commit metadata to have ref "
+                         "binding information, found none");
+    }
+
+  if (requested_ref != NULL)
+    {
+      if (!g_strv_contains ((const char *const *) refs, requested_ref->ref_name))
+        {
+          g_autoptr(GString) refs_dump = g_string_new (NULL);
+          const char *refs_str;
+
+          if (refs != NULL && (*refs) != NULL)
+            {
+              for (const char **iter = refs; *iter != NULL; ++iter)
+                {
+                  const char *ref = *iter;
+
+                  if (refs_dump->len > 0)
+                    g_string_append (refs_dump, ", ");
+                  g_string_append_printf (refs_dump, "‘%s’", ref);
+                }
+
+              refs_str = refs_dump->str;
+            }
+          else
+            {
+              refs_str = "no refs";
+            }
+
+          return glnx_throw (error, "commit has no requested ref ‘%s’ "
+                             "in ref binding metadata (%s)",
+                             requested_ref->ref_name, refs_str);
+        }
+    }
+
+  if (remote_collection_id != NULL)
+    {
+      const char *collection_id;
+      if (!g_variant_lookup (metadata,
+                             OSTREE_COLLECTION_BINDING,
+                             "&s",
+                             &collection_id))
+        return glnx_throw (error,
+                           "expected commit metadata to have collection ID "
+                           "binding information, found none");
+      if (!g_str_equal (collection_id, remote_collection_id))
+        return glnx_throw (error,
+                           "commit has collection ID ‘%s’ in collection binding "
+                           "metadata, while the remote it came from has "
+                           "collection ID ‘%s’",
+                           collection_id, remote_collection_id);
+    }
+
+  return TRUE;
+}
+
 static gboolean
 scan_commit_object (OtPullData                 *pull_data,
                     const char                 *checksum,
@@ -1417,6 +1552,15 @@ scan_commit_object (OtPullData                 *pull_data,
 
   if (!ostree_repo_load_commit (pull_data->repo, checksum, &commit, &commitstate, error))
     goto out;
+
+  /* If ref is non-NULL then the commit we fetched was requested through the
+   * branch, otherwise we requested a commit checksum without specifying a branch.
+   */
+  if (!verify_bindings (pull_data, commit, ref, error))
+    {
+      g_prefix_error (error, "Commit %s: ", checksum);
+      goto out;
+    }
 
   /* If we found a legacy transaction flag, assume all commits are partial */
   is_partial = commitstate_is_partial (pull_data, commitstate);
@@ -5124,9 +5268,8 @@ check_remote_matches_collection_id (OstreeRepo  *repo,
 {
   g_autofree gchar *remote_collection_id = NULL;
 
-  if (!ostree_repo_get_remote_option (repo, remote_name, "collection-id", NULL,
-                                      &remote_collection_id, NULL) ||
-      remote_collection_id == NULL)
+  remote_collection_id = get_real_remote_repo_collection_id (repo, remote_name);
+  if (remote_collection_id == NULL)
     return FALSE;
 
   return g_str_equal (remote_collection_id, collection_id);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1415,8 +1415,9 @@ get_remote_repo_collection_id (OtPullData *pull_data)
  * The ref binding is verified only if it exists. But if we have the
  * collection ID specified in the remote configuration then the ref
  * binding must exist, otherwise the verification will fail. Parts of
- * the verification can be skipped by passing NULL to requested_ref or
- * checksum parameters.
+ * the verification can be skipped by passing NULL to the requested_ref
+ * parameter (in case we requested a checksum directly, without looking it up
+ * from a ref).
  *
  * The collection binding is verified only when we have collection ID
  * specified in the remote configuration. If it is specified, then the
@@ -1441,7 +1442,7 @@ verify_bindings (OtPullData                 *pull_data,
                          &refs))
     {
       /* Early return here - if the remote collection ID is NULL, then
-       * we certainly will verify the collection binding in the
+       * we certainly will not verify the collection binding in the
        * commit.
        */
       if (remote_collection_id == NULL)

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -171,8 +171,10 @@ assert_streq $($OSTREE log test2-no-parent |grep '^commit' | wc -l) "1"
 echo "ok commit no parent"
 
 cd ${test_tmpdir}
-empty_rev=$($OSTREE commit ${COMMIT_ARGS} -b test2-no-subject -s '' --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
-omitted_rev=$($OSTREE commit ${COMMIT_ARGS} -b test2-no-subject-2 --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
+# Do the --bind-ref=<the other test branch>, so we store both branches sorted
+# in metadata and thus the checksums remain the same.
+empty_rev=$($OSTREE commit ${COMMIT_ARGS} -b test2-no-subject --bind-ref=test2-no-subject-2 -s '' --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
+omitted_rev=$($OSTREE commit ${COMMIT_ARGS} -b test2-no-subject-2 --bind-ref=test2-no-subject --timestamp="2005-10-29 12:43:29 +0000" $test_tmpdir/checkout-test2-4)
 assert_streq $empty_rev $omitted_rev
 echo "ok commit no subject"
 

--- a/tests/test-pull-collections.sh
+++ b/tests/test-pull-collections.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo '1..6'
+
+cd ${test_tmpdir}
+
+do_commit() {
+    local repo=$1
+    local branch=$2
+    shift 2
+
+    mkdir -p files
+    pushd files
+    ${CMD_PREFIX} ostree --repo="../${repo}" commit -s "Test ${repo} commit for branch ${branch}" -b "${branch}" --gpg-homedir="${TEST_GPG_KEYHOME}" --gpg-sign="${TEST_GPG_KEYID_1}" "$@" > "../${branch}-checksum"
+    popd
+}
+
+do_summary() {
+    local repo=$1
+    shift 1
+
+    ${CMD_PREFIX} ostree "--repo=${repo}" summary --update --gpg-homedir="${TEST_GPG_KEYHOME}" --gpg-sign="${TEST_GPG_KEYID_1}"
+}
+
+do_collection_ref_show() {
+    local repo=$1
+    local branch=$2
+    shift 2
+
+    echo -n "collection ID: "
+    if ${CMD_PREFIX} ostree "--repo=${repo}" show --print-metadata-key=ostree.collection-binding $(cat "${branch}-checksum")
+    then :
+    else return 1
+    fi
+    echo -n "refs: "
+    if ${CMD_PREFIX} ostree "--repo=${repo}" show --print-metadata-key=ostree.ref-binding $(cat "${branch}-checksum")
+    then return 0
+    else return 1
+    fi
+}
+
+ensure_no_collection_ref() {
+    local repo=$1
+    local branch=$2
+    local error=$3
+    shift 3
+
+    if do_collection_ref_show "${repo}" "${branch}" >/dev/null
+    then
+	assert_not_reached "${error}"
+    fi
+}
+
+do_join() {
+    local IFS=', '
+    echo "$*"
+}
+
+ensure_collection_ref() {
+    local repo=$1
+    local branch=$2
+    local collection_id=$3
+    shift 3
+    local refs=$(do_join "$@")
+
+    do_collection_ref_show "${repo}" "${branch}" >"${branch}-meta"
+    assert_file_has_content "${branch}-meta" "^collection ID: '${collection_id}'$"
+    assert_file_has_content "${branch}-meta" "^refs: \['${refs}'\]$"
+}
+
+do_remote_add() {
+    local repo=$1
+    local remote_repo=$2
+    shift 2
+
+    ${CMD_PREFIX} ostree "--repo=${repo}" remote add "${remote_repo}-remote" "file://$(pwd)/${remote_repo}" "$@" --gpg-import="${test_tmpdir}/gpghome/key1.asc"
+}
+
+do_pull() {
+    local repo=$1
+    local remote_repo=$2
+    local branch=$3
+    shift 3
+
+    if ${CMD_PREFIX} ostree "--repo=${repo}" pull "${remote_repo}-remote" "${branch}"
+    then return 0
+    else return 1
+    fi
+}
+
+do_local_pull() {
+    local repo=$1
+    local remote_repo=$2
+    local branch=$3
+    shift 3
+
+    if ${CMD_PREFIX} ostree "--repo=${repo}" pull-local "${remote_repo}" "${branch}"
+    then return 0
+    else return 1
+    fi
+}
+
+# Create a repo without the collection ID.
+mkdir no-collection-repo
+ostree_repo_init no-collection-repo
+do_commit no-collection-repo goodncref1
+do_commit no-collection-repo sortofbadncref1 --add-metadata-string=ostree.collection-binding=org.example.Ignored
+do_summary no-collection-repo
+ensure_no_collection_ref \
+    no-collection-repo \
+    goodncref1 \
+    "commits in repository without collection ID shouldn't normally contain the ostree.commit.collection metadata information"
+ensure_collection_ref no-collection-repo sortofbadncref1 'org.example.Ignored' 'sortofbadncref1'
+
+echo "ok 1 setup remote repo without collection ID"
+
+# Create a repo with a collection ID.
+mkdir collection-repo
+ostree_repo_init collection-repo
+do_commit collection-repo badcref1 # has no collection ref
+# We set the repo collection ID in this hacky way to get the commit
+# without the collection ID.
+echo "collection-id=org.example.CollectionRepo" >>collection-repo/config
+do_commit collection-repo badcref2 --add-metadata-string=ostree.collection-binding=org.example.Whatever
+do_commit collection-repo badcref3 --add-metadata-string=ostree.collection-binding=
+do_commit collection-repo goodcref1
+# create a badcref4 ref with a commit that has goodcref1 in its collection ref metadata
+${CMD_PREFIX} ostree --repo=collection-repo refs --create=badcref4 $(cat goodcref1-checksum)
+do_summary collection-repo
+ensure_no_collection_ref \
+    collection-repo \
+    badcref1 \
+    "commit in badcref1 should not have the collection ref metadata information"
+ensure_collection_ref collection-repo badcref2 'org.example.Whatever' 'badcref2'
+ensure_collection_ref collection-repo badcref3 '' 'badcref3'
+ensure_collection_ref collection-repo goodcref1 'org.example.CollectionRepo' 'goodcref1'
+
+echo "ok 2 setup remote repo with collection ID"
+
+# Create a local repo without the collection ID.
+mkdir no-collection-local-repo
+ostree_repo_init no-collection-local-repo
+do_commit no-collection-local-repo goodnclref1
+do_commit no-collection-local-repo sortofbadnclref1 --add-metadata-string=ostree.collection-binding=org.example.IgnoredLocal
+do_summary no-collection-local-repo
+ensure_no_collection_ref \
+    no-collection-local-repo \
+    goodnclref1 \
+    "commits in repository without collection ID shouldn't normally contain the ostree.commit.collection metadata information"
+ensure_collection_ref no-collection-local-repo sortofbadnclref1 'org.example.IgnoredLocal' 'sortofbadnclref1'
+
+echo "ok 3 setup local repo without collection ID"
+
+# Create a local repo with a collection ID.
+mkdir collection-local-repo
+ostree_repo_init collection-local-repo
+do_commit collection-local-repo badclref1 # has no collection ref
+# We set the repo collection ID in this hacky way to get the commit
+# without the collection ID.
+echo "collection-id=org.example.CollectionRepoLocal" >>collection-local-repo/config
+do_commit collection-local-repo badclref2 --add-metadata-string=ostree.collection-binding=org.example.WhateverLocal
+do_commit collection-local-repo badclref3 --add-metadata-string=ostree.collection-binding=
+do_commit collection-local-repo goodclref1
+# create a badclref4 ref with a commit that has goodclref1 in its collection ref metadata
+${CMD_PREFIX} ostree --repo=collection-local-repo refs --create=badclref4 $(cat goodclref1-checksum)
+do_summary collection-local-repo
+ensure_no_collection_ref \
+    collection-local-repo \
+    badclref1 \
+    "commit in badclref1 should not have the collection ref metadata information"
+ensure_collection_ref collection-local-repo badclref2 'org.example.WhateverLocal' 'badclref2'
+ensure_collection_ref collection-local-repo badclref3 '' 'badclref3'
+ensure_collection_ref collection-local-repo goodclref1 'org.example.CollectionRepoLocal' 'goodclref1'
+
+echo "ok 4 setup local repo with collection ID"
+
+# Create a local repository where we pull the branches from the remotes as normal, using GPG.
+mkdir local
+ostree_repo_init local
+do_remote_add local collection-repo --collection-id org.example.CollectionRepo
+do_remote_add local no-collection-repo
+
+do_pull local no-collection-repo goodncref1
+do_pull local no-collection-repo sortofbadncref1
+if do_pull local collection-repo badcref1
+then
+    assert_not_reached "pulling a commit without collection ID from a repo with collection ID should fail"
+fi
+if do_pull local collection-repo badcref2
+then
+    assert_not_reached "pulling a commit with a mismatched collection ID from a repo with collection ID should fail"
+fi
+if do_pull local collection-repo badcref3
+then
+    assert_not_reached "pulling a commit with empty collection ID from repo with collection ID should fail"
+fi
+do_pull local collection-repo goodcref1
+if do_pull local collection-repo badcref4
+then
+    assert_not_reached "pulling a commit that was not requested from repo with collection ID should fail"
+fi
+
+echo "ok 5 pull refs from remote repos"
+
+do_local_pull local no-collection-local-repo goodnclref1
+do_local_pull local no-collection-local-repo sortofbadnclref1
+if do_local_pull local collection-local-repo badclref1
+then
+    assert_not_reached "pulling a commit without collection ID from a repo with collection ID should fail"
+fi
+if do_local_pull local collection-local-repo badclref2
+then
+    assert_not_reached "pulling a commit with a mismatched collection ID from a repo with collection ID should fail"
+fi
+if do_local_pull local collection-local-repo badclref3
+then
+    assert_not_reached "pulling a commit with empty collection ID from repo with collection ID should fail"
+fi
+do_local_pull local collection-local-repo goodclref1
+if do_local_pull local collection-local-repo badclref4
+then
+    assert_not_reached "pulling a commit that was not requested from repo with collection ID should fail"
+fi
+
+echo "ok 6 pull refs from local repos"


### PR DESCRIPTION
This is related to #946. This implements adding collection ref information to commit metadata and verification of it during pulls. Includes tests.