### PR TITLE
lib: Add a helper to convert struct stat → GFileInfo

### DIFF
--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ostree-core.h"
+#include <sys/stat.h>
 
 G_BEGIN_DECLS
 
@@ -88,7 +89,8 @@ _ostree_make_temporary_symlink_at (int             tmp_dirfd,
                                    GCancellable   *cancellable,
                                    GError        **error);
 
-GFileInfo * _ostree_header_gfile_info_new (mode_t mode, uid_t uid, gid_t gid);
+GFileInfo * _ostree_stbuf_to_gfileinfo (const struct stat *stbuf);
+GFileInfo * _ostree_mode_uidgid_to_gfileinfo (mode_t mode, uid_t uid, gid_t gid);
 
 static inline void
 _ostree_checksum_inplace_from_bytes_v (GVariant *csum_v, char *buf)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2759,7 +2759,7 @@ write_dfd_iter_to_mtree_internal (OstreeRepo                  *self,
   if (fstat (src_dfd_iter->fd, &dir_stbuf) != 0)
     return glnx_throw_errno (error);
 
-  child_info = _ostree_header_gfile_info_new (dir_stbuf.st_mode, dir_stbuf.st_uid, dir_stbuf.st_gid);
+  child_info = _ostree_stbuf_to_gfileinfo (&dir_stbuf);
 
   if (modifier != NULL)
     {
@@ -2820,13 +2820,11 @@ write_dfd_iter_to_mtree_internal (OstreeRepo                  *self,
           continue;
         }
 
-      child_info = _ostree_header_gfile_info_new (stbuf.st_mode, stbuf.st_uid, stbuf.st_gid);
+      child_info = _ostree_stbuf_to_gfileinfo (&stbuf);
       g_file_info_set_name (child_info, dent->d_name);
 
       if (S_ISREG (stbuf.st_mode))
-        {
-          g_file_info_set_size (child_info, stbuf.st_size);
-        }
+        ;
       else if (S_ISLNK (stbuf.st_mode))
         {
           if (!ot_readlinkat_gfile_info (src_dfd_iter->fd, dent->d_name,

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -515,18 +515,15 @@ dispatch_bspatch (OstreeRepo                 *repo,
 static gboolean
 handle_untrusted_content_checksum (OstreeRepo                 *repo,
                                    StaticDeltaExecutionState  *state,
-                                   GCancellable               *cancellable,  
+                                   GCancellable               *cancellable,
                                    GError                    **error)
 {
-  g_autoptr(GVariant) header = NULL;
-  g_autoptr(GFileInfo) finfo = NULL;
-  gsize bytes_written;
-
-  finfo = _ostree_header_gfile_info_new (state->mode, state->uid, state->gid);
-  header = _ostree_file_header_new (finfo, state->xattrs);
+  g_autoptr(GFileInfo) finfo = _ostree_mode_uidgid_to_gfileinfo (state->mode, state->uid, state->gid);
+  g_autoptr(GVariant) header = _ostree_file_header_new (finfo, state->xattrs);
 
   state->content_checksum = g_checksum_new (G_CHECKSUM_SHA256);
 
+  gsize bytes_written;
   if (!_ostree_write_variant_with_size (NULL, header, 0, &bytes_written, state->content_checksum,
                                         cancellable, error))
     return FALSE;
@@ -629,9 +626,8 @@ dispatch_open_splice_and_close (OstreeRepo                 *repo,
       else
         {
           /* Slower path, for symlinks and unpacking deltas into archive-z2 */
-          g_autoptr(GFileInfo) finfo = NULL;
-      
-          finfo = _ostree_header_gfile_info_new (state->mode, state->uid, state->gid);
+          g_autoptr(GFileInfo) finfo =
+            _ostree_mode_uidgid_to_gfileinfo (state->mode, state->uid, state->gid);
 
           if (S_ISLNK (state->mode))
             {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2791,18 +2791,14 @@ ostree_repo_load_file (OstreeRepo         *self,
         }
       if (out_file_info)
         {
-          *out_file_info = _ostree_header_gfile_info_new (stbuf.st_mode, stbuf.st_uid, stbuf.st_gid);
-          if (S_ISREG (stbuf.st_mode))
-            {
-              g_file_info_set_size (*out_file_info, stbuf.st_size);
-            }
-          else if (S_ISLNK (stbuf.st_mode))
+          *out_file_info = _ostree_stbuf_to_gfileinfo (&stbuf);
+          if (S_ISLNK (stbuf.st_mode))
             {
               g_file_info_set_size (*out_file_info, 0);
               g_file_info_set_symlink_target (*out_file_info, symlink_target);
             }
           else
-            g_assert_not_reached ();
+            g_assert (S_ISREG (stbuf.st_mode));
         }
 
       ot_transfer_out_value (out_xattrs, &ret_xattrs);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2793,10 +2793,7 @@ ostree_repo_load_file (OstreeRepo         *self,
         {
           *out_file_info = _ostree_stbuf_to_gfileinfo (&stbuf);
           if (S_ISLNK (stbuf.st_mode))
-            {
-              g_file_info_set_size (*out_file_info, 0);
-              g_file_info_set_symlink_target (*out_file_info, symlink_target);
-            }
+            g_file_info_set_symlink_target (*out_file_info, symlink_target);
           else
             g_assert (S_ISREG (stbuf.st_mode));
         }

--- a/src/libotutil/ot-gio-utils.c
+++ b/src/libotutil/ot-gio-utils.c
@@ -35,22 +35,6 @@
 #define O_BINARY 0
 #endif
 
-GFileType
-ot_gfile_type_for_mode (guint32 mode)
-{
-  if (S_ISDIR (mode))
-    return G_FILE_TYPE_DIRECTORY;
-  else if (S_ISREG (mode))
-    return G_FILE_TYPE_REGULAR;
-  else if (S_ISLNK (mode))
-    return G_FILE_TYPE_SYMBOLIC_LINK;
-  else if (S_ISBLK (mode) || S_ISCHR(mode) || S_ISFIFO(mode))
-    return G_FILE_TYPE_SPECIAL;
-  else
-    return G_FILE_TYPE_UNKNOWN;
-}
-
-
 GFile *
 ot_gfile_resolve_path_printf (GFile       *path,
                               const char  *format,

--- a/src/libotutil/ot-gio-utils.h
+++ b/src/libotutil/ot-gio-utils.h
@@ -33,8 +33,6 @@ G_BEGIN_DECLS
 #define OSTREE_GIO_FAST_QUERYINFO ("standard::name,standard::type,standard::size,standard::is-symlink,standard::symlink-target," \
                                    "unix::device,unix::inode,unix::mode,unix::uid,unix::gid,unix::rdev")
 
-GFileType ot_gfile_type_for_mode (guint32 mode);
-
 GFile * ot_gfile_resolve_path_printf (GFile       *path,
                                       const char  *format,
                                       ...) G_GNUC_PRINTF(2, 3);


### PR DESCRIPTION
It's more natural for a few calling places. Prep for patches to go the other
way, which in turn are prep for adding a commit filter v2 that takes `struct
stat`.

`ot_gfile_type_for_mode()` was only used in this function, so inline it here.