### PR TITLE
tests: Fix assert_files_hardlinked

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -123,9 +123,7 @@ files_are_hardlinked() {
 }
 
 assert_files_hardlinked() {
-    f1=$(stat -c %i $1)
-    f2=$(stat -c %i $2)
-    if ! files_are_hardlinked "$f1" "$f2"; then
+    if ! files_are_hardlinked "$1" "$2"; then
         fatal "Files '$1' and '$2' are not hardlinked"
     fi
 }


### PR DESCRIPTION
It was always succeeding because we were trying to stat the inode number, and
failing, and thus getting the empty string for both, which compared as true.

Regression from:
<https://github.com/ostreedev/ostree/commit/74e3581e>

Noticed this while working on
<https://github.com/ostreedev/ostree/pull/974>
and looking at the test results.