### PR TITLE
cmdline/pull: Print final status even if noninteractive

### DIFF
--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -39,8 +39,10 @@ echo "1..25"
 
 # Try both syntaxes
 repo_init --no-gpg-verify
-${CMD_PREFIX} ostree --repo=repo pull origin main
-${CMD_PREFIX} ostree --repo=repo pull origin:main
+${CMD_PREFIX} ostree --repo=repo pull origin main >out.txt
+assert_file_has_content out.txt "[1-9][0-9]* metadata, [1-9][0-9]* content objects fetched"
+${CMD_PREFIX} ostree --repo=repo pull origin:main > out.txt
+assert_not_file_has_content out.txt "content objects fetched"
 ${CMD_PREFIX} ostree --repo=repo fsck
 echo "ok pull"
 


### PR DESCRIPTION
Previously, `ostree pull` was silent if not on a tty.  I don't
see a reason not to print the final status line at least.  This
is prep for more work in the test suite, so I can write assertions
on the output.

But it should also be nicer for people who e.g. do an `ostree pull` in a Jenkins
job or whatever.