### PR TITLE
lib/repo: Fix repo-finder deleting remote configs when run

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -181,7 +181,7 @@ _ostree_repo_add_remote (OstreeRepo   *self,
 
   g_mutex_lock (&self->remotes_lock);
 
-  already_existed = g_hash_table_replace (self->remotes, remote->name, ostree_remote_ref (remote));
+  already_existed = !g_hash_table_replace (self->remotes, remote->name, ostree_remote_ref (remote));
 
   g_mutex_unlock (&self->remotes_lock);
 


### PR DESCRIPTION
An inverted condition in _ostree_repo_add_remote() was causing the
OstreeRepoFinder to delete precisely the wrong remote
configurations from memory once it was finished. It’s supposed to delete
the ones which it transiently added; but was instead deleting all the
existing remote configurations.

Signed-off-by: Philip Withnall <withnall@endlessm.com>