### PR TITLE
lib/commit: Fix a tmpfile fd leak in static delta processing

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -156,8 +156,12 @@ _ostree_repo_commit_tmpf_final (OstreeRepo        *self,
                                             cancellable, error))
     return FALSE;
 
-  return glnx_link_tmpfile_at (tmpf, GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST,
-                               dest_dfd, tmpbuf, error);
+  if (!glnx_link_tmpfile_at (tmpf, GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST,
+                             dest_dfd, tmpbuf, error))
+    return FALSE;
+  /* We're done with the fd */
+  glnx_tmpfile_clear (tmpf);
+  return TRUE;
 }
 
 /* Given a dfd+path combination (may be regular file or symlink),


### PR DESCRIPTION
I had thought `glnx_link_tmpfile_at()` actually consumed the tmpfile;
it does consume the *path* but not the fd.  In the non-delta path
things were fine since we used the autocleanup.

But the delta code had a tmpfile allocated in its struct that got reused, and
hence leaked the fd. Fix this by making the commit API actually consume the
tmpfile fully, just like the path path.