### PR TITLE
 lib/repo: Add min-free-space-percent option, default 3%

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -190,6 +190,14 @@ Boston, MA 02111-1307, USA.
         <term><varname>unconfigured-state</varname></term>
         <listitem><para>If set, pulls from this remote will fail with the configured text.  This is intended for OS vendors which have a subscription process to access content.</para></listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>min-free-space-percent</varname></term>
+        <listitem><para>Integer percentage value (0-99) that specifies a minimum
+        percentage of total space (in blocks) in the underlying filesystem to
+        keep free. The default value is 3.</para></listitem>
+      </varlistentry>
+
     </variablelist>
 
   </refsect1>

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <sys/statvfs.h>
 #include "ostree-ref.h"
 #include "ostree-repo.h"
 #include "ostree-remote-private.h"
@@ -102,6 +103,9 @@ struct OstreeRepo {
   GHashTable *txn_collection_refs;  /* (element-type OstreeCollectionRef utf8) */
   GMutex txn_stats_lock;
   OstreeRepoTransactionStats txn_stats;
+  /* Implementation of min-free-space-percent */
+  gulong txn_blocksize;
+  fsblkcnt_t max_txn_blocks;
 
   GMutex cache_lock;
   guint dirmeta_cache_refcount;
@@ -123,6 +127,7 @@ struct OstreeRepo {
   uid_t owner_uid;
   uid_t target_owner_uid;
   gid_t target_owner_gid;
+  guint min_free_space_percent;
 
   guint test_error_flags; /* OstreeRepoTestErrorFlags */
 

--- a/tests/installed/itest-pull-space.sh
+++ b/tests/installed/itest-pull-space.sh
@@ -16,8 +16,7 @@ mkfs.xfs ${blkdev}
 mkdir mnt
 mount ${blkdev} mnt
 ostree --repo=mnt/repo init --mode=bare-user
-host_nonremoteref=$(echo ${host_refspec} | sed 's,[^:]*:,,')
-if ostree --repo=mnt/repo pull-local /ostree/repo ${host_nonremoteref} 2>err.txt; then
+if ostree --repo=mnt/repo pull-local /ostree/repo ${host_commit} 2>err.txt; then
     fatal "succeeded in doing a pull with no free space"
 fi
 assert_file_has_content err.txt "min-free-space-percent"

--- a/tests/installed/itest-pull-space.sh
+++ b/tests/installed/itest-pull-space.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test min-free-space-percent using loopback devices
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+test_tmpdir=$(prepare_tmpdir)
+trap _tmpdir_cleanup EXIT
+
+cd ${test_tmpdir}
+truncate -s 100MB testblk.img
+blkdev=$(losetup --find --show $(pwd)/testblk.img)
+mkfs.xfs ${blkdev}
+mkdir mnt
+mount ${blkdev} mnt
+ostree --repo=mnt/repo init --mode=bare-user
+host_nonremoteref=$(echo ${host_refspec} | sed 's,[^:]*:,,')
+if ostree --repo=mnt/repo pull-local /ostree/repo ${host_nonremoteref} 2>err.txt; then
+    fatal "succeeded in doing a pull with no free space"
+fi
+assert_file_has_content err.txt "min-free-space-percent"
+umount mnt
+losetup -d ${blkdev}


### PR DESCRIPTION
For ostree-as-host, we're the superuser, so we'll blow past
any reserved free space by default.  While deltas have size
metadata, if one happens to do a loose fetch, we can fill
up the disk.

Another case is flatpak: the system helper has similar concerns
here as ostree-as-host, and for `flatpak --user`, we also
want to be nice and avoid filling up the user's quota.

Closes: ostreedev#962