### PR TITLE
 lib/commit: Ensure bare-user objects are always user-readable

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -253,13 +253,15 @@ commit_loose_regfile_object (OstreeRepo        *self,
       /* Note that previously this path added `| 0755` which made every
        * file executable, see
        * https://github.com/ostreedev/ostree/issues/907
+       * We then changed it to mask by 0775, but we always need at least read
+       * permission when running as non-root, so explicitly mask that in.
        *
        * Again here, symlinks in bare-user are a hairy special case; only do a
        * chmod for a *real* regular file, otherwise we'll take the default 0644.
        */
       if (S_ISREG (mode))
         {
-          const mode_t content_mode = (mode & (S_IFREG | 0775));
+          const mode_t content_mode = (mode & (S_IFREG | 0775)) | S_IRUSR;
           if (fchmod (tmpf->fd, content_mode) < 0)
             return glnx_throw_errno_prefix (error, "fchmod");
         }

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -342,8 +342,11 @@ cd ${test_tmpdir}
 cat > test-statoverride.txt <<EOF
 +1048 /a/nested/2
 2048 /a/nested/3
+=384 /a/readable-only
 EOF
 cd ${test_tmpdir}/checkout-test2-4
+echo readable only > a/readable-only
+chmod 664 a/readable-only
 $OSTREE commit ${COMMIT_ARGS} -b test2-override -s "with statoverride" --statoverride=../test-statoverride.txt
 cd ${test_tmpdir}
 $OSTREE checkout test2-override checkout-test2-override
@@ -354,6 +357,7 @@ else
     test '!' -g checkout-test2-override/a/nested/2
     test '!' -u checkout-test2-override/a/nested/3
 fi
+assert_file_has_mode checkout-test2-override/a/readable-only 600
 echo "ok commit statoverride"
 
 cd ${test_tmpdir}

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -25,7 +25,7 @@ skip_without_user_xattrs
 
 setup_test_repository "bare-user"
 
-extra_basic_tests=3
+extra_basic_tests=4
 . $(dirname $0)/basic-test.sh
 
 # Reset things so we don't inherit a lot of state from earlier tests
@@ -64,3 +64,16 @@ $OSTREE checkout -U -H test2-unwritable test2-checkout
 cd test2-checkout
 assert_file_has_mode unwritable 400
 echo "ok bare-user unwritable"
+
+rm test2-checkout -rf
+$OSTREE checkout -U -H test2 test2-checkout
+cat > statoverride.txt <<EOF
+=0 /unreadable
+EOF
+touch test2-checkout/unreadable
+$OSTREE commit -b test2-unreadable --statoverride=statoverride.txt --tree=dir=test2-checkout
+$OSTREE fsck
+rm test2-checkout -rf
+$OSTREE checkout -U -H test2-unreadable test2-checkout
+assert_file_has_mode test2-checkout/unreadable 400
+echo "ok bare-user handled unreadable file"


### PR DESCRIPTION

Some of the Jenkins jobs for Fedora Atomic Host broke after updating
to 2017.7, and it turns out that we regressed handling unreadable
files in `bare-user` mode.  An example of this is `/etc/shadow`, which
ends up in the ostree-as-host content as `/usr/etc/shadow`.

Now there are better fixes here; we should probably delete it and create it
during the config merge if it doesn't exist.  In general, having secret files in
ostree really isn't supported, so it doesn't make sense to include them.

But let's fix this regression - when operating as an unprivileged user we don't
have `CAP_DAC_OVERRIDE` and hence will fail to open un-user-readable objects.

(We still preserve the actual `0` mode of course in the xattr and will
 apply it in `bare`)