### PR TITLE
pull: fix GLNX_HASH_TABLE_FOREACH_KV regression

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1091,9 +1091,9 @@ ostree_repo_checkout_gc (OstreeRepo        *self,
   if (!to_clean_dirs)
     return TRUE; /* Note early return */
 
-  GLNX_HASH_TABLE_FOREACH (to_clean_dirs, guint, prefix)
+  GLNX_HASH_TABLE_FOREACH (to_clean_dirs, gpointer, prefix)
     {
-      g_autofree char *objdir_name = g_strdup_printf ("%02x", prefix);
+      g_autofree char *objdir_name = g_strdup_printf ("%02x", GPOINTER_TO_UINT (prefix));
       g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
 
       if (!glnx_dirfd_iterator_init_at (self->uncompressed_objects_dir_fd, objdir_name, FALSE,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4948,8 +4948,10 @@ ostree_repo_pull_from_remotes_async (OstreeRepo                           *self,
 
   /* Any refs left un-downloaded? If so, we’ve failed. */
   GLNX_HASH_TABLE_FOREACH_KV (refs_pulled, const OstreeCollectionRef*, ref,
-                                           gboolean, is_pulled)
+                                           gpointer, is_pulled_pointer)
     {
+      gboolean is_pulled = GPOINTER_TO_INT (is_pulled_pointer);
+
       if (is_pulled)
         continue;
 


### PR DESCRIPTION
This is a regression from #971. We were stuffing a pointer size inside a
variable of integer size. So the assignment was spilling over into other
variables' storage space. Actually use a gpointer and `GPOINTER_TO_INT` as
was done originally.