### PR TITLE
lib/repo: Immediately error creating bare-user repo on tmpfs

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -217,6 +217,14 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
                                GError             **error);
 
 gboolean
+_ostree_write_bareuser_metadata (int fd,
+                                 guint32       uid,
+                                 guint32       gid,
+                                 guint32       mode,
+                                 GVariant     *xattrs,
+                                 GError       **error);
+
+gboolean
 _ostree_repo_write_directory_meta (OstreeRepo   *self,
                                    GFileInfo    *file_info,
                                    GVariant     *xattrs,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1752,6 +1752,21 @@ ostree_repo_create (OstreeRepo     *self,
         }
     }
 
+  /* Test that the fs supports user xattrs now, so we get an error early rather
+   * than during an object write later.
+   */
+  if (mode == OSTREE_REPO_MODE_BARE_USER)
+    {
+      g_auto(GLnxTmpfile) tmpf = { 0, };
+
+      if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR|O_CLOEXEC, &tmpf, error))
+        return FALSE;
+      if (fchmod (tmpf.fd, 0600) < 0)
+        return glnx_throw_errno_prefix (error, "fchmod");
+      if (!_ostree_write_bareuser_metadata (tmpf.fd, 0, 0, 644, NULL, error))
+        return FALSE;
+  }
+
   if (!ostree_repo_open (self, cancellable, error))
     return FALSE;
 

--- a/tests/installed/itest-bareuser-nouserxattrs.sh
+++ b/tests/installed/itest-bareuser-nouserxattrs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Test that initializing a bare-user repo on tmpfs fails
+# Maybe at some point this will be fixed in the kernel
+# but I doubt it'll be soon
+# https://www.spinics.net/lists/linux-mm/msg109775.html
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+test_tmpdir=$(prepare_tmpdir)
+trap _tmpdir_cleanup EXIT
+cd ${test_tmpdir}
+
+mkdir mnt
+mount -t tmpfs tmpfs mnt
+if ostree --repo=mnt/repo init --mode=bare-user 2>err.txt; then
+    assert_not_reached "bare-user on tmpfs worked?"
+fi
+assert_file_has_content err.txt "Operation not supported"
+umount mnt

--- a/tests/installed/itest-bareuser-nouserxattrs.sh
+++ b/tests/installed/itest-bareuser-nouserxattrs.sh
@@ -17,7 +17,8 @@ cd ${test_tmpdir}
 mkdir mnt
 mount -t tmpfs tmpfs mnt
 if ostree --repo=mnt/repo init --mode=bare-user 2>err.txt; then
+    umount mnt
     assert_not_reached "bare-user on tmpfs worked?"
 fi
-assert_file_has_content err.txt "Operation not supported"
 umount mnt
+assert_file_has_content err.txt "Operation not supported"


### PR DESCRIPTION
And in general, if for some reason we can't write `user.` xattrs, provide an
error immediately rather than doing it during a later pull. This way the failure
cause is a lot more obvious.

Related: https://github.com/ostreedev/ostree/issues/991