### PR TITLE
tests: Run pull tests for bare/bare-user

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -67,7 +67,8 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-help.sh \
 	tests/test-libarchive.sh \
 	tests/test-parent.sh \
-	tests/test-pull-archive.sh \
+	tests/test-pull-bare.sh \
+	tests/test-pull-bareuser.sh \
 	tests/test-pull-commit-only.sh \
 	tests/test-pull-depth.sh \
 	tests/test-pull-mirror-summary.sh \

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -23,7 +23,7 @@ function repo_init() {
     cd ${test_tmpdir}
     rm repo -rf
     mkdir repo
-    ostree_repo_init repo
+    ostree_repo_init repo --mode=${repo_mode}
     ${CMD_PREFIX} ostree --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo "$@"
 }
 

--- a/tests/test-pull-bare.sh
+++ b/tests/test-pull-bare.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive"
+
+repo_mode=bare
+. ${test_srcdir}/pull-test.sh

--- a/tests/test-pull-bareuser.sh
+++ b/tests/test-pull-bareuser.sh
@@ -23,4 +23,5 @@ set -euo pipefail
 
 setup_fake_remote_repo1 "archive"
 
+repo_mode=bare-user
 . ${test_srcdir}/pull-test.sh


### PR DESCRIPTION
We have variants of `test-basic` for all 4 modes, but not for pull-test, which
for some reason was named `pull-archive`, but mostly pulls *into* bare repos.
The test code was structured like the basic one where it called into a
`pull-test.sh`, so let's actually use it for 2/3 bare modes. (I tried to extend
it to `bare-user-only` but it failed, going to look at that after this).

This is related to https://github.com/ostreedev/ostree/issues/991