### PR TITLE
build: Ensure all .sym files are distributed in tarballs

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -187,7 +187,11 @@ symbol_files += $(top_srcdir)/src/libostree/libostree-experimental.sym
 endif
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=
-EXTRA_DIST += $(symbol_files)
+EXTRA_DIST += \
+	$(top_srcdir)/src/libostree/libostree-devel.sym \
+	$(top_srcdir)/src/libostree/libostree-experimental.sym \
+	$(top_srcdir)/src/libostree/libostree-released.sym \
+	$(NULL)
 
 libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree -I$(builddir)/src/libostree \
 	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_OPENSSL_CFLAGS) \


### PR DESCRIPTION
Since we’re using a custom variable for listing the .sym files,
automake’s magic support for automatically distributing all files in
conditionals doesn’t work, and the devel and experimental .sym files
were only being distributed if `make dist` was run on a source tree
which had been configured with --enable-experimental-api or not a
release flag.

Fix that by explicitly listing all the .sym files in EXTRA_DIST.

Specifically, this fixes the case of trying to compile with
--enable-experimental-api from a release tarball which was disted with
--disable-experimental-api.

Signed-off-by: Philip Withnall <withnall@endlessm.com>