### PR TITLE
build: Ensure all experimental tests are distributed in tarballs

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -114,8 +114,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-summary-view.sh \
 	$(NULL)
 
-if ENABLE_EXPERIMENTAL_API
-_installed_or_uninstalled_test_scripts += \
+experimental_test_scripts = \
 	tests/test-find-remotes.sh \
 	tests/test-fsck-collections.sh \
 	tests/test-init-collections.sh \
@@ -125,6 +124,11 @@ _installed_or_uninstalled_test_scripts += \
 	tests/test-summary-collections.sh \
 	tests/test-pull-collections.sh \
 	$(NULL)
+
+if ENABLE_EXPERIMENTAL_API
+_installed_or_uninstalled_test_scripts += $(experimental_test_scripts)
+else
+EXTRA_DIST += $(experimental_test_scripts)
 endif
 
 if BUILDOPT_FUSE


### PR DESCRIPTION
As with the previous commit, ensure that tests which are run when
configured with --enable-experimental-api, are always distributed; even
when running `make dist` from a source tree configured with
--disable-experimental-api.

Signed-off-by: Philip Withnall <withnall@endlessm.com>