### PR TITLE
Move the include directive to the enum template

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -57,7 +57,6 @@ src/libostree/ostree-enumtypes.h: src/libostree/ostree-enumtypes.h.template $(EN
 src/libostree/ostree-enumtypes.c: src/libostree/ostree-enumtypes.c.template $(ENUM_TYPES)
 	$(AM_V_GEN) $(GLIB_MKENUMS) \
 	--template $< \
-	--fhead "#include \"ostree-enumtypes.h\"" \
 	$(ENUM_TYPES) > $@.tmp && mv $@.tmp $@
 
 nodist_libostree_1_la_SOURCES = \

--- a/src/libostree/ostree-enumtypes.c.template
+++ b/src/libostree/ostree-enumtypes.c.template
@@ -23,6 +23,8 @@
 #endif
 #include <string.h>
 
+#include "ostree-enumtypes.h"
+
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/


### PR DESCRIPTION
There is no actual written guarantee in glib-mkenums that the template
line specified using --fhead will be added after the templates specified
inside the template file. Since the template file is only used once, we
can simply move the `#include` directive inside the template, so that it
is guaranteed to be in the right place.