### PR TITLE
 tests: More fixes for gjs tests

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -100,7 +100,7 @@ env:
     CONFIGOPTS: "--with-curl --with-openssl"
     # ASAN conflicts with introspection testing;
     # See https://github.com/ostreedev/ostree/issues/1014
-    INSTALLED_TESTS_PATTERN: "libostree/test-sizes.js libostree/test-sysroot.js libostree/test-core.js libostree/test-corrupt-repo-ref.js"
+    INSTALLED_TESTS_PATTERN: "libostree/test-sizes.js libostree/test-sysroot.js libostree/test-core.js"
 
 tests:
   - ci/build-check.sh

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -191,7 +191,7 @@ js_installed_tests = \
 	$(NULL)
 
 if BUILDOPT_GJS
-dist_installed_test_scripts = $(js_installed_tests)
+_installed_or_uninstalled_test_scripts += $(js_installed_tests)
 else
 EXTRA_DIST += $(js_installed_tests)
 endif

--- a/tests/test-core.js
+++ b/tests/test-core.js
@@ -25,6 +25,8 @@ function assertEquals(a, b) {
 	throw new Error("assertion failed " + JSON.stringify(a) + " == " + JSON.stringify(b));
 }
 
+print('1..1')
+
 let testDataDir = Gio.File.new_for_path('test-data');
 testDataDir.make_directory(null);
 testDataDir.get_child('some-file').replace_contents("hello world!", null, false, 0, null);
@@ -66,4 +68,4 @@ repo.commit_transaction(null, null);
 [,readCommit] = repo.resolve_rev('someref', true);
 assertEquals(readCommit, null);
 
-print("test-core complete");
+print("ok test-core");

--- a/tests/test-sizes.js
+++ b/tests/test-sizes.js
@@ -26,6 +26,8 @@ function assertEquals(a, b) {
 	throw new Error("assertion failed " + JSON.stringify(a) + " == " + JSON.stringify(b));
 }
 
+print('1..1')
+
 let testDataDir = Gio.File.new_for_path('test-data');
 testDataDir.make_directory(null);
 testDataDir.get_child('some-file').replace_contents("hello world!", null, false, 0, null);
@@ -79,4 +81,4 @@ if (expectedUncompressedSizes.length > 0) {
     throw new Error("Failed to match expectedUncompressedSizes: " + JSON.stringify(expectedUncompressedSizes));
 }
 
-print("test-sizes complete");
+print("ok test-sizes");

--- a/tests/test-sysroot.js
+++ b/tests/test-sysroot.js
@@ -33,10 +33,12 @@ function assertNotEquals(a, b) {
 
 function libtestExec(shellCode) {
     let testdatadir = GLib.getenv("G_TEST_SRCDIR");
-    let libtestPath = GLib.build_filenamev([testdatadir, 'libtest.sh'])
+    let libtestPath = GLib.build_filenamev([testdatadir, 'tests/libtest.sh'])
     let proc = Gio.Subprocess.new(['bash', '-c', 'set -xeuo pipefail; . ' + GLib.shell_quote(libtestPath) + '; ' + shellCode], 0);
     proc.wait_check(null);
 }
+
+print('1..1')
 
 libtestExec('setup_os_repository archive-z2 syslinux');
 
@@ -145,3 +147,5 @@ newDeployments = [deployment, newDeployment, thirdDeployment];
 sysroot.write_deployments(newDeployments, null);
 deployments = sysroot.get_deployments();
 assertEquals(deployments.length, 3);
+
+print("ok test-sysroot")


### PR DESCRIPTION

Previous to this commit, the gjs tests were installed-only; and our
logic for handling the "--enable-installed-tests=exclusive" logic
actually also meant they weren't installed.

It did work for me locally with `--enable-installed-tests`.

However, to make things fully symmetric, let's enable the js tests to also be
run under `make check`.

Also remove `corrupt-repo-ref.js` from the PAPR invocation since it's not
actually a unit test, it's a utility helper.