### PR TITLE
lib: Add #defines for current well-known metadata keys

### DIFF
--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -195,6 +195,28 @@ typedef enum {
   OSTREE_REPO_MODE_BARE_USER_ONLY,
 } OstreeRepoMode;
 
+/**
+ * OSTREE_COMMIT_META_KEY_VERSION:
+ *
+ * GVariant type `s`. This metadata key is used for version numbers. A freeform
+ * string; the intention is that systems using ostree do not interpret this
+ * semantically as traditional package managers do.
+ *
+ * This is the only ostree-defined metadata key that does not start with `ostree.`.
+ * Since: 2014.9
+ */
+#define OSTREE_COMMIT_META_KEY_VERSION "version"
+/**
+ * OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE:
+ *
+ * GVariant type `s`.  Should contain a refspec defining a new target branch;
+ * `ostree admin upgrade` and `OstreeSysrootUpgrader` will automatically initiate
+ * a rebase upon encountering this metadata key.
+ *
+ * Since: 2017.7
+ */
+#define OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE "ostree.endoflife-rebase"
+
 _OSTREE_PUBLIC
 const GVariantType *ostree_metadata_variant_type (OstreeObjectType objtype);
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1265,7 +1265,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
                                     &variant, NULL))
         {
           metadata = g_variant_get_child_value (variant, 0);
-          g_variant_lookup (metadata, "version", "s", &deployment_version);
+          g_variant_lookup (metadata, OSTREE_COMMIT_META_KEY_VERSION, "s", &deployment_version);
         }
     }
 
@@ -1292,7 +1292,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   ostree_bootconfig_parser_set (bootconfig, "title", title_key->str);
 
   g_autofree char *version_key = g_strdup_printf ("%d", n_deployments - ostree_deployment_get_index (deployment));
-  ostree_bootconfig_parser_set (bootconfig, "version", version_key);
+  ostree_bootconfig_parser_set (bootconfig, OSTREE_COMMIT_META_KEY_VERSION, version_key);
   g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", dest_kernel_name, NULL);
   ostree_bootconfig_parser_set (bootconfig, "linux", boot_relpath);
 

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -559,7 +559,7 @@ ostree_sysroot_upgrader_pull_one_dir (OstreeSysrootUpgrader  *self,
     return FALSE;
 
   g_variant_get_child (new_variant, 0, "@a{sv}", &new_metadata);
-  rebase = g_variant_lookup_value (new_metadata, "ostree.endoflife-rebase", G_VARIANT_TYPE_STRING);
+  rebase = g_variant_lookup_value (new_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, G_VARIANT_TYPE_STRING);
   if (rebase)
     {
       const char *new_ref = g_variant_get_string (rebase, 0);

--- a/src/ostree/ot-admin-functions.c
+++ b/src/ostree/ot-admin-functions.c
@@ -57,7 +57,7 @@ ot_admin_checksum_version (GVariant *checksum)
 
   metadata = g_variant_get_child_value (checksum, 0);
 
-  if (!g_variant_lookup (metadata, "version", "&s", &ret))
+  if (!g_variant_lookup (metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &ret))
     return NULL;
 
   return g_strdup (ret);


### PR DESCRIPTION
This came up in https://github.com/projectatomic/rpm-ostree/issues/142

Let's add `#define`s for our metadata keys, with documentation so
that, well, they're documented.