### PR TITLE
ci: Enable libcurl by default on Fedora

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -12,8 +12,6 @@ packages:
   - git
 
 env:
-    # At some point soon will encourage distros to use libcurl
-    CONFIGOPTS: "--with-curl --with-openssl"
     # Enable all the sanitizers for this primary build.
     # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
     CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
@@ -85,7 +83,7 @@ required: true
 context: f26-libsoup
 
 env:
-  CONFIGOPTS: "--without-curl --without-openssl"
+  CONFIGOPTS: "--without-curl --without-openssl --with-libsoup"
 
 tests:
   - ci/build-check.sh
@@ -98,7 +96,6 @@ required: true
 context: f26-introspection-tests
 
 env:
-    CONFIGOPTS: "--with-curl --with-openssl"
     # ASAN conflicts with introspection testing;
     # See https://github.com/ostreedev/ostree/issues/1014
     INSTALLED_TESTS_PATTERN: "libostree/test-sizes.js libostree/test-sysroot.js libostree/test-core.js"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,4 +21,11 @@ DETECTED_CONFIGOPTS=
 if test -x /usr/bin/gnome-desktop-testing-runner; then
     DETECTED_CONFIGOPTS="${DETECTED_CONFIGOPTS} --enable-installed-tests=exclusive"
 fi
+# Default libcurl on by default in fedora unless libsoup is enabled
+if sh -c '. /etc/os-release; test "${ID}" = fedora'; then
+    case ${CONFIGOPTS} in
+        *--with-soup*) ;;
+        *) CONFIGOPTS="${CONFIGOPTS} --with-curl"
+    esac
+fi
 build --enable-gtk-doc ${DETECTED_CONFIGOPTS} ${CONFIGOPTS:-}

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -23,7 +23,7 @@ if test -x /usr/bin/gnome-desktop-testing-runner; then
 fi
 # Default libcurl on by default in fedora unless libsoup is enabled
 if sh -c '. /etc/os-release; test "${ID}" = fedora'; then
-    case ${CONFIGOPTS} in
+    case "${CONFIGOPTS:-}" in
         *--with-soup*) ;;
         *) CONFIGOPTS="${CONFIGOPTS} --with-curl"
     esac

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,7 +25,7 @@ fi
 if sh -c '. /etc/os-release; test "${ID}" = fedora'; then
     case "${CONFIGOPTS:-}" in
         *--with-soup*) ;;
-        *) CONFIGOPTS="${CONFIGOPTS} --with-curl"
+        *) CONFIGOPTS="${CONFIGOPTS:-} --with-curl"
     esac
 fi
 build --enable-gtk-doc ${DETECTED_CONFIGOPTS} ${CONFIGOPTS:-}


### PR DESCRIPTION
The insttest fell over since its build used libsoup, but that just dropped out
of FAH.