### PR TITLE
lib: Port gpg verification for remotes to fd-relative

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -279,8 +279,8 @@ _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier  *self,
   self->keyrings = g_list_append (self->keyrings, g_object_ref (path));
 }
 
-/* Given @path which should contain a GPG keyring file, add it
- * to the list of trusted keys.
+/* Given @keyring which should be the contents of a GPG keyring file, add it to
+ * the list of trusted keys.
  */
 void
 _ostree_gpg_verifier_add_keyring_data (OstreeGpgVerifier  *self,

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -55,12 +55,20 @@ gboolean      _ostree_gpg_verifier_add_keyring_dir (OstreeGpgVerifier   *self,
                                                     GCancellable        *cancellable,
                                                     GError             **error);
 
+gboolean      _ostree_gpg_verifier_add_keyring_dir_at (OstreeGpgVerifier   *self,
+                                                       int                  dfd,
+                                                       const char          *path,
+                                                       GCancellable        *cancellable,
+                                                       GError             **error);
+
 gboolean      _ostree_gpg_verifier_add_global_keyring_dir (OstreeGpgVerifier  *self,
                                                            GCancellable       *cancellable,
                                                            GError            **error);
 
-void _ostree_gpg_verifier_add_keyring (OstreeGpgVerifier *self,
-                                       GFile             *path);
+void _ostree_gpg_verifier_add_keyring_data (OstreeGpgVerifier *self,
+                                            GBytes            *data);
+void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
+                                            GFile             *path);
 
 void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);


### PR DESCRIPTION
This was the last use of `repo->repodir` internally, and will help finally add
`ostree_repo_open_at()`.