### PR TITLE
gpg-verify-result: fix _lookup and _get to deal with subkeys

### DIFF
--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -334,7 +334,8 @@ ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
    * (OSTREE_GPG_SIGNATURE_ATTR_KEY_MISSING). */
   for (ii = 0; ii < n_attrs; ii++)
     {
-      if (attrs[ii] == OSTREE_GPG_SIGNATURE_ATTR_USER_NAME ||
+      if (attrs[ii] == OSTREE_GPG_SIGNATURE_ATTR_FINGERPRINT ||
+          attrs[ii] == OSTREE_GPG_SIGNATURE_ATTR_USER_NAME ||
           attrs[ii] == OSTREE_GPG_SIGNATURE_ATTR_USER_EMAIL)
         {
           (void) gpgme_get_key (result->context, signature->fpr, &key, 0);
@@ -378,7 +379,11 @@ ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
             break;
 
           case OSTREE_GPG_SIGNATURE_ATTR_FINGERPRINT:
-            child = g_variant_new_string (signature->fpr);
+            if (key != NULL && key->subkeys != NULL)
+              v_string = key->subkeys->fpr;
+            else
+              v_string = signature->fpr;
+            child = g_variant_new_string (v_string);
             break;
 
           case OSTREE_GPG_SIGNATURE_ATTR_TIMESTAMP:

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -237,7 +237,7 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result,
                                  const gchar *key_id,
                                  guint *out_signature_index)
 {
-  g_autofree char *key_id_upper = NULL;
+  gpgme_key_t lookup_key = NULL;
   gpgme_signature_t signature;
   guint signature_index;
   gboolean ret = FALSE;
@@ -245,24 +245,45 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result,
   g_return_val_if_fail (OSTREE_IS_GPG_VERIFY_RESULT (result), FALSE);
   g_return_val_if_fail (key_id != NULL, FALSE);
 
-  /* signature->fpr is always upper-case. */
-  key_id_upper = g_ascii_strup (key_id, -1);
+  /* fetch requested key_id from keyring to canonicalise ID */
+  (void) gpgme_get_key (result->context, key_id, &lookup_key, 0);
+
+  if (lookup_key == NULL)
+    {
+      g_debug ("Could not find key ID %s to lookup signature.", key_id);
+      return FALSE;
+    }
 
   for (signature = result->details->signatures, signature_index = 0;
        signature != NULL;
        signature = signature->next, signature_index++)
     {
-      if (signature->fpr == NULL)
-        continue;
+      gpgme_key_t signature_key = NULL;
 
-      if (g_str_has_suffix (signature->fpr, key_id_upper))
+      (void) gpgme_get_key (result->context, signature->fpr, &signature_key, 0);
+
+      if (signature_key == NULL)
+        {
+          g_debug ("Could not find key when looking up signature from %s.", signature->fpr);
+          continue;
+        }
+
+      /* the first subkey in the list is the primary key */
+      if (!g_strcmp0 (lookup_key->subkeys->fpr,
+                      signature_key->subkeys->fpr))
         {
           if (out_signature_index != NULL)
             *out_signature_index = signature_index;
           ret = TRUE;
-          break;
         }
+
+      gpgme_key_unref (signature_key);
+
+      if (ret)
+        break;
     }
+
+  gpgme_key_unref (lookup_key);
 
   return ret;
 }


### PR DESCRIPTION
Both of these functions assumed that signature->fpr would correspond to the normal user-provided / user-visible IDs of GPG keys. In the case of keys with signing subkeys, the signature fingerprint is not the normal one that people use to refer to the key, so use gpgme_get_key to canonicalise to the primary key ID when getting or looking up the GPG keys from signatures.

Has the side-effect of also making _lookup more permissive at what kind of key ID it will accept when looking up - anything that works with GPG will work with _lookup now, rather than inventing our own matching semantics with substrings.

https://github.com/ostreedev/ostree/issues/608