### PR TITLE
lib/curl: Only check individual request errors

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -425,11 +425,9 @@ static gboolean
 timer_cb (gpointer data)
 {
   OstreeFetcher *fetcher = data;
-  CURLMcode rc;
   GSource *orig_src = fetcher->timer_event;
 
-  rc = curl_multi_socket_action (fetcher->multi, CURL_SOCKET_TIMEOUT, 0, &fetcher->curl_running);
-  g_assert (rc == CURLM_OK);
+  (void)curl_multi_socket_action (fetcher->multi, CURL_SOCKET_TIMEOUT, 0, &fetcher->curl_running);
   check_multi_info (fetcher);
   if (fetcher->timer_event == orig_src)
     fetcher->timer_event = NULL;
@@ -460,15 +458,12 @@ static gboolean
 event_cb (int fd, GIOCondition condition, gpointer data)
 {
   OstreeFetcher *fetcher = data;
-  CURLMcode rc;
 
   int action =
     (condition & G_IO_IN ? CURL_CSELECT_IN : 0) |
     (condition & G_IO_OUT ? CURL_CSELECT_OUT : 0);
 
-  rc = curl_multi_socket_action (fetcher->multi, fd, action, &fetcher->curl_running);
-  g_assert (rc == CURLM_OK);
-
+  (void)curl_multi_socket_action (fetcher->multi, fd, action, &fetcher->curl_running);
   check_multi_info (fetcher);
   if (fetcher->curl_running > 0)
     {


### PR DESCRIPTION
It looks like `curl_multi_socket_action()` will return an error
if *one* of the requests has an error, but we already check
for that explicitly by iterating over each handle.

In libcurl, the "easy" layer doesn't really make use of this
return value.  I did a bit of looking elsewhere; systemd
does check it as a runtime error, not an assertion.  librepo
doesn't use the multi interface.

Closes: https://github.com/ostreedev/ostree/issues/1035