### PR TITLE
lib: Define and use an autoptr cleanup for gpgme_key_t

### DIFF
--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -28,6 +28,7 @@ G_BEGIN_DECLS
 
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_data_t, gpgme_data_release, NULL);
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_ctx_t, gpgme_release, NULL);
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_key_t, gpgme_key_unref, NULL)
 
 void ot_gpgme_error_to_gio_error (gpgme_error_t gpg_error, GError **error);
 


### PR DESCRIPTION
Followup for previous patch, allows porting a bit to new code style.