### PR TITLE
tree-wide: Use g_autoptr(Ostree*)

### DIFF
--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -48,6 +48,7 @@ struct _OstreeBootloaderInterface
                                                    GError       **error);
   gboolean             (* is_atomic)              (OstreeBootloader  *self);
 };
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeBootloader, g_object_unref)
 
 GType _ostree_bootloader_get_type (void) G_GNUC_CONST;
 

--- a/src/libostree/ostree-deployment.c
+++ b/src/libostree/ostree-deployment.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 
+#include "ostree.h"
 #include "ostree-deployment-private.h"
 #include "libglnx.h"
 
@@ -138,7 +139,7 @@ _ostree_deployment_set_bootcsum (OstreeDeployment *self,
 OstreeDeployment *
 ostree_deployment_clone (OstreeDeployment *self)
 {
-  glnx_unref_object OstreeBootconfigParser *new_bootconfig = NULL;
+  g_autoptr(OstreeBootconfigParser) new_bootconfig = NULL;
   OstreeDeployment *ret = ostree_deployment_new (self->index, self->osname, self->csum,
                                                  self->deployserial,
                                                  self->bootcsum, self->bootserial);

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -350,7 +350,7 @@ session_thread_set_tls_interaction_cb (ThreadClosure *thread_closure,
   const char *cert_and_key_path = data; /* str\0str\0 in one malloc buf */
   const char *cert_path = cert_and_key_path;
   const char *key_path = cert_and_key_path + strlen (cert_and_key_path) + 1;
-  glnx_unref_object OstreeTlsCertInteraction *interaction = NULL;
+  g_autoptr(OstreeTlsCertInteraction) interaction = NULL;
 
   /* The GTlsInteraction instance must be created in the
    * session thread so it uses the correct GMainContext. */

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -40,6 +40,7 @@ struct OstreeMetalinkClass
 {
   GObjectClass parent_class;
 };
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMetalink, g_object_unref)
 
 GType   _ostree_metalink_get_type (void) G_GNUC_CONST;
 

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -22,9 +22,8 @@
 
 #include "config.h"
 
-#include "ostree-mutable-tree.h"
+#include "ostree.h"
 #include "otutil.h"
-#include "ostree-core.h"
 
 /**
  * SECTION:ostree-mutable-tree
@@ -183,7 +182,7 @@ ostree_mutable_tree_ensure_dir (OstreeMutableTree *self,
                                 GError           **error)
 {
   gboolean ret = FALSE;
-  glnx_unref_object OstreeMutableTree *ret_dir = NULL;
+  g_autoptr(OstreeMutableTree) ret_dir = NULL;
 
   g_return_val_if_fail (name != NULL, FALSE);
 
@@ -219,7 +218,7 @@ ostree_mutable_tree_lookup (OstreeMutableTree   *self,
                             GError             **error)
 {
   gboolean ret = FALSE;
-  glnx_unref_object OstreeMutableTree *ret_subdir = NULL;
+  g_autoptr(OstreeMutableTree) ret_subdir = NULL;
   g_autofree char *ret_file_checksum = NULL;
   
   ret_subdir = ot_gobject_refz (g_hash_table_lookup (self->subdirs, name));
@@ -261,7 +260,7 @@ ostree_mutable_tree_ensure_parent_dirs (OstreeMutableTree  *self,
   gboolean ret = FALSE;
   int i;
   OstreeMutableTree *subdir = self; /* nofree */
-  glnx_unref_object OstreeMutableTree *ret_parent = NULL;
+  g_autoptr(OstreeMutableTree) ret_parent = NULL;
 
   g_assert (metadata_checksum != NULL);
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -27,16 +27,16 @@
 #include <gio/gfiledescriptorbased.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
-#include "otutil.h"
+#include <sys/xattr.h>
+#include <glib/gprintf.h>
 
+#include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
 #include "ostree-repo-file-enumerator.h"
 #include "ostree-checksum-input-stream.h"
-#include "ostree-mutable-tree.h"
 #include "ostree-varint.h"
-#include <sys/xattr.h>
-#include <glib/gprintf.h>
+#include "otutil.h"
 
 gboolean
 _ostree_repo_ensure_loose_objdir_at (int             dfd,
@@ -2555,7 +2555,7 @@ write_directory_content_to_mtree_internal (OstreeRepo                  *self,
 {
   g_autoptr(GFile) child = NULL;
   g_autoptr(GFileInfo) modified_info = NULL;
-  glnx_unref_object OstreeMutableTree *child_mtree = NULL;
+  g_autoptr(OstreeMutableTree) child_mtree = NULL;
   g_autofree char *child_relpath = NULL;
   const char *name;
   GFileType file_type;

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -22,10 +22,9 @@
 
 #include "config.h"
 
+#include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
-#include "ostree-repo-file.h"
-#include "ostree-mutable-tree.h"
 
 #ifdef HAVE_LIBARCHIVE
 #include <archive.h>
@@ -185,7 +184,7 @@ mtree_ensure_dir_with_meta (OstreeRepo          *repo,
                             GCancellable        *cancellable,
                             GError             **error)
 {
-  glnx_unref_object OstreeMutableTree *dir = NULL;
+  g_autoptr(OstreeMutableTree) dir = NULL;
   g_autofree guchar *csum_raw = NULL;
   g_autofree char *csum = NULL;
 
@@ -374,7 +373,7 @@ aic_create_parent_dirs (OstreeRepoArchiveImportContext *ctx,
                         GError             **error)
 {
   g_autofree char *fullpath = NULL;
-  glnx_unref_object OstreeMutableTree *dir = NULL;
+  g_autoptr(OstreeMutableTree) dir = NULL;
 
   /* start with the root itself */
   if (!aic_ensure_parent_dir (ctx, ctx->root, "/", &dir, cancellable, error))
@@ -643,7 +642,7 @@ aic_import_entry (OstreeRepoArchiveImportContext *ctx,
                   GError       **error)
 {
   g_autoptr(GFileInfo) fi = NULL;
-  glnx_unref_object OstreeMutableTree *parent = NULL;
+  g_autoptr(OstreeMutableTree) parent = NULL;
   g_autofree char *path = aic_get_final_entry_pathname (ctx, error);
 
   if (path == NULL)
@@ -669,7 +668,7 @@ aic_import_from_hardlink (OstreeRepoArchiveImportContext *ctx,
   const char *name = glnx_basename (target);
   const char *name_dh = glnx_basename (dh->path);
   g_autoptr(GPtrArray) components = NULL;
-  glnx_unref_object OstreeMutableTree *parent = NULL;
+  g_autoptr(OstreeMutableTree) parent = NULL;
 
   if (!ostree_mutable_tree_lookup (dh->parent, name_dh, &csum, NULL, error))
     return FALSE;
@@ -696,8 +695,8 @@ aic_lookup_file_csum (OstreeRepoArchiveImportContext *ctx,
 {
   g_autofree char *csum = NULL;
   const char *name = glnx_basename (target);
-  glnx_unref_object OstreeMutableTree *parent = NULL;
-  glnx_unref_object OstreeMutableTree *subdir = NULL;
+  g_autoptr(OstreeMutableTree) parent = NULL;
+  g_autoptr(OstreeMutableTree) subdir = NULL;
   g_autoptr(GPtrArray) components = NULL;
 
   if (!ot_util_path_split_validate (target, &components, error))

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1418,7 +1418,7 @@ gpg_verify_unwritten_commit (OtPullData         *pull_data,
 {
   if (pull_data->gpg_verify)
     {
-      glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+      g_autoptr(OstreeGpgVerifyResult) result = NULL;
       g_autoptr(GBytes) signed_data = g_variant_get_data_as_bytes (commit);
 
       if (!detached_metadata)
@@ -1624,7 +1624,7 @@ scan_commit_object (OtPullData                 *pull_data,
 
   if (pull_data->gpg_verify)
     {
-      glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+      g_autoptr(OstreeGpgVerifyResult) result = NULL;
 
       result = ostree_repo_verify_commit_for_remote (pull_data->repo,
                                                      checksum,
@@ -2748,7 +2748,7 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
 
   if (is_metalink)
     {
-      glnx_unref_object OstreeMetalink *metalink = NULL;
+      g_autoptr(OstreeMetalink) metalink = NULL;
       GError *local_error = NULL;
 
       /* the metalink uri is buried in the mirrorlist as the first (and only)
@@ -2898,7 +2898,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
                            GCancellable  *cancellable,
                            GError       **error)
 {
-  glnx_unref_object OstreeFetcher *fetcher = NULL;
+  g_autoptr(OstreeFetcher) fetcher = NULL;
   g_autoptr(GMainContext) mainctx = NULL;
   gboolean ret = FALSE;
   gboolean from_cache = FALSE;
@@ -3213,7 +3213,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_autoptr(GHashTable) requested_refs_to_fetch = NULL;  /* (element-type OstreeCollectionRef utf8) */
   g_autoptr(GHashTable) commits_to_fetch = NULL;
   g_autofree char *remote_mode_str = NULL;
-  glnx_unref_object OstreeMetalink *metalink = NULL;
+  g_autoptr(OstreeMetalink) metalink = NULL;
   OtPullData pull_data_real = { 0, };
   OtPullData *pull_data = &pull_data_real;
   GKeyFile *remote_config = NULL;
@@ -4960,7 +4960,7 @@ find_remotes_cb (GObject      *obj,
                                                                &error))
                 goto error;
 
-              glnx_unref_object OstreeGpgVerifyResult *verify_result = NULL;
+              g_autoptr(OstreeGpgVerifyResult) verify_result = NULL;
 
               verify_result = ostree_repo_verify_commit_for_remote (self,
                                                                     commit_metadata->checksum,
@@ -5608,7 +5608,7 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,
   /* Verify any summary signatures. */
   if (gpg_verify_summary && summary != NULL && signatures != NULL)
     {
-      glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+      g_autoptr(OstreeGpgVerifyResult) result = NULL;
 
       result = ostree_repo_verify_summary (self,
                                            name,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4082,7 +4082,7 @@ ostree_repo_sign_commit (OstreeRepo     *self,
    * check if the commit has already been signed with the given key ID.
    * We want to avoid storing duplicate signatures in the metadata. */
   g_autoptr(GError) local_error = NULL;
-  glnx_unref_object OstreeGpgVerifyResult *result
+  g_autoptr(OstreeGpgVerifyResult) result
     =_ostree_repo_gpg_verify_with_metadata (self, commit_data, old_metadata,
                                             NULL, NULL, NULL,
                                             cancellable, &local_error);
@@ -4239,7 +4239,7 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
                                        GCancellable  *cancellable,
                                        GError       **error)
 {
-  glnx_unref_object OstreeGpgVerifier *verifier = NULL;
+  g_autoptr(OstreeGpgVerifier) verifier = NULL;
   gboolean add_global_keyring_dir = TRUE;
 
   verifier = _ostree_gpg_verifier_new ();
@@ -4441,7 +4441,7 @@ ostree_repo_verify_commit (OstreeRepo   *self,
                            GCancellable *cancellable,
                            GError      **error)
 {
-  glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+  g_autoptr(OstreeGpgVerifyResult) result = NULL;
 
   result = ostree_repo_verify_commit_ext (self, commit_checksum,
                                           keyringdir, extra_keyring,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -32,6 +32,7 @@
 #include <systemd/sd-journal.h>
 #endif
 
+#include "ostree.h"
 #include "ostree-sysroot-private.h"
 #include "ostree-sepolicy-private.h"
 #include "ostree-deployment-private.h"
@@ -722,7 +723,7 @@ merge_configuration (OstreeSysroot         *sysroot,
                      GCancellable          *cancellable,
                      GError               **error)
 {
-  glnx_unref_object OstreeSePolicy *sepolicy = NULL;
+  g_autoptr(OstreeSePolicy) sepolicy = NULL;
 
   if (previous_deployment)
     {
@@ -1587,7 +1588,7 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
   gboolean bootloader_is_atomic = FALSE;
   gboolean boot_was_ro_mount = FALSE;
   SyncStats syncstats = { 0, };
-  glnx_unref_object OstreeBootloader *bootloader = NULL;
+  g_autoptr(OstreeBootloader) bootloader = NULL;
 
   g_assert (self->loaded);
 
@@ -1671,7 +1672,7 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
     {
       int new_bootversion = self->bootversion ? 0 : 1;
       g_autofree char* new_loader_entries_dir = NULL;
-      glnx_unref_object OstreeRepo *repo = NULL;
+      g_autoptr(OstreeRepo) repo = NULL;
       gboolean show_osname = FALSE;
 
       if (self->booted_deployment)
@@ -1918,7 +1919,7 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
     return FALSE;
 
   OstreeRepo *repo = ostree_sysroot_repo (self);
-  glnx_unref_object OstreeDeployment *merge_deployment = NULL;
+  g_autoptr(OstreeDeployment) merge_deployment = NULL;
   if (provided_merge_deployment != NULL)
     merge_deployment = g_object_ref (provided_merge_deployment);
 
@@ -1928,7 +1929,7 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
     return FALSE;
 
   g_autofree char *new_bootcsum = NULL;
-  glnx_unref_object OstreeDeployment *new_deployment =
+  g_autoptr(OstreeDeployment) new_deployment =
     ostree_deployment_new (0, osname, revision, new_deployserial,
                            new_bootcsum, -1);
   ostree_deployment_set_origin (new_deployment, origin);
@@ -1966,10 +1967,10 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
   /* Create an empty boot configuration; we will merge things into
    * it as we go.
    */
-  glnx_unref_object OstreeBootconfigParser *bootconfig = ostree_bootconfig_parser_new ();
+  g_autoptr(OstreeBootconfigParser) bootconfig = ostree_bootconfig_parser_new ();
   ostree_deployment_set_bootconfig (new_deployment, bootconfig);
 
-  glnx_unref_object OstreeSePolicy *sepolicy = NULL;
+  g_autoptr(OstreeSePolicy) sepolicy = NULL;
   if (!merge_configuration (self, repo, merge_deployment, new_deployment,
                             deployment_dfd,
                             &sepolicy,
@@ -2047,7 +2048,7 @@ ostree_sysroot_deployment_set_kargs (OstreeSysroot     *self,
 {
   guint i;
   g_autoptr(GPtrArray) new_deployments = g_ptr_array_new_with_free_func (g_object_unref);
-  glnx_unref_object OstreeDeployment *new_deployment = NULL;
+  g_autoptr(OstreeDeployment) new_deployment = NULL;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
   g_autofree char *new_options = NULL;
   OstreeBootconfigParser *new_bootconfig;

--- a/src/libostree/ostree-tls-cert-interaction.h
+++ b/src/libostree/ostree-tls-cert-interaction.h
@@ -31,6 +31,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeTlsCertInteraction        OstreeTlsCertInteraction;
 typedef struct _OstreeTlsCertInteractionClass   OstreeTlsCertInteractionClass;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OstreeTlsCertInteraction, g_object_unref)
 
 GType                       _ostree_tls_cert_interaction_get_type    (void) G_GNUC_CONST;
 

--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -37,7 +37,7 @@ gboolean
 ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   gboolean ret = FALSE;
 
   context = g_option_context_new ("Delete untagged deployments and repository objects");

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -55,11 +55,11 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
   gboolean ret = FALSE;
   const char *refspec;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   g_autoptr(GKeyFile) origin = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
-  glnx_unref_object OstreeDeployment *new_deployment = NULL;
-  glnx_unref_object OstreeDeployment *merge_deployment = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
+  g_autoptr(OstreeDeployment) new_deployment = NULL;
+  g_autoptr(OstreeDeployment) merge_deployment = NULL;
   g_autofree char *revision = NULL;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
 

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -40,9 +40,9 @@ gboolean
 ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   gboolean ret = FALSE;
-  glnx_unref_object OstreeDeployment *deployment = NULL;
+  g_autoptr(OstreeDeployment) deployment = NULL;
   g_autoptr(GFile) deployment_dir = NULL;
   g_autoptr(GPtrArray) modified = NULL;
   g_autoptr(GPtrArray) removed = NULL;

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -37,10 +37,10 @@ gboolean
 ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   gboolean ret = FALSE;
   glnx_fd_close int root_dfd = -1;
-  glnx_unref_object OstreeSysroot *target_sysroot = NULL;
+  g_autoptr(OstreeSysroot) target_sysroot = NULL;
   guint i;
   const char *normal_toplevels[] = {"boot", "dev", "home", "proc", "run", "sys"};
 

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -37,7 +37,7 @@ gboolean
 ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   gboolean ret = FALSE;
   const char *osname = NULL;
 

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -48,9 +48,9 @@ ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, G
   const char *remotename = NULL;
   const char *url = NULL;
   const char *branch = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
-  glnx_unref_object OstreeDeployment *target_deployment = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
+  g_autoptr(OstreeDeployment) target_deployment = NULL;
 
   context = g_option_context_new ("REMOTENAME URL [BRANCH]");
 

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -84,9 +84,9 @@ gboolean
 ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   gboolean ret = FALSE;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   OstreeDeployment *booted_deployment = NULL;
   g_autoptr(OstreeDeployment) pending_deployment = NULL;
   g_autoptr(OstreeDeployment) rollback_deployment = NULL;
@@ -129,7 +129,7 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
           const char *ref = ostree_deployment_get_csum (deployment);
           OstreeDeploymentUnlockedState unlocked = ostree_deployment_get_unlocked (deployment);
           g_autofree char *version = version_of_commit (repo, ref);
-          glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+          g_autoptr(OstreeGpgVerifyResult) result = NULL;
           guint jj, n_signatures;
           GError *local_error = NULL;
 

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -44,9 +44,9 @@ ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GErro
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   const char *new_provided_refspec = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autofree char *origin_refspec = NULL;
   g_autofree char *origin_remote = NULL;
   g_autofree char *origin_ref = NULL;
@@ -54,8 +54,8 @@ ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GErro
   g_autofree char *new_ref = NULL;
   g_autofree char *new_refspec = NULL;
   const char* remote;
-  glnx_unref_object OstreeSysrootUpgrader *upgrader = NULL;
-  glnx_unref_object OstreeAsyncProgress *progress = NULL;
+  g_autoptr(OstreeSysrootUpgrader) upgrader = NULL;
+  g_autoptr(OstreeAsyncProgress) progress = NULL;
   gboolean changed;
   GKeyFile *old_origin;
   g_autoptr(GKeyFile) new_origin = NULL;

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -36,11 +36,11 @@ gboolean
 ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   const char *deploy_index_str;
   int deploy_index;
   g_autoptr(GPtrArray) current_deployments = NULL;
-  glnx_unref_object OstreeDeployment *target_deployment = NULL;
+  g_autoptr(OstreeDeployment) target_deployment = NULL;
 
   context = g_option_context_new ("INDEX - Delete deployment INDEX");
 

--- a/src/ostree/ot-admin-builtin-unlock.c
+++ b/src/ostree/ot-admin-builtin-unlock.c
@@ -43,7 +43,7 @@ ot_admin_builtin_unlock (int argc, char **argv, GCancellable *cancellable, GErro
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   OstreeDeployment *booted_deployment = NULL;
   OstreeDeploymentUnlockedState target_state;
 

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -54,10 +54,10 @@ ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GErr
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
-  glnx_unref_object OstreeSysrootUpgrader *upgrader = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
+  g_autoptr(OstreeSysrootUpgrader) upgrader = NULL;
   g_autoptr(GKeyFile) origin = NULL;
-  glnx_unref_object OstreeAsyncProgress *progress = NULL;
+  g_autoptr(OstreeAsyncProgress) progress = NULL;
   gboolean changed;
   OstreeSysrootUpgraderPullFlags upgraderpullflags = 0;
 

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -39,7 +39,7 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
   gboolean ret = FALSE;
   guint bootversion;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
 
   context = g_option_context_new ("[BOOTVERSION] - generate GRUB2 configuration from given BLS entries");
 

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -185,11 +185,11 @@ ot_admin_instutil_builtin_selinux_ensure_labeled (int argc, char **argv, GCancel
   const char *policy_name;
   g_autoptr(GFile) subpath = NULL;
   const char *prefix = NULL;
-  glnx_unref_object OstreeSePolicy *sepolicy = NULL;
+  g_autoptr(OstreeSePolicy) sepolicy = NULL;
   g_autoptr(GPtrArray) deployments = NULL;
   OstreeDeployment *first_deployment;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   g_autoptr(GFile) deployment_path = NULL;
 
   context = g_option_context_new ("[SUBPATH PREFIX] - relabel all or part of a deployment");

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -51,7 +51,7 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, GCancellable *cancel
   g_autoptr(GPtrArray) deployments = NULL;
   OstreeDeployment *first_deployment = NULL;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
 
   context = g_option_context_new ("ARGS - set new kernel command line arguments");

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -254,7 +254,7 @@ gboolean
 ostree_builtin_checkout (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *commit;
   const char *destination;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -375,7 +375,7 @@ gboolean
 ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   gboolean skip_commit = FALSE;
   g_autoptr(GFile) object_to_commit = NULL;
@@ -384,7 +384,7 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
   g_autoptr(GFile) root = NULL;
   g_autoptr(GVariant) metadata = NULL;
   g_autoptr(GVariant) detached_metadata = NULL;
-  glnx_unref_object OstreeMutableTree *mtree = NULL;
+  g_autoptr(OstreeMutableTree) mtree = NULL;
   g_autofree char *tree_type = NULL;
   g_autoptr(GHashTable) mode_adds = NULL;
   g_autoptr(GHashTable) mode_overrides = NULL;

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -55,7 +55,7 @@ gboolean
 ostree_builtin_config (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *op;
   const char *section_key;

--- a/src/ostree/ot-builtin-diff.c
+++ b/src/ostree/ot-builtin-diff.c
@@ -126,7 +126,7 @@ ostree_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *src;
   const char *target;
   g_autofree char *src_prev = NULL;

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -61,7 +61,7 @@ gboolean
 ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
   g_autoptr(GFile) root = NULL;

--- a/src/ostree/ot-builtin-find-remotes.c
+++ b/src/ostree/ot-builtin-find-remotes.c
@@ -125,9 +125,9 @@ ostree_builtin_find_remotes (int            argc,
                              GError       **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autoptr(GPtrArray) refs = NULL;  /* (element-type OstreeCollectionRef) */
-  glnx_unref_object OstreeAsyncProgress *progress = NULL;
+  g_autoptr(OstreeAsyncProgress) progress = NULL;
   gsize i;
   g_autoptr(GAsyncResult) find_result = NULL, pull_result = NULL;
   g_auto(OstreeRepoFinderResultv) results = NULL;

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -212,7 +212,7 @@ fsck_reachable_objects_from_commits (OstreeRepo            *repo,
 gboolean
 ostree_builtin_fsck (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean found_corruption = FALSE;
 
   g_autoptr(GOptionContext) context = g_option_context_new ("- Check the repository for consistency");

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -55,7 +55,7 @@ delete_signatures (OstreeRepo *repo,
                    GError **error)
 {
   GVariantDict metadata_dict;
-  glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+  g_autoptr(OstreeGpgVerifyResult) result = NULL;
   g_autoptr(GVariant) old_metadata = NULL;
   g_autoptr(GVariant) new_metadata = NULL;
   g_autoptr(GVariant) signature_data = NULL;
@@ -199,7 +199,7 @@ gboolean
 ostree_builtin_gpg_sign (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autofree char *resolved_commit = NULL;
   const char *commit;
   char **key_ids;

--- a/src/ostree/ot-builtin-log.c
+++ b/src/ostree/ot-builtin-log.c
@@ -82,7 +82,7 @@ ostree_builtin_log (int           argc,
                     GError      **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
   g_autofree char *checksum = NULL;

--- a/src/ostree/ot-builtin-ls.c
+++ b/src/ostree/ot-builtin-ls.c
@@ -239,7 +239,7 @@ gboolean
 ostree_builtin_ls (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *rev;
   int i;

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -162,7 +162,7 @@ ostree_builtin_prune (int argc, char **argv, GCancellable *cancellable, GError *
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autofree char *formatted_freed_size = NULL;
   OstreeRepoPruneFlags pruneflags = 0;
   gint n_objects_total;

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -56,11 +56,11 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   int i;
   const char *src_repo_arg;
   g_autofree char *src_repo_uri = NULL;
-  glnx_unref_object OstreeAsyncProgress *progress = NULL;
+  g_autoptr(OstreeAsyncProgress) progress = NULL;
   g_autoptr(GPtrArray) refs_to_fetch = NULL;
   OstreeRepoPullFlags pullflags = 0;
 
@@ -103,7 +103,7 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
   if (argc == 2)
     {
       g_autoptr(GFile) src_repo_path = g_file_new_for_path (src_repo_arg);
-      glnx_unref_object OstreeRepo *src_repo = ostree_repo_new (src_repo_path);
+      g_autoptr(OstreeRepo) src_repo = ostree_repo_new (src_repo_path);
       g_autoptr(GHashTable) refs_to_clone = NULL;
 
       refs_to_fetch = g_ptr_array_new_with_free_func (g_free);

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -138,13 +138,13 @@ gboolean
 ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   g_autofree char *remote = NULL;
   OstreeRepoPullFlags pullflags = 0;
   g_autoptr(GPtrArray) refs_to_fetch = NULL;
   g_autoptr(GPtrArray) override_commit_ids = NULL;
-  glnx_unref_object OstreeAsyncProgress *progress = NULL;
+  g_autoptr(OstreeAsyncProgress) progress = NULL;
   gulong signal_handler_id = 0;
 
   context = g_option_context_new ("REMOTE [BRANCH...] - Download data from remote repository");

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -260,7 +260,7 @@ ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   int i;
 
   context = g_option_context_new ("[PREFIX] - List refs");

--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -38,7 +38,7 @@ ostree_builtin_reset (int           argc,
                       GError      **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   g_autoptr(GHashTable) known_refs = NULL;
   gboolean ret = FALSE;
   const char *ref;

--- a/src/ostree/ot-builtin-rev-parse.c
+++ b/src/ostree/ot-builtin-rev-parse.c
@@ -35,7 +35,7 @@ gboolean
 ostree_builtin_rev_parse (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   gboolean ret = FALSE;
   const char *rev = "master";
   int i;

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -147,7 +147,7 @@ print_object (OstreeRepo          *repo,
 
   if (objtype == OSTREE_OBJECT_TYPE_COMMIT)
     {
-      glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+      g_autoptr(OstreeGpgVerifyResult) result = NULL;
       g_autoptr(GError) local_error = NULL;
       g_autoptr(GFile) gpg_homedir = opt_gpg_homedir ? g_file_new_for_path (opt_gpg_homedir) : NULL;
 
@@ -223,7 +223,7 @@ ostree_builtin_show (int argc, char **argv, GCancellable *cancellable, GError **
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("OBJECT - Output a metadata object");
 
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     return FALSE;
 

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -113,7 +113,7 @@ ot_static_delta_builtin_list (int argc, char **argv, GCancellable *cancellable, 
   g_autoptr(GPtrArray) delta_names = NULL;
   guint i;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
 
   context = g_option_context_new ("LIST - list static delta files");
 
@@ -145,7 +145,7 @@ ot_static_delta_builtin_show (int argc, char **argv, GCancellable *cancellable, 
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *delta_id = NULL;
 
   context = g_option_context_new ("SHOW - Dump information on a delta");
@@ -175,7 +175,7 @@ ot_static_delta_builtin_delete (int argc, char **argv, GCancellable *cancellable
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   const char *delta_id = NULL;
 
   context = g_option_context_new ("DELETE - Remove a delta");
@@ -206,7 +206,7 @@ ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellab
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
 
   context = g_option_context_new ("GENERATE [TO] - Generate static delta files");
   if (!ostree_option_context_parse (context, generate_options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
@@ -357,7 +357,7 @@ ot_static_delta_builtin_apply_offline (int argc, char **argv, GCancellable *canc
   const char *patharg;
   g_autoptr(GFile) path = NULL;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
 
   context = g_option_context_new ("APPLY-OFFLINE - Apply static delta file");
   if (!ostree_option_context_parse (context, apply_offline_options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -81,7 +81,7 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
 {
   gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
-  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
   OstreeDumpFlags flags = OSTREE_DUMP_NONE;
 
   context = g_option_context_new ("Manage summary metadata");

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -372,7 +372,7 @@ ostree_admin_option_context_parse (GOptionContext *context,
   if (opt_sysroot != NULL)
     sysroot_path = g_file_new_for_path (opt_sysroot);
 
-  glnx_unref_object OstreeSysroot *sysroot = ostree_sysroot_new (sysroot_path);
+  g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_path);
 
   if (flags & OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER)
     {

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -101,7 +101,7 @@ ot_remote_builtin_summary (int argc, char **argv, GCancellable *cancellable, GEr
    *     option for raw signature data like "--raw-signatures". */
   if (signature_bytes != NULL && !opt_raw)
     {
-      glnx_unref_object OstreeGpgVerifyResult *result = NULL;
+      g_autoptr(OstreeGpgVerifyResult) result = NULL;
 
       /* The actual signed summary verification happens above in
        * ostree_repo_remote_fetch_summary().  Here we just parse


### PR DESCRIPTION
Part of cleaning up our usage of libglnx; we want to use what's in GLib where we
can.

Had to change a few .c files to `#include ostree.h` early on to pick up
autoptrs for the core types.