### PR TITLE
lib/deploy: Use a FIFREEZE/FITHAW cycle for /boot

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1045,7 +1045,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
         {
           if (TEMP_FAILURE_RETRY (ioctl (rootfs_dfd, FITHAW, 0)) != 0)
             {
-              if (errno == EPERM && getuid () != 0)
+              if (errno == EPERM)
                 ; /* Ignore this for the test suite */
               else
                 err (1, "FITHAW");
@@ -1081,7 +1081,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
           /* Not supported, or we're running in the unit tests (as non-root)?
            * OK, let's just do a syncfs.
            */
-          if (errno == EOPNOTSUPP || (errno == EPERM && getuid () != 0))
+          if (G_IN_SET (errno, EOPNOTSUPP, EPERM))
             {
               if (TEMP_FAILURE_RETRY (syncfs (rootfs_dfd)) != 0)
                 return glnx_throw_errno_prefix (error, "syncfs");

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -979,7 +979,7 @@ checksum_from_kernel_src (const char   *name,
   return TRUE;
 }
 
-/* We used to syncfs(), but doesn't flush the journal on XFS,
+/* We used to syncfs(), but that doesn't flush the journal on XFS,
  * and since GRUB2 can't read the XFS journal, the system
  * could fail to boot.
  *
@@ -1093,6 +1093,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
           else
             return glnx_throw_errno_prefix (error, "ioctl(FIFREEZE)");
         }
+      /* And finally thaw, then signal our completion to the watchdog */
       if (TEMP_FAILURE_RETRY (ioctl (rootfs_dfd, FITHAW, 0)) != 0)
         return glnx_throw_errno_prefix (error, "ioctl(FITHAW)");
       if (write (sock_parent, &c, sizeof (c)) != sizeof (c))

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -33,7 +33,8 @@ typedef enum {
   OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS = 1 << 0,
   /* See https://github.com/ostreedev/ostree/pull/759 */
   OSTREE_SYSROOT_DEBUG_NO_XATTRS = 1 << 1,
-
+  /* https://github.com/ostreedev/ostree/pull/1049 */
+  OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE = 1 << 2,
 } OstreeSysrootDebugFlags;
 
 /**

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -166,6 +166,7 @@ ostree_sysroot_init (OstreeSysroot *self)
 {
   const GDebugKey keys[] = {
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },
+    { "test-fifreeze", OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE },
     { "no-xattrs", OSTREE_SYSROOT_DEBUG_NO_XATTRS },
   };
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -250,7 +250,7 @@ assert_not_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
 assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf testos-repo
 echo "ok remote add nonphysical sysroot"
 
-if strace -f -o strace.log env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
+if env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
        ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
     fatal "fifreeze-test exited successfully?"
 fi

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -249,3 +249,11 @@ ${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false r
 assert_not_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
 assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf testos-repo
 echo "ok remote add nonphysical sysroot"
+
+if strace -f -o strace.log env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
+       ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
+    fatal "fifreeze-test exited successfully?"
+fi
+assert_file_has_content err.txt "fifreeze watchdog was run"
+assert_file_has_content err.txt "During fsfreeze-thaw: aborting due to test-fifreeze"
+echo "ok fifreeze test"

--- a/tests/test-admin-deploy-grub2.sh
+++ b/tests/test-admin-deploy-grub2.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..18"
+echo "1..19"
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..18"
+echo "1..19"
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-echo "1..19"
+echo "1..20"
 
 . $(dirname $0)/libtest.sh
 


### PR DESCRIPTION
See: http://marc.info/?l=linux-fsdevel&m=149520244919284&w=2

XFS doesn't flush the journal on `syncfs()`. GRUB doesn't know how to follow the
XFS journal, so if the filesystem is in a dirty state (possible with xfs
`/boot`, extremely likely with `/`, if the journaled data includes content for
`/boot`, the system may be unbootable if a system crash occurs.

Fix this by doing a `FIFREEZE`+`FITHAW` cycle.  Now, most people
probably would have replaced the `syncfs()` invocation with those two
ioctls.  But this would have become (I believe) the *only* place in
libostree where we weren't safe against interruption.  The failure
mode would be ugly; nothing else would be able to write to the filesystem
until manual intervention.

The real fix here I think is to land an atomic `FIFREEZETHAW` ioctl
in the kernel.  I might try a patch.

In the meantime though, let's jump through some hoops and set up
a "watchdog" child process that acts as a fallback unfreezer.

Closes: https://github.com/ostreedev/ostree/issues/876