### PR TITLE
Documentation: README: Remove deprecated wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ More documentation
 
 New! See the docs online at [Read The Docs (OSTree)](https://ostree.readthedocs.org/en/latest/ )
 
-Some more information is available on the old wiki page:
-<https://wiki.gnome.org/Projects/OSTree>
-
 Contributing
 ------------
 


### PR DESCRIPTION
The old wiki only contains link back to readthedocs.
The link to is useless.