### PR TITLE
tree-wide: Fix the build with old glib (Ubuntu Trusty etc.)

### DIFF
--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gio/gio.h>
+#include "otutil.h"
 
 G_BEGIN_DECLS
 

--- a/src/libostree/ostree-deployment.c
+++ b/src/libostree/ostree-deployment.c
@@ -20,9 +20,9 @@
 
 #include "config.h"
 
+#include "otutil.h"
 #include "ostree.h"
 #include "ostree-deployment-private.h"
-#include "libglnx.h"
 
 typedef GObjectClass OstreeDeploymentClass;
 

--- a/src/libostree/ostree-libarchive-private.h
+++ b/src/libostree/ostree-libarchive-private.h
@@ -25,7 +25,7 @@
 #include "config.h"
 
 #include <gio/gio.h>
-#include "libglnx.h"
+#include "otutil.h"
 #ifdef HAVE_LIBARCHIVE
 #include <archive.h>
 #include <archive_entry.h>

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -22,8 +22,8 @@
 
 #include "config.h"
 
-#include "ostree.h"
 #include "otutil.h"
+#include "ostree.h"
 
 /**
  * SECTION:ostree-mutable-tree

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -30,13 +30,13 @@
 #include <sys/xattr.h>
 #include <glib/gprintf.h>
 
+#include "otutil.h"
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
 #include "ostree-repo-file-enumerator.h"
 #include "ostree-checksum-input-stream.h"
 #include "ostree-varint.h"
-#include "otutil.h"
 
 gboolean
 _ostree_repo_ensure_loose_objdir_at (int             dfd,

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "otutil.h"
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -21,10 +21,10 @@
 #pragma once
 
 #include <sys/statvfs.h>
+#include "otutil.h"
 #include "ostree-ref.h"
 #include "ostree-repo.h"
 #include "ostree-remote-private.h"
-#include "otutil.h"
 
 G_BEGIN_DECLS
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -32,13 +32,13 @@
 #include <systemd/sd-journal.h>
 #endif
 
+#include "otutil.h"
 #include "ostree.h"
 #include "ostree-sysroot-private.h"
 #include "ostree-sepolicy-private.h"
 #include "ostree-deployment-private.h"
 #include "ostree-core-private.h"
 #include "ostree-linuxfsutil.h"
-#include "otutil.h"
 #include "libglnx.h"
 
 #define OSTREE_VARRELABEL_ID          "da679b08acd34504b789d96f818ea781"

--- a/src/libostree/ostree-tls-cert-interaction.h
+++ b/src/libostree/ostree-tls-cert-interaction.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "otutil.h"
 #include <gio/gio.h>
 
 G_BEGIN_DECLS

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -20,12 +20,12 @@
 
 #include "config.h"
 
+#include "otutil.h"
 #include "ot-main.h"
 #include "ot-builtins.h"
+#include "ostree-libarchive-private.h"
 #include "ostree.h"
 #include "ostree-repo-file.h"
-#include "ostree-libarchive-private.h"
-#include "otutil.h"
 
 #ifdef HAVE_LIBARCHIVE
 #include <archive.h>
@@ -68,7 +68,9 @@ ostree_builtin_export (int argc, char **argv, GCancellable *cancellable, GError 
   g_autoptr(GFile) subtree = NULL;
   g_autofree char *commit = NULL;
   g_autoptr(GVariant) commit_data = NULL;
+#ifdef HAVE_LIBARCHIVE
   g_autoptr(OtAutoArchiveWrite) a = NULL;
+#endif
   OstreeRepoExportArchiveOptions opts = { 0, };
 
   context = g_option_context_new ("COMMIT - Stream COMMIT to stdout in tar format");


### PR DESCRIPTION
This regressed with <https://github.com/ostreedev/ostree/pull/1040>
but currently the Travis builds aren't gating.