### PR TITLE
main: Fix subcommand usage output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,15 @@ else
 fi
 AM_CONDITIONAL(BUILDOPT_ASAN, [test x$using_asan = xyes])
 
+AC_MSG_CHECKING([for -fsanitize=thread in CFLAGS])
+if echo $CFLAGS | grep -q -e -fsanitize=thread; then
+  AC_MSG_RESULT([yes])
+  using_tsan=yes
+else
+  AC_MSG_RESULT([no])
+fi
+AM_CONDITIONAL(BUILDOPT_TSAN, [test x$using_tsan = xyes])
+
 # Initialize libtool
 LT_PREREQ([2.2.4])
 LT_INIT([disable-static])

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,8 @@ else
   AC_MSG_RESULT([no])
 fi
 AM_CONDITIONAL(BUILDOPT_ASAN, [test x$using_asan = xyes])
+AM_COND_IF([BUILDOPT_ASAN],
+  [AC_DEFINE([BUILDOPT_ASAN], 1, [Define if we are building with -fsanitize=address])])
 
 AC_MSG_CHECKING([for -fsanitize=thread in CFLAGS])
 if echo $CFLAGS | grep -q -e -fsanitize=thread; then
@@ -67,6 +69,8 @@ else
   AC_MSG_RESULT([no])
 fi
 AM_CONDITIONAL(BUILDOPT_TSAN, [test x$using_tsan = xyes])
+AM_COND_IF([BUILDOPT_TSAN],
+  [AC_DEFINE([BUILDOPT_TSAN], 1, [Define if we are building with -fsanitize=thread])])
 
 # Initialize libtool
 LT_PREREQ([2.2.4])

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -117,6 +117,9 @@ ostree_run (int    argc,
   OstreeCommand *command;
   GError *error = NULL;
   GCancellable *cancellable = NULL;
+#ifndef BUILDOPT_TSAN
+  g_autofree char *prgname = NULL;
+#endif
   const char *command_name = NULL;
   gboolean success = FALSE;
   int in, out;
@@ -191,6 +194,11 @@ ostree_run (int    argc,
 
       goto out;
     }
+
+#ifndef BUILDOPT_TSAN
+  prgname = g_strdup_printf ("%s %s", g_get_prgname (), command_name);
+  g_set_prgname (prgname);
+#endif
 
   if (!command->fn (argc, argv, cancellable, &error))
     goto out;


### PR DESCRIPTION
This commit sets prgname correctly so that the "ostree subcommand
--help" output prints the subcommand rather than just "ostree".