### PR TITLE
lib/pull: Add support for timestamp-check option, use in upgrader

### DIFF
--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -179,6 +179,13 @@ _ostree_raw_file_to_archive_stream (GInputStream       *input,
 gboolean ostree_validate_collection_id (const char *collection_id, GError **error);
 #endif /* !OSTREE_ENABLE_EXPERIMENTAL_API */
 
+gboolean
+_ostree_compare_timestamps (const char   *current_rev,
+                            guint64       current_ts,
+                            const char   *new_rev,
+                            guint64       new_ts,
+                            GError      **error);
+
 #if (defined(OSTREE_COMPILATION) || GLIB_CHECK_VERSION(2, 44, 0)) && !defined(OSTREE_ENABLE_EXPERIMENTAL_API)
 #include <libglnx.h>
 #include "ostree-ref.h"

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -34,6 +34,7 @@ static gboolean opt_dry_run;
 static gboolean opt_disable_static_deltas;
 static gboolean opt_require_static_deltas;
 static gboolean opt_untrusted;
+static gboolean opt_timestamp_check;
 static gboolean opt_bareuseronly_files;
 static char** opt_subpaths;
 static char** opt_http_headers;
@@ -64,6 +65,7 @@ static GOptionEntry options[] = {
    { "http-header", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_http_headers, "Add NAME=VALUE as HTTP header to all requests", "NAME=VALUE" },
    { "update-frequency", 0, 0, G_OPTION_ARG_INT, &opt_frequency, "Sets the update frequency, in milliseconds (0=1000ms) (default: 0)", "FREQUENCY" },
    { "localcache-repo", 'L', 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_localcache_repos, "Add REPO as local cache source for objects during this pull", "REPO" },
+   { "timestamp-check", 'T', 0, G_OPTION_ARG_NONE, &opt_timestamp_check, "Require fetched commits to have newer timestamps", NULL },
    { NULL }
  };
 
@@ -288,6 +290,9 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
     g_variant_builder_add (&builder, "{s@v}", "dry-run",
                            g_variant_new_variant (g_variant_new_boolean (opt_dry_run)));
+    if (opt_timestamp_check)
+      g_variant_builder_add (&builder, "{s@v}", "timestamp-check",
+                             g_variant_new_variant (g_variant_new_boolean (opt_timestamp_check)));
 
     if (override_commit_ids)
       g_variant_builder_add (&builder, "{s@v}", "override-commit-ids",

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -548,6 +548,14 @@ ostree_file_path_to_checksum() {
     $CMD_PREFIX ostree --repo=$repo ls -C $ref $path | awk '{ print $5 }'
 }
 
+# Given an object checksum, print its relative file path
+ostree_checksum_to_relative_object_path() {
+    repo=$1
+    checksum=$2
+    if grep -Eq -e '^mode=archive' ${repo}/config; then suffix=z; else suffix=''; fi
+    echo objects/${checksum:0:2}/${checksum:2}.file${suffix}
+}
+
 # Given a path to a file in a repo for a ref, print the (relative) path to its
 # object
 ostree_file_path_to_relative_object_path() {
@@ -556,7 +564,7 @@ ostree_file_path_to_relative_object_path() {
     path=$3
     checksum=$(ostree_file_path_to_checksum $repo $ref $path)
     test -n "${checksum}"
-    echo objects/${checksum:0:2}/${checksum:2}.file
+    ostree_checksum_to_relative_object_path ${repo} ${checksum}
 }
 
 # Given a path to a file in a repo for a ref, print the path to its object

--- a/tests/test-admin-upgrade-not-backwards.sh
+++ b/tests/test-admin-upgrade-not-backwards.sh
@@ -61,7 +61,7 @@ assert_file_has_content upgrade-err.txt 'chronologically older'
 currev=$(ostree --repo=sysroot/ostree/repo rev-parse testos:${ref})
 assert_not_streq ${newrev} ${currev}
 assert_streq ${origrev} ${currev}
-assert_not_has_file sysroot/ostree/repo/$(ostree_checksum_to_relative_object_path sysroot/ostree/repo ${tscheck_checksum})
+assert_not_has_file sysroot/ostree/repo/$tscheck_fileobjpath
 
 echo 'ok upgrade will not go backwards'
 

--- a/tests/test-admin-upgrade-not-backwards.sh
+++ b/tests/test-admin-upgrade-not-backwards.sh
@@ -26,26 +26,42 @@ setup_os_repository "archive-z2" "syslinux"
 
 echo "1..2"
 
+ref=testos/buildmaster/x86_64-runtime
 cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo
-${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmaster/x86_64-runtime
-rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos ${ref}
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse ${ref})
 export rev
 echo "rev=${rev}"
-# This initial deployment gets kicked off with some kernel arguments 
-${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+# This initial deployment gets kicked off with some kernel arguments
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:${ref}
 assert_has_dir sysroot/boot/ostree/testos-${bootcsum}
 
 # This should be a no-op
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 
-# Now reset to an older revision
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo reset testos/buildmaster/x86_64-runtime{,^}
-
+# Generate a new commit with an older timestamp that also has
+# some new content, so we test timestamp checking during pull
+# <https://github.com/ostreedev/ostree/pull/1055>
+origrev=$(ostree --repo=${test_tmpdir}/sysroot/ostree/repo rev-parse testos:${ref})
+cd ${test_tmpdir}/osdata
+echo "new content for pull timestamp checking" > usr/share/test-pull-ts-check.txt
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=tscheck" \
+              -b ${ref} --timestamp='October 25 1985'
+newrev=$(ostree --repo=${test_tmpdir}/testos-repo rev-parse ${ref})
+assert_not_streq ${origrev} ${newrev}
+cd ${test_tmpdir}
+tscheck_checksum=$(ostree_file_path_to_checksum testos-repo ${ref} /usr/share/test-pull-ts-check.txt)
+tscheck_fileobjpath=$(ostree_checksum_to_relative_object_path testos-repo ${tscheck_checksum})
+assert_has_file testos-repo/${tscheck_fileobjpath}
 if ${CMD_PREFIX} ostree admin upgrade --os=testos 2>upgrade-err.txt; then
     assert_not_reached 'upgrade unexpectedly succeeded'
 fi
 assert_file_has_content upgrade-err.txt 'chronologically older'
+currev=$(ostree --repo=sysroot/ostree/repo rev-parse testos:${ref})
+assert_not_streq ${newrev} ${currev}
+assert_streq ${origrev} ${currev}
+assert_not_has_file sysroot/ostree/repo/$(ostree_checksum_to_relative_object_path sysroot/ostree/repo ${tscheck_checksum})
 
 echo 'ok upgrade will not go backwards'
 


### PR DESCRIPTION
For both flatpak and ostree-as-host, we really want to verify up front during
pulls that we're not being downgraded. Currently both flatpak and
`OstreeSysrootUpgrader` do this before deployments, but at that point we've
already downloaded all the data, which is annoying.

Closes: https://github.com/ostreedev/ostree/issues/687