### PR TITLE
tree-wide: Remove trailing semicolon from autoptr declarations

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -36,7 +36,7 @@
 
 #ifdef HAVE_LIBMOUNT
 typedef FILE OtLibMountFile;
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtLibMountFile, endmntent);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtLibMountFile, endmntent)
 
 /* Taken from systemd path-util.c */
 static bool

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -46,7 +46,7 @@ checkout_state_clear (CheckoutState *state)
   if (state->selabel_path_buf)
     g_string_free (state->selabel_path_buf, TRUE);
 }
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(CheckoutState, checkout_state_clear);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(CheckoutState, checkout_state_clear)
 
 static gboolean
 checkout_object_for_uncompressed_cache (OstreeRepo      *self,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -173,7 +173,7 @@ _ostree_repo_memory_cache_ref_init (OstreeRepoMemoryCacheRef *state,
 
 void
 _ostree_repo_memory_cache_ref_destroy (OstreeRepoMemoryCacheRef *state);
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OstreeRepoMemoryCacheRef, _ostree_repo_memory_cache_ref_destroy);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OstreeRepoMemoryCacheRef, _ostree_repo_memory_cache_ref_destroy)
 
 #define OSTREE_REPO_TMPDIR_STAGING "staging-"
 #define OSTREE_REPO_TMPDIR_FETCHER "fetcher-"

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -49,7 +49,7 @@ ot_cleanup_unlinkat (OtCleanupUnlinkat *cleanup)
       ot_cleanup_unlinkat_clear (cleanup);
     }
 }
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OtCleanupUnlinkat, ot_cleanup_unlinkat);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OtCleanupUnlinkat, ot_cleanup_unlinkat)
 
 GFile * ot_fdrel_to_gfile (int dfd, const char *path);
 

--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -26,8 +26,8 @@
 
 G_BEGIN_DECLS
 
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_data_t, gpgme_data_release, NULL);
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_ctx_t, gpgme_release, NULL);
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_data_t, gpgme_data_release, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_ctx_t, gpgme_release, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_key_t, gpgme_key_unref, NULL)
 
 void ot_gpgme_error_to_gio_error (gpgme_error_t gpg_error, GError **error);


### PR DESCRIPTION
It confuses `g-ir-scanner`, and isn't necessary.