### PR TITLE
Documentation: static delta default from

### DIFF
--- a/man/ostree-static-delta.xml
+++ b/man/ostree-static-delta.xml
@@ -90,6 +90,8 @@ Boston, MA 02111-1307, USA.
 
                 <listitem><para>
                     Create delta to revision REV.  (This option is required.)
+                    The delta is from the parent of REV, unless specified otherwise by <option>--from</option>
+                    or <option>--empty</option>.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
Document that the default behavior of `ostree static-delta generate` if to generate the delta from the parent.

Note: I didn't try to compile after this change.
It was easier to suggest an edit than to create a bug report describing the issue.
