### PR TITLE
lib/repo-pull: Fix counting of latest commits when finding repos

### DIFF
--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -82,6 +82,7 @@ ostree_repo_get_collection_id
 ostree_repo_set_collection_id
 ostree_validate_collection_id
 ostree_repo_list_collection_refs
+ostree_repo_remote_list_collection_refs
 ostree_repo_set_collection_ref_immediate
 ostree_repo_transaction_set_collection_ref
 </SECTION>

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -70,6 +70,7 @@ global:
   ostree_repo_list_collection_refs;
   ostree_repo_pull_from_remotes_async;
   ostree_repo_pull_from_remotes_finish;
+  ostree_repo_remote_list_collection_refs;
   ostree_repo_resolve_keyring_for_collection;
   ostree_repo_set_collection_id;
   ostree_repo_set_collection_ref_immediate;

--- a/src/libostree/ostree-repo-finder-config.c
+++ b/src/libostree/ostree-repo-finder-config.c
@@ -111,7 +111,7 @@ ostree_repo_finder_config_resolve_async (OstreeRepoFinder                  *find
   for (i = 0; i < n_remotes; i++)
     {
       g_autoptr(GError) local_error = NULL;
-      g_autoptr(GHashTable) remote_refs = NULL;  /* (element-type utf8 utf8) */
+      g_autoptr(GHashTable) remote_refs = NULL;  /* (element-type OstreeCollectionRef utf8) */
       const gchar *checksum;
       g_autofree gchar *remote_collection_id = NULL;
 
@@ -127,8 +127,9 @@ ostree_repo_finder_config_resolve_async (OstreeRepoFinder                  *find
           continue;
         }
 
-      if (!ostree_repo_remote_list_refs (parent_repo, remote_name, &remote_refs,
-                                         cancellable, &local_error))
+      if (!ostree_repo_remote_list_collection_refs (parent_repo, remote_name,
+                                                    &remote_refs, cancellable,
+                                                    &local_error))
         {
           g_debug ("Ignoring remote ‘%s’ due to error loading its refs: %s",
                    remote_name, local_error->message);
@@ -138,8 +139,7 @@ ostree_repo_finder_config_resolve_async (OstreeRepoFinder                  *find
 
       for (j = 0; refs[j] != NULL; j++)
         {
-          if (g_strcmp0 (refs[j]->collection_id, remote_collection_id) == 0 &&
-              g_hash_table_lookup_extended (remote_refs, refs[j]->ref_name, NULL, (gpointer *) &checksum))
+          if (g_hash_table_lookup_extended (remote_refs, refs[j], NULL, (gpointer *) &checksum))
             {
               /* The requested ref is listed in the refs for this remote. Add
                * the remote to the results, and the ref to its

--- a/src/libostree/ostree-repo-finder-config.c
+++ b/src/libostree/ostree-repo-finder-config.c
@@ -139,7 +139,8 @@ ostree_repo_finder_config_resolve_async (OstreeRepoFinder                  *find
 
       for (j = 0; refs[j] != NULL; j++)
         {
-          if (g_hash_table_lookup_extended (remote_refs, refs[j], NULL, (gpointer *) &checksum))
+          if (g_strcmp0 (refs[j]->collection_id, remote_collection_id) == 0 &&
+              g_hash_table_lookup_extended (remote_refs, refs[j], NULL, (gpointer *) &checksum))
             {
               /* The requested ref is listed in the refs for this remote. Add
                * the remote to the results, and the ref to its

--- a/src/libostree/ostree-repo-finder.c
+++ b/src/libostree/ostree-repo-finder.c
@@ -550,7 +550,9 @@ ostree_repo_finder_result_free (OstreeRepoFinderResult *result)
 {
   g_return_if_fail (result != NULL);
 
-  g_hash_table_unref (result->ref_to_checksum);
+  /* This may be NULL iff the result is freed half-way through find_remotes_cb()
+   * in ostree-repo-pull.c, and at no other time. */
+  g_clear_pointer (&result->ref_to_checksum, g_hash_table_unref);
   g_object_unref (result->finder);
   ostree_remote_unref (result->remote);
   g_free (result);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3270,6 +3270,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       (void) g_variant_lookup (options, "localcache-repos", "^a&s", &opt_localcache_repos);
     }
 
+  g_return_val_if_fail (OSTREE_IS_REPO (self), FALSE);
   g_return_val_if_fail (pull_data->maxdepth >= -1, FALSE);
   g_return_val_if_fail (!opt_collection_refs_set ||
                         (refs_to_fetch == NULL && override_commit_ids == NULL), FALSE);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5077,7 +5077,7 @@ find_remotes_cb (GObject      *obj,
     {
       OstreeRepoFinderResult *result = g_ptr_array_index (results, i);
       g_autoptr(GHashTable) validated_ref_to_checksum = NULL;  /* (element-type utf8 utf8) */
-      gsize j;
+      gsize j, n_latest_refs;
 
       /* Previous error processing this result? */
       if (result == NULL)
@@ -5089,6 +5089,7 @@ find_remotes_cb (GObject      *obj,
                                                          ostree_collection_ref_equal,
                                                          (GDestroyNotify) ostree_collection_ref_free,
                                                          g_free);
+      n_latest_refs = 0;
 
       for (j = 0; refs[j] != NULL; j++)
         {
@@ -5096,11 +5097,13 @@ find_remotes_cb (GObject      *obj,
 
           if (pointer_table_get (refs_and_remotes_table, j, i) != latest_commit_for_ref)
             latest_commit_for_ref = NULL;
+          if (latest_commit_for_ref != NULL)
+            n_latest_refs++;
 
           g_hash_table_insert (validated_ref_to_checksum, ostree_collection_ref_dup (refs[j]), g_strdup (latest_commit_for_ref));
         }
 
-      if (g_hash_table_size (validated_ref_to_checksum) == 0)
+      if (n_latest_refs == 0)
         {
           g_debug ("%s: Omitting remote ‘%s’ from results as none of its refs are new enough.",
                    G_STRFUNC, result->remote->name);

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -482,6 +482,15 @@ gboolean ostree_repo_remote_list_refs (OstreeRepo       *self,
                                        GCancellable     *cancellable,
                                        GError          **error);
 
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+_OSTREE_PUBLIC
+gboolean ostree_repo_remote_list_collection_refs (OstreeRepo    *self,
+                                                  const char    *remote_name,
+                                                  GHashTable   **out_all_refs,
+                                                  GCancellable  *cancellable,
+                                                  GError       **error);
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
+
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_variant (OstreeRepo  *self,
                                         OstreeObjectType objtype,


### PR DESCRIPTION
The intended behaviour of ostree_repo_find_remotes() is to return
results which have the latest version of at least one of the requested
refs. Results which have some of the requested refs, but don’t have the
latest version of any of them, should be ignored. The logic to do this
was broken in the case that a result contained a positive number of the
requested refs, but none of them were the latest version. (It previously
worked when the result contained none of the requested refs.)

Fix the counting to work correctly in both cases.

Signed-off-by: Philip Withnall <withnall@endlessm.com>