### PR TITLE
libotutil: Drop trailing semicolons from GObject definitions

### DIFF
--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -49,7 +49,7 @@ ot_cleanup_unlinkat (OtCleanupUnlinkat *cleanup)
       ot_cleanup_unlinkat_clear (cleanup);
     }
 }
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OtCleanupUnlinkat, ot_cleanup_unlinkat);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(OtCleanupUnlinkat, ot_cleanup_unlinkat)
 
 GFile * ot_fdrel_to_gfile (int dfd, const char *path);
 

--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -26,8 +26,8 @@
 
 G_BEGIN_DECLS
 
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_data_t, gpgme_data_release, NULL);
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_ctx_t, gpgme_release, NULL);
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_data_t, gpgme_data_release, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_ctx_t, gpgme_release, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gpgme_key_t, gpgme_key_unref, NULL)
 
 void ot_gpgme_error_to_gio_error (gpgme_error_t gpg_error, GError **error);


### PR DESCRIPTION
g-ir-scanner now emits a warning about them. It’s generally accepted
convention to *not* have a trailing semicolon after G_DEFINE_*() macro
invocations.

Signed-off-by: Philip Withnall <withnall@endlessm.com>