### PR TITLE
man: The min-free-space-percent item goes in [core] section

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -114,6 +114,14 @@ Boston, MA 02111-1307, USA.
 	</para>
 	</listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>min-free-space-percent</varname></term>
+        <listitem><para>Integer percentage value (0-99) that specifies a minimum
+        percentage of total space (in blocks) in the underlying filesystem to
+        keep free. The default value is 3.</para></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 
@@ -189,13 +197,6 @@ Boston, MA 02111-1307, USA.
       <varlistentry>
         <term><varname>unconfigured-state</varname></term>
         <listitem><para>If set, pulls from this remote will fail with the configured text.  This is intended for OS vendors which have a subscription process to access content.</para></listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><varname>min-free-space-percent</varname></term>
-        <listitem><para>Integer percentage value (0-99) that specifies a minimum
-        percentage of total space (in blocks) in the underlying filesystem to
-        keep free. The default value is 3.</para></listitem>
       </varlistentry>
 
     </variablelist>


### PR DESCRIPTION
The documentation incorrectly indicates that ```min-free-space-percent```
goes in the ```[remote "name"]``` section. It should go in ```[core]``` instead.