### PR TITLE
autogen.sh: Fix running out of tree

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -28,7 +28,6 @@ else
         gtkdocize
 fi
 
-cd $olddir
 if ! test -f libglnx/README.md || ! test -f bsdiff/README.md; then
     git submodule update --init
 fi
@@ -41,4 +40,5 @@ ln -sf ../libglnx/libglnx.m4 buildutil/libglnx.m4
 
 autoreconf --force --install --verbose
 
+cd $olddir
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"


### PR DESCRIPTION
The autogen.sh script should be runnable out of tree. It's mostly
already the case, just one little tweak to make it work.

    $ mkdir build
    $ cd build
    $ ../autogen.sh --prefix=/usr