### PR TITLE
lib/repo: Fix handling of missing summary files when downloading

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -556,7 +556,8 @@ get_refs_and_checksums_from_summary (GBytes      *summary_bytes,
 }
 
 /* Download the summary file from @remote, and return the bytes of the file in
- * @out_summary_bytes. */
+ * @out_summary_bytes. This will return %TRUE and set @out_summary_bytes to %NULL
+ * if the summary file does not exist. */
 static gboolean
 fetch_summary_from_remote (OstreeRepo    *repo,
                            OstreeRemote  *remote,
@@ -647,6 +648,13 @@ get_checksums (OstreeRepoFinderAvahi  *finder,
                                   finder->avahi_cancellable,
                                   error))
     return FALSE;
+
+  if (summary_bytes == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "No summary file found on server");
+      return FALSE;
+    }
 
   return get_refs_and_checksums_from_summary (summary_bytes, supported_ref_to_checksum, error);
 }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4834,6 +4834,14 @@ find_remotes_cb (GObject      *obj,
           g_clear_error (&error);
           continue;
         }
+      else if (summary_bytes == NULL)
+        {
+          g_debug ("%s: Failed to download summary for result ‘%s’. Ignoring. %s",
+                   G_STRFUNC, result->remote->name,
+                   "No summary file exists on server");
+          g_clear_pointer (&g_ptr_array_index (results, i), (GDestroyNotify) ostree_repo_finder_result_free);
+          continue;
+        }
 
       /* Check the metadata in the summary file, especially whether it contains
        * all the @refs we are interested in. */


### PR DESCRIPTION
The API for downloading a summary file can legitimately return NULL for
the summary file contents when it returns TRUE (success). This indicates
an error 404 — the summary file was not found.

Two call sites were not handling that correctly, which was causing later
assertion failures.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://github.com/ostreedev/ostree/issues/1061