### PR TITLE
lib/repo-finder: Emit gpg-verify-summary=false in dynamic remote config

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -824,9 +824,10 @@ ostree_avahi_service_build_repo_finder_result (OstreeAvahiService               
       g_clear_pointer (&remote->keyring, g_free);
       remote->keyring = g_strdup (repo->keyring);
 
+      /* gpg-verify-summary is false since we use the unsigned summary file support. */
       g_key_file_set_string (remote->options, remote->group, "url", repo->uri);
       g_key_file_set_boolean (remote->options, remote->group, "gpg-verify", TRUE);
-      g_key_file_set_boolean (remote->options, remote->group, "gpg-verify-summary", TRUE);
+      g_key_file_set_boolean (remote->options, remote->group, "gpg-verify-summary", FALSE);
 
       get_checksums (finder, parent_repo, remote, supported_ref_to_checksum, &error);
       if (error != NULL)

--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -392,9 +392,10 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder                  *finde
           g_clear_pointer (&remote->keyring, g_free);
           remote->keyring = g_strdup (repo->keyring);
 
+          /* gpg-verify-summary is false since we use the unsigned summary file support. */
           g_key_file_set_string (remote->options, remote->group, "url", repo->uri);
           g_key_file_set_boolean (remote->options, remote->group, "gpg-verify", TRUE);
-          g_key_file_set_boolean (remote->options, remote->group, "gpg-verify-summary", TRUE);
+          g_key_file_set_boolean (remote->options, remote->group, "gpg-verify-summary", FALSE);
 
           /* Set the timestamp in the #OstreeRepoFinderResult to 0 because
            * the code in ostree_repo_pull_from_remotes_async() will be able to

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5344,7 +5344,7 @@ ostree_repo_pull_from_remotes_async (OstreeRepo                           *self,
       g_variant_dict_insert (&local_options_dict, "flags", "i", OSTREE_REPO_PULL_FLAGS_UNTRUSTED | flags);
       g_variant_dict_insert_value (&local_options_dict, "collection-refs", g_variant_builder_end (&refs_to_pull_builder));
       g_variant_dict_insert (&local_options_dict, "gpg-verify", "b", TRUE);
-      g_variant_dict_insert (&local_options_dict, "gpg-verify-summary", "b", TRUE);
+      g_variant_dict_insert (&local_options_dict, "gpg-verify-summary", "b", FALSE);
       g_variant_dict_insert (&local_options_dict, "inherit-transaction", "b", TRUE);
       copy_option (&options_dict, &local_options_dict, "depth", G_VARIANT_TYPE ("i"));
       copy_option (&options_dict, &local_options_dict, "disable-static-deltas", G_VARIANT_TYPE ("b"));


### PR DESCRIPTION
When returning results from finding repos, set gpg-verify-summary=false
in their configs, since any pulls from such remotes will necessarily
involve collection IDs, and hence should be using the unsigned summary
support. In the intended deployment mode for P2P transmission of OSTree
refs, summaries *cannot* be signed, so setting gpg-verify-summary=true
would cause all the pulls to fail.

The unsigned summary support is the move of repository metadata from
the summary file (not spliceable) to the well-known ostree-metadata ref
(spliceable, as it can exist for multiple collection IDs in the same
repository).

Signed-off-by: Philip Withnall <withnall@endlessm.com>