### PR TITLE
Improve API for listing refs

### DIFF
--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -314,7 +314,9 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder                  *finde
 
           g_autoptr(GHashTable) repo_refs = NULL;  /* (element-type OstreeCollectionRef utf8) */
 
-          if (!ostree_repo_list_collection_refs (repo, refs[i]->collection_id, &repo_refs, cancellable, &local_error))
+          if (!ostree_repo_list_collection_refs (repo, refs[i]->collection_id, &repo_refs,
+                                                 OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES,
+                                                 cancellable, &local_error))
             {
               g_debug ("Ignoring ref (%s, %s) on mount ‘%s’ as its refs could not be listed: %s",
                        refs[i]->collection_id, refs[i]->ref_name, mount_name, local_error->message);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -396,11 +396,12 @@ gboolean      ostree_repo_set_collection_id (OstreeRepo   *self,
                                              const gchar  *collection_id,
                                              GError      **error);
 
-gboolean      ostree_repo_list_collection_refs (OstreeRepo    *self,
-                                                const char    *match_collection_id,
-                                                GHashTable   **out_all_refs,
-                                                GCancellable  *cancellable,
-                                                GError       **error);
+gboolean      ostree_repo_list_collection_refs (OstreeRepo                  *self,
+                                                const char                  *match_collection_id,
+                                                GHashTable                 **out_all_refs,
+                                                OstreeRepoListRefsExtFlags   flags,
+                                                GCancellable                *cancellable,
+                                                GError                     **error);
 
 void          ostree_repo_transaction_set_collection_ref (OstreeRepo                *self,
                                                           const OstreeCollectionRef *ref,

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -335,7 +335,7 @@ ostree_repo_prune (OstreeRepo        *self,
       g_autoptr(GHashTable) all_collection_refs = NULL;  /* (element-type OstreeChecksumRef utf8) */
 
       if (!ostree_repo_list_collection_refs (self, NULL, &all_collection_refs,
-                                             cancellable, error))
+                                             OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES, cancellable, error))
         return FALSE;
 
       GLNX_HASH_TABLE_FOREACH_V (all_collection_refs, const char*, checksum)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4914,7 +4914,8 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
    * backwards compatibility). */
   {
     g_autoptr(GHashTable) collection_refs = NULL;
-    if (!ostree_repo_list_collection_refs (self, NULL, &collection_refs, cancellable, error))
+    if (!ostree_repo_list_collection_refs (self, NULL, &collection_refs,
+                                           OSTREE_REPO_LIST_REFS_EXT_NONE, cancellable, error))
       return FALSE;
 
     gsize collection_map_size = 0;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -475,10 +475,12 @@ gboolean      ostree_repo_list_refs (OstreeRepo       *self,
  * OstreeRepoListRefsExtFlags:
  * @OSTREE_REPO_LIST_REFS_EXT_NONE: No flags.
  * @OSTREE_REPO_LIST_REFS_EXT_ALIASES: Only list aliases.  Since: 2017.10
+ * @OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES: Exclude remote refs.  Since: 2017.11
  */
 typedef enum {
   OSTREE_REPO_LIST_REFS_EXT_NONE = 0,
-  OSTREE_REPO_LIST_REFS_EXT_ALIASES = 1,
+  OSTREE_REPO_LIST_REFS_EXT_ALIASES = (1 << 0),
+  OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES = (1 << 1),
 } OstreeRepoListRefsExtFlags;
 
 _OSTREE_PUBLIC
@@ -1185,11 +1187,12 @@ gchar *ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
                                                    GError       **error);
 
 _OSTREE_PUBLIC
-gboolean ostree_repo_list_collection_refs (OstreeRepo    *self,
-                                           const char    *match_collection_id,
-                                           GHashTable   **out_all_refs,
-                                           GCancellable  *cancellable,
-                                           GError       **error);
+gboolean ostree_repo_list_collection_refs (OstreeRepo                 *self,
+                                           const char                 *match_collection_id,
+                                           GHashTable                 **out_all_refs,
+                                           OstreeRepoListRefsExtFlags flags,
+                                           GCancellable               *cancellable,
+                                           GError                     **error);
 
 #endif /* OSTREE_ENABLE_EXPERIMENTAL_API */
 

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -252,6 +252,7 @@ ostree_builtin_fsck (int argc, char **argv, GCancellable *cancellable, GError **
 
   g_autoptr(GHashTable) all_collection_refs = NULL;  /* (element-type OstreeCollectionRef utf8) */
   if (!ostree_repo_list_collection_refs (repo, NULL, &all_collection_refs,
+                                         OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES,
                                          cancellable, error))
     return FALSE;
 

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -82,7 +82,9 @@ delete_commit (OstreeRepo *repo, const char *commit_to_delete, GCancellable *can
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
   /* And check refs which *are* in a collection. */
-  if (!ostree_repo_list_collection_refs (repo, NULL, &collection_refs, cancellable, error))
+  if (!ostree_repo_list_collection_refs (repo, NULL, &collection_refs,
+                                         OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES,
+                                         cancellable, error))
     goto out;
 
   g_hash_table_iter_init (&hashiter, collection_refs);

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -64,7 +64,8 @@ do_ref_with_collections (OstreeRepo    *repo,
 
   if (!ostree_repo_list_collection_refs (repo,
                                          (!opt_create) ? refspec_prefix : NULL,
-                                         &refs, cancellable, error))
+                                         &refs, OSTREE_REPO_LIST_REFS_EXT_NONE,
+                                         cancellable, error))
     goto out;
 
   if (!opt_delete && !opt_create)

--- a/tests/test-find-remotes.sh
+++ b/tests/test-find-remotes.sh
@@ -57,7 +57,7 @@ assert_file_has_content refs "^apps-remote:app1$"
 assert_file_has_content refs "^os-remote:os/amd64/master$"
 
 ${CMD_PREFIX} ostree --repo=local refs --collections | wc -l > refscount
-assert_file_has_content refscount "^0$"
+assert_file_has_content refscount "^2$"
 
 # Create a local mirror repository where we pull the branches *in mirror mode* from the two remotes.
 # This should pull them into refs/mirrors, since the remotes advertise a collection ID.

--- a/tests/test-find-remotes.sh
+++ b/tests/test-find-remotes.sh
@@ -56,7 +56,10 @@ ${CMD_PREFIX} ostree --repo=local refs > refs
 assert_file_has_content refs "^apps-remote:app1$"
 assert_file_has_content refs "^os-remote:os/amd64/master$"
 
-${CMD_PREFIX} ostree --repo=local refs --collections | wc -l > refscount
+${CMD_PREFIX} ostree --repo=local refs --collections > refs
+cat refs | wc -l > refscount
+assert_file_has_content refs "^(org.example.AppsCollection, app1)$"
+assert_file_has_content refs "^(org.example.OsCollection, os/amd64/master)$"
 assert_file_has_content refscount "^2$"
 
 # Create a local mirror repository where we pull the branches *in mirror mode* from the two remotes.

--- a/tests/test-refs-collections.sh
+++ b/tests/test-refs-collections.sh
@@ -103,6 +103,28 @@ ${CMD_PREFIX} ostree --repo=repo refs --collections > refs
 assert_file_has_content refs "^(org.example.Collection, ctest)$"
 assert_file_has_content refs "^(org.example.NewCollection, ctest-mirror)$"
 
+# Remote refs should be listed if they have collection IDs
+
+cd ${test_tmpdir}
+mkdir collection-repo
+ostree_repo_init collection-repo --collection-id org.example.RemoteCollection
+mkdir -p adir
+${CMD_PREFIX} ostree --repo=collection-repo commit --branch=rcommit -m rcommit -s rcommit adir
+${CMD_PREFIX} ostree --repo=repo remote add --no-gpg-verify --collection-id org.example.RemoteCollection collection-repo-remote "file://${test_tmpdir}/collection-repo"
+${CMD_PREFIX} ostree --repo=repo pull collection-repo-remote rcommit
+${CMD_PREFIX} ostree --repo=repo refs --collections > refs
+assert_file_has_content refs "^(org.example.RemoteCollection, rcommit)$"
+
+cd ${test_tmpdir}
+mkdir no-collection-repo
+ostree_repo_init no-collection-repo
+mkdir -p adir2
+${CMD_PREFIX} ostree --repo=no-collection-repo commit --branch=rcommit2 -m rcommit2 -s rcommit2 adir2
+${CMD_PREFIX} ostree --repo=repo remote add --no-gpg-verify no-collection-repo-remote "file://${test_tmpdir}/no-collection-repo"
+${CMD_PREFIX} ostree --repo=repo pull no-collection-repo-remote rcommit2
+${CMD_PREFIX} ostree --repo=repo refs --collections > refs
+assert_not_file_has_content refs "rcommit2"
+
 echo "ok 1 refs collections"
 
 # Test that listing, creating and deleting refs works from an old repository

--- a/tests/test-summary-collections.sh
+++ b/tests/test-summary-collections.sh
@@ -55,4 +55,29 @@ ${CMD_PREFIX} ostree --repo=repo summary --update
 ${CMD_PREFIX} ostree --repo=repo summary --view > summary
 assert_file_has_content summary "(org.example.OtherCollection, test-1-mirror)$"
 
+# Test that remote refs are listed, but only if they have collection IDs
+cd ${test_tmpdir}
+mkdir collection-repo
+ostree_repo_init collection-repo --collection-id org.example.RemoteCollection
+mkdir -p adir
+${CMD_PREFIX} ostree --repo=collection-repo commit --branch=rcommit -m rcommit -s rcommit adir
+${CMD_PREFIX} ostree --repo=repo remote add --no-gpg-verify --collection-id org.example.RemoteCollection collection-repo-remote "file://${test_tmpdir}/collection-repo"
+${CMD_PREFIX} ostree --repo=repo pull collection-repo-remote rcommit
+${CMD_PREFIX} ostree --repo=repo summary --update
+
+${CMD_PREFIX} ostree --repo=repo summary --view > summary
+assert_file_has_content summary "(org.example.RemoteCollection, rcommit)$"
+
+cd ${test_tmpdir}
+mkdir no-collection-repo
+ostree_repo_init no-collection-repo
+mkdir -p adir2
+${CMD_PREFIX} ostree --repo=no-collection-repo commit --branch=rcommit2 -m rcommit2 -s rcommit2 adir2
+${CMD_PREFIX} ostree --repo=repo remote add --no-gpg-verify no-collection-repo-remote "file://${test_tmpdir}/no-collection-repo"
+${CMD_PREFIX} ostree --repo=repo pull no-collection-repo-remote rcommit2
+${CMD_PREFIX} ostree --repo=repo summary --update
+
+${CMD_PREFIX} ostree --repo=repo summary --view > summary
+assert_not_file_has_content summary "rcommit2"
+
 echo "ok summary collections"


### PR DESCRIPTION
Based on the manpage and the commit message on b7b79fa78, the expected
behavior for "ostree refs -c" is to list all the refs that have
collection IDs, but instead only the local and mirrored refs are being
shown. This commit makes the refs command also print refs from
configured remotes, as it does without the -c option.