### PR TITLE
lib/deploy: Close test suite race condition

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1074,7 +1074,12 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
         return glnx_throw_errno_prefix (error, "write(watchdog start)");
       /* Testing infrastructure */
       if (debug_fifreeze)
-        return glnx_throw (error, "aborting due to test-fifreeze");
+        {
+          int wstatus;
+          /* Ensure the child has written its data */
+          (void) TEMP_FAILURE_RETRY (waitpid (pid, &wstatus, 0));
+          return glnx_throw (error, "aborting due to test-fifreeze");
+        }
       /* Do a freeze/thaw cycle; TODO add a FIFREEZETHAW ioctl */
       if (ioctl (rootfs_dfd, FIFREEZE, 0) != 0)
         {


### PR DESCRIPTION
Saw this in a PR result; we need to wait for the child to have written its
result to stderr before we exit, otherwise the test suite may not read it in
time.