### PR TITLE
lib/gpg-verify: Add an OstreeGpgError error domain

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -194,6 +194,7 @@ ostree_diff_item_get_type
 
 <SECTION>
 <FILE>ostree-gpg-verify-result</FILE>
+OstreeGpgError
 OstreeGpgVerifyResult
 OstreeGpgSignatureAttr
 ostree_gpg_verify_result_count_all
@@ -210,6 +211,8 @@ OSTREE_GPG_VERIFY_RESULT
 OSTREE_IS_GPG_VERIFY_RESULT
 OSTREE_TYPE_GPG_VERIFY_RESULT
 ostree_gpg_verify_result_get_type
+OSTREE_GPG_ERROR
+ostree_gpg_error_quark
 </SECTION>
 
 <FILE>ostree-lzma-compressor</FILE>

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,7 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2017.10 {
+  ostree_gpg_error_quark;
   ostree_repo_set_alias_ref_immediate;
 };
 

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -682,9 +682,12 @@ ostree_gpg_verify_result_require_valid_signature (OstreeGpgVerifyResult *result,
 
   if (ostree_gpg_verify_result_count_valid (result) == 0)
     {
-      return glnx_throw (error, "%s",
-                        "GPG signatures found, but none are in trusted keyring");
+      g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_MISSING_KEY,
+                   "GPG signatures found, but none are in trusted keyring");
+      return FALSE;
     }
 
   return TRUE;
 }
+
+G_DEFINE_QUARK (OstreeGpgError, ostree_gpg_error)

--- a/src/libostree/ostree-gpg-verify-result.h
+++ b/src/libostree/ostree-gpg-verify-result.h
@@ -137,4 +137,25 @@ _OSTREE_PUBLIC
 gboolean ostree_gpg_verify_result_require_valid_signature (OstreeGpgVerifyResult *result,
                                                            GError **error);
 
+/**
+ * OstreeGpgError:
+ * @OSTREE_GPG_ERROR_NO_SIGNATURE: A signature was expected, but not found.
+ * @OSTREE_GPG_ERROR_INVALID_SIGNATURE: A signature was malformed.
+ * @OSTREE_GPG_ERROR_MISSING_KEY: A signature was found, but was created with a key not in the configured keyrings.
+ *
+ * Errors returned by signature creation and verification operations in OSTree.
+ * These may be returned by any API which creates or verifies signatures.
+ *
+ * Since: 2017.10
+ */
+typedef enum {
+  OSTREE_GPG_ERROR_NO_SIGNATURE = 0,
+  OSTREE_GPG_ERROR_INVALID_SIGNATURE,
+  OSTREE_GPG_ERROR_MISSING_KEY,
+} OstreeGpgError;
+
+_OSTREE_PUBLIC
+GQuark ostree_gpg_error_quark (void);
+#define OSTREE_GPG_ERROR (ostree_gpg_error_quark ())
+
 G_END_DECLS

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1423,7 +1423,7 @@ gpg_verify_unwritten_commit (OtPullData         *pull_data,
 
       if (!detached_metadata)
         {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+          g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,
                        "Commit %s: no detached metadata found for GPG verification",
                        checksum);
           return FALSE;
@@ -2463,7 +2463,7 @@ on_superblock_fetched (GObject   *src,
        */
       if (pull_data->gpg_verify_summary && !summary_csum)
         {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+          g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,
                        "GPG verification enabled, but no summary signatures found (use gpg-verify-summary=false in remote config to disable)");
           goto out;
         }
@@ -3653,21 +3653,21 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     if (!bytes_summary && pull_data->gpg_verify_summary)
       {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
                      "GPG verification enabled, but no summary found (use gpg-verify-summary=false in remote config to disable)");
         goto out;
       }
 
     if (!bytes_summary && pull_data->require_static_deltas)
       {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
                      "Fetch configured to require static deltas, but no summary found");
         goto out;
       }
 
     if (!bytes_sig && pull_data->gpg_verify_summary)
       {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+        g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,
                      "GPG verification enabled, but no summary.sig found (use gpg-verify-summary=false in remote config to disable)");
         goto out;
       }
@@ -5612,7 +5612,7 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,
 
   if (gpg_verify_summary && signatures == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+      g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,
                    "GPG verification enabled, but no summary signatures found (use gpg-verify-summary=false in remote config to disable)");
       goto out;
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4089,7 +4089,7 @@ ostree_repo_sign_commit (OstreeRepo     *self,
   if (!result)
     {
       /* "Not found" just means the commit is not yet signed.  That's okay. */
-      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+      if (g_error_matches (local_error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE))
         {
           g_clear_error (&local_error);
         }
@@ -4351,7 +4351,7 @@ _ostree_repo_gpg_verify_with_metadata (OstreeRepo          *self,
                                             _OSTREE_METADATA_GPGSIGS_TYPE);
   if (!signaturedata)
     {
-      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+      g_set_error_literal (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,
                            "GPG verification enabled, but no signatures found (use gpg-verify=false in remote config to disable)");
       return NULL;
     }

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -163,7 +163,7 @@ print_object (OstreeRepo          *repo,
                                                   &local_error);
         }
 
-      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+      if (g_error_matches (local_error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE))
         {
           /* Ignore */
         }


### PR DESCRIPTION
Add a new error domain for GPG signing/verification errors, and use it
throughout libostree for describing verification errors. This replaces
various uses of G_IO_ERROR_FAILED, and one instance of
G_IO_ERROR_NOT_FOUND (for which some code in ot-builtin-show.c had to be
changed to ensure it was still handled correctly).

The use of a separate error domain allows failures in GPG operations to
be handled separately from network failures (where the summary file
could not be found to be downloaded, for example) or timeouts.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

Closes: #1064