### PR TITLE
pull: mark commits from local cache as partial

### DIFF
--- a/man/ostree-pull.xml
+++ b/man/ostree-pull.xml
@@ -78,7 +78,7 @@ Boston, MA 02111-1307, USA.
 
               <listitem><para>
                 Like git's <literal>clone --reference</literal>.  Reuse the provided
-                OSTree repo as a local object cache of objects when doing HTTP fetches.
+                OSTree repo as a local object cache when doing HTTP fetches.
                 May be specified multiple times.
               </para></listitem>
             </varlistentry>

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1790,6 +1790,7 @@ scan_one_metadata_object_c (OtPullData                 *pull_data,
         {
           if (objtype == OSTREE_OBJECT_TYPE_COMMIT)
             {
+              /* mark as partial to ensure we scan the commit below */
               if (!write_commitpartial_for (pull_data, tmp_checksum, error))
                 return FALSE;
             }
@@ -1819,6 +1820,12 @@ scan_one_metadata_object_c (OtPullData                 *pull_data,
             return FALSE;
           if (!localcache_repo_has_obj)
             continue;
+          if (objtype == OSTREE_OBJECT_TYPE_COMMIT)
+            {
+              /* mark as partial to ensure we scan the commit below */
+              if (!write_commitpartial_for (pull_data, tmp_checksum, error))
+                return FALSE;
+            }
           if (!ostree_repo_import_object_from_with_trust (pull_data->repo, refd_repo,
                                                           objtype, tmp_checksum,
                                                           !pull_data->is_untrusted,

--- a/tests/test-pull-localcache.sh
+++ b/tests/test-pull-localcache.sh
@@ -23,23 +23,43 @@ set -euo pipefail
 
 setup_fake_remote_repo1 "archive"
 
-echo '1..1'
+echo '1..2'
 
 cd ${test_tmpdir}
 gnomerepo_url="$(cat httpd-address)/ostree/gnomerepo"
-ostree_repo_init repo --mode "archive"
+
+# Set up our local cache
 ostree_repo_init repo-local --mode "archive"
-for repo in repo{,-local}; do
-    ${CMD_PREFIX} ostree --repo=${repo} remote add --set=gpg-verify=false origin ${gnomerepo_url}
-done
+${CMD_PREFIX} ostree --repo=repo-local remote add --set=gpg-verify=false origin ${gnomerepo_url}
+
+init_repo() {
+  ostree_repo_init repo --mode "archive"
+  ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin ${gnomerepo_url}
+}
 
 # Pull the contents to our local cache
 ${CMD_PREFIX} ostree --repo=repo-local pull origin main
 rm files -rf
 ${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo checkout main files
 echo anewfile > files/anewfile
-${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo commit -b main --tree=dir=files
+commit=$(${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo commit -b main --tree=dir=files)
 
-${CMD_PREFIX} ostree --repo=repo pull -L repo-local origin main >out.txt
+# Check that pulling a new commit of the same tree hits our cache
+rm -rf repo
+init_repo
+${CMD_PREFIX} ostree --repo=repo pull --localcache-repo repo-local origin main >out.txt
 assert_file_has_content out.txt '3 metadata, 1 content objects fetched (4 meta, 5 content local)'
-echo "ok pull --reference"
+echo "ok pull --localcache-repo"
+
+# Check that pulling the same commit works as well
+rm -rf repo
+init_repo
+${CMD_PREFIX} ostree --repo=repo-local pull origin $commit
+${CMD_PREFIX} ostree --repo=repo pull -L repo-local origin main
+commit2=$(${CMD_PREFIX} ostree --repo=repo rev-parse main)
+[[ $commit == $commit2 ]]
+# and check that it's not partial
+rm -rf files
+${CMD_PREFIX} ostree --repo=repo checkout main files
+test -f files/anewfile
+echo "ok pull --localcache-repo same commit"


### PR DESCRIPTION
If one of the localcache repos has the exact same commit we resolved
from the remote, then we need to make sure to mark it as partial so that
we download the full tree.

Closes: #1074