### PR TITLE
lib/sysroot: Support /usr/lib/modules/$kver for kernel/initramfs

### DIFF
--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -43,8 +43,13 @@ to a filesystem tree that represents the underlying basis of a
 deployment.  For short, we will call this the "tree", to
 distinguish it from the concept of a deployment.
 
-First, the tree must include a kernel stored as
-`vmlinuz(-.*)?-$checksum` in either `/boot` or `/usr/lib/ostree-boot`.
+First, the tree must include a kernel (and optionally an initramfs).  The
+current standard locations for these are `/usr/lib/modules/$kver/vmlinuz` and
+`/usr/lib/modules/$kver/initramfs`.  The "boot checksum" will be computed
+automatically.  This follows the current Fedora kernel layout, and is
+the current recommended path.  However, older versions of libostree don't
+support this; you may need to also put kernels in the previous (legacy)
+paths, which are `vmlinuz(-.*)?-$checksum` in either `/boot` or `/usr/lib/ostree-boot`.
 The checksum should be a SHA256 hash of the kernel contents; it must be
 pre-computed before storing the kernel in the repository.  Optionally,
 the directory can also contain an initramfs, stored as

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..20"
+echo "1..22"
 
 . $(dirname $0)/libtest.sh
 
@@ -28,22 +28,43 @@ setup_os_repository "archive-z2" "syslinux"
 
 . $(dirname $0)/admin-test.sh
 
+# Test the legacy dirs
+for test_bootdir in "boot" "usr/lib/ostree-boot"; do
+    cd ${test_tmpdir}
+    rm httpd osdata testos-repo sysroot -rf
+    setup_os_repository "archive" "syslinux" $test_bootdir
+    ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+    rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+    ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* quiet'
+    assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
+    assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0 'an initramfs'
+    # kernel/initrams should also be in the tree's /boot with the checksum
+    assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/$test_bootdir/vmlinuz-3.6.0-${bootcsum} 'a kernel'
+    assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/$test_bootdir/initramfs-3.6.0-${bootcsum} 'an initramfs'
+    assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
+    assert_file_has_content sysroot/ostree/boot.1/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
+    ${CMD_PREFIX} ostree admin status
+    validate_bootloader
+    echo "ok kernel in $test_bootdir"
+done
+
+# And test that legacy overrides /usr/lib/modules
 cd ${test_tmpdir}
 rm httpd osdata testos-repo sysroot -rf
-setup_os_repository "archive-z2" "syslinux" "boot"
-
+setup_os_repository "archive" "syslinux" "usr/lib/ostree-boot"
+cd osdata
+echo "this is a kernel without an initramfs like Fedora 26" > usr/lib/modules/3.6.0/vmlinuz
+usrlib_modules_bootcsum=$(cat usr/lib/modules/3.6.0/vmlinuz | sha256sum | cut -f 1 -d ' ')
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --add-metadata-string version=1.0.9 -b testos/buildmaster/x86_64-runtime -s "Build"
+cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
 assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* quiet'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0 'an initramfs'
-# kernel/initrams should also be in the tree's /boot with the checksum
-assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/boot/vmlinuz-3.6.0-${bootcsum} 'a kernel'
-assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/boot/initramfs-3.6.0-${bootcsum} 'an initramfs'
-assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
-assert_file_has_content sysroot/ostree/boot.1/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
-${CMD_PREFIX} ostree admin status
-validate_bootloader
-echo "ok kernel in tree's /boot"
+# Note this bootcsum shouldn't be the modules one
+assert_not_streq "${bootcsum}" "${usrlib_modules_bootcsum}"
+echo "ok kernel in /usr/lib/modules and /usr/lib/ostree-boot"

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -30,6 +30,7 @@ setup_os_repository "archive-z2" "uboot"
 . $(dirname $0)/admin-test.sh
 
 cd ${test_tmpdir}
+mkdir -p osdata/usr/lib/ostree-boot
 cat << 'EOF' > osdata/usr/lib/ostree-boot/uEnv.txt
 loaduimage=load mmc ${bootpart} ${loadaddr} ${kernel_image}
 loadfdt=load mmc ${bootpart} ${fdtaddr} ${bootdir}${fdtfile}


### PR DESCRIPTION
This is the new Fedora kernel standard layout; it has the advantage
of being in `/usr` like `/usr/lib/ostree-boot`, but it's not OSTree
specific.

Further, I think in practice forcing tree builders to compute the checksum is an
annoying stumbling block; since we already switched to e.g. computing checksums
always when doing pulls, the cost of doing another checksum for the
kernel/initramfs is tiny. The "bootcsum" becomes more of an internal
implementation detail.

Now, there is a transition; my current thought for this is that rpm-ostree will
change to default to injecting into both `/usr/lib/ostree-boot` and
`/usr/lib/modules`, and stop doing `/boot`, then maybe next year say we drop the
`/usr/lib/ostree-boot` by default.