### PR TITLE
Add naggy comments to help keep options in sync

### DIFF
--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -56,6 +56,11 @@ typedef struct {
   GOutputStream *log;
 } OtTrivialHttpd;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-trivial-httpd.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "daemonize", 'd', 0, G_OPTION_ARG_NONE, &opt_daemonize, "Fork into background when ready", NULL },
   { "autoexit", 0, 0, G_OPTION_ARG_NONE, &opt_autoexit, "Automatically exit when directory is deleted", NULL },

--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -29,6 +29,11 @@
 
 #include <glib/gi18n.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-cleanup.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -39,6 +39,11 @@ static gboolean opt_kernel_proc_cmdline;
 static char *opt_osname;
 static char *opt_origin_path;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-deploy.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
   { "origin-file", 0, 0, G_OPTION_ARG_FILENAME, &opt_origin_path, "Specify origin file", "FILENAME" },

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -31,6 +31,11 @@
 
 static char *opt_osname;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-config-diff.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
   { NULL }

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -29,6 +29,11 @@
 
 #include <glib/gi18n.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-init-fs.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -29,6 +29,11 @@
 
 #include <glib/gi18n.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-os-init.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -34,6 +34,11 @@
 static int opt_index = -1;
 static char **opt_set;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-set-origin.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "set", 's', 0, G_OPTION_ARG_STRING_ARRAY, &opt_set, "Set config option KEY=VALUE for remote", "KEY=VALUE" },
   { "index", 0, 0, G_OPTION_ARG_INT, &opt_index, "Operate on the deployment INDEX, starting from zero", "INDEX" },

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -29,6 +29,11 @@
 
 #include <glib/gi18n.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-status.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -33,6 +33,11 @@
 static gboolean opt_reboot;
 static char *opt_osname;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-switch.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Reboot after switching trees", NULL },
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -28,6 +28,11 @@
 #include "ostree.h"
 #include "otutil.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-undeploy.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-builtin-unlock.c
+++ b/src/ostree/ot-admin-builtin-unlock.c
@@ -33,6 +33,11 @@
 
 static gboolean opt_hotfix;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-unlock.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "hotfix", 0, 0, G_OPTION_ARG_NONE, &opt_hotfix, "Retain changes across reboots", NULL },
   { NULL }

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -39,6 +39,11 @@ static gboolean opt_deploy_only;
 static char *opt_osname;
 static char *opt_override_commit;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-upgrade.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Reboot after a successful upgrade", NULL },

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -29,6 +29,11 @@
 
 #include "otutil.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-instutil.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -174,6 +174,11 @@ selinux_relabel_dir (OstreeSePolicy                *sepolicy,
   return ret;
 }
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-instutil.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -35,6 +35,11 @@ static gboolean opt_merge;
 static char **opt_replace;
 static char **opt_append;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-admin-instutil.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "import-proc-cmdline", 0, 0, G_OPTION_ARG_NONE, &opt_proc_cmdline, "Import current /proc/cmdline", NULL },
   { "merge", 0, 0, G_OPTION_ARG_NONE, &opt_merge, "Merge with previous command line", NULL },

--- a/src/ostree/ot-builtin-cat.c
+++ b/src/ostree/ot-builtin-cat.c
@@ -29,6 +29,11 @@
 
 #include <gio/gunixoutputstream.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-cat.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL },
 };

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -61,6 +61,11 @@ parse_fsync_cb (const char  *option_name,
   return TRUE;
 }
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-checkout.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "user-mode", 'U', 0, G_OPTION_ARG_NONE, &opt_user_mode, "Do not change file ownership or initialize extended attributes", NULL },
   { "disable-cache", 0, 0, G_OPTION_ARG_NONE, &opt_disable_cache, "Do not update or use the internal repository uncompressed object cache", NULL },

--- a/src/ostree/ot-builtin-checksum.c
+++ b/src/ostree/ot-builtin-checksum.c
@@ -28,6 +28,11 @@
 
 #include <string.h>
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-checksum.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -72,6 +72,11 @@ parse_fsync_cb (const char  *option_name,
   return TRUE;
 }
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-commit.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "parent", 0, 0, G_OPTION_ARG_STRING, &opt_parent, "Parent ref, or \"none\"", "REF" },
   { "subject", 's', 0, G_OPTION_ARG_STRING, &opt_subject, "One line subject", "SUBJECT" },

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -27,6 +27,11 @@
 #include "ostree.h"
 #include "otutil.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-config.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-builtin-diff.c
+++ b/src/ostree/ot-builtin-diff.c
@@ -33,6 +33,11 @@ static gboolean opt_no_xattrs;
 static gint opt_owner_uid = -1;
 static gint opt_owner_gid = -1;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-diff.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "stats", 0, 0, G_OPTION_ARG_NONE, &opt_stats, "Print various statistics", NULL },
   { "fs-diff", 0, 0, G_OPTION_ARG_NONE, &opt_fs_diff, "Print filesystem diff", NULL },

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -37,6 +37,11 @@ static char *opt_subpath;
 static char *opt_prefix;
 static gboolean opt_no_xattrs;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-export.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Skip output of extended attributes", NULL },
   { "subpath", 0, 0, G_OPTION_ARG_FILENAME, &opt_subpath, "Checkout sub-directory PATH", "PATH" },

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -32,6 +32,11 @@ static gboolean opt_quiet;
 static gboolean opt_delete;
 static gboolean opt_add_tombstones;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-fsck.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "add-tombstones", 0, 0, G_OPTION_ARG_NONE, &opt_add_tombstones, "Add tombstones for missing commits", NULL },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &opt_quiet, "Only print error messages", NULL },

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -31,6 +31,11 @@
 static gboolean opt_delete;
 static char *opt_gpg_homedir;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-gpg-sign.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "delete", 'd', 0, G_OPTION_ARG_NONE, &opt_delete, "Delete signatures having any of the GPG KEY-IDs" },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_FILENAME, &opt_gpg_homedir, "GPG Homedir to use when looking for keyrings", "HOMEDIR" },

--- a/src/ostree/ot-builtin-init.c
+++ b/src/ostree/ot-builtin-init.c
@@ -31,6 +31,11 @@ static char *opt_mode = "bare";
 static char *opt_collection_id = NULL;
 #endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-init.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "mode", 0, 0, G_OPTION_ARG_STRING, &opt_mode, "Initialize repository in given mode (bare, archive-z2)", NULL },
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API

--- a/src/ostree/ot-builtin-log.c
+++ b/src/ostree/ot-builtin-log.c
@@ -30,6 +30,11 @@
 
 static gboolean opt_raw;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-log.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "Show raw variant data" },
   { NULL }

--- a/src/ostree/ot-builtin-ls.c
+++ b/src/ostree/ot-builtin-ls.c
@@ -34,6 +34,11 @@ static gboolean opt_checksum;
 static gboolean opt_xattrs;
 static gboolean opt_nul_filenames_only;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-ls.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "dironly", 'd', 0, G_OPTION_ARG_NONE, &opt_dironly, "Do not recurse into directory arguments", NULL },
   { "recursive", 'R', 0, G_OPTION_ARG_NONE, &opt_recursive, "Print directories recursively", NULL },

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -36,6 +36,11 @@ static char *opt_delete_commit;
 static char *opt_keep_younger_than;
 static char **opt_retain_branch_depth;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-prune.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "no-prune", 0, 0, G_OPTION_ARG_NONE, &opt_no_prune, "Only display unreachable objects; don't delete", NULL },
   { "refs-only", 0, 0, G_OPTION_ARG_NONE, &opt_refs_only, "Only compute reachability via refs", NULL },

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -39,6 +39,11 @@ static gboolean opt_gpg_verify;
 static gboolean opt_gpg_verify_summary;
 static int opt_depth = 0;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-pull-local.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "remote", 0, 0, G_OPTION_ARG_STRING, &opt_remote, "Add REMOTE to refspec", "REMOTE" },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -43,6 +43,11 @@ static int opt_frequency = 0;
 static char* opt_url;
 static char** opt_localcache_repos;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-pull.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
    { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
    { "cache-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_cache_dir, "Use custom cache dir", NULL },

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -34,6 +34,11 @@ static char *opt_create;
 static gboolean opt_collections;
 #endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-refs.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "delete", 0, 0, G_OPTION_ARG_NONE, &opt_delete, "Delete refs which match PREFIX, rather than listing them", NULL },
   { "list", 0, 0, G_OPTION_ARG_NONE, &opt_list, "Do not remove the prefix from the refs", NULL },

--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -27,6 +27,11 @@
 #include "ostree.h"
 #include "otutil.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-reset.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-builtin-rev-parse.c
+++ b/src/ostree/ot-builtin-rev-parse.c
@@ -27,6 +27,11 @@
 #include "ostree.h"
 #include "otutil.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-rev-parse.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { NULL }
 };

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -36,6 +36,11 @@ static gboolean opt_raw;
 static char *opt_gpg_homedir;
 static char *opt_gpg_verify_remote;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-show.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "print-related", 0, 0, G_OPTION_ARG_NONE, &opt_print_related, "Show the \"related\" commits", NULL },
   { "print-variant-type", 0, 0, G_OPTION_ARG_STRING, &opt_print_variant_type, "Memory map OBJECT (in this case a filename) to the GVariant type string", "TYPE" },

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -59,6 +59,10 @@ static OstreeCommand static_delta_subcommands[] = {
   { NULL, NULL }
 };
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-static-delta.xml) when changing the option list(s).
+ */
 
 static GOptionEntry generate_options[] = {
   { "from", 0, 0, G_OPTION_ARG_STRING, &opt_from_rev, "Create delta from revision REV", "REV" },

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -32,6 +32,11 @@ static char **opt_key_ids;
 static char *opt_gpg_homedir;
 static char **opt_metadata;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-summary.xml) when changing the option list.
+ */
+
 static GOptionEntry options[] = {
   { "update", 'u', 0, G_OPTION_ARG_NONE, &opt_update, "Update the summary", NULL },
   { "view", 'v', 0, G_OPTION_ARG_NONE, &opt_view, "View the local summary file", NULL },

--- a/src/ostree/ot-remote-builtin-add-cookie.c
+++ b/src/ostree/ot-remote-builtin-add-cookie.c
@@ -28,6 +28,10 @@
 #include "ostree-repo-private.h"
 #include "ot-remote-cookie-util.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
 
 static GOptionEntry option_entries[] = {
   { NULL }

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -37,6 +37,11 @@ static char *opt_collection_id;
 static char *opt_sysroot;
 static char *opt_repo;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "set", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_set, "Set config option KEY=VALUE for remote", "KEY=VALUE" },
   { "no-gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_no_gpg_verify, "Disable GPG verification", NULL },

--- a/src/ostree/ot-remote-builtin-delete-cookie.c
+++ b/src/ostree/ot-remote-builtin-delete-cookie.c
@@ -29,6 +29,11 @@
 #include "ostree-repo-private.h"
 #include "ot-remote-cookie-util.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { NULL }
 };

--- a/src/ostree/ot-remote-builtin-delete.c
+++ b/src/ostree/ot-remote-builtin-delete.c
@@ -29,6 +29,11 @@ static gboolean opt_if_exists = FALSE;
 static char *opt_sysroot;
 static char *opt_repo;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "if-exists", 0, 0, G_OPTION_ARG_NONE, &opt_if_exists, "Do nothing if the provided remote does not exist", NULL },
   { "repo", 0, 0, G_OPTION_ARG_FILENAME, &opt_repo, "Path to OSTree repository (defaults to /sysroot/ostree/repo)", "PATH" },

--- a/src/ostree/ot-remote-builtin-gpg-import.c
+++ b/src/ostree/ot-remote-builtin-gpg-import.c
@@ -34,6 +34,11 @@
 static gboolean opt_stdin;
 static char **opt_keyrings;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "keyring", 'k', 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_keyrings, "Import keys from a keyring file (repeatable)", "FILE" },
   { "stdin", 0, 0, G_OPTION_ARG_NONE, &opt_stdin, "Import keys from standard input", NULL },

--- a/src/ostree/ot-remote-builtin-list-cookies.c
+++ b/src/ostree/ot-remote-builtin-list-cookies.c
@@ -28,6 +28,11 @@
 #include "ostree-repo-private.h"
 #include "ot-remote-cookie-util.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { NULL }
 };

--- a/src/ostree/ot-remote-builtin-list.c
+++ b/src/ostree/ot-remote-builtin-list.c
@@ -25,6 +25,11 @@
 
 static gboolean opt_show_urls;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "show-urls", 'u', 0, G_OPTION_ARG_NONE, &opt_show_urls, "Show remote URLs in list", NULL },
   { NULL }

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -27,6 +27,11 @@
 
 static char* opt_cache_dir;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "cache-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_cache_dir, "Use custom cache dir", NULL },
   { NULL }

--- a/src/ostree/ot-remote-builtin-show-url.c
+++ b/src/ostree/ot-remote-builtin-show-url.c
@@ -25,6 +25,11 @@
 #include "ot-main.h"
 #include "ot-remote-builtins.h"
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { NULL }
 };

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -30,6 +30,11 @@ static gboolean opt_raw;
 
 static char* opt_cache_dir;
 
+/* ATTENTION:
+ * Please remember to update the bash-completion script (bash/ostree) and
+ * man page (man/ostree-remote.xml) when changing the option list.
+ */
+
 static GOptionEntry option_entries[] = {
   { "cache-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_cache_dir, "Use custom cache dir", NULL },
   { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "Show raw variant data", NULL },


### PR DESCRIPTION
I meant to tack this on to #1077...

CLI options have to be kept synchronized in three different places now (code, man pages, bash completions).  I don't know how to automatically enforce this, so I just added a bunch of comments as a reminder to developers.

No code changes here.