### PR TITLE
Update libglnx

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -122,7 +122,7 @@ write_regular_file_content (OstreeRepo            *self,
       int infd = g_file_descriptor_based_get_fd ((GFileDescriptorBased*) input);
       guint64 len = g_file_info_get_size (file_info);
 
-      if (glnx_regfile_copy_bytes (infd, outfd, (off_t)len, TRUE) < 0)
+      if (glnx_regfile_copy_bytes (infd, outfd, (off_t)len) < 0)
         return glnx_throw_errno_prefix (error, "regfile copy");
     }
   else

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -467,7 +467,7 @@ create_regular_tmpfile_linkable_with_content (OstreeRepo *self,
   if (G_IS_FILE_DESCRIPTOR_BASED (input))
     {
       int infd = g_file_descriptor_based_get_fd ((GFileDescriptorBased*) input);
-      if (glnx_regfile_copy_bytes (infd, tmpf.fd, (off_t)length, TRUE) < 0)
+      if (glnx_regfile_copy_bytes (infd, tmpf.fd, (off_t)length) < 0)
         return glnx_throw_errno_prefix (error, "regfile copy");
     }
   else


### PR DESCRIPTION
This is mostly the `copy_file_range` changes plus the Coverity files.

```
Colin Walters (4):
      localalloc: Abort on EBADF from close() by default
      local-alloc: Remove almost all macros like glnx_free, glnx_unref_variant
      console: Fix Coverity NULL deref warning
      fdio: Merge systemd code to use copy_file_range(), use FICLONE

Jonathan Lebon (1):
      console: trim useless check

Matthew Leeds (1):
      dirfd: Fix typo in comment

Philip Withnall (1):
      glnx-console: Add missing NULL check before writing out text
```

Update submodule: libglnx