### PR TITLE
build-sys: Move bash completions to /usr/share/ by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ m4_define_default(
      AS_IF([test -n "$$1"], [$4], [$5])])
 
 PKG_CHECK_VAR(BASH_COMPLETIONSDIR, [bash-completion], [completionsdir], ,
-  BASH_COMPLETIONSDIR="${sysconfdir}/bash_completion.d")
+  BASH_COMPLETIONSDIR="${prefix}/bash-completion/completions")
 AC_SUBST(BASH_COMPLETIONSDIR)
 
 AM_PATH_GLIB_2_0(,,AC_MSG_ERROR([GLib not found]))

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ m4_define_default(
      AS_IF([test -n "$$1"], [$4], [$5])])
 
 PKG_CHECK_VAR(BASH_COMPLETIONSDIR, [bash-completion], [completionsdir], ,
-  BASH_COMPLETIONSDIR="${prefix}/bash-completion/completions")
+  BASH_COMPLETIONSDIR="${datadir}/bash-completion/completions")
 AC_SUBST(BASH_COMPLETIONSDIR)
 
 AM_PATH_GLIB_2_0(,,AC_MSG_ERROR([GLib not found]))


### PR DESCRIPTION
This is in line with the "/etc is for sysadmins", "/usr is OS" model;
e.g. systemd's bash completions go there.

Making this change since I was looking at the required spec file changes.