### PR TITLE
lib: Fix v2017.10 symbols to inherit from v2017.8

### DIFF
--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -23,7 +23,11 @@ LIBOSTREE_2017.10 {
   ostree_repo_set_alias_ref_immediate;
   ostree_repo_open_at;
   ostree_repo_create_at;
-};
+/* Inherit from .8 since .9 is empty and is also broken
+ * in that it doesn't have a parent currently;
+ * <https://github.com/ostreedev/ostree/issues/1087>
+ */
+} LIBOSTREE_2017.8;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste


### PR DESCRIPTION
I actually don't quite know what the version inheritance really does, but let's
be safe and fix this. I'm being conservative here and fixing it to inherit from
2017.8, skipping .9 since that doesn't have a parent.

Related: https://github.com/ostreedev/ostree/issues/1087