### PR TITLE
boot: Add a tmpfiles.d snippet to clean up /var/tmp/ostree-ovl.XXX

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -38,6 +38,8 @@ endif
 if BUILDOPT_SYSTEMD
 systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
 	src/boot/ostree-remount.service
+systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d
+systemdtmpfiles_DATA = src/boot/ostree-tmpfiles.conf
 
 # Allow the distcheck install under $prefix test to pass
 AM_DISTCHECK_CONFIGURE_FLAGS += --with-systemdsystemunitdir='$${libdir}/systemd/system'

--- a/src/boot/ostree-tmpfiles.conf
+++ b/src/boot/ostree-tmpfiles.conf
@@ -1,0 +1,19 @@
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+# https://github.com/ostreedev/ostree/issues/393
+R! /var/tmp/ostree-unlock-ovl.*


### PR DESCRIPTION
This is simplest for now.  Compare with similar logic from
`/usr/lib/tmpfiles.d/tmp.conf`:
```
R! /tmp/systemd-private-*
```

Closes: https://github.com/ostreedev/ostree/issues/393