### PR TITLE
bin: Squash some -Wuninit warnings with porting to new style

### DIFF
--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -65,10 +65,7 @@ ostree_admin_instutil_option_context_new_with_commands (void)
 gboolean
 ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  gboolean ret = FALSE;
-  OstreeAdminInstUtilCommand *subcommand;
   const char *subcommand_name = NULL;
-  g_autofree char *prgname = NULL;
   int in, out;
 
   for (in = 1, out = 1; in < argc; in++, out++)
@@ -94,7 +91,7 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
   argc = out;
 
-  subcommand = admin_instutil_subcommands;
+  OstreeAdminInstUtilCommand *subcommand = admin_instutil_subcommands;
   while (subcommand->name)
     {
       if (g_strcmp0 (subcommand_name, subcommand->name) == 0)
@@ -104,10 +101,8 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (!subcommand->name)
     {
-      g_autoptr(GOptionContext) context = NULL;
-      g_autofree char *help;
-
-      context = ostree_admin_instutil_option_context_new_with_commands ();
+      g_autoptr(GOptionContext) context =
+        ostree_admin_instutil_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
       if (ostree_admin_option_context_parse (context, NULL, &argc, &argv,
@@ -126,19 +121,16 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
             }
         }
 
-      help = g_option_context_get_help (context, FALSE, NULL);
+      g_autofree char *help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-
-      goto out;
+      return FALSE;
     }
 
-  prgname = g_strdup_printf ("%s %s", g_get_prgname (), subcommand_name);
+  g_autofree char *prgname = g_strdup_printf ("%s %s", g_get_prgname (), subcommand_name);
   g_set_prgname (prgname);
 
   if (!subcommand->fn (argc, argv, cancellable, error))
-    goto out;
- 
-  ret = TRUE;
- out:
-  return ret;
+    return FALSE;
+
+  return TRUE;
 }

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -78,15 +78,11 @@ int
 ostree_usage (OstreeCommand *commands,
               gboolean is_error)
 {
-  g_autoptr(GOptionContext) context = NULL;
-  g_autofree char *help;
-
-  context = ostree_option_context_new_with_commands (commands);
-
+  g_autoptr(GOptionContext) context =
+    ostree_option_context_new_with_commands (commands);
   g_option_context_add_main_entries (context, global_entries, NULL);
 
-  help = g_option_context_get_help (context, FALSE, NULL);
-
+  g_autofree char *help = g_option_context_get_help (context, FALSE, NULL);
   if (is_error)
     g_printerr ("%s", help);
   else


### PR DESCRIPTION
I noticed this with a local build of an RPM:

```
/usr/include/glib-2.0/glib/glib-autocleanups.h:28:3: warning: 'help' may be used uninitialized in this function [-Wmaybe-uninitialized]
   g_free (*pp);
   ^~~~~~~~~~~~
src/ostree/ot-main.c:82:20: note: 'help' was declared here
   g_autofree char *help;
                    ^~~~
```