### PR TITLE
docs/build: s/libOSTree/libostree/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-libOSTree
-======
+libostree
+---------
 
 New! See the docs online at [Read The Docs (OSTree)](https://ostree.readthedocs.org/en/latest/ )
 
 -----
 
-This project is now known as "libOSTree", renamed from "OSTree"; the focus is on
-the shared library. However, in most of the rest of the documentation, we will
-use the term "OSTree", since it's slightly shorter, and changing all
-documentation at once is impractical. We expect to transition to the new name
-over time.
+This project is now known as "libostree", though it is still appropriate to use
+the previous name: "OSTree" (or "ostree"). The focus is on projects which use
+libostree's shared library, rather than users directly invoking the command line
+tools (except for build systems). However, in most of the rest of the
+documentation, we will use the term "OSTree", since it's slightly shorter, and
+changing all documentation at once is impractical. We expect to transition to
+the new name over time.
 
-libOSTree is a library and suite of command line tools that combines a
-"git-like" model for committing and downloading bootable filesystem trees, along
-with a layer for deploying them and managing the bootloader configuration.
+As implied above, libostree is both a shared library and suite of command line
+tools that combines a "git-like" model for committing and downloading bootable
+filesystem trees, along with a layer for deploying them and managing the
+bootloader configuration.
 
 The core OSTree model is like git in that it checksums individual files and has
 a content-addressed-object store. It's unlike git in that it "checks out" the
@@ -24,16 +27,14 @@ of
 
 **Features:**
 
- - Atomic upgrades and rollback for the system
+ - Transactional upgrades and rollback for the system
  - Replicating content incrementally over HTTP via GPG signatures and "pinned TLS" support
  - Support for parallel installing more than just 2 bootable roots
  - Binary history on the server side (and client)
  - Introspectable shared library API for build and deployment systems
-
-This last point is important - you should think of the OSTree command
-line as effectively a "demo" for the shared library.  The intent is that
-package managers, system upgrade tools, container build tools and the like
-use OSTree as a "deduplicating hardlink store".
+ - Flexible support for multiple branches and repositories, supporting 
+   projects like [flatpak](https://github.com/flatpak/flatpak) which
+   use libostree for applications, rather than hosts.
 
 Projects using OSTree
 ---------------------
@@ -87,6 +88,7 @@ Once you have a git clone or recursive archive, building is the
 same as almost every autotools project:
 
 ```
+git submodule update --init
 env NOCONFIGURE=1 ./autogen.sh
 ./configure --prefix=...
 make

--- a/configure.ac
+++ b/configure.ac
@@ -525,7 +525,7 @@ src/libostree/ostree-version.h
 AC_OUTPUT
 
 echo "
-    libOSTree $VERSION ($release_build_type)
+    libostree $VERSION ($release_build_type)
     ===============
 
 


### PR DESCRIPTION
I find "libOSTree" awkward to type and really to look at. Let's be nicer on
people's pinky fingers and eyes and drop it all down to lowercase.