### PR TITLE
lib/deploy: Add .img to end of initramfs in /usr/lib/modules

### DIFF
--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -45,7 +45,7 @@ distinguish it from the concept of a deployment.
 
 First, the tree must include a kernel (and optionally an initramfs).  The
 current standard locations for these are `/usr/lib/modules/$kver/vmlinuz` and
-`/usr/lib/modules/$kver/initramfs`.  The "boot checksum" will be computed
+`/usr/lib/modules/$kver/initramfs.img`.  The "boot checksum" will be computed
 automatically.  This follows the current Fedora kernel layout, and is
 the current recommended path.  However, older versions of libostree don't
 support this; you may need to also put kernels in the previous (legacy)

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -381,14 +381,15 @@ setup_os_repository () {
     cd ${test_tmpdir}
     mkdir osdata
     cd osdata
-    mkdir -p usr/bin ${bootdir} usr/lib/modules/3.6.0 usr/share usr/etc
+    kver=3.6.0
+    mkdir -p usr/bin ${bootdir} usr/lib/modules/${kver} usr/share usr/etc
     kernel_path=${bootdir}/vmlinuz
-    initramfs_path=${bootdir}/initramfs
+    initramfs_path=${bootdir}/initramfs.img
     # /usr/lib/modules just uses "vmlinuz", since the version is in the module
     # directory name.
     if [[ $bootdir != usr/lib/modules/* ]]; then
-        kernel_path=${kernel_path}-3.6.0
-        initramfs_path=${initramfs_path}-3.6.0
+        kernel_path=${kernel_path}-${kver}
+        initramfs_path=${bootdir}/initramfs-${kver}.img
     fi
     echo "a kernel" > ${kernel_path}
     echo "an initramfs" > ${initramfs_path}
@@ -472,8 +473,9 @@ os_repository_new_commit ()
     branch=${3:-testos/buildmaster/x86_64-runtime}
     echo "BOOT ITERATION: $boot_checksum_iteration"
     cd ${test_tmpdir}/osdata
-    if test -f usr/lib/modules/3.6.0/vmlinuz; then
-        bootdir=usr/lib/modules/3.6.0
+    kver=3.6.0
+    if test -f usr/lib/modules/${kver}/vmlinuz; then
+        bootdir=usr/lib/modules/${kver}
     else
         if test -d usr/lib/ostree-boot; then
             bootdir=usr/lib/ostree-boot
@@ -483,10 +485,10 @@ os_repository_new_commit ()
     fi
     rm ${bootdir}/*
     kernel_path=${bootdir}/vmlinuz
-    initramfs_path=${bootdir}/initramfs
+    initramfs_path=${bootdir}/initramfs.img
     if [[ $bootdir != usr/lib/modules/* ]]; then
-        kernel_path=${kernel_path}-3.6.0
-        initramfs_path=${initramfs_path}-3.6.0
+        kernel_path=${kernel_path}-${kver}
+        initramfs_path=${bootdir}/initramfs-${kver}.img
     fi
     echo "new: a kernel ${boot_checksum_iteration}" > ${kernel_path}
     echo "new: an initramfs ${boot_checksum_iteration}" > ${initramfs_path}

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -39,10 +39,10 @@ for test_bootdir in "boot" "usr/lib/ostree-boot"; do
     assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
     assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* quiet'
     assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
-    assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0 'an initramfs'
+    assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
     # kernel/initrams should also be in the tree's /boot with the checksum
     assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/$test_bootdir/vmlinuz-3.6.0-${bootcsum} 'a kernel'
-    assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/$test_bootdir/initramfs-3.6.0-${bootcsum} 'an initramfs'
+    assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/$test_bootdir/initramfs-3.6.0.img-${bootcsum} 'an initramfs'
     assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
     assert_file_has_content sysroot/ostree/boot.1/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
     ${CMD_PREFIX} ostree admin status
@@ -64,7 +64,7 @@ rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmast
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
 assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
-assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0 'an initramfs'
+assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
 # Note this bootcsum shouldn't be the modules one
 assert_not_streq "${bootcsum}" "${usrlib_modules_bootcsum}"
 echo "ok kernel in /usr/lib/modules and /usr/lib/ostree-boot"


### PR DESCRIPTION
Follow up to <https://github.com/ostreedev/ostree/pull/1079>; I was working on
the rpm-ostree updates for this, and I think it's more consistent if we have
`.img` here, since that's a closer match to the "remove $kver" that results in
`vmlinuz`. Also just best practice to have file suffix types where they make
sense.

The astute reader might notice this sneaks in a change where we'd crash if the
legacy bootdir didn't have an initramfs...yeah, should probably have test
coverage of that.