### PR TITLE
lib/sysroot: fix placement for not-default deployment

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1545,7 +1545,7 @@ ostree_sysroot_simple_write_deployment (OstreeSysroot      *sysroot,
           g_ptr_array_add (new_deployments, g_object_ref (deployment));
         }
 
-      if (!added_new)
+      if ((!added_new) && is_merge_or_booted)
         {
           g_ptr_array_add (new_deployments, g_object_ref (new_deployment));
           added_new = TRUE;


### PR DESCRIPTION
When using the
OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NOT_DEFAULT flag, the
deployment is said to be added after the booted or merge deployment.
Fix the condition to do so instead of adding it in the second place.