### PR TITLE
build: Add --with-bashcompletionsdir configure argument

### DIFF
--- a/Makefile-bash.am
+++ b/Makefile-bash.am
@@ -17,5 +17,5 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-completionsdir = @BASH_COMPLETIONSDIR@
+completionsdir = @bashcompletionsdir@
 dist_completions_DATA = bash/ostree

--- a/configure.ac
+++ b/configure.ac
@@ -88,16 +88,13 @@ AS_IF([test "$YACC" != "bison -y"], [AC_MSG_ERROR([bison not found but required]
 
 PKG_PROG_PKG_CONFIG
 
-# PKG_CHECK_VAR added to pkg-config 0.28
-m4_define_default(
-    [PKG_CHECK_VAR],
-    [AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])
-     AS_IF([test -z "$$1"], [$1=`$PKG_CONFIG --variable="$3" "$2"`])
-     AS_IF([test -n "$$1"], [$4], [$5])])
-
-PKG_CHECK_VAR(BASH_COMPLETIONSDIR, [bash-completion], [completionsdir], ,
-  BASH_COMPLETIONSDIR="${datadir}/bash-completion/completions")
-AC_SUBST(BASH_COMPLETIONSDIR)
+AC_ARG_WITH([bashcompletionsdir],
+  AS_HELP_STRING([--with-bashcompletionsdir=DIR], [Directory for bash-completion scripts]),
+  [],
+  [with_bashcompletionsdir=$($PKG_CONFIG --variable=completionsdir bash-completion)])
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"], [
+  AC_SUBST([bashcompletionsdir], [$with_bashcompletionsdir])
+])
 
 AM_PATH_GLIB_2_0(,,AC_MSG_ERROR([GLib not found]))
 


### PR DESCRIPTION
Allow the distributor to specify where the bash completions are
installed. This is necessary for building in a prefix; otherwise the
directory from your system bash-completions.pc file will be used. i.e.
This is needed for the same reason we have --with-systemdsystemunitdir
and friends.

Signed-off-by: Philip Withnall <withnall@endlessm.com>