### PR TITLE
Distcheck fixes

### DIFF
--- a/Makefile-bash.am
+++ b/Makefile-bash.am
@@ -19,3 +19,6 @@
 
 completionsdir = @BASH_COMPLETIONSDIR@
 dist_completions_DATA = bash/ostree
+
+# Allow the distcheck install under $prefix test to pass
+AM_DISTCHECK_CONFIGURE_FLAGS += BASH_COMPLETIONSDIR='$${datadir}/bash-completion/completions'

--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -39,7 +39,7 @@ if BUILDOPT_SYSTEMD
 systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
 	src/boot/ostree-remount.service
 systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d
-systemdtmpfiles_DATA = src/boot/ostree-tmpfiles.conf
+dist_systemdtmpfiles_DATA = src/boot/ostree-tmpfiles.conf
 
 # Allow the distcheck install under $prefix test to pass
 AM_DISTCHECK_CONFIGURE_FLAGS += --with-systemdsystemunitdir='$${libdir}/systemd/system'

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -68,4 +68,7 @@ ostree_system_generator_SOURCES = src/switchroot/ostree-mount-util.h \
 ostree_system_generator_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libostree
 ostree_system_generator_CFLAGS = $(AM_CFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS)
 ostree_system_generator_LDADD = $(AM_LDFLAGS) libglnx.la libostree-1.la $(OT_INTERNAL_GIO_UNIX_LIBS)
+
+# Allow the distcheck install under $prefix test to pass
+AM_DISTCHECK_CONFIGURE_FLAGS += --with-systemdsystemgeneratordir='$${libdir}/systemd/system-generators'
 endif


### PR DESCRIPTION
These are the fixes which I should have made in my earlier half-hearted attempt to ‘fix’ the bash-completion build machinery.

The fixes for systemd and bash-completion affect the 2017.10 release, as far as I can tell. The tmpfiles stuff landed after 2017.10 so is unaffected.