### PR TITLE
libarchive: Add support for translating paths during commit

### DIFF
--- a/src/libostree/ostree-libarchive-private.h
+++ b/src/libostree/ostree-libarchive-private.h
@@ -38,6 +38,28 @@ typedef struct archive OtAutoArchiveWrite;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtAutoArchiveWrite, archive_write_free)
 typedef struct archive OtAutoArchiveRead;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OtAutoArchiveRead, archive_read_free)
+
+static inline OtAutoArchiveRead *
+ot_open_archive_read (const char *path, GError **error)
+{
+  g_autoptr(OtAutoArchiveRead) a = archive_read_new ();
+
+#ifdef HAVE_ARCHIVE_READ_SUPPORT_FILTER_ALL
+  archive_read_support_filter_all (a);
+#else
+  archive_read_support_compression_all (a);
+#endif
+  archive_read_support_format_all (a);
+  if (archive_read_open_filename (a, path, 8192) != ARCHIVE_OK)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "%s", archive_error_string (a));
+      return NULL;
+    }
+
+  return g_steal_pointer (&a);
+}
+
 #endif
 
 G_END_DECLS

--- a/tests/test-libarchive.sh
+++ b/tests/test-libarchive.sh
@@ -26,14 +26,14 @@ fi
 
 . $(dirname $0)/libtest.sh
 
-echo "1..21"
+echo "1..13"
 
 setup_test_repository "bare"
 
 cd ${test_tmpdir}
 mkdir foo
 cd foo
-mkdir -p usr/bin
+mkdir -p usr/bin usr/lib
 echo contents > usr/bin/foo
 touch usr/bin/foo0
 ln usr/bin/foo usr/bin/bar
@@ -45,8 +45,12 @@ ln usr/bin/foo0 usr/local/bin/baz0
 ln usr/bin/sl usr/local/bin/slhl
 touch usr/bin/setuidme
 touch usr/bin/skipme
+echo "a library" > usr/lib/libfoo.so
+echo "another library" > usr/lib/libbar.so
 
+# Create a tar archive
 tar -c -z -f ../foo.tar.gz .
+# Create a cpio archive
 find . | cpio -o -H newc > ../foo.cpio
 
 cd ..
@@ -71,10 +75,17 @@ $OSTREE commit -s "from cpio" -b test-cpio \
 echo "ok cpio commit"
 
 assert_valid_checkout () {
-  cd ${test_tmpdir}
-  $OSTREE checkout test-$1 test-$1-checkout
-  cd test-$1-checkout
+  ref=$1
+  rm test-${ref}-checkout -rf
+  $OSTREE checkout test-${ref} test-${ref}-checkout
 
+  assert_valid_content test-${ref}-checkout
+  rm -rf test-${ref}-checkout
+}
+
+assert_valid_content () {
+  dn=$1
+  cd ${dn}
   # basic content check
   assert_file_has_content usr/bin/foo contents
   assert_file_has_content usr/bin/bar contents
@@ -82,39 +93,35 @@ assert_valid_checkout () {
   assert_file_empty usr/bin/foo0
   assert_file_empty usr/bin/bar0
   assert_file_empty usr/local/bin/baz0
-  echo "ok $1 contents"
+  assert_file_has_content usr/lib/libfoo.so 'a library'
+  assert_file_has_content usr/lib/libbar.so 'another library'
 
   # hardlinks
   assert_files_hardlinked usr/bin/foo usr/bin/bar
   assert_files_hardlinked usr/bin/foo usr/local/bin/baz
-  echo "ok $1 hardlink"
   assert_files_hardlinked usr/bin/foo0 usr/bin/bar0
   assert_files_hardlinked usr/bin/foo0 usr/local/bin/baz0
-  echo "ok $1 hardlink to empty files"
 
   # symlinks
   assert_symlink_has_content usr/bin/sl foo
   assert_file_has_content usr/bin/sl contents
-  echo "ok $1 symlink"
   # ostree checkout doesn't care if two symlinks are actually hardlinked
   # together (which is fine). checking that it's also a symlink is good enough.
   assert_symlink_has_content usr/local/bin/slhl foo
-  echo "ok $1 hardlink to symlink"
 
   # stat override
   test -u usr/bin/setuidme
-  echo "ok $1 setuid"
 
   # skip list
   test ! -f usr/bin/skipme
-  echo "ok $1 file skip"
 
   cd ${test_tmpdir}
-  rm -rf test-$1-checkout
 }
 
 assert_valid_checkout tar
+echo "ok tar contents"
 assert_valid_checkout cpio
+echo "ok cpio contents"
 
 cd ${test_tmpdir}
 mkdir multicommit-files
@@ -155,12 +162,59 @@ cd partial-checkout
 assert_file_has_content subdir/original "original"
 echo "ok tar partial commit contents"
 
-cd ${test_tmpdir}
-tar -cf empty.tar.gz -T /dev/null
 uid=$(id -u)
 gid=$(id -g)
-$OSTREE commit -b tar-empty --tar-autocreate-parents \
-        --owner-uid=${uid} --owner-gid=${gid} --tree=tar=empty.tar.gz
+autocreate_args="--tar-autocreate-parents --owner-uid=${uid} --owner-gid=${gid}"
+
+cd ${test_tmpdir}
+tar -cf empty.tar.gz -T /dev/null
+$OSTREE commit -b tar-empty ${autocreate_args} --tree=tar=empty.tar.gz
 $OSTREE ls tar-empty > ls.txt
 assert_file_has_content ls.txt "d00755 ${uid} ${gid}      0 /"
 echo "ok tar autocreate with owner uid/gid"
+
+# noop pathname filter
+cd ${test_tmpdir}
+$OSTREE commit -b test-tar ${autocreate_args} \
+        --tar-pathname-filter='^nosuchfile/,nootherfile/' \
+        --statoverride=statoverride.txt \
+        --skip-list=skiplist.txt \
+        --tree=tar=foo.tar.gz
+rm test-tar-co -rf
+$OSTREE checkout test-tar test-tar-co
+assert_valid_content ${test_tmpdir}/test-tar-co
+echo "ok tar pathname filter prefix (noop)"
+
+# Add a prefix
+cd ${test_tmpdir}
+# Update the metadata overrides matching our pathname filter
+for f in statoverride.txt skiplist.txt; do
+    sed -i -e 's,/usr/,/foo/usr/,' $f
+done
+$OSTREE commit -b test-tar ${autocreate_args} \
+        --tar-pathname-filter='^,foo/' \
+        --statoverride=statoverride.txt \
+        --skip-list=skiplist.txt \
+        --tree=tar=foo.tar.gz
+rm test-tar-co -rf
+$OSTREE checkout test-tar test-tar-co
+assert_has_dir test-tar-co/foo
+assert_valid_content ${test_tmpdir}/test-tar-co/foo
+echo "ok tar pathname filter prefix"
+
+# Test anchored and not-anchored
+for filter in '^usr/bin/,usr/sbin/' '/bin/,/sbin/'; do
+    cd ${test_tmpdir}
+    $OSTREE commit -b test-tar ${autocreate_args} \
+            --tar-pathname-filter=$filter \
+            --tree=tar=foo.tar.gz
+    rm test-tar-co -rf
+    $OSTREE checkout test-tar test-tar-co
+    cd test-tar-co
+    # Check that we just had usr/bin → usr/sbin
+    assert_not_has_file usr/bin/foo
+    assert_file_has_content usr/sbin/foo contents
+    assert_not_has_file usr/sbin/libfoo.so
+    assert_file_has_content usr/lib/libfoo.so 'a library'
+    echo "ok tar pathname filter modification: ${filter}"
+done


### PR DESCRIPTION
For rpm-ostree, I want to move RPM files in `/boot` to `/usr/lib/ostree-boot`.
This is currently impossible without forking the libarchive code.  Supporting
this is pretty straightforward; we already had pathname translation in
the libarchive code, we just need to expose it as an option.

On the command line side, I chose to wrap this as a regexp. That should be good
enough for a lot of use cases; sophisticated users should as always be making
use of the API. Note that this required some new `#ifdef LIBARCHIVE` bits to use
the new API. Following previous patterns here, we use the new API only if a
relevant option is enabled, ensuring unit test coverage of both paths.

For the test cases, I ended up changing the accounting to avoid having to
multiply the test count.