### PR TITLE
bin/main: Remove duplicated usage output on unknown commands

### DIFF
--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -185,9 +185,6 @@ ostree_run (int    argc,
             }
         }
 
-      help = g_option_context_get_help (context, FALSE, NULL);
-      g_printerr ("%s", help);
-
       goto out;
     }
 


### PR DESCRIPTION
It's been this way for a long time, though not forever; I went
back to v2014.11 as a random choice and it worked then.  Not
going to bother doing a full archive search for this though.
Anyone who wants more context can help themselves.

Closes: https://github.com/ostreedev/ostree/issues/1096