### PR TITLE
build/maint.mk: Comment out setting of LC_ALL

### DIFF
--- a/maint.mk
+++ b/maint.mk
@@ -105,7 +105,8 @@ my_distdir = $(PACKAGE)-$(VERSION)
 
 # Prevent programs like 'sort' from considering distinct strings to be equal.
 # Doing it here saves us from having to set LC_ALL elsewhere in this file.
-export LC_ALL = C
+# NOTE: commented out for https://github.com/ostreedev/ostree/issues/1101
+# export LC_ALL = C
 
 ## --------------- ##
 ## Sanity checks.  ##


### PR DESCRIPTION
This triggers obscure bugs; really we shouldn't be overriding
the global locale here.  In practice, production build systems
will be using fixed locales anyways.

Also, we only use a small subset of this file (`make syntax-check`),
which appears to work OK without this.

I will probably try to work out where to submit this as at
least an issue report for upstream gnulib.

Closes: https://github.com/ostreedev/ostree/issues/1101