### PR TITLE
lib/repo: Add some assertions for ABI sizes

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -47,6 +47,33 @@
 #include <sys/file.h>
 #include <sys/statvfs.h>
 
+/* ABI Size checks for ostree-repo.h, only for LP64 systems;
+ * https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
+ */
+#if __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 8 && __SIZEOF_INT__ == 4
+G_STATIC_ASSERT(sizeof(OstreeRepoTransactionStats) == sizeof(int) * 4 + 8 * 5);
+G_STATIC_ASSERT(sizeof(OstreeRepoImportArchiveOptions) == sizeof(int) * 9 + 4 + sizeof(void*) * 8);
+G_STATIC_ASSERT(sizeof(OstreeRepoExportArchiveOptions) == sizeof(int) * 9 + 4 + 8 + sizeof(void*) * 8);
+G_STATIC_ASSERT(sizeof(OstreeRepoCheckoutAtOptions) ==
+                sizeof(OstreeRepoCheckoutMode) + sizeof(OstreeRepoCheckoutOverwriteMode) +
+                sizeof(int)*6 +
+                sizeof(int)*5 +
+                sizeof(int) +
+                sizeof(void*)*2 +
+                sizeof(int)*6 +
+                sizeof(void*)*7);
+G_STATIC_ASSERT(sizeof(OstreeRepoCommitTraverseIter) ==
+                sizeof(int) + sizeof(int) +
+                sizeof(void*) * 10 +
+                130 + 6);  /* 6 byte hole */
+G_STATIC_ASSERT(sizeof(OstreeRepoPruneOptions) ==
+                sizeof(OstreeRepoPruneFlags) +
+                4 +
+                sizeof(void*) +
+                sizeof(int) * 12 +
+                sizeof(void*) * 7);
+#endif
+
 /**
  * SECTION:ostree-repo
  * @title: Content-addressed object store

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -724,6 +724,7 @@ typedef struct {
   guint disable_xattrs : 1;
   guint reserved : 31;
 
+  /* 4 byte hole on 64 bit arches */
   guint64 timestamp_secs;
 
   guint unused_uint[8];
@@ -838,6 +839,7 @@ typedef struct {
   gboolean force_copy; /* Since: 2017.6 */
   gboolean bareuseronly_dirs; /* Since: 2017.7 */
   gboolean unused_bools[5];
+  /* 4 byte hole on 64 bit */
 
   const char *subpath;
 
@@ -972,6 +974,7 @@ gboolean ostree_repo_traverse_commit_union (OstreeRepo         *repo,
 
 struct _OstreeRepoCommitTraverseIter {
   gboolean initialized;
+  /* 4 byte hole on 64 bit */
   gpointer dummy[10];
   char dummy_checksum_data[(OSTREE_SHA256_STRING_LEN+1)*2];
 };
@@ -1059,6 +1062,8 @@ gboolean ostree_repo_prune (OstreeRepo        *self,
 
 struct _OstreeRepoPruneOptions {
   OstreeRepoPruneFlags flags;
+
+  /* 4 byte hole on 64 bit */
 
   GHashTable *reachable; /* Set<GVariant> (object names) */
 


### PR DESCRIPTION
Things like https://sourceware.org/libabigail/manual/abidiff.html
look interesting but in a brief look I couldn't work out
how to conveniently use them for quick ABI sanity checking without
doing a diff from a previous build (which we could do but would be
more involved).

This way will at least catch struct ABI breaks on x86_64 which
I think we'd be most likely to do accidentally when trying
to use one of the previous unused values.

I found the hole values via gdb's `pahole` command.