### PR TITLE
Remove shebang from bash completions

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # bash completion file for ostree commands
 #
 # This script provides completion of:


### PR DESCRIPTION
bash completions are to be sourced. It makes little sense to
execute them.

Detected by Debian's Lintian tool, which warns about non-executable
files that appear to be #! scripts.