### PR TITLE
Fix build-time tests when /var/tmp and/or /tmp do not support user xattrs

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -511,6 +511,17 @@ os_repository_new_commit ()
     cd ${test_tmpdir}
 }
 
+# Usage: if ! skip_one_without_user_xattrs; then ... more tests ...; fi
+skip_one_without_user_xattrs () {
+    touch test-xattrs
+    if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+        echo "ok # SKIP - this test requires xattr support"
+        return 0
+    else
+        return 1
+    fi
+}
+
 skip_without_user_xattrs () {
     touch test-xattrs
     setfattr -n user.testvalue -v somevalue test-xattrs || \

--- a/tests/test-pull-bareuser.sh
+++ b/tests/test-pull-bareuser.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_user_xattrs
 setup_fake_remote_repo1 "archive"
 
 repo_mode=bare-user


### PR DESCRIPTION
I'm sure I fixed this at least once before, but I had to ignore the build-time tests' results in Debian due to intermittent failures (which are hopefully now resolved), and it regressed.

Some (all?) Debian autobuilders work by unpacking a cached OS tarball onto a tmpfs and building in that chroot, so there is no location visible to the builder where xattrs work.