### PR TITLE
commit: filter out selinux label before commit

### DIFF
--- a/tests/installed/itest-label-selinux.sh
+++ b/tests/installed/itest-label-selinux.sh
@@ -24,6 +24,7 @@ ostree --repo=/ostree/repo commit -b testbranch --link-checkout-speedup \
        --selinux-policy co --tree=dir=co
 ostree --repo=/ostree/repo ls -X testbranch /usr/bin/foo-a-generic-binary > ls.txt
 assert_file_has_content ls.txt ${oldcon}
+ostree --repo=/ostree/repo fsck
 
 ostree --repo=/ostree/repo refs --delete testbranch
 rm co -rf


### PR DESCRIPTION
The new --selinux-policy added in [0] exposed a subtle issue in the way
we handle labeling during commit. The CI system in rpm-ostree hit this
when trying to make use of it[1].

Basically, because of the way we use a GVariant to represent xattrs, if
a file to be committed already has an SELinux label, the xattr object
ends up with *two* label entries. This of course throws off fsck later
on, since the checksum will have gone over both entries, even though the
on-disk file will only have a single label (in which the second entry
wins).

I confirmed that the `fsck` added in the installed test fails without
the rest of this patch.

[0] https://github.com/ostreedev/ostree/pull/1114
[1] https://github.com/projectatomic/rpm-ostree/pull/953