### PR TITLE
tree-wide: Replace archive-z2 with archive

### DIFF
--- a/man/ostree-init.xml
+++ b/man/ostree-init.xml
@@ -67,9 +67,13 @@ Boston, MA 02111-1307, USA.
         <variablelist>
             <varlistentry>
                 <term><option>--mode</option>="MODE"</term>
-                <listitem><para>
-                    Initialize repository in given mode (bare, bare-user, archive-z2).  Default is "bare".
-                </para></listitem>
+                <listitem><para> Initialize repository in given mode
+                (<literal>bare</literal>, <literal>bare-user</literal>,
+                <literal>archive</literal>). The default is
+                <literal>bare</literal>. Note that for
+                <literal>archive</literal> the repository configuration file
+                will actually have <literal>archive-z2</literal>, as that's the
+                historical name.</para></listitem>
             </varlistentry>
 
             <varlistentry>

--- a/man/ostree-pull.xml
+++ b/man/ostree-pull.xml
@@ -157,7 +157,7 @@ Boston, MA 02111-1307, USA.
 
 	<para>Perform a complete mirror of the remote.  (This is
 	likely most useful if your repository is also
-	<literal>archive-z2</literal> mode)</para>
+	<literal>archive</literal> mode)</para>
 
         <para><command>$ ostree --repo=repo pull remote_name exampleos/x86_64/standard</command></para>
 

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -76,7 +76,7 @@ Boston, MA 02111-1307, USA.
     <variablelist>
       <varlistentry>
         <term><varname>mode</varname></term>
-        <listitem><para>One of <literal>bare</literal>, <literal>bare-user</literal> or <literal>archive-z2</literal> (Note that <literal>archive</literal> is used everywhere else.)</para></listitem>
+        <listitem><para>One of <literal>bare</literal>, <literal>bare-user</literal> or <literal>archive-z2</literal> (note that <literal>archive</literal> is used everywhere else.)</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -76,7 +76,7 @@ Boston, MA 02111-1307, USA.
     <variablelist>
       <varlistentry>
         <term><varname>mode</varname></term>
-        <listitem><para>One of <literal>bare</literal>, <literal>bare-user</literal> or <literal>archive-z2</literal>.  </para></listitem>
+        <listitem><para>One of <literal>bare</literal>, <literal>bare-user</literal> or <literal>archive-z2</literal> (Note that <literal>archive</literal> is used everywhere else.)</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -312,7 +312,7 @@ _ostree_file_header_new (GFileInfo         *file_info,
  * @file_info: a #GFileInfo
  * @xattrs: (allow-none): Optional extended attribute array
  *
- * Returns: (transfer full): A new #GVariant containing file header for an archive-z2 repository
+ * Returns: (transfer full): A new #GVariant containing file header for an archive repository
  */
 GVariant *
 _ostree_zlib_file_header_new (GFileInfo         *file_info,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3631,7 +3631,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
     }
 
-  /* We can't use static deltas if pulling into an archive-z2 repo. */
+  /* We can't use static deltas if pulling into an archive repo. */
   if (self->mode == OSTREE_REPO_MODE_ARCHIVE_Z2)
     {
       if (pull_data->require_static_deltas)

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -608,7 +608,7 @@ dispatch_open_splice_and_close (OstreeRepo                 *repo,
         }
       else
         {
-          /* Slower path, for symlinks and unpacking deltas into archive-z2 */
+          /* Slower path, for symlinks and unpacking deltas into archive */
           g_autoptr(GFileInfo) finfo =
             _ostree_mode_uidgid_to_gfileinfo (state->mode, state->uid, state->gid);
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -780,7 +780,7 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
       if (!ostree_repo_commit_transaction (repo, &stats, cancellable, error))
         goto out;
 
-      /* The default for this option is FALSE, even for archive-z2 repos,
+      /* The default for this option is FALSE, even for archive repos,
        * because ostree supports multiple processes committing to the same
        * repo (but different refs) concurrently, and in fact gnome-continuous
        * actually does this.  In that context it's best to update the summary

--- a/src/ostree/ot-builtin-init.c
+++ b/src/ostree/ot-builtin-init.c
@@ -37,7 +37,7 @@ static char *opt_collection_id = NULL;
  */
 
 static GOptionEntry options[] = {
-  { "mode", 0, 0, G_OPTION_ARG_STRING, &opt_mode, "Initialize repository in given mode (bare, archive-z2)", NULL },
+  { "mode", 0, 0, G_OPTION_ARG_STRING, &opt_mode, "Initialize repository in given mode (bare, archive)", NULL },
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id,
     "Globally unique ID for this repository as an collection of refs for redistribution to other repositories", "COLLECTION-ID" },

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -70,7 +70,7 @@ ot_test_setup_repo (GCancellable *cancellable,
   g_autoptr(GFile) repo_path = g_file_new_for_path ("repo");
   glnx_unref_object OstreeRepo* ret_repo = NULL;
 
-  if (!ot_test_run_libtest ("setup_test_repository archive-z2", error))
+  if (!ot_test_run_libtest ("setup_test_repository archive", error))
     goto out;
 
   ret_repo = ostree_repo_new (repo_path);
@@ -94,7 +94,7 @@ ot_test_setup_sysroot (GCancellable *cancellable,
   glnx_unref_object OstreeSysroot *ret_sysroot = NULL;
   struct statfs stbuf;
 
-  if (!ot_test_run_libtest ("setup_os_repository \"archive-z2\" \"syslinux\"", error))
+  if (!ot_test_run_libtest ("setup_os_repository \"archive\" \"syslinux\"", error))
     goto out;
 
   { g_autoptr(GString) buf = g_string_new ("mutable-deployments");

--- a/tests/test-admin-deploy-2.sh
+++ b/tests/test-admin-deploy-2.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..3"
 

--- a/tests/test-admin-deploy-bootid-gc.sh
+++ b/tests/test-admin-deploy-bootid-gc.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..1"
 

--- a/tests/test-admin-deploy-clean.sh
+++ b/tests/test-admin-deploy-clean.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..1"
 

--- a/tests/test-admin-deploy-etcmerge-cornercases.sh
+++ b/tests/test-admin-deploy-etcmerge-cornercases.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..2"
 

--- a/tests/test-admin-deploy-grub2.sh
+++ b/tests/test-admin-deploy-grub2.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "grub2 ostree-grub-generator"
+setup_os_repository "archive" "grub2 ostree-grub-generator"
 
 extra_admin_tests=0
 

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..3"
 

--- a/tests/test-admin-deploy-switch.sh
+++ b/tests/test-admin-deploy-switch.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..4"
 

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 extra_admin_tests=3
 

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "uboot"
+setup_os_repository "archive" "uboot"
 
 extra_admin_tests=1
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..5"
 

--- a/tests/test-admin-locking.sh
+++ b/tests/test-admin-locking.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 # If parallel is not installed, skip the test
 if ! parallel --gnu /bin/true </dev/null >/dev/null 2>&1; then

--- a/tests/test-admin-pull-deploy-commit.sh
+++ b/tests/test-admin-pull-deploy-commit.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 echo "1..1"
 
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo

--- a/tests/test-admin-pull-deploy-split.sh
+++ b/tests/test-admin-pull-deploy-split.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 echo "1..1"
 
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo

--- a/tests/test-admin-upgrade-endoflife.sh
+++ b/tests/test-admin-upgrade-endoflife.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 # This does:
 # - init ostree repo in testos-repo
 # - create system files in osdata and commit twice those contents into testos-repo

--- a/tests/test-admin-upgrade-not-backwards.sh
+++ b/tests/test-admin-upgrade-not-backwards.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..2"
 

--- a/tests/test-admin-upgrade-unconfigured.sh
+++ b/tests/test-admin-upgrade-unconfigured.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 # Exports OSTREE_SYSROOT so --sysroot not needed.
-setup_os_repository "archive-z2" "syslinux"
+setup_os_repository "archive" "syslinux"
 
 echo "1..2"
 

--- a/tests/test-archivez.sh
+++ b/tests/test-archivez.sh
@@ -21,11 +21,14 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..11'
+echo '1..12'
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 . ${test_srcdir}/archive-test.sh
+
+${CMD_PREFIX} ostree --repo=repo-archive-z2 init --mode=archive-z2
+echo "ok did an init with archive-z2 alias"
 
 cd ${test_tmpdir}
 mkdir repo2

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -55,7 +55,7 @@ input_stream_to_bytes (GInputStream *input)
 }
 
 static void
-test_raw_file_to_archive_z2_stream (gconstpointer data)
+test_raw_file_to_archive_stream (gconstpointer data)
 {
   OstreeRepo *repo = OSTREE_REPO (data);
   g_autofree gchar *commit_checksum = NULL;
@@ -249,7 +249,7 @@ int main (int argc, char **argv)
     goto out;
 
   g_test_add_data_func ("/repo-not-system", repo, test_repo_is_not_system);
-  g_test_add_data_func ("/raw-file-to-archive-z2-stream", repo, test_raw_file_to_archive_z2_stream);
+  g_test_add_data_func ("/raw-file-to-archive-stream", repo, test_raw_file_to_archive_stream);
   g_test_add_data_func ("/objectwrites", repo, test_object_writes);
   g_test_add_func ("/remotename", test_validate_remotename);
 

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -33,7 +33,7 @@ oldpwd=`pwd`
 mkdir ostree-srv
 cd ostree-srv
 mkdir gnomerepo
-ostree_repo_init gnomerepo --mode="archive-z2"
+ostree_repo_init gnomerepo --mode="archive"
 mkdir gnomerepo-files
 cd gnomerepo-files 
 echo first > firstfile

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -29,7 +29,7 @@ morebindatafiles="false ls"
 echo '1..12'
 
 mkdir repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 
 mkdir files
 for bin in ${bindatafiles}; do

--- a/tests/test-demo-buildsystem.sh
+++ b/tests/test-demo-buildsystem.sh
@@ -68,7 +68,7 @@ packages="bash systemd"
 mkdir build-repo
 ostree_repo_init build-repo --mode=bare-user
 mkdir repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 # Our FUSE mount point
 mkdir mnt
 

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 echo '1..5'
 

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -29,7 +29,7 @@ fi
 
 echo "1..1"
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 export OSTREE_GPG_SIGN="${OSTREE} gpg-sign --gpg-homedir=${TEST_GPG_KEYHOME}"
 

--- a/tests/test-local-pull-depth.sh
+++ b/tests/test-local-pull-depth.sh
@@ -21,13 +21,13 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 echo "1..1"
 
 cd ${test_tmpdir}
 mkdir repo2
-ostree_repo_init repo2 --mode="archive-z2"
+ostree_repo_init repo2 --mode="archive"
 
 ${CMD_PREFIX} ostree --repo=repo2 pull-local repo
 find repo2/objects -name '*.commit' | wc -l > commitcount

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -28,7 +28,7 @@ skip_without_user_xattrs
 
 echo "1..8"
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 echo "ok setup"
 
 cd ${test_tmpdir}
@@ -40,7 +40,7 @@ ${CMD_PREFIX} ostree --repo=repo2 fsck
 echo "ok pull-local z2 to bare-user"
 
 mkdir repo3
-ostree_repo_init repo3 --mode="archive-z2"
+ostree_repo_init repo3 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo3 pull-local repo2
 ${CMD_PREFIX} ostree --repo=repo3 fsck
 echo "ok pull-local bare-user to z2"
@@ -62,7 +62,7 @@ cmp checkout1.files checkout3.files
 echo "ok checkouts same"
 
 mkdir repo4
-ostree_repo_init repo4 --mode="archive-z2"
+ostree_repo_init repo4 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo4 remote add --gpg-import ${test_tmpdir}/gpghome/key1.asc origin repo
 if ${CMD_PREFIX} ostree --repo=repo4 pull-local --remote=origin --gpg-verify repo test2 2>&1; then
     assert_not_reached "GPG verification unexpectedly succeeded"
@@ -72,13 +72,13 @@ echo "ok --gpg-verify with no signature"
 ${OSTREE} gpg-sign --gpg-homedir=${TEST_GPG_KEYHOME} test2  ${TEST_GPG_KEYID_1}
 
 mkdir repo5
-ostree_repo_init repo5 --mode="archive-z2"
+ostree_repo_init repo5 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo5 remote add --gpg-import ${test_tmpdir}/gpghome/key1.asc origin repo
 ${CMD_PREFIX} ostree --repo=repo5 pull-local --remote=origin --gpg-verify repo test2
 echo "ok --gpg-verify"
 
 mkdir repo6
-ostree_repo_init repo6 --mode="archive-z2"
+ostree_repo_init repo6 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo6 remote add --gpg-import ${test_tmpdir}/gpghome/key1.asc origin repo
 if ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-summary repo test2 2>&1; then
     assert_not_reached "GPG summary verification with no summary unexpectedly succeeded"
@@ -97,7 +97,7 @@ ${CMD_PREFIX} ostree --repo=repo6 pull-local --remote=origin --gpg-verify-summar
 echo "ok --gpg-verify-summary"
 
 mkdir repo7
-ostree_repo_init repo7 --mode="archive-z2"
+ostree_repo_init repo7 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo7 pull-local repo
 ${CMD_PREFIX} ostree --repo=repo7 fsck
 for src_object in `find repo/objects -name '*.filez'`; do

--- a/tests/test-oldstyle-partial.sh
+++ b/tests/test-oldstyle-partial.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 

--- a/tests/test-parent.sh
+++ b/tests/test-parent.sh
@@ -25,7 +25,7 @@ skip_without_user_xattrs
 
 echo '1..2'
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 export OSTREE_GPG_SIGN="${OSTREE} gpg-sign --gpg-homedir=${TEST_GPG_KEYHOME}"
 

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_user_xattrs
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..5'
 

--- a/tests/test-pull-commit-only.sh
+++ b/tests/test-pull-commit-only.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 

--- a/tests/test-pull-contenturl.sh
+++ b/tests/test-pull-contenturl.sh
@@ -28,7 +28,7 @@ if has_gpgme; then
   COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 fi
 
-setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}"
 
 # create a summary
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo \

--- a/tests/test-pull-corruption.sh
+++ b/tests/test-pull-corruption.sh
@@ -27,7 +27,7 @@ fi
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..2'
 

--- a/tests/test-pull-depth.sh
+++ b/tests/test-pull-depth.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 

--- a/tests/test-pull-large-metadata.sh
+++ b/tests/test-pull-large-metadata.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 

--- a/tests/test-pull-metalink.sh
+++ b/tests/test-pull-metalink.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..9'
 

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 echo "1..5"
 
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
-setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}"
 
 # Now, setup multiple branches
 mkdir ${test_tmpdir}/ostree-srv/other-files
@@ -41,7 +41,7 @@ ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
 
 prev_dir=`pwd`
 cd ${test_tmpdir}
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull --mirror origin
 assert_has_file repo/summary
@@ -69,13 +69,13 @@ cd $prev_dir
 
 cd ${test_tmpdir}
 rm -rf repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${OSTREE} --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
 echo "ok pull mirror without checking signed summary"
 
 cd ${test_tmpdir}
 rm -rf repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${OSTREE} --repo=repo remote add --set=gpg-verify-summary=true origin $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} --repo=repo pull --mirror origin 2>err.txt; then
     assert_not_reached "Mirroring unexpectedly succeeded"
@@ -86,7 +86,7 @@ ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
 cd ${test_tmpdir}
 rm -rf repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${OSTREE} --repo=repo remote add --set=gpg-verify-summary=true origin $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} --repo=repo pull --mirror origin
 assert_has_file repo/summary
@@ -99,7 +99,7 @@ truncate --size=1 ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig
 cd ${test_tmpdir}
 rm -rf repo
 mkdir repo
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${OSTREE} --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} --repo=repo pull --mirror origin
 assert_has_file repo/summary

--- a/tests/test-pull-mirrorlist.sh
+++ b/tests/test-pull-mirrorlist.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 echo "1..3"
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 setup_mirror () {
   name=$1; shift

--- a/tests/test-pull-override-url.sh
+++ b/tests/test-pull-override-url.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 
@@ -34,7 +34,7 @@ gnomerepo_url="$(cat httpd-address)/ostree/gnomerepo"
 mkdir mirror-srv
 cd mirror-srv
 mkdir gnomerepo
-ostree_repo_init gnomerepo --mode "archive-z2"
+ostree_repo_init gnomerepo --mode "archive"
 ${CMD_PREFIX} ostree --repo=gnomerepo remote add --set=gpg-verify=false origin ${gnomerepo_url}
 ${CMD_PREFIX} ostree --repo=gnomerepo pull --mirror --depth=-1 origin main
 

--- a/tests/test-pull-repeated.sh
+++ b/tests/test-pull-repeated.sh
@@ -24,10 +24,10 @@ set -euo pipefail
 echo "1..1"
 
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
-setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}" --random-500s=50
+setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}" --random-500s=50
 
 cd ${test_tmpdir}
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 for x in $(seq 200); do
     if ${CMD_PREFIX} ostree --repo=repo pull --mirror origin main 2>err.txt; then

--- a/tests/test-pull-resume.sh
+++ b/tests/test-pull-resume.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2" "" "--force-range-requests"
+setup_fake_remote_repo1 "archive" "" "--force-range-requests"
 
 echo '1..1'
 

--- a/tests/test-pull-subpath.sh
+++ b/tests/test-pull-subpath.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..4'
 

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 echo "1..7"
 
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
-setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}"
 
 # Now, setup multiple branches
 mkdir ${test_tmpdir}/ostree-srv/other-files
@@ -41,7 +41,7 @@ ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
 
 prev_dir=`pwd`
 cd ${test_tmpdir}
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull --mirror origin
 assert_has_file repo/summary
@@ -66,7 +66,7 @@ repo_reinit () {
   cd ${test_tmpdir}
   rm -rf repo
   mkdir repo
-  ostree_repo_init repo --mode=archive-z2
+  ostree_repo_init repo --mode=archive
   ${OSTREE} --repo=repo remote add --set=gpg-verify-summary=true origin $(cat httpd-address)/ostree/gnomerepo
 }
 

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo '1..2'
 

--- a/tests/test-remote-cookies.sh
+++ b/tests/test-remote-cookies.sh
@@ -24,7 +24,7 @@ echo '1..4'
 
 . $(dirname $0)/libtest.sh
 
-setup_fake_remote_repo1 "archive-z2" "" \
+setup_fake_remote_repo1 "archive" "" \
   "--expected-cookies foo=bar --expected-cookies baz=badger"
 
 assert_fail (){ 

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # We don't want OSTREE_GPG_HOME used for these tests.
 unset OSTREE_GPG_HOME
 
-setup_fake_remote_repo1 "archive-z2"
+setup_fake_remote_repo1 "archive"
 
 echo "1..4"
 

--- a/tests/test-reset-nonlinear.sh
+++ b/tests/test-reset-nonlinear.sh
@@ -23,7 +23,7 @@ echo "1..1"
 
 . $(dirname $0)/libtest.sh
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 cd ${test_tmpdir}/files
 $OSTREE commit -b testx -s "Another Commit"
 cd ${test_tmpdir}

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 echo "1..2"
 
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
-setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
+setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}"
 
 # Set up a second branch.
 mkdir ${test_tmpdir}/ostree-srv/other-files
@@ -41,7 +41,7 @@ ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
 # Check out the repository.
 prev_dir=`pwd`
 cd ${test_tmpdir}
-ostree_repo_init repo --mode=archive-z2
+ostree_repo_init repo --mode=archive
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull --mirror origin
 

--- a/tests/test-sysroot.js
+++ b/tests/test-sysroot.js
@@ -40,7 +40,7 @@ function libtestExec(shellCode) {
 
 print('1..1')
 
-libtestExec('setup_os_repository archive-z2 syslinux');
+libtestExec('setup_os_repository archive syslinux');
 
 GLib.setenv("OSTREE_SYSROOT_DEBUG", "mutable-deployments", true);
 

--- a/tests/test-xattrs.sh
+++ b/tests/test-xattrs.sh
@@ -28,7 +28,7 @@ skip_without_user_xattrs
 
 echo "1..2"
 
-setup_test_repository "archive-z2"
+setup_test_repository "archive"
 
 cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=repo checkout test2 test2-checkout1


### PR DESCRIPTION
In almost all places. There are just a few exceptions; one tricky bit for
example is that the repo config must still have `mode=archive-z2`, since
`archive` used to mean something else. (We could very likely just get rid of
that check, but eh, later).

I also added a test that one can still do `ostree repo init --mode=archive-z2`.