### PR TITLE
lib/repo: Add error prefixing during hardlink object import

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3324,6 +3324,9 @@ import_one_object_link (OstreeRepo    *self,
                         GCancellable  *cancellable,
                         GError        **error)
 {
+  const char *errprefix = glnx_strjoina ("Importing ", checksum, ".",
+                                         ostree_object_type_to_string (objtype));
+  GLNX_AUTO_PREFIX_ERROR (errprefix, error);
   char loose_path_buf[_OSTREE_LOOSE_PATH_MAX];
   _ostree_loose_path (loose_path_buf, checksum, objtype, self->mode);
 
@@ -3370,7 +3373,7 @@ import_one_object_link (OstreeRepo    *self,
           return TRUE;
         }
       else
-        return glnx_throw_errno (error);
+        return glnx_throw_errno_prefix (error, "linkat");
     }
 
   if (objtype == OSTREE_OBJECT_TYPE_COMMIT)


### PR DESCRIPTION
I happened to have a repo with a missing commit object, and got an unprefixed
error during a pull-local.