### PR TITLE
lib/gpg: Port a few misc gpg functions to new style

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -368,31 +368,22 @@ _ostree_gpg_verifier_add_global_keyring_dir (OstreeGpgVerifier  *self,
                                              GCancellable       *cancellable,
                                              GError            **error)
 {
-  const char *global_keyring_path = g_getenv ("OSTREE_GPG_HOME");
-  g_autoptr(GFile) global_keyring_dir = NULL;
-  gboolean ret = FALSE;
-
   g_return_val_if_fail (OSTREE_IS_GPG_VERIFIER (self), FALSE);
 
+  const char *global_keyring_path = g_getenv ("OSTREE_GPG_HOME");
   if (global_keyring_path == NULL)
     global_keyring_path = DATADIR "/ostree/trusted.gpg.d/";
 
   if (g_file_test (global_keyring_path, G_FILE_TEST_IS_DIR))
     {
-      global_keyring_dir = g_file_new_for_path (global_keyring_path);
+      g_autoptr(GFile) global_keyring_dir = g_file_new_for_path (global_keyring_path);
       if (!_ostree_gpg_verifier_add_keyring_dir (self, global_keyring_dir,
                                                  cancellable, error))
-        {
-          g_prefix_error (error, "Reading keyring directory '%s'",
-                          gs_file_get_path_cached (global_keyring_dir));
-          goto out;
-        }
+        return glnx_prefix_error (error, "Reading keyring directory '%s'",
+                                  gs_file_get_path_cached (global_keyring_dir));
     }
 
-  ret = TRUE;
-
-out:
-  return ret;
+  return TRUE;
 }
 
 OstreeGpgVerifier*

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4561,32 +4561,23 @@ _ostree_repo_verify_commit_internal (OstreeRepo    *self,
                                      GCancellable  *cancellable,
                                      GError       **error)
 {
-  OstreeGpgVerifyResult *result = NULL;
   g_autoptr(GVariant) commit_variant = NULL;
-  g_autoptr(GVariant) metadata = NULL;
-  g_autoptr(GBytes) signed_data = NULL;
-
   /* Load the commit */
   if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT,
                                  commit_checksum, &commit_variant,
                                  error))
-    {
-      g_prefix_error (error, "Failed to read commit: ");
-      goto out;
-    }
+    return glnx_prefix_error_null (error, "Failed to read commit");
 
   /* Load the metadata */
+  g_autoptr(GVariant) metadata = NULL;
   if (!ostree_repo_read_commit_detached_metadata (self,
                                                   commit_checksum,
                                                   &metadata,
                                                   cancellable,
                                                   error))
-    {
-      g_prefix_error (error, "Failed to read detached metadata: ");
-      goto out;
-    }
+    return glnx_prefix_error_null (error, "Failed to read detached metadata");
 
-  signed_data = g_variant_get_data_as_bytes (commit_variant);
+  g_autoptr(GBytes) signed_data = g_variant_get_data_as_bytes (commit_variant);
 
   /* XXX This is a hackish way to indicate to use ALL remote-specific
    *     keyrings in the signature verification.  We want this when
@@ -4594,17 +4585,10 @@ _ostree_repo_verify_commit_internal (OstreeRepo    *self,
   if (remote_name == NULL)
     remote_name = OSTREE_ALL_REMOTES;
 
-  result = _ostree_repo_gpg_verify_with_metadata (self,
-                                                  signed_data,
-                                                  metadata,
-                                                  remote_name,
-                                                  keyringdir,
-                                                  extra_keyring,
-                                                  cancellable,
-                                                  error);
-
-out:
-  return result;
+  return _ostree_repo_gpg_verify_with_metadata (self, signed_data,
+                                                metadata, remote_name,
+                                                keyringdir, extra_keyring,
+                                                cancellable, error);
 }
 
 /**
@@ -4636,10 +4620,7 @@ ostree_repo_verify_commit (OstreeRepo   *self,
                                           cancellable, error);
 
   if (!ostree_gpg_verify_result_require_valid_signature (result, error))
-    {
-      g_prefix_error (error, "Commit %s: ", commit_checksum);
-      return FALSE;
-    }
+    return glnx_prefix_error (error, "Commit %s", commit_checksum);
   return TRUE;
 }
 


### PR DESCRIPTION
I'd mostly been skipping the GPG functions due to lack of autoptr for a few
things, but I noticed these bits were straightforward.