### PR TITLE
Uboot fallback support

### DIFF
--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -62,6 +62,44 @@ _ostree_bootloader_uboot_get_name (OstreeBootloader *bootloader)
   return "U-Boot";
 }
 
+/* Append system's uEnv.txt, if it exists in $deployment/usr/lib/ostree-boot/ */
+static gboolean
+append_system_uenv (OstreeBootloaderUboot   *self,
+                    const char              *bootargs,
+                    GPtrArray               *new_lines,
+                    GCancellable            *cancellable,
+                    GError                 **error)
+{
+  glnx_fd_close int uenv_fd = -1;
+  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
+  const char *uenv_path = NULL;
+  const char *ostree_arg = NULL;
+
+  kargs = _ostree_kernel_args_from_string (bootargs);
+  ostree_arg = _ostree_kernel_args_get_last_value (kargs, "ostree");
+  if (!ostree_arg)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "No ostree= kernel argument found in boot loader configuration file");
+      return FALSE;
+    }
+  ostree_arg += 1;
+  uenv_path = glnx_strjoina (ostree_arg, "/usr/lib/ostree-boot/uEnv.txt");
+  if (!ot_openat_ignore_enoent (self->sysroot->sysroot_fd, uenv_path, &uenv_fd, error))
+    return FALSE;
+  if (uenv_fd != -1)
+    {
+      char *uenv = glnx_fd_readall_utf8 (uenv_fd, NULL, cancellable, error);
+      if (!uenv)
+        {
+          g_prefix_error (error, "Reading %s: ", uenv_path);
+          return FALSE;
+        }
+      g_ptr_array_add (new_lines, uenv);
+    }
+  return TRUE;
+}
+
 static gboolean
 create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
                                         int                    bootversion,
@@ -96,43 +134,9 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
   val = ostree_bootconfig_parser_get (config, "options");
   if (val)
     {
-      glnx_fd_close int uenv_fd = -1;
-      __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
-      const char *uenv_path = NULL;
-      const char *ostree_arg = NULL;
-
       g_ptr_array_add (new_lines, g_strdup_printf ("bootargs=%s", val));
-
-      /* Append system's uEnv.txt, if it exists in $deployment/usr/lib/ostree-boot/ */
-      kargs = _ostree_kernel_args_from_string (val);
-      ostree_arg = _ostree_kernel_args_get_last_value (kargs, "ostree");
-      if (!ostree_arg)
-      {
-        g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                             "No ostree= kernel argument found in boot loader configuration file");
+      if (!append_system_uenv (self, val, new_lines, cancellable, error))
         return FALSE;
-      }
-      ostree_arg += 1;
-      uenv_path = glnx_strjoina (ostree_arg, "/usr/lib/ostree-boot/uEnv.txt");
-      uenv_fd = openat (self->sysroot->sysroot_fd, uenv_path, O_CLOEXEC | O_RDONLY);
-      if (uenv_fd != -1)
-        {
-          char *uenv = glnx_fd_readall_utf8 (uenv_fd, NULL, cancellable, error);
-          if (!uenv)
-            {
-              g_prefix_error (error, "Reading %s: ", uenv_path);
-              return FALSE;
-            }
-          g_ptr_array_add (new_lines, uenv);
-        }
-      else
-        {
-          if (errno != ENOENT)
-            {
-              g_prefix_error (error, "openat %s: ", uenv_path);
-              return FALSE;
-            }
-        }
     }
 
   return TRUE;

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -42,5 +42,7 @@ ${CMD_PREFIX} ostree --repo=testos-repo commit --tree=dir=osdata/ -b testos/buil
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 assert_file_has_content sysroot/boot/uEnv.txt "loadfdt="
 assert_file_has_content sysroot/boot/uEnv.txt "kernel_image="
+assert_file_has_content sysroot/boot/uEnv.txt "kernel_image2="
+assert_file_has_content sysroot/boot/uEnv.txt "kernel_image3="
 
 echo "ok merging uEnv.txt files"


### PR DESCRIPTION
As promised on the [mailing list](https://mail.gnome.org/archives/ostree-list/2017-September/msg00000.html), here is my attempt to add fallback support for U-Boot users.

The first commit is a general cleanup, the second is the actual change.