### PR TITLE
tree-wide: Use helpers for unlinkat()

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1121,11 +1121,8 @@ ostree_repo_checkout_gc (OstreeRepo        *self,
 
           if (stbuf.st_nlink == 1)
             {
-              if (unlinkat (dfd_iter.fd, dent->d_name, 0) != 0)
-                {
-                  glnx_set_error_from_errno (error);
-                  return FALSE;
-                }
+              if (!glnx_unlinkat (dfd_iter.fd, dent->d_name, 0, error))
+                return FALSE;
             }
         }
     }

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -43,13 +43,7 @@ prune_commitpartial_file (OstreeRepo    *repo,
                           GError       **error)
 {
   g_autofree char *path = _ostree_get_commitpartial_path (checksum);
-  if (unlinkat (repo->repo_dir_fd, path, 0) != 0)
-    {
-      if (errno != ENOENT)
-        return glnx_throw_errno_prefix (error, "unlinkat");
-    }
-
-  return TRUE;
+  return ot_ensure_unlinked_at (repo->repo_dir_fd, path, error);
 }
 
 static gboolean
@@ -147,8 +141,8 @@ _ostree_repo_prune_tmp (OstreeRepo *self,
           if (has_sig_suffix)
             dent->d_name[len - 4] = '.';
 
-          if (unlinkat (dfd_iter.fd, dent->d_name, 0) < 0)
-            return glnx_throw_errno_prefix (error, "unlinkat");
+          if (!glnx_unlinkat (dfd_iter.fd, dent->d_name, 0, error))
+            return FALSE;
         }
     }
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1357,11 +1357,8 @@ static_deltapart_fetch_on_complete (GObject           *object,
     goto out;
 
   /* From here on, if we fail to apply the delta, we'll re-fetch it */
-  if (unlinkat (_ostree_fetcher_get_dfd (fetcher), temp_path, 0) < 0)
-    {
-      glnx_set_error_from_errno (error);
-      goto out;
-    }
+  if (!glnx_unlinkat (_ostree_fetcher_get_dfd (fetcher), temp_path, 0, error))
+    goto out;
 
   in = g_unix_input_stream_new (fd, FALSE);
 

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -1007,11 +1007,8 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
     {
       if (dfd >= 0)
         {
-          if (unlinkat (dfd, ref->ref_name, 0) != 0)
-            {
-              if (errno != ENOENT)
-                return glnx_throw_errno (error);
-            }
+          if (!ot_ensure_unlinked_at (dfd, ref->ref_name, error))
+            return FALSE;
         }
     }
   else if (rev != NULL)

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -90,6 +90,7 @@ ot_openat_read_stream (int             dfd,
   return TRUE;
 }
 
+/* Like unlinkat() but ignore ENOENT */
 gboolean
 ot_ensure_unlinked_at (int dfd,
                        const char *path,


### PR DESCRIPTION
We have `ot_ensure_unlinked_at()` for the "ignore ENOENT" case, and
`glnx_unlinkat()` otherwise. Port all in-tree callers to one or the other as
appropriate.

Just noticed an unprefixed error in the refs case and decided to do a tree-wide
check.