### PR TITLE
lib/pull: Only look for cookie files for non-local remotes

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2746,18 +2746,19 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
       _ostree_fetcher_set_proxy (fetcher, http_proxy);
   }
 
-  {
-    g_autofree char *cookie_file = g_strdup_printf ("%s.cookies.txt", remote_name);
-    /* TODO; port away from this; a bit hard since both libsoup and libcurl
-     * expect a file. Doing ot_fdrel_to_gfile() works for now though.
-     */
-    GFile*repo_path = ostree_repo_get_path (self);
-    g_autofree char *jar_path =
-      g_build_filename (gs_file_get_path_cached (repo_path), cookie_file, NULL);
+  if (!_ostree_repo_remote_name_is_file (remote_name))
+    {
+      g_autofree char *cookie_file = g_strdup_printf ("%s.cookies.txt", remote_name);
+      /* TODO; port away from this; a bit hard since both libsoup and libcurl
+       * expect a file. Doing ot_fdrel_to_gfile() works for now though.
+       */
+      GFile*repo_path = ostree_repo_get_path (self);
+      g_autofree char *jar_path =
+        g_build_filename (gs_file_get_path_cached (repo_path), cookie_file, NULL);
 
-    if (g_file_test (jar_path, G_FILE_TEST_IS_REGULAR))
-      _ostree_fetcher_set_cookie_jar (fetcher, jar_path);
-  }
+      if (g_file_test (jar_path, G_FILE_TEST_IS_REGULAR))
+        _ostree_fetcher_set_cookie_jar (fetcher, jar_path);
+    }
 
   success = TRUE;
 


### PR DESCRIPTION
Just noticed this while reading an strace.

Closes: https://github.com/ostreedev/ostree/issues/1139