### PR TITLE
tests: Check "refs -c PREFIX" behavior

### DIFF
--- a/tests/test-refs-collections.sh
+++ b/tests/test-refs-collections.sh
@@ -112,8 +112,15 @@ mkdir -p adir
 ${CMD_PREFIX} ostree --repo=collection-repo commit --branch=rcommit -m rcommit -s rcommit adir
 ${CMD_PREFIX} ostree --repo=repo remote add --no-gpg-verify --collection-id org.example.RemoteCollection collection-repo-remote "file://${test_tmpdir}/collection-repo"
 ${CMD_PREFIX} ostree --repo=repo pull collection-repo-remote rcommit
+
 ${CMD_PREFIX} ostree --repo=repo refs --collections > refs
 assert_file_has_content refs "^(org.example.RemoteCollection, rcommit)$"
+
+${CMD_PREFIX} ostree --repo=repo refs --collections org.example.RemoteCollection > refs
+assert_file_has_content refs "^(org.example.RemoteCollection, rcommit)$"
+
+${CMD_PREFIX} ostree --repo=repo refs --collections org.example.NonexistentID > refs
+assert_not_file_has_content refs "^(org.example.RemoteCollection, rcommit)$"
 
 cd ${test_tmpdir}
 mkdir no-collection-repo


### PR DESCRIPTION
This commit adds tests to check the behavior of "refs -c PREFIX", where
prefix is interpreted as a collection ID.

@cgwalters this is the test that would have failed without 5f8e339e45314174dd49221fcf09197e8d1e7ba4.