### PR TITLE
tree-wide: Add error prefixing for most remaining syscalls

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1534,7 +1534,7 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
   if (g_getenv ("OSTREE_SUPPRESS_SYNCFS") == NULL)
     {
       if (syncfs (self->tmp_dir_fd) < 0)
-        return glnx_throw_errno (error);
+        return glnx_throw_errno_prefix (error, "syncfs");
     }
 
   if (!rename_pending_loose_objects (self, cancellable, error))
@@ -2798,8 +2798,8 @@ write_dfd_iter_to_mtree_internal (OstreeRepo                  *self,
   OstreeRepoCommitFilterResult filter_result;
   struct stat dir_stbuf;
 
-  if (fstat (src_dfd_iter->fd, &dir_stbuf) != 0)
-    return glnx_throw_errno (error);
+  if (!glnx_fstat (src_dfd_iter->fd, &dir_stbuf, error))
+    return FALSE;
 
   child_info = _ostree_stbuf_to_gfileinfo (&dir_stbuf);
 

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -521,7 +521,7 @@ ostree_sepolicy_get_label (OstreeSePolicy    *self,
       if (errno == ENOENT)
         *out_label = NULL;
       else
-        return glnx_throw_errno (error);
+        return glnx_throw_errno_prefix (error, "selabel_lookup");
     }
   else
     {

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -171,8 +171,8 @@ copy_dir_recurse (int              src_parent_dfd,
     return FALSE;
 
   /* Create with mode 0700, we'll fchmod/fchown later */
-  if (mkdirat (dest_parent_dfd, name, 0700) != 0)
-    return glnx_throw_errno (error);
+  if (!glnx_ensure_dir (dest_parent_dfd, name, 0700, error))
+    return FALSE;
 
   if (!glnx_opendirat (dest_parent_dfd, name, TRUE, &dest_dfd, error))
     return FALSE;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -471,8 +471,8 @@ _ostree_sysroot_read_boot_loader_configs (OstreeSysroot *self,
       if (dent == NULL)
         break;
 
-      if (fstatat (dfd_iter.fd, dent->d_name, &stbuf, 0) != 0)
-        return glnx_throw_errno (error);
+      if (!glnx_fstatat (dfd_iter.fd, dent->d_name, &stbuf, 0, error))
+        return FALSE;
 
       if (g_str_has_prefix (dent->d_name, "ostree-") &&
           g_str_has_suffix (dent->d_name, ".conf") &&


### PR DESCRIPTION
There were some important ones there like a random `syncfs()`. The remaining
users are mostly blocked on the "fstatat enoent" case, I'll wait to port those.