### PR TITLE
repo: Fix non-system remotes-config-dir usage

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -186,6 +186,7 @@ endif
 
 js_installed_tests = \
 	tests/test-core.js \
+	tests/test-remotes-config-dir.js \
 	tests/test-sizes.js \
 	tests/test-sysroot.js \
 	$(NULL)

--- a/tests/test-remotes-config-dir.js
+++ b/tests/test-remotes-config-dir.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env gjs
+//
+// Copyright (C) 2013 Colin Walters <walters@verbum.org>
+// Copyright (C) 2017 Dan Nicholson <nicholson@endlessm.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const OSTree = imports.gi.OSTree;
+
+function assertEquals(a, b) {
+    if (a != b)
+	throw new Error("assertion failed " + JSON.stringify(a) + " == " + JSON.stringify(b));
+}
+
+function assertNotEquals(a, b) {
+    if (a == b)
+	throw new Error("assertion failed " + JSON.stringify(a) + " != " + JSON.stringify(b));
+}
+
+print('1..3')
+
+let remotesDir = Gio.File.new_for_path('remotes.d');
+remotesDir.make_directory(null);
+
+let remoteConfig = GLib.KeyFile.new()
+remoteConfig.set_value('remote "foo"', 'url', 'http://foo')
+
+let remoteConfigFile = remotesDir.get_child('foo.conf')
+remoteConfig.save_to_file(remoteConfigFile.get_path())
+
+// Use the full Repo constructor to set remotes-config-dir
+let repoFile = Gio.File.new_for_path('repo');
+let repo = new OSTree.Repo({path: repoFile,
+                            remotes_config_dir: remotesDir.get_path()});
+repo.create(OSTree.RepoMode.ARCHIVE_Z2, null);
+repo.open(null);
+
+// See if the remotes.d remote exists
+let remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('foo'), -1);
+
+print("ok read-remotes-config-dir");
+
+// Adding a remote should not go in the remotes.d dir
+repo.remote_add('bar', 'http://bar', null, null);
+remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('bar'), -1);
+assertEquals(remotesDir.get_child('bar.conf').query_exists(null), false);
+
+print("ok add-not-in-remotes-config-dir");
+
+// Removing the remotes.d remote should delete the conf file
+repo.remote_delete('foo', null);
+remotes = repo.remote_list()
+assertEquals(remotes.indexOf('foo'), -1);
+assertEquals(remotesDir.get_child('foo.conf').query_exists(null), false);
+
+print("ok delete-in-remotes-config-dir");


### PR DESCRIPTION
Before commit e0346c1, a non-system repo could specify
remotes-config-dir and have remotes read from there. However, adding
remotes would only be done in the config dir for a system repo. Restore
that by respecting remotes-config-dir when no sysroot is found and
adding back the ostree_repo_is_system() check when adding remotes.

Closes: #1133