### PR TITLE
repo: Add add-remotes-config-dir option

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -122,6 +122,27 @@ Boston, MA 02111-1307, USA.
         keep free. The default value is 3.</para></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>add-remotes-config-dir</varname></term>
+        <listitem>
+          <para>
+            Boolean value controlling whether new remotes will be added
+            in the remotes configuration directory. Defaults to
+            <literal>true</literal> for system ostree repositories. When
+            this is <literal>false</literal>, remotes will be added in
+            the repository's <filename>config</filename> file.
+          </para>
+          <para>
+            This only applies to repositories that use a remotes
+            configuration directory such as system ostree repositories,
+            which use <filename>/etc/ostree/remotes.d</filename>.
+            Non-system repositories do not use a remotes configuration
+            directory unless one is specified when the repository is
+            opened.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -154,6 +154,7 @@ struct OstreeRepo {
   gboolean generate_sizes;
   guint64 tmp_expiry_seconds;
   gchar *collection_id;
+  gboolean add_remotes_config_dir; /* Add new remotes in remotes.d dir */
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -772,6 +772,13 @@ ensure_repo (OstreeSysroot  *self,
    */
   g_weak_ref_init (&self->repo->sysroot, self);
   self->repo->sysroot_kind = OSTREE_REPO_SYSROOT_KIND_VIA_SYSROOT;
+
+  /* Reload the repo config in case any defaults depend on knowing if this is
+   * a system repo.
+   */
+  if (!ostree_repo_reload_config (self->repo, NULL, error))
+    return FALSE;
+
   return TRUE;
 }
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((21 + ${extra_admin_tests:-0}))"
+echo "1..$((22 + ${extra_admin_tests:-0}))"
 
 function validate_bootloader() {
     cd ${test_tmpdir};
@@ -280,6 +280,15 @@ ${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false r
 assert_not_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
 assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf testos-repo
 echo "ok remote add nonphysical sysroot"
+
+# Test that setting add-remotes-config-dir to false adds a remote in the
+# config file rather than the remotes config dir even though this is a
+# "system" repo.
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set core.add-remotes-config-dir false
+${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false remote-test-config-dir file://$(pwd)/testos-repo
+assert_not_has_file ${deployment}/etc/ostree/remotes.d/remote-test-config-dir.conf testos-repo
+assert_file_has_content sysroot/ostree/repo/config remote-test-config-dir
+echo "ok remote add nonphysical sysroot add-remotes-config-dir false"
 
 if env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
        ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then

--- a/tests/test-remotes-config-dir.js
+++ b/tests/test-remotes-config-dir.js
@@ -32,7 +32,7 @@ function assertNotEquals(a, b) {
 	throw new Error("assertion failed " + JSON.stringify(a) + " != " + JSON.stringify(b));
 }
 
-print('1..3')
+print('1..4')
 
 let remotesDir = Gio.File.new_for_path('remotes.d');
 remotesDir.make_directory(null);
@@ -56,7 +56,8 @@ assertNotEquals(remotes.indexOf('foo'), -1);
 
 print("ok read-remotes-config-dir");
 
-// Adding a remote should not go in the remotes.d dir
+// Adding a remote should not go in the remotes.d dir unless this is a
+// system repo or add-remotes-config-dir is set to true
 repo.remote_add('bar', 'http://bar', null, null);
 remotes = repo.remote_list()
 assertNotEquals(remotes.indexOf('bar'), -1);
@@ -71,3 +72,16 @@ assertEquals(remotes.indexOf('foo'), -1);
 assertEquals(remotesDir.get_child('foo.conf').query_exists(null), false);
 
 print("ok delete-in-remotes-config-dir");
+
+// Set add-remotes-config-dir to true and check that a remote gets added
+// in the config dir
+let repoConfig = repo.copy_config();
+repoConfig.set_boolean('core', 'add-remotes-config-dir', true);
+repo.write_config(repoConfig);
+repo.reload_config(null);
+repo.remote_add('baz', 'http://baz', null, null);
+remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('baz'), -1);
+assertEquals(remotesDir.get_child('baz.conf').query_exists(null), true);
+
+print("ok add-in-remotes-config-dir");


### PR DESCRIPTION
This option allows a repo to explicitly opt out of adding new remotes in
a remotes configuration directory. This currently defaults to true for
system repos and false for non-system repos to maintain legacy behavior
that non-system repos don't add remotes in a configuration directory.
That would be problematic for flatpak, which specifies a remotes config
dir but adds remotes in ways that are incompatible with it.

So, what this really does is allow system repos to control whether they
want to add remotes in the config dir or not. That's important if your
flatpak repo is the system repo like at Endless.

Closes: #1134