### PR TITLE
ostree/summary: Generate an ostree-metadata ref when updating summary

### DIFF
--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -90,7 +90,7 @@ Boston, MA 02111-1307, USA.
                 <term><option>--gpg-sign</option>=KEYID</term>
 
                 <listitem><para>
-                    GPG Key ID to sign the delta with.
+                    GPG Key ID to sign the summary with.
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -83,7 +83,16 @@ Boston, MA 02111-1307, USA.
                   your organisation or repository using a dot prefix. The values
                   must be in GVariant text format. For example,
                   <command>exampleos.end-of-life "@t 1445385600"</command>.
-                </para></listitem>
+                </para>
+
+                <!-- FIXME: Uncomment this when collection ID support becomes non-experimental.
+                <para>If the repository has a collection ID configured, the
+                  <filename>ostree-metadata</filename> branch for that collection ID
+                  will also be updated with a new commit containing the given metadata,
+                  which will be signed if the summary file is signed.</para>
+                -->
+
+                </listitem>
             </varlistentry>
 
             <varlistentry>

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -83,7 +83,6 @@ build_additional_metadata (const char * const  *args,
 gboolean
 ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
-  gboolean ret = FALSE;
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(OstreeRepo) repo = NULL;
   OstreeDumpFlags flags = OSTREE_DUMP_NONE;
@@ -91,24 +90,24 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
   context = g_option_context_new ("Manage summary metadata");
 
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (opt_update)
     {
       g_autoptr(GVariant) additional_metadata = NULL;
 
       if (!ostree_ensure_repo_writable (repo, error))
-        goto out;
+        return FALSE;
 
       if (opt_metadata != NULL)
         {
           additional_metadata = build_additional_metadata ((const char * const *) opt_metadata, error);
           if (additional_metadata == NULL)
-            goto out;
+            return FALSE;
         }
 
       if (!ostree_repo_regenerate_summary (repo, additional_metadata, cancellable, error))
-        goto out;
+        return FALSE;
 
       if (opt_key_ids)
         {
@@ -117,7 +116,7 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
                                                       opt_gpg_homedir,
                                                       cancellable,
                                                       error))
-            goto out;
+            return FALSE;
         }
     }
   else if (opt_view)
@@ -129,7 +128,7 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
 
       summary_data = ot_file_mapat_bytes (repo->repo_dir_fd, "summary", error);
       if (!summary_data)
-        goto out;
+        return FALSE;
 
       ot_dump_summary_bytes (summary_data, flags);
     }
@@ -137,10 +136,8 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "No option specified; use -u to update summary");
-      goto out;
+      return FALSE;
     }
 
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -91,4 +91,23 @@ ${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata=map='@a{sv} {}'
 ${CMD_PREFIX} ostree --repo=repo summary --view > summary
 assert_file_has_content summary "^map: {}$"
 
+# Check the ostree-metadata ref has also been created with the same content and appropriate bindings.
+${CMD_PREFIX} ostree --repo=repo refs --collections > refs
+assert_file_has_content refs "^(org.example.Collection1, ostree-metadata)$"
+
+${CMD_PREFIX} ostree --repo=repo show ostree-metadata --raw > metadata
+assert_file_has_content metadata "'map': <@a{sv} {}>"
+assert_file_has_content metadata "'ostree.ref-binding': <\['ostree-metadata'\]>"
+assert_file_has_content metadata "'ostree.collection-binding': <'org.example.Collection1'>"
+
+# There should be 5 commits in the ostree-metadata branch, since we’ve updated the summary 5 times.
+${CMD_PREFIX} ostree --repo=repo log ostree-metadata | grep 'commit ' | wc -l > commit-count
+assert_file_has_content commit-count "^5$"
+
+# The ostree-metadata commits should not contain any files
+${CMD_PREFIX} ostree --repo=repo ls ostree-metadata > files
+assert_file_has_content files " /$"
+cat files | wc -l > files-count
+assert_file_has_content files-count "^1$"
+
 echo "ok 2 update summary with collections"


### PR DESCRIPTION
This is the new way of publishing repository metadata, rather than as
additional-metadata in the summary file. The use of an ostree-metadata
ref means that the metadata from multiple upstream collections is not
conflated when doing P2P mirroring of many repositories.

The new ref is only generated if the repository has a collection ID set.
The old summary file continues to be generated for backwards
compatibility (and because it continues to be the canonical ref →
checksum map for the repository).

The new code is only used if configured with --enable-experimental-api.

Includes unit tests.

Signed-off-by: Philip Withnall <withnall@endlessm.com>