### PR TITLE
ci: Fixate CentOS container image until rpm-md repos sync

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -41,9 +41,9 @@ env:
     CFLAGS: ''
 
 tests:
-  - docker run --privileged -v $PWD:$PWD --workdir $PWD
-    # FIXME revert this when repos sync
+    # FIXME revert setting to 7/3/1611 when repos sync
     # https://github.com/projectatomic/rpm-ostree/pull/985
+  - docker run --privileged -v $PWD:$PWD --workdir $PWD
     registry.centos.org/centos/centos:7.3.1611 sh -c
     'yum install -y git && ci/build-check.sh'
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -42,7 +42,9 @@ env:
 
 tests:
   - docker run --privileged -v $PWD:$PWD --workdir $PWD
-    registry.centos.org/centos/centos:7 sh -c
+    # FIXME revert this when repos sync
+    # https://github.com/projectatomic/rpm-ostree/pull/985
+    registry.centos.org/centos/centos:7.3.1611 sh -c
     'yum install -y git && ci/build-check.sh'
 
 ---


### PR DESCRIPTION
Copy of https://github.com/projectatomic/rpm-ostree/pull/985