### PR TITLE
lib/sysroot: Use direct g_mkdtemp() for overlay tmpdir

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1738,8 +1738,8 @@ ostree_sysroot_deployment_unlock (OstreeSysroot     *self,
                                                     "/usr", 0755, error))
             return FALSE;
 
-          if (!glnx_mkdtempat (AT_FDCWD, development_ovldir, 0755, error))
-            return FALSE;
+          if (g_mkdtemp_full (development_ovldir, 0755) == NULL)
+            return glnx_throw_errno_prefix (error, "mkdtemp");
         }
 
         development_ovl_upper = glnx_strjoina (development_ovldir, "/upper");


### PR DESCRIPTION
The new libglnx `glnx_mkdtempat()` uses autocleanups, which
is inconvenient for this use case where we *don't* want autocleanups.
Since we don't need it to be fd-relative, just directly invoke
`g_mkdtemp_full()` which is fine for this use case.

Prep for updating libglnx.