### PR TITLE
Replace remote change op

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -985,6 +985,7 @@ _ostree_remote_add() {
     local boolean_options="
         $main_boolean_options
         --if-not-exists
+        --force
         --no-gpg-verify
     "
 

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -129,6 +129,14 @@ Boston, MA 02111-1307, USA.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--if-not-exists</option></term>
+
+                <listitem><para>
+                    Do nothing if the provided remote exists.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--no-gpg-verify</option></term>
 
                 <listitem><para>

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -137,6 +137,14 @@ Boston, MA 02111-1307, USA.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--force</option></term>
+
+                <listitem><para>
+                    Replace the provided remote if it exists.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--no-gpg-verify</option></term>
 
                 <listitem><para>

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1735,6 +1735,87 @@ ostree_repo_remote_delete (OstreeRepo     *self,
   return impl_repo_remote_delete (self, NULL, FALSE, name, cancellable, error);
 }
 
+
+static gboolean
+impl_repo_remote_replace (OstreeRepo     *self,
+                          GFile          *sysroot,
+                          const char     *name,
+                          const char     *url,
+                          GVariant       *options,
+                          GCancellable   *cancellable,
+                          GError        **error)
+{
+  g_return_val_if_fail (name != NULL, FALSE);
+  g_return_val_if_fail (url != NULL, FALSE);
+  g_return_val_if_fail (options == NULL || g_variant_is_of_type (options, G_VARIANT_TYPE ("a{sv}")), FALSE);
+
+  if (!ostree_validate_remote_name (name, error))
+    return FALSE;
+
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(OstreeRemote) remote = _ostree_repo_get_remote (self, name, &local_error);
+  if (remote == NULL)
+    {
+      if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+      if (!impl_repo_remote_add (self, sysroot, FALSE, name, url, options,
+                                 cancellable, error))
+        return FALSE;
+    }
+  else
+    {
+      /* Replace the entire option group */
+      if (!g_key_file_remove_group (remote->options, remote->group, error))
+        return FALSE;
+
+      if (g_str_has_prefix (url, "metalink="))
+        g_key_file_set_string (remote->options, remote->group, "metalink",
+                               url + strlen ("metalink="));
+      else
+        g_key_file_set_string (remote->options, remote->group, "url", url);
+
+      if (options != NULL)
+        keyfile_set_from_vardict (remote->options, remote->group, options);
+
+      /* Write out updated settings */
+      if (remote->file != NULL)
+        {
+          gsize length;
+          g_autofree char *data = g_key_file_to_data (remote->options, &length,
+                                                      NULL);
+
+          if (!g_file_replace_contents (remote->file, data, length,
+                                        NULL, FALSE, 0, NULL,
+                                        cancellable, error))
+            return FALSE;
+        }
+      else
+        {
+          g_autoptr(GKeyFile) config = ostree_repo_copy_config (self);
+
+          /* Remove the existing group if it exists */
+          if (!g_key_file_remove_group (config, remote->group, &local_error))
+            {
+              if (!g_error_matches (local_error, G_KEY_FILE_ERROR,
+                                    G_KEY_FILE_ERROR_GROUP_NOT_FOUND))
+                {
+                  g_propagate_error (error, g_steal_pointer (&local_error));
+                  return FALSE;
+                }
+            }
+
+          ot_keyfile_copy_group (remote->options, config, remote->group);
+          if (!ostree_repo_write_config (self, config, error))
+            return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
 /**
  * ostree_repo_remote_change:
  * @self: Repo
@@ -1776,6 +1857,9 @@ ostree_repo_remote_change (OstreeRepo     *self,
     case OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS:
       return impl_repo_remote_delete (self, sysroot, TRUE, name,
                                       cancellable, error);
+    case OSTREE_REPO_REMOTE_CHANGE_REPLACE:
+      return impl_repo_remote_replace (self, sysroot, name, url, options,
+                                       cancellable, error);
     }
   g_assert_not_reached ();
 }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1761,6 +1761,7 @@ impl_repo_remote_replace (OstreeRepo     *self,
           g_propagate_error (error, g_steal_pointer (&local_error));
           return FALSE;
         }
+      g_clear_error (&local_error);
       if (!impl_repo_remote_add (self, sysroot, FALSE, name, url, options,
                                  cancellable, error))
         return FALSE;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -166,12 +166,14 @@ gboolean      ostree_repo_remote_delete (OstreeRepo     *self,
  * @OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS: Like above, but do nothing if the remote exists
  * @OSTREE_REPO_REMOTE_CHANGE_DELETE: Delete a remote
  * @OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS: Delete a remote, do nothing if the remote does not exist
+ * @OSTREE_REPO_REMOTE_CHANGE_REPLACE: Add or replace a remote (Since: 2019.1)
  */
 typedef enum {
   OSTREE_REPO_REMOTE_CHANGE_ADD,
   OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS,
   OSTREE_REPO_REMOTE_CHANGE_DELETE,
-  OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS
+  OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS,
+  OSTREE_REPO_REMOTE_CHANGE_REPLACE,
 } OstreeRepoRemoteChange;
 
 _OSTREE_PUBLIC

--- a/tests/test-remote-add.sh
+++ b/tests/test-remote-add.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..14'
+echo '1..16'
 
 setup_test_repository "bare"
 $OSTREE remote add origin http://example.com/ostree/gnome
@@ -106,3 +106,15 @@ assert_not_file_has_content list.txt "origin"
 # Can't grep for 'another' because of 'another-noexist'
 assert_file_has_content list.txt "another-noexist"
 echo "ok remote list remaining"
+
+# Both --if-not-exists and --force cannot be used
+if $OSTREE remote add --if-not-exists --force yetanother http://yetanother.com/repo 2>/dev/null; then
+    assert_not_reached "Adding remote with --if-not-exists and --force unexpectedly succeeded"
+fi
+echo "ok remote add fail --if-not-exists and --force"
+
+# Overwrite with --force
+$OSTREE remote add --force another http://another.example.com/anotherrepo
+$OSTREE remote list --show-urls > list.txt
+assert_file_has_content list.txt "^another \+http://another.example.com/anotherrepo$"
+echo "ok remote add --force"


### PR DESCRIPTION
The current add and delete remote change ops don't handle the case of modification of existing remotes. There are 2 cases this PR is trying to cover:

1. Making modifications to an existing remote. This is the merge operation. It's exposed in the CLI through a new `ostree remote modify` subcommand.

2. Setting a remote whether it previously existed or not. This is the replace operation. It's exposed in the CLI through the new `--force` option for `ostree remote add`. Here I've allowed replace to succeed even if the remote doesn't exist since it really seemed like a force add is the only place it would be used. Let me know what you think.

One question I had is if the new `OstreeRepoRemoteChange` enum values should be documented with a Since or something like that.

This also fixes https://bugzilla.gnome.org/show_bug.cgi?id=753373 by merging when the remote exists or adding when it doesn't.