### PR TITLE
build-sys: Add -Werror=switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
 	-Werror=pointer-arith -Werror=init-self \
         -Werror=missing-declarations \
         -Werror=return-type \
+        -Werror=switch \
         -Werror=overflow \
         -Werror=int-conversion \
         -Werror=parenthesis \


### PR DESCRIPTION
We use the "exhaustive enum" pattern (i.e. no `default:`) in some places so
we're forced to touch all users when adding cases.