### PR TITLE
Fix test-help.sh for the case where ostree trivial-httpd is enabled

### DIFF
--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -75,7 +75,16 @@ test_recursive() {
         assert_file_empty out
 
         for subcmd in $builtins; do
-            test_recursive "$cmd $subcmd"
+            case "$subcmd" in
+                (trivial-httpd)
+                    # Skip trivial-httpd if enabled, it doesn't work
+                    # uninstalled (and also doesn't produce the output
+                    # we expect).
+                    ;;
+                (*)
+                    test_recursive "$cmd $subcmd"
+                    ;;
+            esac
         done
     fi
 }


### PR DESCRIPTION
It's deprecated, but as long as it's still supported at all, it
shouldn't make the tests fail.

$ ostree trivial-httpd --help
Usage:
  /usr/lib/libostree/ostree-trivial-httpd [OPTION…] [DIR] - Simple webserver

Signed-off-by: Simon McVittie <smcv@collabora.com>