### PR TITLE
Fix JavaScript tests with gjs 1.50.0

### DIFF
--- a/tests/corrupt-repo-ref.js
+++ b/tests/corrupt-repo-ref.js
@@ -47,7 +47,6 @@ function listObjectChecksumsRecurse(dir, allObjects) {
     e.close(null);
 } 
 
-let [,commit] = repo.resolve_rev(refToCorrupt, false);
 let [,root,commit] = repo.read_commit(refToCorrupt, null);
 let allObjects = {};
 allObjects[commit + '.commit'] = true;

--- a/tests/test-sysroot.js
+++ b/tests/test-sysroot.js
@@ -97,9 +97,9 @@ assertEquals(deploymentPath.query_exists(null), false);
 
 //// Ok, redeploy, then add a new revision upstream and pull it
 
-let [,deployment] = sysroot.deploy_tree('testos', rev, origin,
-					mergeDeployment, null,
-					null);
+[,deployment] = sysroot.deploy_tree('testos', rev, origin,
+				 mergeDeployment, null,
+				 null);
 newDeployments = deployments;
 deployments = null;
 newDeployments.unshift(deployment);


### PR DESCRIPTION
In recent gjs, you can't declare a variable with "let" multiple times.

Signed-off-by: Simon McVittie <smcv@collabora.com>