### PR TITLE
lib/repo-finder-mount: Change the schema for finding repos on volumes

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -287,6 +287,7 @@ ostree_repo_get_path
 ostree_repo_get_mode
 ostree_repo_get_config
 ostree_repo_get_dfd
+ostree_repo_equal
 ostree_repo_copy_config
 ostree_repo_remote_add
 ostree_repo_remote_delete

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,8 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2017.12 {
+global:
+  ostree_repo_equal;
 } LIBOSTREE_2017.11;
 
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2612,6 +2612,31 @@ ostree_repo_get_dfd (OstreeRepo  *self)
   return self->repo_dir_fd;
 }
 
+/**
+ * ostree_repo_equal:
+ * @a: an #OstreeRepo
+ * @b: an #OstreeRepo
+ *
+ * Check whether two opened repositories are the same on disk: if their root
+ * directories are the same inode. If @a or @b are not open yet (due to
+ * ostree_repo_open() not being called on them yet), %FALSE will be returned.
+ *
+ * Returns: %TRUE if @a and @b are the same repository on disk, %FALSE otherwise
+ * Since: 2017.11
+ */
+gboolean
+ostree_repo_equal (OstreeRepo *a,
+                   OstreeRepo *b)
+{
+  g_return_val_if_fail (OSTREE_IS_REPO (a), FALSE);
+  g_return_val_if_fail (OSTREE_IS_REPO (b), FALSE);
+
+  if (a->repo_dir_fd < 0 || b->repo_dir_fd < 0)
+    return FALSE;
+
+  return (a->device == b->device && a->inode == b->inode);
+}
+
 OstreeRepoMode
 ostree_repo_get_mode (OstreeRepo  *self)
 {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2622,7 +2622,7 @@ ostree_repo_get_dfd (OstreeRepo  *self)
  * ostree_repo_open() not being called on them yet), %FALSE will be returned.
  *
  * Returns: %TRUE if @a and @b are the same repository on disk, %FALSE otherwise
- * Since: 2017.11
+ * Since: 2017.12
  */
 gboolean
 ostree_repo_equal (OstreeRepo *a,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1156,33 +1156,6 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
                           GCancellable             *cancellable,
                           GError                  **error);
 
-
-
-#if 0
-FIXME
-Called with: remote_name, refs, override-commit-ids
-or: URL, refs, override-commit-ids
-=> we only need refs; could use the remote_name or URL as additional results
-
-Summary file is downloaded first, so this would result in multiple downloads of
-the summary, but we don’t care because of caching.
-
-Big problem preventing this from being the overall API: presenting the download
-sizes in the gnome-software UI before the user chooses to download.
-
-_OSTREE_PUBLIC
-gboolean ostree_repo_find_remotes_squashed (OstreeRepo           *self,
-                                                   const gchar * const  *refs, -> options
-                                                   GVariant             *options,
-                                                   OstreeRepoFinder    **finders, -> options
-                                                   GMainContext         *context, -> nope
-                                                   OstreeAsyncProgress  *progress,
-                                                   GCancellable         *cancellable,
-                                                   GError              **error);
-#endif
-
-
-
 _OSTREE_PUBLIC
 gboolean ostree_repo_pull_with_options (OstreeRepo             *self,
                                         const char             *remote_name_or_baseurl,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -124,6 +124,10 @@ _OSTREE_PUBLIC
 int           ostree_repo_get_dfd (OstreeRepo  *self);
 
 _OSTREE_PUBLIC
+gboolean      ostree_repo_equal (OstreeRepo *a,
+                                 OstreeRepo *b);
+
+_OSTREE_PUBLIC
 OstreeRepoMode ostree_repo_get_mode (OstreeRepo  *self);
 
 _OSTREE_PUBLIC


### PR DESCRIPTION
See issue #1174 for the rationale behind this. In summary:
 • It required two lists of collection–refs to be maintained: one in the
   repository, and one pointing to the repository.
 • It didn’t automatically work for live USBs of OSs based on OSTree
   (where there’s always a repository at /ostree/repo).
 • It was unnecessarily complex.

The new scheme allows a list of repositories to be searched, but without
needing a layer of indirection through their collection–refs. It adds
/ostree/repo and /.ostree/repo as well-known repository locations which
are always checked on a mounted volume (if they exist).

Update the unit tests accordingly.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

Plus a few other trivial fixes.

https://github.com/ostreedev/ostree/issues/1174