### PR TITLE
 lib/repo: Don't syncfs or fsync() dirs if fsync opt is disabled

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,7 +10,7 @@ pkg_upgrade
 pkg_install_builddeps ostree
 # Until this propagates farther
 pkg_install 'pkgconfig(libcurl)' 'pkgconfig(openssl)'
-pkg_install sudo which attr fuse \
+pkg_install sudo which attr fuse strace \
     libubsan libasan libtsan PyYAML redhat-rpm-config \
     elfutils
 if test -n "${CI_PKGS:-}"; then

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1188,7 +1188,7 @@ rename_pending_loose_objects (OstreeRepo        *self,
           renamed_some_object = TRUE;
         }
 
-      if (renamed_some_object)
+      if (renamed_some_object && !self->disable_fsync)
         {
           /* Ensure that in the case of a power cut all the directory metadata that
              we want has reached the disk. In particular, we want this before we
@@ -1209,8 +1209,11 @@ rename_pending_loose_objects (OstreeRepo        *self,
     }
 
   /* In case we created any loose object subdirs, make sure they are on disk */
-  if (fsync (self->objects_dir_fd) == -1)
-    return glnx_throw_errno_prefix (error, "fsync");
+  if (!self->disable_fsync)
+    {
+      if (fsync (self->objects_dir_fd) == -1)
+        return glnx_throw_errno_prefix (error, "fsync");
+    }
 
   if (!glnx_shutil_rm_rf_at (self->tmp_dir_fd, self->commit_stagedir_name,
                              cancellable, error))
@@ -1521,10 +1524,11 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
   if ((self->test_error_flags & OSTREE_REPO_TEST_ERROR_PRE_COMMIT) > 0)
     return glnx_throw (error, "OSTREE_REPO_TEST_ERROR_PRE_COMMIT specified");
 
-  /* FIXME: Added since valgrind in el7 doesn't know about
-   * `syncfs`...we should delete this later.
+  /* FIXME: Added OSTREE_SUPPRESS_SYNCFS since valgrind in el7 doesn't know
+   * about `syncfs`...we should delete this later.
    */
-  if (g_getenv ("OSTREE_SUPPRESS_SYNCFS") == NULL)
+  if (!self->disable_fsync &&
+      g_getenv ("OSTREE_SUPPRESS_SYNCFS") == NULL)
     {
       if (syncfs (self->tmp_dir_fd) < 0)
         return glnx_throw_errno_prefix (error, "syncfs");

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -512,9 +512,21 @@ os_repository_new_commit ()
 }
 
 # Usage: if ! skip_one_without_user_xattrs; then ... more tests ...; fi
+_have_user_xattrs=''
+have_user_xattrs() {
+    if test "${_have_user_xattrs}" = ''; then
+        touch test-xattrs
+        if setfattr -n user.testvalue -v somevalue test-xattrs 2>/dev/null; then
+            _have_user_xattrs=0
+        else
+            _have_user_xattrs=1
+        fi
+        rm -f test-xattrs
+    fi
+    return ${_have_user_xattrs}
+}
 skip_one_without_user_xattrs () {
-    touch test-xattrs
-    if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+    if ! have_user_xattrs; then
         echo "ok # SKIP - this test requires xattr support"
         return 0
     else
@@ -523,9 +535,9 @@ skip_one_without_user_xattrs () {
 }
 
 skip_without_user_xattrs () {
-    touch test-xattrs
-    setfattr -n user.testvalue -v somevalue test-xattrs || \
+    if ! have_user_xattrs; then
         skip "this test requires xattr support"
+    fi
 }
 
 skip_without_fuse () {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -540,6 +540,29 @@ skip_without_user_xattrs () {
     fi
 }
 
+# https://brokenpi.pe/tools/strace-fault-injection
+_have_strace_fault_injection=''
+have_strace_fault_injection() {
+    if test "${_have_strace_fault_injection}" = ''; then
+        if strace -P ${test_srcdir}/libtest-core.sh -e inject=read:retval=0 cat ${test_srcdir}/libtest-core.sh >out.txt &&
+           test '!' -s out.txt; then
+            _have_strace_fault_injection=0
+        else
+            _have_strace_fault_injection=1
+        fi
+        rm -f out.txt
+    fi
+    return ${_have_strace_fault_injection}
+}
+
+skip_one_without_strace_fault_injection() {
+    if ! have_strace_fault_injection; then
+        echo "ok # SKIP this test requires strace fault injection"
+        return 0
+    fi
+    return 1
+}
+
 skip_without_fuse () {
     fusermount --version >/dev/null 2>&1 || skip "no fusermount"
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -546,13 +546,13 @@ have_strace_fault_injection() {
     if test "${_have_strace_fault_injection}" = ''; then
         if strace -P ${test_srcdir}/libtest-core.sh -e inject=read:retval=0 cat ${test_srcdir}/libtest-core.sh >out.txt &&
            test '!' -s out.txt; then
-            _have_strace_fault_injection=0
+            _have_strace_fault_injection=yes
         else
-            _have_strace_fault_injection=1
+            _have_strace_fault_injection=no
         fi
         rm -f out.txt
     fi
-    return ${_have_strace_fault_injection}
+    test ${_have_strace_fault_injection} = yes
 }
 
 skip_one_without_strace_fault_injection() {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -517,13 +517,13 @@ have_user_xattrs() {
     if test "${_have_user_xattrs}" = ''; then
         touch test-xattrs
         if setfattr -n user.testvalue -v somevalue test-xattrs 2>/dev/null; then
-            _have_user_xattrs=0
+            _have_user_xattrs=yes
         else
-            _have_user_xattrs=1
+            _have_user_xattrs=no
         fi
         rm -f test-xattrs
     fi
-    return ${_have_user_xattrs}
+    test ${_have_user_xattrs} = yes
 }
 skip_one_without_user_xattrs () {
     if ! have_user_xattrs; then


### PR DESCRIPTION

There are use cases for not syncing at all; think build cache repos, etc. Let's
be consistent here and make sure if fsync is disabled we do no sync at all.

I chose this opportunity to add tests using the shiny new strace fault
injection.  I can forsee using this for a lot more things, so I made
the support for detecting things generic.

Related: #1184