### PR TITLE
tests: Explicitly unset LANGUAGE after setting LC_ALL

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -40,6 +40,8 @@ if locale -a | grep C.UTF-8 >/dev/null; then
 else
     export LC_ALL=C
 fi
+# A GNU extension, used whenever LC_ALL is not C
+unset LANGUAGE
 
 # This should really be the default IMO
 export G_DEBUG=fatal-warnings


### PR DESCRIPTION
As a GNU extension, LANGUAGE takes precedence over LC_ALL for
gettext(3) whenever the locale is not C, causing tests that grep for
specific English strings to fail when run in non-English locales.
The upstream glibc proposal for C.UTF-8 would give C.UTF-8 the same
special case as C here, but the implementation in Debian does not
currently have this, so we have to unset LANGUAGE too.