### PR TITLE
Add support for GnuTLS for hashing

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -63,6 +63,20 @@ tests:
 
 ---
 
+context: f26-gnutls
+inherit: true
+container:
+    image: registry.fedoraproject.org/fedora:26
+env:
+  CONFIGOPTS: '--with-crypto=gnutls'
+  CI_PKGS: pkgconfig(gnutls)
+
+tests:
+    - ci/build.sh
+    - make check TESTS=tests/test-basic.sh
+
+---
+
 inherit: true
 
 context: f26-experimental-api

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -193,11 +193,11 @@ EXTRA_DIST += \
 	$(NULL)
 
 libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree -I$(builddir)/src/libostree \
-	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_OPENSSL_CFLAGS) \
+	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_CRYPTO_CFLAGS) \
 	-fvisibility=hidden '-D_OSTREE_PUBLIC=__attribute__((visibility("default"))) extern'
 libostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions $(addprefix $(wl_versionscript_arg),$(symbol_files))
 libostree_1_la_LIBADD = libotutil.la libglnx.la libbsdiff.la libostree-kernel-args.la $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) \
-                        $(OT_DEP_LZMA_LIBS) $(OT_DEP_ZLIB_LIBS) $(OT_DEP_OPENSSL_LIBS)
+                        $(OT_DEP_LZMA_LIBS) $(OT_DEP_ZLIB_LIBS) $(OT_DEP_CRYPTO_LIBS)
 libostree_1_la_LIBADD += $(bupsplitpath)
 EXTRA_libostree_1_la_DEPENDENCIES = $(symbol_files)
 

--- a/configure.ac
+++ b/configure.ac
@@ -329,15 +329,29 @@ AS_IF([ test x$with_smack = xyes], [
 ])
 AM_CONDITIONAL(USE_SMACK, test $with_smack != no)
 
+dnl crypto
+AC_ARG_WITH(crypto,
+AS_HELP_STRING([--with-crypto], [Choose library for checksums, one of glib, openssl, gnutls (default: glib)]),
+:, with_crypto=glib)
+
+AS_IF([test $with_crypto = glib],
+      [],
+      [test $with_crypto = openssl],
+      [with_openssl=yes],
+      [test $with_crypto = gnutls],
+      [],
+      [AC_MSG_ERROR([Invalid --with-crypto $with_crypto])]
+      )
+
 dnl begin openssl (really just libcrypto right now)
+dnl Note this option is now deprecated in favor of --with-crypto=openssl
 OPENSSL_DEPENDENCY="libcrypto >= 1.0.1"
 AC_ARG_WITH(openssl,
-AS_HELP_STRING([--with-openssl], [Enable use of OpenSSL libcrypto (checksums)]),
-:, with_openssl=no)
-
+AS_HELP_STRING([--with-openssl], [Enable use of OpenSSL libcrypto (checksums)]),with_openssl=$withval,with_openssl=no)
 AS_IF([ test x$with_openssl != xno ], [
-      PKG_CHECK_MODULES(OT_DEP_OPENSSL, $OPENSSL_DEPENDENCY)
+      PKG_CHECK_MODULES(OT_DEP_CRYPTO, $OPENSSL_DEPENDENCY)
       AC_DEFINE([HAVE_OPENSSL], 1, [Define if we have openssl])
+      with_crypto=openssl
       with_openssl=yes
 ], [
       with_openssl=no
@@ -345,6 +359,17 @@ AS_IF([ test x$with_openssl != xno ], [
 if test x$with_openssl != xno; then OSTREE_FEATURES="$OSTREE_FEATURES openssl"; fi
 AM_CONDITIONAL(USE_OPENSSL, test $with_openssl != no)
 dnl end openssl
+
+dnl begin gnutls; in contrast to openssl this one only
+dnl supports --with-crypto=gnutls
+GNUTLS_DEPENDENCY="gnutls >= 3.5.0"
+AS_IF([ test $with_crypto = gnutls ], [
+      PKG_CHECK_MODULES(OT_DEP_CRYPTO, $GNUTLS_DEPENDENCY)
+      AC_DEFINE([HAVE_GNUTLS], 1, [Define if we have gnutls])
+      OSTREE_FEATURES="$OSTREE_FEATURES gnutls"
+])
+AM_CONDITIONAL(USE_GNUTLS, test $with_crypto = gnutls)
+dnl end gnutls
 
 dnl Avahi dependency for finding repos
 AVAHI_DEPENDENCY="avahi-client >= 0.6.31 avahi-glib >= 0.6.31"
@@ -536,7 +561,7 @@ echo "
     HTTP backend:                                 $fetcher_backend
     \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
-    OpenSSL libcrypto (checksums):                $with_openssl
+    cryptographic checksums:                      $with_crypto
     systemd:                                      $have_libsystemd
     libmount:                                     $with_libmount
     libarchive (parse tar files directly):        $with_libarchive


### PR DESCRIPTION
Support for GnuTLS is also partially preparatory work for supporting PKCS#7 signatures using X.509 keys instead of GnuPG through gpgme.

There is also a separate build fix patch for misplaced #ifdef in the sources that incorrectly crosses control block.