### PR TITLE
ci: don't run tests on overlayfs/tmpfs

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -6,8 +6,8 @@ branches:
 required: true
 context: f26-primary
 
-container:
-    image: registry.fedoraproject.org/fedora:26
+host:
+    distro: fedora/26/atomic
 
 env:
     # Enable all the sanitizers for this primary build.
@@ -17,11 +17,15 @@ env:
     GI_SCANNERFLAGS: '--warn-error'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
     # TODO when we're doing leak checks: G_SLICE: "always-malloc"
+    TEST_TMPDIR: /srv
 
 tests:
-  - ci/ci-commitmessage-submodules.sh
-  - ci/build-check.sh
-  - ci/ci-release-build.sh
+  - docker run -e TEST_TMPDIR -e CFLAGS -e GI_SCANNERFLAGS -e ASAN_OPTIONS
+    --privileged -v $PWD:$PWD --workdir $PWD -v /srv:/srv
+    registry.fedoraproject.org/fedora:26 sh -c
+    'ci/ci-commitmessage-submodules.sh &&
+     ci/build-check.sh &&
+     ci/ci-release-build.sh'
 
 timeout: 30m
 
@@ -38,13 +42,13 @@ host:
   distro: centos/7/atomic
 
 env:
-    CFLAGS: ''
+    TEST_TMPDIR: /srv
 
 tests:
     # FIXME revert setting to 7/3/1611 when repos sync
     # https://github.com/projectatomic/rpm-ostree/pull/985
-  - docker run --privileged -v $PWD:$PWD --workdir $PWD
-    registry.centos.org/centos/centos:7.3.1611 sh -c
+  - docker run -e TEST_TMPDIR --privileged -v $PWD:$PWD --workdir $PWD
+    -v /srv:/srv registry.centos.org/centos/centos:7.3.1611 sh -c
     'yum install -y git && ci/build-check.sh'
 
 ---

--- a/.papr.yml
+++ b/.papr.yml
@@ -17,11 +17,12 @@ env:
     GI_SCANNERFLAGS: '--warn-error'
     ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
     # TODO when we're doing leak checks: G_SLICE: "always-malloc"
-    TEST_TMPDIR: /srv
+    TEST_TMPDIR: /srv/tmpdir
 
 tests:
+  - mkdir -m 0777 /srv/tmpdir
   - docker run -e TEST_TMPDIR -e CFLAGS -e GI_SCANNERFLAGS -e ASAN_OPTIONS
-    -v $PWD:$PWD:z --workdir $PWD -v /srv:/srv:z
+    -v $PWD:$PWD:z --workdir $PWD -v /srv/tmpdir:/srv/tmpdir:z
     registry.fedoraproject.org/fedora:26 sh -c
     'ci/ci-commitmessage-submodules.sh &&
      ci/build-check.sh &&
@@ -42,14 +43,15 @@ host:
   distro: centos/7/atomic
 
 env:
-    TEST_TMPDIR: /srv
+    TEST_TMPDIR: /srv/tmpdir
 
 tests:
+  - mkdir -m 0777 /srv/tmpdir
     # FIXME revert setting to 7/3/1611 when repos sync
     # https://github.com/projectatomic/rpm-ostree/pull/985
   - docker run -e TEST_TMPDIR -v $PWD:$PWD:z --workdir $PWD
-    -v /srv:/srv:z registry.centos.org/centos/centos:7.3.1611 sh -c
-    'yum install -y git && ci/build-check.sh'
+    -v /srv/tmpdir:/srv/tmpdir:z registry.centos.org/centos/centos:7.3.1611
+    sh -c 'yum install -y git && ci/build-check.sh'
 
 ---
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -21,7 +21,7 @@ env:
 
 tests:
   - docker run -e TEST_TMPDIR -e CFLAGS -e GI_SCANNERFLAGS -e ASAN_OPTIONS
-    --privileged -v $PWD:$PWD --workdir $PWD -v /srv:/srv
+    -v $PWD:$PWD:z --workdir $PWD -v /srv:/srv:z
     registry.fedoraproject.org/fedora:26 sh -c
     'ci/ci-commitmessage-submodules.sh &&
      ci/build-check.sh &&
@@ -47,8 +47,8 @@ env:
 tests:
     # FIXME revert setting to 7/3/1611 when repos sync
     # https://github.com/projectatomic/rpm-ostree/pull/985
-  - docker run -e TEST_TMPDIR --privileged -v $PWD:$PWD --workdir $PWD
-    -v /srv:/srv registry.centos.org/centos/centos:7.3.1611 sh -c
+  - docker run -e TEST_TMPDIR -v $PWD:$PWD:z --workdir $PWD
+    -v /srv:/srv:z registry.centos.org/centos/centos:7.3.1611 sh -c
     'yum install -y git && ci/build-check.sh'
 
 ---

--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -8,7 +8,8 @@
 
 srcd=$(cd $(dirname $1) && pwd)
 bn=$(basename $1)
-tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
+TEST_TMPDIR=${TEST_TMPDIR:-/var/tmp}
+tempdir=$(mktemp -d $TEST_TMPDIR/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
     if test -f ${tempdir}/.testtmp; then

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -11,6 +11,10 @@ make syntax-check  # TODO: do syntax-check under check
 # And now run the installed tests
 make install
 if test -x /usr/bin/gnome-desktop-testing-runner; then
+    # if a TEST_TMPDIR was given, use it also for installed tests
+    if [ -n "${TEST_TMPDIR:-}" ]; then
+      export TMPDIR=$TEST_TMPDIR
+    fi
     gnome-desktop-testing-runner -p 0 ${INSTALLED_TESTS_PATTERN:-libostree/}
 fi
 

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -80,11 +80,13 @@ ot_test_setup_sysroot (GCancellable *cancellable,
   if (!ot_test_run_libtest ("setup_os_repository \"archive\" \"syslinux\"", error))
     return FALSE;
 
+  /* Keep this in sync with the overlayfs bits in libtest.sh */
   struct statfs stbuf;
   { g_autoptr(GString) buf = g_string_new ("mutable-deployments");
-    if (statfs ("/", &stbuf) < 0)
+    const char *pwd = g_getenv ("PWD");
+    g_assert (pwd);
+    if (statfs (pwd, &stbuf) < 0)
       return glnx_null_throw_errno (error);
-    /* Keep this in sync with the overlayfs bits in libtest.sh */
 #ifndef OVERLAYFS_SUPER_MAGIC
 #define OVERLAYFS_SUPER_MAGIC 0x794c7630
 #endif

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -517,6 +517,9 @@ os_repository_new_commit ()
 # Usage: if ! skip_one_without_user_xattrs; then ... more tests ...; fi
 _have_user_xattrs=''
 have_user_xattrs() {
+    if ! which setfattr 2>/dev/null; then
+        fatal "no setfattr available to determine xattr support"
+    fi
     if test "${_have_user_xattrs}" = ''; then
         touch test-xattrs
         if setfattr -n user.testvalue -v somevalue test-xattrs 2>/dev/null; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -73,7 +73,7 @@ export OSTREE_GPG_HOME=${test_tmpdir}/gpghome/trusted
 # See comment in ot-builtin-commit.c and https://github.com/ostreedev/ostree/issues/758
 # Also keep this in sync with the bits in libostreetest.c
 echo evaluating for overlayfs...
-case $(stat -f --printf '%T' /) in
+case $(stat -f --printf '%T' $PWD) in
     overlayfs)
         echo "overlayfs found; enabling OSTREE_NO_XATTRS"
         export OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},no-xattrs"


### PR DESCRIPTION
It occurred to me that a simple way of getting coverage for tests that don't work on overlayfs/tmpfs is to simply run them in a directory mounted from the host.

To do this, we switch `f26-primary` to execute on a test node rather than in a container, and make use of the new `TEST_TMPDIR` var to point it at the mounted `/srv` dir.

We also have to tweak the overlayfs detection logic only check the filesystem in which we're actually running the test, rather than just `/`.