### PR TITLE
tests: allow specifying tmpdir

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -8,7 +8,8 @@
 
 srcd=$(cd $(dirname $1) && pwd)
 bn=$(basename $1)
-tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
+TEST_TMPDIR=${TEST_TMPDIR:-/var/tmp}
+tempdir=$(mktemp -d $TEST_TMPDIR/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
     if test -f ${tempdir}/.testtmp; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -517,6 +517,9 @@ os_repository_new_commit ()
 # Usage: if ! skip_one_without_user_xattrs; then ... more tests ...; fi
 _have_user_xattrs=''
 have_user_xattrs() {
+    if ! which setfattr 2>/dev/null; then
+        fatal "no setfattr available to determine xattr support"
+    fi
     if test "${_have_user_xattrs}" = ''; then
         touch test-xattrs
         if setfattr -n user.testvalue -v somevalue test-xattrs 2>/dev/null; then


### PR DESCRIPTION
Allow developers to override the default `/var/tmp` dir, which e.g. might
be on overlayfs and thus produces reduced coverage.