### PR TITLE
tests,ci: Move "test-basic" (bare mode) to installed test

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -153,7 +153,7 @@ tests:
   - make install DESTDIR=$(pwd)/insttree
   - yum -y install rsync
   - rsync -rl -e 'ssh -o User=root' . vmcheck:ostree/
-  - ssh root@vmcheck './ostree/tests/installed/fah-prep.sh && ostree admin unlock && rsync -rlv ./ostree/insttree/usr/ /usr/ && ./ostree/tests/installed/run.sh'
+  - ssh root@vmcheck './ostree/tests/installed/fah-prep.sh && ./ostree/tests/installed/run.sh'
 
 ---
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,11 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((73 + ${extra_basic_tests:-0}))"
-
-$CMD_PREFIX ostree --version > version.yaml
-python -c 'import yaml; yaml.safe_load(open("version.yaml"))'
-echo "ok yaml version"
+echo "1..$((72 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"

--- a/tests/installed/fah-prep.sh
+++ b/tests/installed/fah-prep.sh
@@ -6,3 +6,5 @@ if lvm lvs atomicos/docker-pool &>/dev/null; then
     lvm lvremove -f atomicos/docker-pool
 fi
 lvm lvextend -r -l +100%FREE atomicos/root
+ostree admin unlock
+rsync -rlv ./ostree/insttree/usr/ /usr/

--- a/tests/installed/itest-bare-unit.sh
+++ b/tests/installed/itest-bare-unit.sh
@@ -9,7 +9,7 @@ dn=$(dirname $0)
 . ${dn}/libinsttest.sh
 
 # Use /var/tmp to hopefully use XFS + O_TMPFILE etc.
-tempdir=$(mktemp -d $/var/tmp/tap-test.XXXXXX)
+tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
     if test -f ${tempdir}/.testtmp; then

--- a/tests/installed/itest-bare-unit.sh
+++ b/tests/installed/itest-bare-unit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Run test-basic.sh as root.
+# https://github.com/ostreedev/ostree/pull/1199
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+# Use /var/tmp to hopefully use XFS + O_TMPFILE etc.
+tempdir=$(mktemp -d $/var/tmp/tap-test.XXXXXX)
+touch ${tempdir}/.testtmp
+function cleanup () {
+    if test -f ${tempdir}/.testtmp; then
+	      rm "${tempdir}" -rf
+    fi
+}
+trap cleanup EXIT
+cd ${tempdir}
+# This sort of bypasses the installed-tests spec;
+# fixing that would require installing g-d-t-r, though
+# more ideally we architect things with a "control" container
+# distinct from the host.
+/usr/libexec/installed-tests/libostree/test-basic.sh

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -549,7 +549,8 @@ skip_without_user_xattrs () {
 # Skip unless SELinux is disabled, or we can relabel.
 # Default Docker has security.selinux xattrs, but returns
 # EOPNOTSUPP when trying to set them, even to the existing value.
-# https://github.com/ostreedev/ostree/pull/1182
+# https://github.com/ostreedev/ostree/pull/759
+# https://github.com/ostreedev/ostree/pull/1217
 skip_without_no_selinux_or_relabel () {
     cd ${test_tmpdir}
     echo testlabel > testlabel.txt

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -22,8 +22,12 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 setup_test_repository "bare-user-only"
-extra_basic_tests=4
+extra_basic_tests=5
 . $(dirname $0)/basic-test.sh
+
+$CMD_PREFIX ostree --version > version.yaml
+python -c 'import yaml; yaml.safe_load(open("version.yaml"))'
+echo "ok yaml version"
 
 # Reset things so we don't inherit a lot of state from earlier tests
 cd ${test_tmpdir}

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_test_repository "bare"
+skip_without_no_selinux_or_relabel
 
+setup_test_repository "bare"
 . $(dirname $0)/basic-test.sh


### PR DESCRIPTION
Our CI uses default Docker, which has SELinux labeling but is rather
evil in returning `EOPNOTSUPP` to any attempts to set `security.selinux`,
even if to the same value.

The previous fire 🔥 for this was: https://github.com/ostreedev/ostree/pull/759

The `bare` repo mode really only makes sense as uid 0, so our installed
test framework is a good match for this.  However, the unit tests *do*
work in a privileged container even as non-root, and *also* should
work on SELinux-disabled systems.  So let's teach the test framework
how to skip in those situations.

I tested this both in a priv container (my default builder) and an unpriv
container (like our CI).

At the same time, start executing the `test-basic.sh` from an installed test,
so we get better coverage than before.

This is just the start - all of the sysroot tests really need the
same treatment.