### PR TITLE
ci: Record primary context results using g-d-t-r --report-directory

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -25,9 +25,11 @@ tests:
 
 timeout: 30m
 
+# Keep this in sync with build-check.sh
 artifacts:
   - test-suite.log
   - config.log
+  - gdtr-results
 ---
 
 context: c7-primary


### PR DESCRIPTION
So the output isn't all intermingled.  Yes, need to improve g-d-t-r.