### PR TITLE
lib/pull: Don't request deltas for unchanged commits

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3083,14 +3083,14 @@ initiate_request (OtPullData                 *pull_data,
             g_clear_pointer (&delta_from_revision, g_free);
         }
 
-      /* If the current ref is different from the target, then this is similar
-       * to the below, except we *might* use the previous commit, or we might do
-       * a scratch delta first.
+      /* If the current ref is the same, we don't do a delta request, just a
+       * scan. Otherise, use the previous commit if available, or a scratch
+       * delta.
        */
-      if (!(delta_from_revision && g_str_equal (delta_from_revision, to_revision)))
-        initiate_delta_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
-      else
+      if (delta_from_revision && g_str_equal (delta_from_revision, to_revision))
         queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, ref);
+      else
+        initiate_delta_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
     }
   else
     {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3083,10 +3083,14 @@ initiate_request (OtPullData                 *pull_data,
             g_clear_pointer (&delta_from_revision, g_free);
         }
 
-      /* This is similar to the below, except we *might* use the previous
-       * commit, or we might do a scratch delta first.
+      /* If the current ref is different from the target, then this is similar
+       * to the below, except we *might* use the previous commit, or we might do
+       * a scratch delta first.
        */
-      initiate_delta_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
+      if (!(delta_from_revision && g_str_equal (delta_from_revision, to_revision)))
+        initiate_delta_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
+      else
+        queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, ref);
     }
   else
     {

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -80,11 +80,8 @@ cd ${test_tmpdir}
 mkdir repo
 ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
-${CMD_PREFIX} ostree --repo=repo pull origin main
-${CMD_PREFIX} ostree --repo=repo show --gpg-verify-remote=origin main > show.txt
-cat show.txt
-grep -o 'Found [[:digit:]] signature' show.txt > verify.txt
-assert_file_has_content verify.txt 'Found 1 signature'
+${CMD_PREFIX} ostree --repo=repo pull origin main > show.txt
+assert_file_has_content_literal show.txt 'Found 1 signature'
 rm repo -rf
 echo "ok pull verify"
 
@@ -124,11 +121,11 @@ ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo show main > show.txt
-assert_not_file_has_content show.txt 'Found [[:digit:]] signature'
+assert_not_file_has_content show.txt 'Found.*signature'
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome main $keyid
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo show main > show.txt
-assert_file_has_content show.txt 'Found 1 signature'
+assert_file_has_content_literal show.txt 'Found 1 signature'
 echo "ok pull unsigned, then sign"
 
 # Delete the signature from the commit so the detached metadata is empty,
@@ -136,7 +133,7 @@ echo "ok pull unsigned, then sign"
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome --delete main $keyid
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo show main >show.txt
-assert_not_file_has_content show.txt 'Found [[:digit:]] signature'
+assert_not_file_has_content show.txt 'Found.*signature'
 echo "ok pull sig deleted"
 
 rm -rf repo gnomerepo-files

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -26,7 +26,7 @@ if ! has_gpgme; then
     exit 0
 fi
 
-echo "1..1"
+echo "1..6"
 
 keyid="472CDAFA"
 oldpwd=`pwd`
@@ -73,6 +73,7 @@ if env OSTREE_GPG_HOME=${test_tmpdir} ${CMD_PREFIX} ostree --repo=repo pull orig
     assert_not_reached "pull with no trusted GPG keys unexpectedly succeeded!"
 fi
 rm repo -rf
+echo "ok pull no trusted GPG"
 
 # And a test case with valid signature
 cd ${test_tmpdir}
@@ -80,9 +81,12 @@ mkdir repo
 ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull origin main
-${CMD_PREFIX} ostree --repo=repo show --gpg-verify-remote=origin main | grep -o 'Found [[:digit:]] signature' > show-verify-remote
-assert_file_has_content show-verify-remote 'Found 1 signature'
+${CMD_PREFIX} ostree --repo=repo show --gpg-verify-remote=origin main > show.txt
+cat show.txt
+grep -o 'Found [[:digit:]] signature' show.txt > verify.txt
+assert_file_has_content verify.txt 'Found 1 signature'
 rm repo -rf
+echo "ok pull verify"
 
 # A test with corrupted detached signature
 cd ${test_tmpdir}
@@ -96,6 +100,7 @@ if ${CMD_PREFIX} ostree --repo=repo pull origin main; then
     assert_not_reached "pull with corrupted signature unexpectedly succeeded!"
 fi
 rm repo -rf
+echo "ok pull corrupted sig"
 
 # And now attempt to pull the same corrupted commit, but with GPG
 # verification off
@@ -105,6 +110,7 @@ ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 rm repo -rf
+echo "ok repull corrupted"
 
 # Add an unsigned commit to the repo, then pull, then sign the commit,
 # then pull again.  Make sure we get the expected number of signatures
@@ -117,23 +123,21 @@ mkdir repo
 ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 ${CMD_PREFIX} ostree --repo=repo pull origin main
-if ${CMD_PREFIX} ostree --repo=repo show main | grep -o 'Found [[:digit:]] signature'; then
-  assert_not_reached
-fi
+${CMD_PREFIX} ostree --repo=repo show main > show.txt
+assert_not_file_has_content show.txt 'Found [[:digit:]] signature'
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome main $keyid
 ${CMD_PREFIX} ostree --repo=repo pull origin main
-${CMD_PREFIX} ostree --repo=repo show main | grep -o 'Found [[:digit:]] signature' > show
-assert_file_has_content show 'Found 1 signature'
+${CMD_PREFIX} ostree --repo=repo show main > show.txt
+assert_file_has_content show.txt 'Found 1 signature'
+echo "ok pull unsigned, then sign"
 
 # Delete the signature from the commit so the detached metadata is empty,
 # then pull and verify the signature is also deleted on the client side.
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome --delete main $keyid
 ${CMD_PREFIX} ostree --repo=repo pull origin main
-if ${CMD_PREFIX} ostree --repo=repo show main | grep -o 'Found [[:digit:]] signature'; then
-  assert_not_reached
-fi
+${CMD_PREFIX} ostree --repo=repo show main >show.txt
+assert_not_file_has_content show.txt 'Found [[:digit:]] signature'
+echo "ok pull sig deleted"
 
 rm -rf repo gnomerepo-files
 libtest_cleanup_gpg
-
-echo "ok"

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -80,7 +80,8 @@ cd ${test_tmpdir}
 mkdir repo
 ostree_repo_init repo
 ${CMD_PREFIX} ostree --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
-${CMD_PREFIX} ostree --repo=repo pull origin main > show.txt
+${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo show --gpg-verify-remote=origin main > show.txt
 assert_file_has_content_literal show.txt 'Found 1 signature'
 rm repo -rf
 echo "ok pull verify"


### PR DESCRIPTION
I noticed this while debugging why I was seeing "2 metadata objects" fetched for
a different PR. I knew 1 was detached meta, but the other turned out to be this.

There's no reason to request a delta if the ref is unchanged.