### PR TITLE
lib/diff: Add compile-time ABI check on 64 bit arches

### DIFF
--- a/src/libostree/ostree-diff.c
+++ b/src/libostree/ostree-diff.c
@@ -26,6 +26,16 @@
 #include "ostree-repo-private.h"
 #include "otutil.h"
 
+/* See ostree-repo.c for a bit more info about these ABI checks */
+#if __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 8 && __SIZEOF_INT__ == 4
+G_STATIC_ASSERT(sizeof(OstreeDiffDirsOptions) ==
+                sizeof(int) * 2 +
+                sizeof(gpointer) +
+                sizeof(int) * (7+6) +
+                sizeof(int) +  /* hole */
+                sizeof(gpointer) * 7);
+#endif
+
 static gboolean
 get_file_checksum (OstreeDiffFlags  flags,
                    GFile *f,

--- a/src/libostree/ostree-diff.h
+++ b/src/libostree/ostree-diff.h
@@ -85,6 +85,7 @@ typedef struct {
 
   gboolean unused_bools[7];
   int unused_ints[6];
+  /* 4 byte hole on 64 bit */
   gpointer unused_ptrs[7];
 } OstreeDiffDirsOptions;
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -48,6 +48,10 @@
 
 /* ABI Size checks for ostree-repo.h, only for LP64 systems;
  * https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
+ *
+ * To generate this data, I used `pahole` from gdb. More concretely, `gdb --args
+ * /usr/bin/ostree`, then `start`, (to ensure debuginfo was loaded), then e.g.
+ * `$ pahole OstreeRepoTransactionStats`.
  */
 #if __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 8 && __SIZEOF_INT__ == 4
 G_STATIC_ASSERT(sizeof(OstreeRepoTransactionStats) == sizeof(int) * 4 + 8 * 5);


### PR DESCRIPTION
Like what was done for most of the `ostree-repo.h` values.  Prep
for adding a new option.