### PR TITLE
tree-wide: Bump libglnx, port to new lockfile init

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1234,7 +1234,7 @@ cleanup_tmpdir (OstreeRepo        *self,
       guint64 delta;
       struct dirent *dent;
       struct stat stbuf;
-      g_auto(GLnxLockFile) lockfile = GLNX_LOCK_FILE_INIT;
+      g_auto(GLnxLockFile) lockfile = { 0, };
       gboolean did_lock;
 
       if (!glnx_dirfd_iterator_next_dent (&dfd_iter, &dent, cancellable, error))

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -662,7 +662,6 @@ static void
 ostree_repo_init (OstreeRepo *self)
 {
   static gsize gpgme_initialized;
-  GLnxLockFile empty_lockfile = GLNX_LOCK_FILE_INIT;
   const GDebugKey test_error_keys[] = {
     { "pre-commit", OSTREE_REPO_TEST_ERROR_PRE_COMMIT },
   };
@@ -690,7 +689,6 @@ ostree_repo_init (OstreeRepo *self)
   self->tmp_dir_fd = -1;
   self->objects_dir_fd = -1;
   self->uncompressed_objects_dir_fd = -1;
-  self->commit_stagedir_lock = empty_lockfile;
   self->sysroot_kind = OSTREE_REPO_SYSROOT_KIND_UNKNOWN;
 }
 

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -197,7 +197,6 @@ ostree_sysroot_init (OstreeSysroot *self)
                                             keys, G_N_ELEMENTS (keys));
 
   self->sysroot_fd = -1;
-  self->lock = (GLnxLockFile)GLNX_LOCK_FILE_INIT;
 }
 
 /**


### PR DESCRIPTION
In particular I'd like to get the copy fix in, since it might affect users for
the keyring bits.

Update submodule: libglnx