### PR TITLE
lib/bloom: Add some missing preconditions on n_bytes

### DIFF
--- a/src/libostree/ostree-bloom.c
+++ b/src/libostree/ostree-bloom.c
@@ -76,7 +76,7 @@
 struct _OstreeBloom
 {
   guint ref_count;
-  gsize n_bytes;
+  gsize n_bytes;  /* 0 < n_bytes <= G_MAXSIZE / 8 */
   gboolean is_mutable;  /* determines which of [im]mutable_bytes is accessed */
   union
     {
@@ -117,6 +117,7 @@ ostree_bloom_new (gsize               n_bytes,
   g_autoptr(OstreeBloom) bloom = NULL;
 
   g_return_val_if_fail (n_bytes > 0, NULL);
+  g_return_val_if_fail (n_bytes <= G_MAXSIZE / 8, NULL);
   g_return_val_if_fail (k > 0, NULL);
   g_return_val_if_fail (hash_func != NULL, NULL);
 
@@ -159,6 +160,7 @@ ostree_bloom_new_from_bytes (GBytes              *bytes,
 
   g_return_val_if_fail (bytes != NULL, NULL);
   g_return_val_if_fail (g_bytes_get_size (bytes) > 0, NULL);
+  g_return_val_if_fail (g_bytes_get_size (bytes) <= G_MAXSIZE / 8, NULL);
   g_return_val_if_fail (k > 0, NULL);
   g_return_val_if_fail (hash_func != NULL, NULL);
 


### PR DESCRIPTION
These shouldn’t change the bloom filter’s behaviour at all, but make it
a bit more obvious what the programmatical limitations are on the sizes
it can deal with.

In reality, those sizes should never be reached because they won’t fit
in a DNS-SD record.

Signed-off-by: Philip Withnall <withnall@endlessm.com>