### PR TITLE
lib/gpg: Print debug info when reading GPG keys

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -272,6 +272,9 @@ _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier  *self,
 {
   g_return_if_fail (G_IS_FILE (path));
 
+  g_autofree gchar *path_str = g_file_get_path (path);
+  g_debug ("Adding GPG keyring file %s to verifier", path_str);
+
   self->keyrings = g_list_append (self->keyrings, g_object_ref (path));
 }
 
@@ -280,8 +283,11 @@ _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier  *self,
  */
 void
 _ostree_gpg_verifier_add_keyring_data (OstreeGpgVerifier  *self,
-                                       GBytes             *keyring)
+                                       GBytes             *keyring,
+                                       const char         *data_source)
 {
+  g_debug ("Adding GPG keyring data from %s to verifier", data_source);
+
   g_ptr_array_add (self->keyring_data, g_bytes_ref (keyring));
 }
 
@@ -289,6 +295,8 @@ void
 _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                          const char        *path)
 {
+  g_debug ("Adding GPG key ASCII file %s to verifier", path);
+
   if (!self->key_ascii_files)
     self->key_ascii_files = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (self->key_ascii_files, g_strdup (path));
@@ -318,6 +326,8 @@ _ostree_gpg_verifier_add_keyring_dir_at (OstreeGpgVerifier   *self,
   if (!glnx_dirfd_iterator_init_at (dfd, path, FALSE,
                                     &dfd_iter, error))
     return FALSE;
+
+  g_debug ("Adding GPG keyring dir %s to verifier", path);
 
   while (TRUE)
     {

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -65,7 +65,8 @@ gboolean      _ostree_gpg_verifier_add_global_keyring_dir (OstreeGpgVerifier  *s
                                                            GError            **error);
 
 void _ostree_gpg_verifier_add_keyring_data (OstreeGpgVerifier *self,
-                                            GBytes            *data);
+                                            GBytes            *data,
+                                            const char        *data_source);
 void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
                                             GFile             *path);
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4328,7 +4328,7 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
 
       if (keyring_data != NULL)
         {
-          _ostree_gpg_verifier_add_keyring_data (verifier, keyring_data);
+          _ostree_gpg_verifier_add_keyring_data (verifier, keyring_data, remote->keyring);
           add_global_keyring_dir = FALSE;
         }
 


### PR DESCRIPTION
This commit adds debug output whenever libostree reads GPG keys, which
can come from different locations in the file system. This is especially
helpful in debugging "GPG signatures found, but none are in trusted
keyring" errors, which in my case was caused by OSTree looking in
/usr/local/share/ostree/trusted.gpg.d/ rather than
/usr/share/ostree/trusted.gpg.d/.