### PR TITLE
lib/repo-commit: Import detached metadata even if hardlink exists

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -3319,7 +3319,7 @@ import_one_object_direct (OstreeRepo    *dest_repo,
       if (linkat (src_repo->objects_dir_fd, loose_path_buf, dest_dfd, loose_path_buf, 0) != 0)
         {
           if (errno == EEXIST)
-            return TRUE;
+            did_hardlink = TRUE;
           else if (errno == EMLINK || errno == EXDEV || errno == EPERM)
             {
               /* EMLINK, EXDEV and EPERM shouldn't be fatal; we just can't do


### PR DESCRIPTION
Spotted while reading through the code, it looks like the
copy_detached_metadata() call is accidentally omitted if a hardlink
already exists for the .commit object.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

@cgwalters, this change passes the tests, but you’d better take a look and see if it fits in with what you were thinking about in commit 8a7a35970928331a028ccddd04590ac300dbd26e (PR #1197).