### PR TITLE
app/main: use HAVE_LIBCURL_OR_LIBSOUP for pull CLI

### DIFF
--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -51,7 +51,7 @@ static OstreeCommand commands[] = {
   { "ls", ostree_builtin_ls },
   { "prune", ostree_builtin_prune },
   { "pull-local", ostree_builtin_pull_local },
-#ifdef HAVE_LIBSOUP 
+#ifdef HAVE_LIBCURL_OR_LIBSOUP
   { "pull", ostree_builtin_pull },
 #endif
   { "refs", ostree_builtin_refs },


### PR DESCRIPTION
We want `pull` to be included as long as we have at least either
`libcurl` or `libsoup` to back it. Of course, this is a moot point for
now since `libsoup` is currently a build requirement.