### PR TITLE
ci: really turn on warnings

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -28,14 +28,13 @@ if test -x /usr/bin/gnome-desktop-testing-runner; then
     gnome-desktop-testing-runner -L ${resultsdir}/gdtr-results -p 0 ${INSTALLED_TESTS_PATTERN:-libostree/}
 fi
 
+# And now a clang build to find unused variables because it does a better
+# job than gcc for vars with cleanups; perhaps in the future these could
+# parallelize
 if test -x /usr/bin/clang; then
-    # always fail on warnings; https://github.com/ostreedev/ostree/pull/971
     # Except for clang-4.0: error: argument unused during compilation: '-specs=/usr/lib/rpm/redhat/redhat-hardened-cc1' [-Werror,-Wunused-command-line-argument]
-    export CFLAGS="-Wno-error=unused-command-line-argument -Werror ${CFLAGS:-}"
+    export CFLAGS="-Wall -Werror -Wno-error=unused-command-line-argument ${CFLAGS:-}"
     git clean -dfx && git submodule foreach git clean -dfx
-    # And now a clang build to find unused variables because it does a better
-    # job than gcc for vars with cleanups; perhaps in the future these could
-    # parallelize
     export CC=clang
     build
 fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,9 +18,6 @@ if test -n "${CI_PKGS:-}"; then
 fi
 pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang
 
-# always fail on warnings; https://github.com/ostreedev/ostree/pull/971
-export CFLAGS="-Werror ${CFLAGS:-}"
-
 # Default libcurl on by default in fedora unless libsoup is enabled
 if sh -c '. /etc/os-release; test "${ID}" = fedora'; then
     case "${CONFIGOPTS:-}" in
@@ -35,5 +32,9 @@ case "${CONFIGOPTS:-}" in
         fi
         ;;
 esac
+
+# always fail on warnings; https://github.com/ostreedev/ostree/pull/971
+# NB: this disables the default set of flags from configure.ac
+export CFLAGS="-Wall -Werror ${CFLAGS:-}"
 
 build --enable-gtk-doc ${CONFIGOPTS:-}

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -693,7 +693,7 @@ adopt_steal_mainctx (OstreeFetcher *self,
       guint64 readytime = g_source_get_ready_time (self->timer_event);
       guint64 curtime = g_source_get_time (self->timer_event);
       guint64 timeout_micros = curtime - readytime;
-      if (timeout_micros < 0)
+      if (curtime < readytime)
         timeout_micros = 0;
       update_timeout_cb (self->multi, timeout_micros / 1000, self);
     }
@@ -706,7 +706,7 @@ static void
 initiate_next_curl_request (FetcherRequest *req,
                             GTask *task)
 {
-  CURLMcode rc;
+  CURLcode rc;
   OstreeFetcher *self = req->fetcher;
 
   if (req->easy)
@@ -802,8 +802,8 @@ initiate_next_curl_request (FetcherRequest *req,
   curl_easy_setopt (req->easy, CURLOPT_WRITEDATA, task);
   curl_easy_setopt (req->easy, CURLOPT_PROGRESSDATA, task);
 
-  rc = curl_multi_add_handle (self->multi, req->easy);
-  g_assert (rc == CURLM_OK);
+  CURLMcode multi_rc = curl_multi_add_handle (self->multi, req->easy);
+  g_assert (multi_rc == CURLM_OK);
 }
 
 static void

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4960,7 +4960,6 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
   while (!ret_tmpdir.initialized)
     {
       struct dirent *dent;
-      glnx_fd_close int existing_tmpdir_fd = -1;
       g_autoptr(GError) local_error = NULL;
 
       if (!glnx_dirfd_iterator_next_dent (&dfd_iter, &dent, cancellable, error))

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -163,10 +163,8 @@ ostree_run (int    argc,
 
   if (!command->fn)
     {
-      g_autoptr(GOptionContext) context = NULL;
-      g_autofree char *help = NULL;
-
-      context = ostree_option_context_new_with_commands (commands);
+      g_autoptr(GOptionContext) context =
+        ostree_option_context_new_with_commands (commands);
 
       /* This will not return for some options (e.g. --version). */
       if (ostree_option_context_parse (context, NULL, &argc, &argv, OSTREE_BUILTIN_FLAG_NO_REPO, NULL, cancellable, &error))


### PR DESCRIPTION
We didn't have `-Wall` in our `CFLAGS`. It's normally injected by
`configure.ac`, but because we *did* have `-Werror`, it was skipped.

We just turn it on from very early on in `build-check.sh` so that both
the gcc and clang builds make use of it and install a self-test to make
sure we don't regress on it.