### PR TITLE
Deduplicate and fix up our use of mmap()

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1228,8 +1228,8 @@ meta_fetch_on_complete (GObject           *object,
 
   if (fetch_data->is_detached_meta)
     {
-      if (!ot_util_variant_map_fd (fd, 0, G_VARIANT_TYPE ("a{sv}"),
-                                   FALSE, &metadata, error))
+      if (!ot_variant_read_fd (fd, 0, G_VARIANT_TYPE ("a{sv}"),
+                               FALSE, &metadata, error))
         goto out;
 
       if (!ostree_repo_write_commit_detached_metadata (pull_data->repo, checksum, metadata,
@@ -1245,8 +1245,8 @@ meta_fetch_on_complete (GObject           *object,
     }
   else
     {
-      if (!ot_util_variant_map_fd (fd, 0, ostree_metadata_variant_type (objtype),
-                                   FALSE, &metadata, error))
+      if (!ot_variant_read_fd (fd, 0, ostree_metadata_variant_type (objtype),
+                               FALSE, &metadata, error))
         goto out;
 
       /* Write the commitpartial file now while we're still fetching data */

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -172,7 +172,7 @@ ot_fd_readall_or_mmap (int           fd,
 
   /* http://stackoverflow.com/questions/258091/when-should-i-use-mmap-for-file-access */
   if (start > stbuf.st_size)
-    start = stbuf.st_size;
+    return g_bytes_new_static (NULL, 0);
   const gsize len = stbuf.st_size - start;
   if (len > 16*1024)
     {

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -22,6 +22,7 @@
 #include "ot-fs-utils.h"
 #include "libglnx.h"
 #include <sys/xattr.h>
+#include <sys/mman.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
 
@@ -144,22 +145,57 @@ ot_dfd_iter_init_allow_noent (int dfd,
   return TRUE;
 }
 
-GBytes *
-ot_file_mapat_bytes (int dfd,
-                     const char *path,
-                     GError **error)
+typedef struct {
+  gpointer addr;
+  gsize len;
+} MapData;
+
+static void
+map_data_destroy (gpointer data)
 {
-  glnx_fd_close int fd = openat (dfd, path, O_RDONLY | O_CLOEXEC);
-  g_autoptr(GMappedFile) mfile = NULL;
+  MapData *mdata = data;
+  (void) munmap (mdata->addr, mdata->len);
+  g_free (mdata);
+}
 
-  if (fd < 0)
-    return glnx_null_throw_errno_prefix (error, "openat(%s)", path);
-
-  mfile = g_mapped_file_new_from_fd (fd, FALSE, error);
-  if (!mfile)
+/* Return a newly-allocated GBytes that refers to the contents of the file
+ * starting at offset @start. If the file is large enough, mmap() may be used.
+ */
+GBytes *
+ot_fd_readall_or_mmap (int           fd,
+                       goffset       start,
+                       GError      **error)
+{
+  struct stat stbuf;
+  if (!glnx_fstat (fd, &stbuf, error))
     return FALSE;
 
-  return g_mapped_file_get_bytes (mfile);
+  /* http://stackoverflow.com/questions/258091/when-should-i-use-mmap-for-file-access */
+  if (start > stbuf.st_size)
+    start = stbuf.st_size;
+  const gsize len = stbuf.st_size - start;
+  if (len > 16*1024)
+    {
+      /* The reason we don't use g_mapped_file_new_from_fd() here
+       * is it doesn't support passing an offset, which is actually
+       * used by the static delta code.
+       */
+      gpointer map = mmap (NULL, len, PROT_READ, MAP_PRIVATE, fd, start);
+      if (map == (void*)-1)
+        return glnx_null_throw_errno_prefix (error, "mmap");
+
+      MapData *mdata = g_new (MapData, 1);
+      mdata->addr = map;
+      mdata->len = len;
+
+      return g_bytes_new_with_free_func (map, len, map_data_destroy, mdata);
+    }
+
+  /* Fall through to plain read into a malloc buffer */
+  if (lseek (fd, start, SEEK_SET) < 0)
+    return glnx_null_throw_errno_prefix (error, "lseek");
+  /* Not cancellable since this should be small */
+  return glnx_fd_readall_bytes (fd, NULL, error);
 }
 
 /* Given an input stream, splice it to an anonymous file (O_TMPFILE).

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -85,8 +85,7 @@ ot_map_anonymous_tmpfile_from_content (GInputStream *instream,
                                        GCancellable *cancellable,
                                        GError      **error);
 
-GBytes *ot_file_mapat_bytes (int dfd,
-                             const char *path,
-                             GError **error);
+GBytes *ot_fd_readall_or_mmap (int fd, goffset offset,
+                               GError **error);
 
 G_END_DECLS

--- a/src/libotutil/ot-variant-utils.h
+++ b/src/libotutil/ot-variant-utils.h
@@ -36,24 +36,12 @@ GHashTable *ot_util_variant_asv_to_hash_table (GVariant *variant);
 
 GVariant * ot_util_variant_take_ref (GVariant *variant);
 
-typedef enum {
-  OT_VARIANT_MAP_TRUSTED = (1 << 0),
-  OT_VARIANT_MAP_ALLOW_NOENT = (1 << 1)
-} OtVariantMapFlags;
-
-gboolean ot_util_variant_map_at (int dfd,
-                                 const char *path,
-                                 const GVariantType *type,
-                                 OtVariantMapFlags flags,
-                                 GVariant **out_variant,
-                                 GError  **error);
-
-gboolean ot_util_variant_map_fd (int                  fd,
-                                 goffset              offset,
-                                 const GVariantType  *type,
-                                 gboolean             trusted,
-                                 GVariant           **out_variant,
-                                 GError             **error);
+gboolean ot_variant_read_fd (int                  fd,
+                             goffset              offset,
+                             const GVariantType  *type,
+                             gboolean             trusted,
+                             GVariant           **out_variant,
+                             GError             **error);
 
 GInputStream *ot_variant_read (GVariant             *variant);
 

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -58,7 +58,10 @@ do_print_variant_generic (const GVariantType *type,
 {
   g_autoptr(GVariant) variant = NULL;
 
-  if (!ot_util_variant_map_at (AT_FDCWD, filename, type, TRUE, &variant, error))
+  glnx_fd_close int fd = -1;
+  if (!glnx_openat_rdonly (AT_FDCWD, filename, TRUE, &fd, error))
+    return FALSE;
+  if (!ot_variant_read_fd (fd, 0, type, FALSE, &variant, error))
     return FALSE;
 
   ot_dump_variant (variant);

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -217,7 +217,10 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
       if (opt_raw)
         flags |= OSTREE_DUMP_RAW;
 
-      summary_data = ot_file_mapat_bytes (repo->repo_dir_fd, "summary", error);
+      glnx_fd_close int fd = -1;
+      if (!glnx_openat_rdonly (repo->repo_dir_fd, "summary", TRUE, &fd, error))
+        return FALSE;
+      summary_data = ot_fd_readall_or_mmap (fd, 0, error);
       if (!summary_data)
         return FALSE;
 


### PR DESCRIPTION
Buried in this large patch is a logical fix:

```
-  if (!map)
-    return glnx_throw_errno_prefix (error, "mmap");
+  if (map == (void*)-1)
+    return glnx_null_throw_errno_prefix (error, "mmap");
```

Which would have helped me debug another patch I was working
on.  But it turns out that actually correctly checking for
errors from `mmap()` triggers lots of other bugs - basically
because we sometimes handle zero-length variants (in detached
metadata).  When we start actually returning errors due to
this, things break.  (It wasn't a problem in practice before
because most things looked at the zero size, not the data).

Anyways there's a bigger picture issue here - a while ago
we made a fix to only use `mmap()` for reading metadata from disk
only if it was large enough (i.e. `>16k`).  But that didn't
help various other paths in the pull code and others that were
directly doing the `mmap()`.

Fix this by having a proper low level fs helper that does "read all data from
fd+offset into GBytes", which handles the size check. Then the `GVariant` bits
are just a clean layer on top of this. (At the small cost of an additional
allocation)

Side note: I had to remind myself, but the reason we can't just use
`GMappedFile` here is it doesn't support passing an offset into `mmap()`.