### PR TITLE
tree-wide: Update to new libglnx fd APIs

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -416,7 +416,7 @@ _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
     }
 
   /* Now let's fdatasync() for the new file */
-  { glnx_fd_close int new_config_fd = -1;
+  { glnx_autofd int new_config_fd = -1;
     if (!glnx_openat_rdonly (AT_FDCWD, gs_file_get_path_cached (new_config_path), TRUE, &new_config_fd, error))
       return FALSE;
 

--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -73,7 +73,7 @@ append_system_uenv (OstreeBootloaderUboot   *self,
                     GCancellable            *cancellable,
                     GError                 **error)
 {
-  glnx_fd_close int uenv_fd = -1;
+  glnx_autofd int uenv_fd = -1;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
   const char *uenv_path = NULL;
   const char *ostree_arg = NULL;

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -781,7 +781,7 @@ ostree_content_file_parse_at (gboolean                compressed,
                               GCancellable           *cancellable,
                               GError                **error)
 {
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
   if (!glnx_openat_rdonly (parent_dfd, path, TRUE, &fd, error))
     return FALSE;
 

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -177,7 +177,7 @@ _ostree_gpg_verifier_check_signature (OstreeGpgVerifier  *self,
       for (guint i = 0; i < self->key_ascii_files->len; i++)
         {
           const char *path = self->key_ascii_files->pdata[i];
-          glnx_fd_close int fd = -1;
+          glnx_autofd int fd = -1;
           g_auto(gpgme_data_t) kdata = NULL;
 
           if (!glnx_openat_rdonly (AT_FDCWD, path, TRUE, &fd, error))
@@ -355,7 +355,7 @@ _ostree_gpg_verifier_add_keyring_dir_at (OstreeGpgVerifier   *self,
       if (g_str_equal (name, "secring.gpg"))
         continue;
 
-      glnx_fd_close int fd = -1;
+      glnx_autofd int fd = -1;
       if (!glnx_openat_rdonly (dfd_iter.fd, dent->d_name, TRUE, &fd, error))
         return FALSE;
 

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -164,7 +164,7 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
   /* Prepare to write to the output unit dir; we use the "normal" dir
    * that overrides /usr, but not /etc.
    */
-  glnx_fd_close int normal_dir_dfd = -1;
+  glnx_autofd int normal_dir_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, normal_dir, TRUE, &normal_dir_dfd, error))
     return FALSE;
 

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -782,7 +782,7 @@ checkout_tree_at_recurse (OstreeRepo                        *self,
       }
   }
 
-  glnx_fd_close int destination_dfd = -1;
+  glnx_autofd int destination_dfd = -1;
   if (!glnx_opendirat (destination_parent_fd, destination_name, TRUE,
                        &destination_dfd, error))
     return FALSE;
@@ -947,7 +947,7 @@ checkout_tree_at (OstreeRepo                        *self,
        * exists.
        */
       int destination_dfd = destination_parent_fd;
-      glnx_fd_close int destination_dfd_owned = -1;
+      glnx_autofd int destination_dfd_owned = -1;
       if (strcmp (destination_name, ".") != 0)
         {
           if (mkdirat (destination_parent_fd, destination_name, 0700) < 0

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1227,7 +1227,7 @@ rename_pending_loose_objects (OstreeRepo        *self,
           /* Ensure that in the case of a power cut all the directory metadata that
              we want has reached the disk. In particular, we want this before we
              update the refs to point to these objects. */
-          glnx_fd_close int target_dir_fd = -1;
+          glnx_autofd int target_dir_fd = -1;
 
           loose_objpath[2] = 0;
 
@@ -2219,7 +2219,7 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
 
   if (self->commit_stagedir.initialized)
     {
-      glnx_fd_close int fd = -1;
+      glnx_autofd int fd = -1;
       if (!ot_openat_ignore_enoent (self->commit_stagedir.fd, buf, &fd, error))
         return FALSE;
       if (fd != -1)
@@ -2227,7 +2227,7 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
                                    out_metadata, error);
     }
 
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
   if (!ot_openat_ignore_enoent (self->objects_dir_fd, buf, &fd, error))
     return FALSE;
   if (fd != -1)
@@ -3402,7 +3402,7 @@ import_one_object_direct (OstreeRepo    *dest_repo,
        * that basically just optionally does chown().  Perhaps
        * in the future we should add flags for those things?
        */
-      glnx_fd_close int src_fd = -1;
+      glnx_autofd int src_fd = -1;
       if (!glnx_openat_rdonly (src_repo->objects_dir_fd, loose_path_buf,
                                FALSE, &src_fd, error))
         return FALSE;

--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -328,9 +328,9 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder                  *finde
       g_autofree gchar *mount_name = NULL;
       g_autoptr(GFile) mount_root = NULL;
       g_autofree gchar *mount_root_path = NULL;
-      glnx_fd_close int mount_root_dfd = -1;
+      glnx_autofd int mount_root_dfd = -1;
       struct stat mount_root_stbuf;
-      glnx_fd_close int repos_dfd = -1;
+      glnx_autofd int repos_dfd = -1;
       gsize i;
       g_autoptr(GHashTable) repo_to_refs = NULL;  /* (element-type UriAndKeyring GHashTable) */
       GHashTable *supported_ref_to_checksum;  /* (element-type OstreeCollectionRef utf8) */

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -547,7 +547,7 @@ write_commitpartial_for (OtPullData *pull_data,
                          GError **error)
 {
   g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (checksum);
-  glnx_fd_close int fd = openat (pull_data->repo->repo_dir_fd, commitpartial_path, O_EXCL | O_CREAT | O_WRONLY | O_CLOEXEC | O_NOCTTY, 0644);
+  glnx_autofd int fd = openat (pull_data->repo->repo_dir_fd, commitpartial_path, O_EXCL | O_CREAT | O_WRONLY | O_CLOEXEC | O_NOCTTY, 0644);
   if (fd == -1)
     {
       if (errno != EEXIST)
@@ -2495,7 +2495,7 @@ _ostree_repo_load_cache_summary_if_same_sig (OstreeRepo        *self,
     return TRUE;
 
   const char *summary_cache_sig_file = glnx_strjoina (_OSTREE_SUMMARY_CACHE_DIR, "/", remote, ".sig");
-  glnx_fd_close int prev_fd = -1;
+  glnx_autofd int prev_fd = -1;
   if (!ot_openat_ignore_enoent (self->cache_dir_fd, summary_cache_sig_file, &prev_fd, error))
     return FALSE;
   if (prev_fd < 0)
@@ -2508,7 +2508,7 @@ _ostree_repo_load_cache_summary_if_same_sig (OstreeRepo        *self,
   if (g_bytes_compare (old_sig_contents, summary_sig) == 0)
     {
       const char *summary_cache_file = glnx_strjoina (_OSTREE_SUMMARY_CACHE_DIR, "/", remote);
-      glnx_fd_close int summary_fd = -1;
+      glnx_autofd int summary_fd = -1;
       GBytes *summary_data;
 
 

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -150,7 +150,7 @@ find_ref_in_remotes (OstreeRepo         *self,
                      GError            **error)
 {
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
-  glnx_fd_close int ret_fd = -1;
+  glnx_autofd int ret_fd = -1;
 
   if (!glnx_dirfd_iterator_init_at (self->repo_dir_fd, "refs/remotes", TRUE, &dfd_iter, error))
     return FALSE;
@@ -158,7 +158,7 @@ find_ref_in_remotes (OstreeRepo         *self,
   while (TRUE)
     {
       struct dirent *dent = NULL;
-      glnx_fd_close int remote_dfd = -1;
+      glnx_autofd int remote_dfd = -1;
 
       if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, NULL, error))
         return FALSE;
@@ -234,7 +234,7 @@ resolve_refspec (OstreeRepo     *self,
 {
   __attribute__((unused)) GCancellable *cancellable = NULL;
   g_autofree char *ret_rev = NULL;
-  glnx_fd_close int target_fd = -1;
+  glnx_autofd int target_fd = -1;
 
   g_return_val_if_fail (ref != NULL, FALSE);
 
@@ -637,7 +637,7 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
         {
           if (S_ISDIR (stbuf.st_mode))
             {
-              glnx_fd_close int base_fd = -1;
+              glnx_autofd int base_fd = -1;
               g_autoptr(GString) base_path = g_string_new ("");
               if (!cut_prefix)
                 g_string_printf (base_path, "%s/", ref_prefix);
@@ -652,7 +652,7 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
             }
           else
             {
-              glnx_fd_close int prefix_dfd = -1;
+              glnx_autofd int prefix_dfd = -1;
 
               if (!glnx_opendirat (self->repo_dir_fd, prefix_path, TRUE, &prefix_dfd, error))
                 return FALSE;
@@ -667,7 +667,7 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
     {
       g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
       g_autoptr(GString) base_path = g_string_new ("");
-      glnx_fd_close int refs_heads_dfd = -1;
+      glnx_autofd int refs_heads_dfd = -1;
 
       if (!glnx_opendirat (self->repo_dir_fd, "refs/heads", TRUE, &refs_heads_dfd, error))
         return FALSE;
@@ -687,7 +687,7 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
           while (TRUE)
             {
               struct dirent *dent;
-              glnx_fd_close int remote_dfd = -1;
+              glnx_autofd int remote_dfd = -1;
 
               if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
                 return FALSE;
@@ -992,7 +992,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
                         GCancellable               *cancellable,
                         GError                    **error)
 {
-  glnx_fd_close int dfd = -1;
+  glnx_autofd int dfd = -1;
 
   g_return_val_if_fail (remote == NULL || ref->collection_id == NULL, FALSE);
   g_return_val_if_fail (!(rev != NULL && alias != NULL), FALSE);
@@ -1016,7 +1016,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
     }
   else if (remote == NULL && ref->collection_id != NULL)
     {
-      glnx_fd_close int refs_mirrors_dfd = -1;
+      glnx_autofd int refs_mirrors_dfd = -1;
 
       /* refs/mirrors might not exist in older repositories, so create it. */
       if (!glnx_shutil_mkdir_p_at_open (self->repo_dir_fd, "refs/mirrors", 0777,
@@ -1039,7 +1039,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
     }
   else
     {
-      glnx_fd_close int refs_remotes_dfd = -1;
+      glnx_autofd int refs_remotes_dfd = -1;
 
       if (!glnx_opendirat (self->repo_dir_fd, "refs/remotes", TRUE,
                            &refs_remotes_dfd, error))
@@ -1212,7 +1212,7 @@ ostree_repo_list_collection_refs (OstreeRepo                 *self,
   if (main_collection_id != NULL &&
       (match_collection_id == NULL || g_strcmp0 (match_collection_id, main_collection_id) == 0))
     {
-      glnx_fd_close int refs_heads_dfd = -1;
+      glnx_autofd int refs_heads_dfd = -1;
 
       if (!glnx_opendirat (self->repo_dir_fd, "refs/heads", TRUE, &refs_heads_dfd, error))
         return FALSE;
@@ -1237,7 +1237,7 @@ ostree_repo_list_collection_refs (OstreeRepo                 *self,
       while (refs_dir_exists)
         {
           struct dirent *dent;
-          glnx_fd_close int subdir_fd = -1;
+          glnx_autofd int subdir_fd = -1;
           const gchar *current_collection_id;
           g_autofree gchar *remote_collection_id = NULL;
 

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1209,12 +1209,12 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
   g_autoptr(GVariant) to_commit = NULL;
   const char *opt_filename;
   g_autofree char *descriptor_name = NULL;
-  glnx_fd_close int descriptor_dfd = -1;
+  glnx_autofd int descriptor_dfd = -1;
   g_autoptr(GVariant) fallback_headers = NULL;
   g_autoptr(GVariant) detached = NULL;
   gboolean inline_parts;
   guint endianness = G_BYTE_ORDER;
-  glnx_fd_close int tmp_dfd = -1;
+  glnx_autofd int tmp_dfd = -1;
   builder.parts = g_ptr_array_new_with_free_func ((GDestroyNotify)ostree_static_delta_part_builder_unref);
   builder.fallback_objects = g_ptr_array_new_with_free_func ((GDestroyNotify)g_variant_unref);
 

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -224,7 +224,7 @@ ostree_repo_static_delta_execute_offline (OstreeRepo                    *self,
   const char *dir_or_file_path = gs_file_get_path_cached (dir_or_file);
 
   /* First, try opening it as a directory */
-  glnx_fd_close int dfd = glnx_opendirat_with_errno (AT_FDCWD, dir_or_file_path, TRUE);
+  glnx_autofd int dfd = glnx_opendirat_with_errno (AT_FDCWD, dir_or_file_path, TRUE);
   if (dfd < 0)
     {
       if (errno != ENOTDIR)
@@ -241,7 +241,7 @@ ostree_repo_static_delta_execute_offline (OstreeRepo                    *self,
   else
     basename = g_strdup ("superblock");
 
-  glnx_fd_close int meta_fd = openat (dfd, basename, O_RDONLY | O_CLOEXEC);
+  glnx_autofd int meta_fd = openat (dfd, basename, O_RDONLY | O_CLOEXEC);
   if (meta_fd < 0)
     return glnx_throw_errno_prefix (error, "openat(%s)", basename);
 
@@ -377,7 +377,7 @@ ostree_repo_static_delta_execute_offline (OstreeRepo                    *self,
       else
         {
           g_autofree char *relpath = g_strdup_printf ("%u", i); /* TODO avoid malloc here */
-          glnx_fd_close int part_fd = openat (dfd, relpath, O_RDONLY | O_CLOEXEC);
+          glnx_autofd int part_fd = openat (dfd, relpath, O_RDONLY | O_CLOEXEC);
           if (part_fd < 0)
             return glnx_throw_errno_prefix (error, "Opening deltapart '%s'", relpath);
 
@@ -525,7 +525,7 @@ show_one_part (OstreeRepo                    *self,
   g_print ("PartMeta%u: nobjects=%u size=%" G_GUINT64_FORMAT " usize=%" G_GUINT64_FORMAT "\n",
            i, (guint)(g_variant_get_size (objects) / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN), size, usize);
 
-  glnx_fd_close gint part_fd = openat (self->repo_dir_fd, part_path, O_RDONLY | O_CLOEXEC);
+  glnx_autofd int part_fd = openat (self->repo_dir_fd, part_path, O_RDONLY | O_CLOEXEC);
   if (part_fd < 0)
     return glnx_throw_errno_prefix (error, "openat(%s)", part_path);
   g_autoptr(GInputStream) part_in = g_unix_input_stream_new (part_fd, FALSE);
@@ -767,7 +767,7 @@ _ostree_repo_static_delta_dump (OstreeRepo                    *self,
 
   superblock_path = _ostree_get_relative_static_delta_superblock_path (from, to);
 
-  glnx_fd_close int superblock_fd = -1;
+  glnx_autofd int superblock_fd = -1;
   if (!glnx_openat_rdonly (self->repo_dir_fd, superblock_path, TRUE, &superblock_fd, error))
     return FALSE;
   if (!ot_variant_read_fd (superblock_fd, 0,

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -766,11 +766,7 @@ dispatch_set_read_source (OstreeRepo                 *repo,
   GLNX_AUTO_PREFIX_ERROR("opcode set-read-source", error);
   guint64 source_offset;
 
-  if (state->read_source_fd != -1)
-    {
-      (void) close (state->read_source_fd);
-      state->read_source_fd = -1;
-    }
+  glnx_close_fd (&state->read_source_fd);
 
   if (!read_varuint64 (state, &source_offset, error))
     return FALSE;
@@ -803,12 +799,7 @@ dispatch_unset_read_source (OstreeRepo                 *repo,
   if (state->stats_only)
     return TRUE; /* Early return */
 
-  if (state->read_source_fd != -1)
-    {
-      (void) close (state->read_source_fd);
-      state->read_source_fd = -1;
-    }
-
+  glnx_close_fd (&state->read_source_fd);
   g_clear_pointer (&state->read_source_object, g_free);
 
   return TRUE;

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -203,7 +203,7 @@ get_policy_checksum (char        **out_csum,
   g_autofree char *best_policy = NULL;
   int best_version = 0;
 
-  glnx_fd_close int bindir_dfd = -1;
+  glnx_autofd int bindir_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, bindir_path, TRUE, &bindir_dfd, error))
     return FALSE;
 

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -282,7 +282,7 @@ cleanup_old_deployments (OstreeSysroot       *self,
       if (!g_hash_table_lookup (active_deployment_dirs, deployment_path))
         {
           struct stat stbuf;
-          glnx_fd_close int deployment_fd = -1;
+          glnx_autofd int deployment_fd = -1;
 
           if (!glnx_opendirat (self->sysroot_fd, deployment_path, TRUE,
                                &deployment_fd, error))

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -296,11 +296,7 @@ _ostree_sysroot_bump_mtime (OstreeSysroot *self,
 void
 ostree_sysroot_unload (OstreeSysroot  *self)
 {
-  if (self->sysroot_fd != -1)
-    {
-      (void) close (self->sysroot_fd);
-      self->sysroot_fd = -1;
-    }
+  glnx_close_fd (&self->sysroot_fd);
 }
 
 /**
@@ -638,7 +634,7 @@ parse_deployment (OstreeSysroot       *self,
                                                &treecsum, &deployserial, error))
     return FALSE;
 
-  glnx_fd_close int deployment_dfd = -1;
+  glnx_autofd int deployment_dfd = -1;
   if (!glnx_opendirat (self->sysroot_fd, relative_boot_link, TRUE,
                        &deployment_dfd, error))
     return FALSE;
@@ -1438,7 +1434,7 @@ ostree_sysroot_init_osname (OstreeSysroot       *self,
   if (mkdirat (self->sysroot_fd, deploydir, 0777) < 0)
     return glnx_throw_errno_prefix (error, "Creating %s", deploydir);
 
-  glnx_fd_close int dfd = -1;
+  glnx_autofd int dfd = -1;
   if (!glnx_opendirat (self->sysroot_fd, deploydir, TRUE, &dfd, error))
     return FALSE;
 
@@ -1694,7 +1690,7 @@ ostree_sysroot_deployment_unlock (OstreeSysroot     *self,
     return FALSE;
 
   g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (self, deployment);
-  glnx_fd_close int deployment_dfd = -1;
+  glnx_autofd int deployment_dfd = -1;
   if (!glnx_opendirat (self->sysroot_fd, deployment_path, TRUE, &deployment_dfd, error))
     return FALSE;
 

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -79,7 +79,7 @@ ot_openat_read_stream (int             dfd,
                        GCancellable   *cancellable,
                        GError        **error)
 {
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
   if (!glnx_openat_rdonly (dfd, path, follow, &fd, error))
     return FALSE;
   *out_istream = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
@@ -127,7 +127,7 @@ ot_dfd_iter_init_allow_noent (int dfd,
                               gboolean *out_exists,
                               GError **error)
 {
-  glnx_fd_close int fd = glnx_opendirat_with_errno (dfd, path, TRUE);
+  glnx_autofd int fd = glnx_opendirat_with_errno (dfd, path, TRUE);
   if (fd < 0)
     {
       if (errno != ENOENT)

--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -353,7 +353,7 @@ do_get (OtTrivialHttpd    *self,
       
       if (msg->method == SOUP_METHOD_GET)
         {
-          glnx_fd_close int fd = -1;
+          glnx_autofd int fd = -1;
           g_autoptr(GMappedFile) mapping = NULL;
           gsize buffer_length, file_size;
           SoupRange *ranges;

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -57,7 +57,7 @@ ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GErr
 
   const char *sysroot_path = argv[1];
 
-  glnx_fd_close int root_dfd = -1;
+  glnx_autofd int root_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, sysroot_path, TRUE, &root_dfd, error))
     return FALSE;
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -501,7 +501,7 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
                                                   &filter_data, NULL);
       if (opt_selinux_policy)
         {
-          glnx_fd_close int rootfs_dfd = -1;
+          glnx_autofd int rootfs_dfd = -1;
           if (!glnx_opendirat (AT_FDCWD, opt_selinux_policy, TRUE, &rootfs_dfd, error))
             {
               g_prefix_error (error, "selinux-policy: ");

--- a/src/ostree/ot-builtin-create-usb.c
+++ b/src/ostree/ot-builtin-create-usb.c
@@ -80,7 +80,7 @@ ostree_builtin_create_usb (int            argc,
   const char *mount_root_path = argv[1];
   struct stat mount_root_stbuf;
 
-  glnx_fd_close int mount_root_dfd = -1;
+  glnx_autofd int mount_root_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, mount_root_path, TRUE, &mount_root_dfd, error))
     return FALSE;
   if (!glnx_fstat (mount_root_dfd, &mount_root_stbuf, error))

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -58,7 +58,7 @@ do_print_variant_generic (const GVariantType *type,
 {
   g_autoptr(GVariant) variant = NULL;
 
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
   if (!glnx_openat_rdonly (AT_FDCWD, filename, TRUE, &fd, error))
     return FALSE;
   if (!ot_variant_read_fd (fd, 0, type, FALSE, &variant, error))

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -217,7 +217,7 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
       if (opt_raw)
         flags |= OSTREE_DUMP_RAW;
 
-      glnx_fd_close int fd = -1;
+      glnx_autofd int fd = -1;
       if (!glnx_openat_rdonly (repo->repo_dir_fd, "summary", TRUE, &fd, error))
         return FALSE;
       summary_data = ot_fd_readall_or_mmap (fd, 0, error);

--- a/src/ostree/ot-remote-cookie-util.c
+++ b/src/ostree/ot-remote-cookie-util.c
@@ -79,7 +79,7 @@ ot_parse_cookies_at (int dfd, const char *path,
 {
   OtCookieParser *parser;
   g_autofree char *cookies_content = NULL;
-  glnx_fd_close int infd = -1;
+  glnx_autofd int infd = -1;
 
   infd = openat (dfd, path, O_RDONLY | O_CLOEXEC);
   if (infd < 0)
@@ -143,7 +143,7 @@ ot_add_cookie_at (int dfd, const char *jar_path,
                   const char *name, const char *value,
                   GError **error)
 {
-  glnx_fd_close int fd = openat (dfd, jar_path, O_WRONLY | O_APPEND | O_CREAT, 0644);
+  glnx_autofd int fd = openat (dfd, jar_path, O_WRONLY | O_APPEND | O_CREAT, 0644);
   if (fd < 0)
     return glnx_throw_errno_prefix (error, "open(%s)", jar_path);
 

--- a/src/rofiles-fuse/main.c
+++ b/src/rofiles-fuse/main.c
@@ -268,7 +268,7 @@ callback_chown (const char *path, uid_t uid, gid_t gid)
 static int
 callback_truncate (const char *path, off_t size)
 {
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
 
   path = ENSURE_RELPATH (path);
   VERIFY_WRITE(path);

--- a/tests/test-repo-finder-mount.c
+++ b/tests/test-repo-finder-mount.c
@@ -154,7 +154,7 @@ assert_create_repos_dir (Fixture      *fixture,
                          int          *out_repos_dfd,
                          GMount      **out_mount)
 {
-  glnx_fd_close int repos_dfd = -1;
+  glnx_autofd int repos_dfd = -1;
   g_autoptr(GError) error = NULL;
 
   g_autofree gchar *path = g_build_filename (mount_root_name, ".ostree", "repos.d", NULL);
@@ -242,7 +242,7 @@ assert_create_repo_dir (Fixture     *fixture,
                         gchar      **out_uri,
                         ...)
 {
-  glnx_fd_close int ref_dfd = -1;
+  glnx_autofd int ref_dfd = -1;
   g_autoptr(OstreeRepo) repo = NULL;
   g_autoptr(GError) error = NULL;
   va_list args;
@@ -318,9 +318,9 @@ test_repo_finder_mount_mixed_mounts (Fixture       *fixture,
   g_autoptr(GMount) repo1_mount = NULL;
   g_autoptr(GMount) repo2_mount = NULL;
   g_autoptr(GFile) non_removable_root = NULL;
-  glnx_fd_close int no_repos_repos = -1;
-  glnx_fd_close int repo1_repos = -1;
-  glnx_fd_close int repo2_repos = -1;
+  glnx_autofd int no_repos_repos = -1;
+  glnx_autofd int repo1_repos = -1;
+  glnx_autofd int repo2_repos = -1;
   g_autoptr(OstreeRepo) repo1_repo_a = NULL, repo1_repo_b = NULL;
   g_autoptr(OstreeRepo) repo2_repo_a = NULL;
   g_autofree gchar *repo1_repo_a_uri = NULL, *repo1_repo_b_uri = NULL;
@@ -464,7 +464,7 @@ test_repo_finder_mount_well_known (Fixture       *fixture,
   g_autoptr(GError) error = NULL;
   g_autoptr(GList) mounts = NULL;  /* (element-type OstreeMockMount)  */
   g_autoptr(GMount) mount = NULL;
-  glnx_fd_close int repos = -1;
+  glnx_autofd int repos = -1;
   g_autoptr(OstreeRepo) repo_a = NULL, repo_b = NULL;
   g_autofree gchar *repo_a_uri = NULL, *repo_b_uri = NULL;
   g_autofree gchar *ref_a_checksum = NULL, *ref_b_checksum = NULL;


### PR DESCRIPTION
This ends up a lot better IMO.  This commit is *mostly* just
`s/glnx_close_fd/glnx_autofd`, but there's also a number of hunks like:

```
-  if (self->sysroot_fd != -1)
-    {
-      (void) close (self->sysroot_fd);
-      self->sysroot_fd = -1;
-    }
+  glnx_close_fd (&self->sysroot_fd);
```