### PR TITLE
lib/deploy: Use _exit() for FIFREEZE watchdog

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1301,7 +1301,12 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
         }
       if (debug_fifreeze)
         g_printerr ("fifreeze watchdog was run\n");
-      exit (EXIT_SUCCESS);
+      /* We use _exit() rather than exit() to avoid tripping over any shared
+       * libraries in process that aren't fork() safe; for example gjs/spidermonkey:
+       * https://github.com/ostreedev/ostree/issues/1262
+       * This doesn't help for the err()/errx() calls above, but eh...
+       */
+      _exit (EXIT_SUCCESS);
     }
   else /* Parent process. */
     {


### PR DESCRIPTION
This works around an (IMO) SpiderMonkey bug - it tries to
clean up in a shared library destructor, but doesn't install a
`pthread_atfork()` handler to unset its state.

Closes: https://github.com/ostreedev/ostree/issues/1262