### PR TITLE
lib/utils: Check for invalid UTF-8 in filenames

### DIFF
--- a/src/libotutil/ot-unix-utils.c
+++ b/src/libotutil/ot-unix-utils.c
@@ -47,6 +47,8 @@ ot_util_filename_validate (const char *name,
     return glnx_throw (error, "Invalid path uplink filename '..'");
   if (strchr (name, '/') != NULL)
     return glnx_throw (error, "Invalid / in filename %s", name);
+  if (!g_utf8_validate (name, -1, NULL))
+    return glnx_throw (error, "Invalid UTF-8 in filename %s", name);
   return TRUE;
 }
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((75 + ${extra_basic_tests:-0}))"
+echo "1..$((76 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -370,6 +370,14 @@ echo "ok commit from ref with modifier"
 
 $OSTREE commit ${COMMIT_ARGS} -b trees/test2 -s 'ref with / in it' --tree=ref=test2
 echo "ok commit ref with /"
+
+mkdir badutf8
+echo "invalid utf8 filename" > badutf8/$(printf '\x80')
+if $OSTREE commit ${COMMIT_ARGS} -b badutf8 --tree=dir=badutf8 2>err.txt; then
+    assert_not_reached "commit filename with invalid UTF-8"
+fi
+assert_file_has_content err.txt "Invalid UTF-8 in filename"
+echo "ok commit bad UTF-8"
 
 old_rev=$($OSTREE rev-parse test2)
 $OSTREE ls -R -C test2


### PR DESCRIPTION
In case a filename contains invalid UTF-8 characters, libostree will
pass it to g_variant_builder_add() in create_tree_variant_from_hashes()
anyway, which leads to a critical warning from glib and an invalid
commit. This commit makes ostree print a useful error and exit instead.