### PR TITLE
Make sure *.am.inc are up to date before `make dist`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,13 +90,18 @@ endif # end ENABLE_RUST
 libglnx_srcpath := $(srcdir)/libglnx
 libglnx_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(libglnx_srcpath)"
 libglnx_libs := $(OT_DEP_GIO_UNIX_LIBS)
+$(srcdir)/libglnx/Makefile-libglnx.am.inc: $(srcdir)/libglnx/Makefile-libglnx.am
+	sed -e 's,$(libglnx_srcpath),libglnx,g' < $< > $@
 include libglnx/Makefile-libglnx.am.inc
 EXTRA_DIST += libglnx/Makefile-libglnx.am
 noinst_LTLIBRARIES += libglnx.la
 
 libbsdiff_srcpath := $(srcdir)/bsdiff
+
 libbsdiff_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(bsdiff_srcpath)"
 libbsdiff_libs := $(OT_DEP_GIO_UNIX_LIBS)
+$(srcdir)/bsdiff/Makefile-bsdiff.am.inc: $(srcdir)/bsdiff/Makefile-bsdiff.am.inc
+	sed -e 's,$(libbsdiff_srcpath),bsdiff,g' < $< > $@
 include bsdiff/Makefile-bsdiff.am.inc
 EXTRA_DIST += bsdiff/Makefile-bsdiff.am
 noinst_LTLIBRARIES += libbsdiff.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,11 @@ endif # end ENABLE_RUST
 libglnx_srcpath := $(srcdir)/libglnx
 libglnx_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(libglnx_srcpath)"
 libglnx_libs := $(OT_DEP_GIO_UNIX_LIBS)
+# See also autogen.sh and https://github.com/ostreedev/ostree/pull/1274/
+#
+# v2017.12 didn't include test-libglnx-shutil.c, but if you re-run
+# autogen.sh (as we do in Debian, to update the Autotools build system)
+# it will try to build it.
 $(srcdir)/libglnx/Makefile-libglnx.am.inc: $(srcdir)/libglnx/Makefile-libglnx.am
 	sed -e 's,$(libglnx_srcpath),libglnx,g' < $< > $@
 include libglnx/Makefile-libglnx.am.inc
@@ -100,6 +105,7 @@ libbsdiff_srcpath := $(srcdir)/bsdiff
 
 libbsdiff_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(bsdiff_srcpath)"
 libbsdiff_libs := $(OT_DEP_GIO_UNIX_LIBS)
+# See the comment for the similar libglnx bit above
 $(srcdir)/bsdiff/Makefile-bsdiff.am.inc: $(srcdir)/bsdiff/Makefile-bsdiff.am.inc
 	sed -e 's,$(libbsdiff_srcpath),bsdiff,g' < $< > $@
 include bsdiff/Makefile-bsdiff.am.inc

--- a/autogen.sh
+++ b/autogen.sh
@@ -31,7 +31,8 @@ fi
 if ! test -f libglnx/README.md || ! test -f bsdiff/README.md; then
     git submodule update --init
 fi
-# Workaround automake bug with subdir-objects and computed paths
+# Workaround automake bug with subdir-objects and computed paths; if
+# changing this, please also change Makefile.am.
 sed -e 's,$(libglnx_srcpath),libglnx,g' < libglnx/Makefile-libglnx.am >libglnx/Makefile-libglnx.am.inc
 sed -e 's,$(libbsdiff_srcpath),bsdiff,g' < bsdiff/Makefile-bsdiff.am >bsdiff/Makefile-bsdiff.am.inc
 


### PR DESCRIPTION
v2017.12 didn't include test-libglnx-shutil.c, but if you re-run
autogen.sh (as we do in Debian, to update the Autotools build system)
it will try to build it.