### PR TITLE
Cope with xattr syscalls raising EOPNOTSUPP

### DIFF
--- a/src/ostree/ot-builtin-create-usb.c
+++ b/src/ostree/ot-builtin-create-usb.c
@@ -113,7 +113,7 @@ ostree_builtin_create_usb (int            argc,
   OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
 
   if (TEMP_FAILURE_RETRY (fgetxattr (mount_root_dfd, "user.test", NULL, 0)) < 0 &&
-      errno == ENOTSUP)
+      (errno == ENOTSUP || errno == EOPNOTSUPP))
     mode = OSTREE_REPO_MODE_ARCHIVE;
 
   g_debug ("%s: Creating repository in mode %u", G_STRFUNC, mode);


### PR DESCRIPTION
ENOTSUP and EOPNOTSUPP are numerically equal on most Linux ports,
but inexplicably differ on PA-RISC (hppa) and possibly other
rare architectures.