### PR TITLE
build: Fix bsdiff Makefile circular dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ libbsdiff_srcpath := $(srcdir)/bsdiff
 libbsdiff_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(bsdiff_srcpath)"
 libbsdiff_libs := $(OT_DEP_GIO_UNIX_LIBS)
 # See the comment for the similar libglnx bit above
-$(srcdir)/bsdiff/Makefile-bsdiff.am.inc: $(srcdir)/bsdiff/Makefile-bsdiff.am.inc
+$(srcdir)/bsdiff/Makefile-bsdiff.am.inc: $(srcdir)/bsdiff/Makefile-bsdiff.am
 	sed -e 's,$(libbsdiff_srcpath),bsdiff,g' < $< > $@
 include bsdiff/Makefile-bsdiff.am.inc
 EXTRA_DIST += bsdiff/Makefile-bsdiff.am


### PR DESCRIPTION
The intended use was to have the .am.inc generated from the .am like the
libglnx one. Without this, make was detecting a circular dependency and
dropping the rule:

  make: Circular bsdiff/Makefile-bsdiff.am.inc <- bsdiff/Makefile-bsdiff.am.inc dependency dropped.