### PR TITLE
lib/commit: Use direct fd xattr operations again on regular  files

### DIFF
--- a/cfg.mk
+++ b/cfg.mk
@@ -31,8 +31,12 @@ sc_glnx_errno_prefix_colon:
 	@prohibit='\<glnx_throw_errno_prefix *\(.*: ",' halt="don't add trailing : for glnx_throw_errno_prefix"	\
 	  $(_sc_search_regexp)
 
+sc_glnx_no_fd_close:
+	@prohibit='\<glnx_fd_close int' halt="Use glnx_autofd, not glnx_fd_close"	\
+	  $(_sc_search_regexp)
+
 #SHELL=bash -x
 show-vc-list-except:
 	@$(VC_LIST_EXCEPT)
 
-VC_LIST_ALWAYS_EXCLUDE_REGEX = ^ABOUT-NLS|maint.mk|*.gpg|*.sig|.xz$$
+VC_LIST_ALWAYS_EXCLUDE_REGEX = ^ABOUT-NLS|cfg.mk|maint.mk|*.gpg|*.sig|.xz$$

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -819,7 +819,7 @@ adopt_and_commit_regfile (OstreeRepo   *self,
   ot_checksum_init (&hasher);
   ot_checksum_update_bytes (&hasher, header);
 
-  glnx_fd_close int fd = -1;
+  glnx_autofd int fd = -1;
   if (!glnx_openat_rdonly (dfd, name, FALSE, &fd, error))
     return FALSE;
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2791,7 +2791,7 @@ write_directory_content_to_mtree_internal (OstreeRepo                  *self,
     }
   else
     {
-      glnx_fd_close int file_input_fd = -1;
+      glnx_autofd int file_input_fd = -1;
 
       /* Open the file now, since it's better for reading xattrs
        * rather than using the /proc/self/fd links.

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2878,21 +2878,21 @@ write_directory_content_to_mtree_internal (OstreeRepo                  *self,
                 }
             }
 
-            if (!ostree_raw_file_to_content_stream (file_input,
-                                                    modified_info, xattrs,
-                                                    &file_object_input, &file_obj_length,
-                                                    cancellable, error))
-              return FALSE;
-            g_autofree guchar *child_file_csum = NULL;
-            if (!ostree_repo_write_content (self, NULL, file_object_input, file_obj_length,
+          if (!ostree_raw_file_to_content_stream (file_input,
+                                                  modified_info, xattrs,
+                                                  &file_object_input, &file_obj_length,
+                                                  cancellable, error))
+            return FALSE;
+          g_autofree guchar *child_file_csum = NULL;
+          if (!ostree_repo_write_content (self, NULL, file_object_input, file_obj_length,
                                           &child_file_csum, cancellable, error))
-              return FALSE;
+            return FALSE;
 
-            char tmp_checksum[OSTREE_SHA256_STRING_LEN+1];
-            ostree_checksum_inplace_from_bytes (child_file_csum, tmp_checksum);
-            if (!ostree_mutable_tree_replace_file (mtree, name, tmp_checksum,
-                                                   error))
-              return FALSE;
+          char tmp_checksum[OSTREE_SHA256_STRING_LEN+1];
+          ostree_checksum_inplace_from_bytes (child_file_csum, tmp_checksum);
+          if (!ostree_mutable_tree_replace_file (mtree, name, tmp_checksum,
+                                                 error))
+            return FALSE;
         }
 
       /* Process delete_after_commit. In the adoption case though, we already


### PR DESCRIPTION

A side effect of commit 8fe45362578a43260876134d6547ebd0bb2485c3 is that
we started listing all xattrs even for files with device/inode matches;
further, we did that using the dfd/name which means we went through
the `/proc` path, which is slower and uglier.

Noticed this in strace while looking at adoption code.
