### PR TITLE
build: Do *.am.inc substitutions from make correctly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,7 @@ libglnx_libs := $(OT_DEP_GIO_UNIX_LIBS)
 # autogen.sh (as we do in Debian, to update the Autotools build system)
 # it will try to build it.
 $(srcdir)/libglnx/Makefile-libglnx.am.inc: $(srcdir)/libglnx/Makefile-libglnx.am
-	sed -e 's,$(libglnx_srcpath),libglnx,g' < $< > $@
+	sed -e 's,$$(libglnx_srcpath),libglnx,g' < $< > $@
 include libglnx/Makefile-libglnx.am.inc
 EXTRA_DIST += libglnx/Makefile-libglnx.am
 noinst_LTLIBRARIES += libglnx.la
@@ -107,7 +107,7 @@ libbsdiff_cflags := $(OT_DEP_GIO_UNIX_CFLAGS) "-I$(bsdiff_srcpath)"
 libbsdiff_libs := $(OT_DEP_GIO_UNIX_LIBS)
 # See the comment for the similar libglnx bit above
 $(srcdir)/bsdiff/Makefile-bsdiff.am.inc: $(srcdir)/bsdiff/Makefile-bsdiff.am
-	sed -e 's,$(libbsdiff_srcpath),bsdiff,g' < $< > $@
+	sed -e 's,$$(libbsdiff_srcpath),bsdiff,g' < $< > $@
 include bsdiff/Makefile-bsdiff.am.inc
 EXTRA_DIST += bsdiff/Makefile-bsdiff.am
 noinst_LTLIBRARIES += libbsdiff.la


### PR DESCRIPTION
The string needs to be escaped with a $ since we want to replace the
literal string $(path). Without this make will run the command with the
value of the variable, which won't match anything in the input Makefile
stub.

CC @smcv