### PR TITLE
lib/repo-finder-avahi: Fix a leak in a GVariantIter loop

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -429,7 +429,7 @@ fill_refs_and_checksums_from_summary_map (GVariantIter  *summary_map,
   g_autofree gchar *ref_name = NULL;
   g_autoptr(GVariant) checksum_variant = NULL;
 
-  while (g_variant_iter_next (summary_map, "(s(t@aya{sv}))",
+  while (g_variant_iter_loop (summary_map, "(s(t@aya{sv}))",
                               (gpointer *) &ref_name, NULL,
                               (gpointer *) &checksum_variant, NULL))
     {


### PR DESCRIPTION
Use g_variant_iter_loop() rather than next(), since it automatically
handles freeing the child memory each iteration. Previously, we leaked
it for all but the last iteration.

Signed-off-by: Philip Withnall <withnall@endlessm.com>