### PR TITLE
lib/checkout: For "process whiteouts" mode, replace directories too

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -325,7 +325,17 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
           /* Handled above */
           break;
         case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES:
-          replace_mode = GLNX_LINK_TMPFILE_REPLACE;
+          /* Special case OCI/Docker - see similar code in checkout_file_hardlink()
+           * and above for symlinks.
+           */
+          if (options->process_whiteouts)
+            {
+              if (!glnx_shutil_rm_rf_at (destination_dfd, destination_name, NULL, error))
+                return FALSE;
+              /* Inherit the NOREPLACE default...we deleted whatever's there */
+            }
+          else
+            replace_mode = GLNX_LINK_TMPFILE_REPLACE;
           break;
         case OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES:
           replace_mode = GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -848,7 +848,7 @@ typedef enum {
 /**
  * OstreeRepoCheckoutOverwriteMode:
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_NONE: No special options
- * @OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES: When layering checkouts, unlink() and replace existing files, but do not modify existing directories
+ * @OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES: When layering checkouts, unlink() and replace existing files, but do not modify existing directories (unless whiteouts are enabled, then directories are replaced)
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES: Only add new files/directories
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL: Like UNION_FILES, but error if files are not identical (requires hardlink checkouts)
  */

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -879,6 +879,20 @@ if touch overlay/baz/.wh.cow && touch overlay/.wh.deeper; then
     assert_has_file overlay-co/anewdir/blah
     assert_has_file overlay-co/anewfile
 
+    # And test replacing a directory wholesale with a symlink as well as a regular file
+    mkdir overlay
+    echo baz to file > overlay/baz
+    ln -s anewfile overlay/anewdir
+    $OSTREE --repo=repo commit ${COMMIT_ARGS} -b overlay-dir-convert --tree=dir=overlay
+    rm overlay -rf
+
+    rm overlay-co -rf
+    for branch in test2 overlay-dir-convert; do
+        $OSTREE --repo=repo checkout --union --whiteouts ${branch} overlay-co
+    done
+    assert_has_file overlay-co/baz
+    test -L overlay-co/anewdir
+
     echo "ok whiteouts enabled"
 
     # Now double check whiteouts are not processed without --whiteouts


### PR DESCRIPTION
I'm playing around with some ostree ⇔ OCI/Docker bits, and ran
into this while importing an OCI image that built from the Fedora
base image where `/home` is a regular directory, and I added a layer
that did the ostree bits of moving it to `/var` and leaving a symlink.

OCI/Docker supports this.  Now since "process whiteouts" is really the
"enable OCI/Docker" mode, let's only replace dirs if that's enabled.
This leaves the `UNION_FILES` targeted for its original use case
which is unioning components/packages.  (Although that use case itself
is now a bit superceded by `UNION_IDENTICAL`, but eh).