### PR TITLE
core: Add standard SOURCE_TITLE metadata key

### DIFF
--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -229,6 +229,23 @@ typedef enum {
  */
 #define OSTREE_COMMIT_META_KEY_ENDOFLIFE "ostree.endoflife"
 /**
+ * OSTREE_COMMIT_META_KEY_SOURCE_TITLE:
+ *
+ * GVariant type `s`. This should hold a relatively short single line value
+ * containing a human-readable "source" for a commit, intended to be displayed
+ * near the origin ref.  This is particularly useful for systems that inject
+ * content into an OSTree commit from elsewhere - for example, generating from
+ * an OCI or qcow2 image. Or if generating from packages, the enabled repository
+ * names and their versions.
+ *
+ * Try to keep this key short (e.g. < 80 characters) and human-readable; if you
+ * desire machine readable data, consider injecting separate metadata keys.
+ *
+ * Since: 2017.13
+ */
+#define OSTREE_COMMIT_META_KEY_SOURCE_TITLE "ostree.source-title"
+
+/**
  * OSTREE_COMMIT_META_KEY_REF_BINDING:
  *
  * GVariant type `as`; each element is a branch name. If this is added to a

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -114,8 +114,12 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
             commit_metadata = g_variant_get_child_value (commit, 0);
 
           const char *version = NULL;
+          const char *source_title = NULL;
           if (commit_metadata)
-            (void) g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &version);
+            {
+              (void) g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &version);
+              (void) g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_SOURCE_TITLE, "&s", &source_title);
+            }
 
           GKeyFile *origin = ostree_deployment_get_origin (deployment);
 
@@ -152,6 +156,8 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
                 g_print ("    origin: <unknown origin type>\n");
               else
                 g_print ("    origin refspec: %s\n", origin_refspec);
+              if (source_title)
+                g_print ("    `- %s\n", source_title);
             }
 
           if (deployment_get_gpg_verify (deployment, repo))

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -41,15 +41,12 @@ static char *
 version_of_commit (OstreeRepo *repo, const char *checksum)
 {
   g_autoptr(GVariant) variant = NULL;
-  
   /* Shouldn't fail, but if it does, we ignore it */
   if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, checksum,
                                  &variant, NULL))
-    goto out;
+    return NULL;
 
   return ot_admin_checksum_version (variant);
- out:
-  return NULL;
 }
 
 static gboolean
@@ -58,61 +55,51 @@ deployment_get_gpg_verify (OstreeDeployment *deployment,
 {
   /* XXX Something like this could be added to the OstreeDeployment
    *     API in libostree if the OstreeRepo parameter is acceptable. */
-
-  GKeyFile *origin;
-  g_autofree char *refspec = NULL;
-  g_autofree char *remote = NULL;
-  gboolean gpg_verify = FALSE;
-
-  origin = ostree_deployment_get_origin (deployment);
+  GKeyFile *origin = ostree_deployment_get_origin (deployment);
 
   if (origin == NULL)
-    goto out;
+    return FALSE;
 
-  refspec = g_key_file_get_string (origin, "origin", "refspec", NULL);
+  g_autofree char *refspec = g_key_file_get_string (origin, "origin", "refspec", NULL);
 
   if (refspec == NULL)
-    goto out;
+    return FALSE;
 
+  g_autofree char *remote = NULL;
   if (!ostree_parse_refspec (refspec, &remote, NULL, NULL))
-    goto out;
+    return FALSE;
 
+  gboolean gpg_verify = FALSE;
   if (remote)
     (void) ostree_repo_remote_get_gpg_verify (repo, remote, &gpg_verify, NULL);
 
-out:
   return gpg_verify;
 }
 
 gboolean
 ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = NULL;
-  g_autoptr(OstreeSysroot) sysroot = NULL;
-  gboolean ret = FALSE;
-  g_autoptr(OstreeRepo) repo = NULL;
-  OstreeDeployment *booted_deployment = NULL;
-  g_autoptr(OstreeDeployment) pending_deployment = NULL;
-  g_autoptr(OstreeDeployment) rollback_deployment = NULL;
-  g_autoptr(GPtrArray) deployments = NULL;
   const int is_tty = isatty (1);
   const char *red_bold_prefix = is_tty ? "\x1b[31m\x1b[1m" : "";
   const char *red_bold_suffix = is_tty ? "\x1b[22m\x1b[0m" : "";
-  guint i;
 
-  context = g_option_context_new ("");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
 
+  g_autoptr(OstreeSysroot) sysroot = NULL;
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
                                           OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                           invocation, &sysroot, cancellable, error))
-    goto out;
+    return FALSE;
 
+  g_autoptr(OstreeRepo) repo = NULL;
   if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
-    goto out;
+    return FALSE;
 
-  deployments = ostree_sysroot_get_deployments (sysroot);
-  booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
+  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
+  g_autoptr(OstreeDeployment) pending_deployment = NULL;
+  g_autoptr(OstreeDeployment) rollback_deployment = NULL;
   if (booted_deployment)
     ostree_sysroot_query_deployments_for (sysroot, NULL, &pending_deployment,
                                           &rollback_deployment);
@@ -123,18 +110,13 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
     }
   else
     {
-      for (i = 0; i < deployments->len; i++)
+      for (guint i = 0; i < deployments->len; i++)
         {
           OstreeDeployment *deployment = deployments->pdata[i];
-          GKeyFile *origin;
           const char *ref = ostree_deployment_get_csum (deployment);
-          OstreeDeploymentUnlockedState unlocked = ostree_deployment_get_unlocked (deployment);
           g_autofree char *version = version_of_commit (repo, ref);
-          g_autoptr(OstreeGpgVerifyResult) result = NULL;
-          guint jj, n_signatures;
-          GError *local_error = NULL;
 
-          origin = ostree_deployment_get_origin (deployment);
+          GKeyFile *origin = ostree_deployment_get_origin (deployment);
 
           const char *deployment_status = "";
           if (deployment == pending_deployment)
@@ -149,6 +131,8 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
                    deployment_status);
           if (version)
             g_print ("    Version: %s\n", version);
+
+          OstreeDeploymentUnlockedState unlocked = ostree_deployment_get_unlocked (deployment);
           switch (unlocked)
             {
             case OSTREE_DEPLOYMENT_UNLOCKED_NONE:
@@ -174,8 +158,10 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
               g_autoptr(GString) output_buffer = g_string_sized_new (256);
               /* Print any digital signatures on this commit. */
 
-              result = ostree_repo_verify_commit_ext (repo, ref, NULL, NULL,
-                                                      cancellable, &local_error);
+              g_autoptr(GError) local_error = NULL;
+              g_autoptr(OstreeGpgVerifyResult) result =
+                ostree_repo_verify_commit_ext (repo, ref, NULL, NULL,
+                                               cancellable, &local_error);
 
               /* G_IO_ERROR_NOT_FOUND just means the commit is not signed. */
               if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -185,13 +171,12 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
                 }
               else if (local_error != NULL)
                 {
-                  g_propagate_error (error, local_error);
-                  goto out;
+                  g_propagate_error (error, g_steal_pointer (&local_error));
+                  return FALSE;
                 }
 
-              n_signatures = ostree_gpg_verify_result_count_all (result);
-
-              for (jj = 0; jj < n_signatures; jj++)
+              const guint n_signatures = ostree_gpg_verify_result_count_all (result);
+              for (guint jj = 0; jj < n_signatures; jj++)
                 {
                   ostree_gpg_verify_result_describe (result, jj, output_buffer, "    GPG: ",
                                                      OSTREE_GPG_SIGNATURE_FORMAT_DEFAULT);
@@ -202,7 +187,5 @@ ot_admin_builtin_status (int argc, char **argv, OstreeCommandInvocation *invocat
         }
     }
 
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -279,7 +279,7 @@ echo "ok upgrade with and without override-commit"
 
 
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" \
-              --add-metadata-string 'ostree.source-title=libtest os_repository_new_commit()' -b $branch \
+              --add-metadata-string 'ostree.source-title=libtest os_repository_new_commit()' -b testos/buildmaster/x86_64-runtime \
               -s "Build" --tree=dir=${test_tmpdir}/osdata
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 ${CMD_PREFIX} ostree admin status | tee status.txt

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((22 + ${extra_admin_tests:-0}))"
+echo "1..$((23 + ${extra_admin_tests:-0}))"
 
 function validate_bootloader() {
     cd ${test_tmpdir};
@@ -276,6 +276,15 @@ curr_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buil
 assert_streq ${curr_rev} ${head_rev}
 
 echo "ok upgrade with and without override-commit"
+
+
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" \
+              --add-metadata-string 'ostree.source-title=libtest os_repository_new_commit()' -b $branch \
+              -s "Build" --tree=dir=${test_tmpdir}/osdata
+${CMD_PREFIX} ostree admin upgrade --os=testos
+${CMD_PREFIX} ostree admin status | tee status.txt
+assert_file_has_content_literal status.txt '`- libtest os_repository_new_commit()'
+echo "ok source title"
 
 deployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
 ${CMD_PREFIX} ostree --sysroot=sysroot remote add --set=gpg-verify=false remote-test-physical file://$(pwd)/testos-repo

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -277,7 +277,6 @@ assert_streq ${curr_rev} ${head_rev}
 
 echo "ok upgrade with and without override-commit"
 
-
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" \
               --add-metadata-string 'ostree.source-title=libtest os_repository_new_commit()' -b testos/buildmaster/x86_64-runtime \
               -s "Build" --tree=dir=${test_tmpdir}/osdata

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -30,6 +30,10 @@ extra_admin_tests=1
 . $(dirname $0)/admin-test.sh
 
 cd ${test_tmpdir}
+# Note this test actually requires a checksum change to /boot,
+# because adding the uEnv.txt isn't currently covered by the
+# "bootcsum".
+os_repository_new_commit "uboot test" "test upgrade multiple kernel args"
 mkdir -p osdata/usr/lib/ostree-boot
 cat << 'EOF' > osdata/usr/lib/ostree-boot/uEnv.txt
 loaduimage=load mmc ${bootpart} ${loadaddr} ${kernel_image}


### PR DESCRIPTION
This is a freeform string useful to track/display when a commit is "derived"
from some other format.  For example, in the rpm-ostree test we make a
`vmcheck` ref that conceptually overlays the default ref like
`fedora-atomic:fedora/26/x86_64/atomic-host`.

My current patch sets the source title to e.g.
"Dev overlay on fedora-atomic:fedora/26/x86_64/atomic-host".

Another case I'm working on now is importing OCI images to use
as host images.  For that case, the source title is
With this patch we could then set the original OCI image name + tag
as the source name, like:
"oci:cgwalters/demo-custom-fedora-atomic-host:26".