### PR TITLE
tree-wide: Use autoptr for OstreeKernelArgs

### DIFF
--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -74,7 +74,7 @@ append_system_uenv (OstreeBootloaderUboot   *self,
                     GError                 **error)
 {
   glnx_autofd int uenv_fd = -1;
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
+  g_autoptr(OstreeKernelArgs) kargs = NULL;
   const char *uenv_path = NULL;
   const char *ostree_arg = NULL;
 

--- a/src/libostree/ostree-kernel-args.c
+++ b/src/libostree/ostree-kernel-args.c
@@ -81,19 +81,13 @@ _ostree_kernel_args_new (void)
 }
 
 void
-_ostree_kernel_arg_autofree (OstreeKernelArgs *kargs)
+_ostree_kernel_args_free (OstreeKernelArgs *kargs)
 {
   if (!kargs)
     return;
   g_ptr_array_unref (kargs->order);
   g_hash_table_unref (kargs->table);
   g_free (kargs);
-}
-
-void
-_ostree_kernel_args_cleanup (void *loc)
-{
-  _ostree_kernel_arg_autofree (*((OstreeKernelArgs**)loc));
 }
 
 void

--- a/src/libostree/ostree-kernel-args.h
+++ b/src/libostree/ostree-kernel-args.h
@@ -19,15 +19,15 @@
 
 #pragma once
 
-#include <gio/gio.h>
+#include "libglnx.h"
 
 G_BEGIN_DECLS
 
 typedef struct _OstreeKernelArgs OstreeKernelArgs;
+void _ostree_kernel_args_free (OstreeKernelArgs *kargs);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OstreeKernelArgs, _ostree_kernel_args_free);
 
 OstreeKernelArgs *_ostree_kernel_args_new (void);
-void _ostree_kernel_args_free (OstreeKernelArgs *kargs);
-void _ostree_kernel_args_cleanup (void *loc);
 void _ostree_kernel_args_replace_take (OstreeKernelArgs  *kargs,
                                        char              *key);
 void _ostree_kernel_args_replace (OstreeKernelArgs  *kargs,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1712,7 +1712,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   g_autofree char *ostree_kernel_arg = g_strdup_printf ("ostree=/ostree/boot.%d/%s/%s/%d",
                                        new_bootversion, osname, bootcsum,
                                        ostree_deployment_get_bootserial (deployment));
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = _ostree_kernel_args_from_string (val);
+  g_autoptr(OstreeKernelArgs) kargs = _ostree_kernel_args_from_string (val);
   _ostree_kernel_args_replace_take (kargs, ostree_kernel_arg);
   ostree_kernel_arg = NULL;
   g_autofree char *options_key = _ostree_kernel_args_to_string (kargs);
@@ -1839,8 +1839,8 @@ deployment_bootconfigs_equal (OstreeDeployment *a,
     OstreeBootconfigParser *b_bootconfig = ostree_deployment_get_bootconfig (b);
     const char *a_boot_options = ostree_bootconfig_parser_get (a_bootconfig, "options");
     const char *b_boot_options = ostree_bootconfig_parser_get (b_bootconfig, "options");
-    __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *a_kargs = NULL;
-    __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *b_kargs = NULL;
+    g_autoptr(OstreeKernelArgs) a_kargs = NULL;
+    g_autoptr(OstreeKernelArgs) b_kargs = NULL;
     g_autofree char *a_boot_options_without_ostree = NULL;
     g_autofree char *b_boot_options_without_ostree = NULL;
 
@@ -2400,7 +2400,7 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
    */
   if (override_kernel_argv)
     {
-      __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
+      g_autoptr(OstreeKernelArgs) kargs = NULL;
       g_autofree char *new_options = NULL;
 
       kargs = _ostree_kernel_args_new ();
@@ -2434,7 +2434,7 @@ ostree_sysroot_deployment_set_kargs (OstreeSysroot     *self,
   g_autoptr(OstreeDeployment) new_deployment = ostree_deployment_clone (deployment);
   OstreeBootconfigParser *new_bootconfig = ostree_deployment_get_bootconfig (new_deployment);
 
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = _ostree_kernel_args_new ();
+  g_autoptr(OstreeKernelArgs) kargs = _ostree_kernel_args_new ();
   _ostree_kernel_args_append_argv (kargs, new_kargs);
   g_autofree char *new_options = _ostree_kernel_args_to_string (kargs);
   ostree_bootconfig_parser_set (new_bootconfig, "options", new_options);

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1130,7 +1130,7 @@ find_booted_deployment (OstreeSysroot       *self,
   if (root_stbuf.st_dev == self_stbuf.st_dev &&
       root_stbuf.st_ino == self_stbuf.st_ino)
     {
-      __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kernel_args = NULL;
+      g_autoptr(OstreeKernelArgs) kernel_args = NULL;
       if (!parse_kernel_commandline (&kernel_args, cancellable, error))
         return FALSE;
 
@@ -1620,7 +1620,7 @@ clone_deployment (OstreeSysroot  *sysroot,
   /* Copy the bootloader config options */
   OstreeBootconfigParser *bootconfig = ostree_deployment_get_bootconfig (merge_deployment);
   g_auto(GStrv) previous_args = g_strsplit (ostree_bootconfig_parser_get (bootconfig, "options"), " ", -1);
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = _ostree_kernel_args_new ();
+  g_autoptr(OstreeKernelArgs) kargs = _ostree_kernel_args_new ();
   _ostree_kernel_args_append_argv (kargs, previous_args);
 
   /* Deploy the copy */

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -62,7 +62,7 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_deploy (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
+  g_autoptr(OstreeKernelArgs) kargs = NULL;
 
   g_autoptr(GOptionContext) context =
     g_option_context_new ("REFSPEC");

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -56,7 +56,7 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, OstreeCommandInvocat
   OstreeDeployment *first_deployment = NULL;
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(OstreeSysroot) sysroot = NULL;
-  __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = NULL;
+  g_autoptr(OstreeKernelArgs) kargs = NULL;
 
   context = g_option_context_new ("ARGS");
 


### PR DESCRIPTION
Much nicer looking.  Prep for more cleanup from
https://github.com/projectatomic/rpm-ostree/pull/1013