### PR TITLE
ci: Update centos container to current again

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -45,10 +45,8 @@ env:
     CONFIGOPTS: '--with-curl --with-openssl'
 
 tests:
-    # FIXME revert setting to 7/3/1611 when repos sync
-    # https://github.com/projectatomic/rpm-ostree/pull/985
   - docker run --privileged -v $PWD:$PWD --workdir $PWD
-    registry.centos.org/centos/centos:7.3.1611 sh -c
+    registry.centos.org/centos/centos:7 sh -c
     'yum install -y git && ci/build-check.sh'
 
 ---


### PR DESCRIPTION
Repo sync issue should be cleared now, and for some reason the previous
container is already GC'd.