### PR TITLE
lib/repo: Properly handle NULL homedir when signing commit

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4092,7 +4092,9 @@ ostree_repo_sign_commit (OstreeRepo     *self,
    * pass the homedir so that the signing key can be imported, allowing
    * subkey signatures to be recognised. */
   g_autoptr(GError) local_error = NULL;
-  g_autoptr(GFile) verify_keydir = g_file_new_for_path (homedir);
+  g_autoptr(GFile) verify_keydir = NULL;
+  if (homedir != NULL)
+    verify_keydir = g_file_new_for_path (homedir);
   g_autoptr(OstreeGpgVerifyResult) result
     =_ostree_repo_gpg_verify_with_metadata (self, commit_data, old_metadata,
                                             NULL, verify_keydir, NULL,


### PR DESCRIPTION
Without this, ostree_repo_sign_commit throws a critical message when no
homedir is provided:

(ostree gpg-sign:5034): GLib-GIO-CRITICAL **: g_file_new_for_path: assertion 'path != NULL' failed