### PR TITLE
ostree-system-generator: Include <libglnx.h> for autocleanups

### DIFF
--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -25,6 +25,8 @@
 #include <fcntl.h>
 #include <stdlib.h>
 
+#include <libglnx.h>
+
 #include "ostree-cmdprivate.h"
 #include "ostree-mount-util.h"
 


### PR DESCRIPTION
g_autoptr was new in GLib 2.44, but we officially only require 2.40,
so we need to use the backport in libglnx.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

For context, I'm seeing whether the Flatpak 0.10 stack is still buildable and usable on Debian 8 with a bit of patching.

Alternatively, if you have a minimum GLib of interest for recent ostree and it's newer than 2.42, we could document that and drop backwards-compat code paths, and I'll stop trying to make this work.