### PR TITLE
lib: Minor static delta fixes

### DIFF
--- a/manual-tests/static-delta-generate-crosscheck.sh
+++ b/manual-tests/static-delta-generate-crosscheck.sh
@@ -42,11 +42,11 @@ assert_streq() {
 }
 
 validate_delta_options() {
-    mkdir testrepo
-    ostree_repo_init testrepo --mode=bare-user
+    ostree --repo=testrepo init --mode=bare-user
     ostree --repo=testrepo remote add --set=gpg-verify=false local file://${repo}
     ostree --repo=${repo} static-delta generate $@ --from=${from} --to=${to}
-    ostree --repo=testrepo pull --require-static-deltas local ${branch}@${from}
+    ostree --repo=${repo} summary -u
+    ostree --repo=testrepo pull local ${branch}@${from}
     assert_streq $(ostree --repo=testrepo rev-parse ${branch}) ${from}
     ostree --repo=testrepo pull --require-static-deltas local ${branch}
     assert_streq $(ostree --repo=testrepo rev-parse ${branch}) ${to}

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -514,8 +514,8 @@ try_content_rollsum (OstreeRepo                       *repo,
 
   if (opts & DELTAOPT_FLAG_VERBOSE)
     {
-      g_printerr ("rollsum for %s; crcs=%u bufs=%u total=%u matchsize=%llu\n",
-                  to, matches->crcmatches,
+      g_printerr ("rollsum for %s -> %s; crcs=%u bufs=%u total=%u matchsize=%llu\n",
+                  from, to, matches->crcmatches,
                   matches->bufmatches,
                   matches->total, (unsigned long long)matches->match_size);
     }

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -711,7 +711,7 @@ dispatch_write (OstreeRepo                 *repo,
                GCancellable               *cancellable,
                GError                    **error)
 {
-  GLNX_AUTO_PREFIX_ERROR("opcode open-splice-and-close", error);
+  GLNX_AUTO_PREFIX_ERROR("opcode write", error);
   guint64 content_size;
   guint64 content_offset;
 
@@ -815,7 +815,7 @@ dispatch_close (OstreeRepo                 *repo,
                 GCancellable               *cancellable,
                 GError                    **error)
 {
-  GLNX_AUTO_PREFIX_ERROR("opcode open-splice-and-close", error);
+  GLNX_AUTO_PREFIX_ERROR("opcode close", error);
 
   if (state->content_out)
     {


### PR DESCRIPTION
First, the manual crosscheck script bitrotted; it got caught up
in the "use libtest repo creation wrapper" bit, and also it
seems like at some point `pull --require-static-deltas` changed
meaning when dealing with `file:///` repos.  I have more work to
unwind that.

Next, I'm seeing a delta failure which looks like a static delta
miscompilation with rollsums; change the compiler to print out
the source object too, which helped me debug this.

And finally in the processing code, fix incorrect error prefixing, which was
misleading.