### PR TITLE
lib/deltas: Fix change to use pread() in write opcode

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -745,6 +745,7 @@ dispatch_write (OstreeRepo                 *repo,
                 return FALSE;
 
               content_size -= bytes_read;
+              content_offset += bytes_read;
             }
         }
       else


### PR DESCRIPTION
Fixes: 93457071cb5d47c08b60d3244f9632725634010a "lib/deltas: Use pread() instead of lseek()+read()"

Caught this when trying to test alex's patch locally. I am going to review our
static delta pulls and try to get something more comprehensive locally. But in
the meantime this patch is clearly right.