### PR TITLE
static deltas: Set optional flag for superblock

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3045,7 +3045,7 @@ initiate_delta_request (OtPullData *pull_data,
 
   _ostree_fetcher_request_to_membuf (pull_data->fetcher,
                                      pull_data->content_mirrorlist,
-                                     delta_name, 0,
+                                     delta_name, OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
                                      OSTREE_MAX_METADATA_SIZE,
                                      0, pull_data->cancellable,
                                      on_superblock_fetched, fdata);


### PR DESCRIPTION
I believe static delta fetching should be optional. Following on from the changes made in [this commit](https://github.com/ostreedev/ostree/pull/1004/files), this PR sets the `OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT` flag for fetching the superblock as well. 