### PR TITLE
Enable bindings to experimental APIs

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -261,6 +261,10 @@ OSTree-1.0.gir: libostree-1.la Makefile
 OSTree_1_0_gir_EXPORT_PACKAGES = ostree-1
 OSTree_1_0_gir_INCLUDES = Gio-2.0
 OSTree_1_0_gir_CFLAGS = $(libostree_1_la_CFLAGS)
+if ENABLE_EXPERIMENTAL_API
+# When compiling this is set via config.h, but g-ir-scanner can't use that
+OSTree_1_0_gir_CFLAGS += -DOSTREE_ENABLE_EXPERIMENTAL_API=1
+endif
 OSTree_1_0_gir_LIBS = libostree-1.la
 OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree $(GI_SCANNERFLAGS)
 OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h $(libostree_experimental_headers),$(libostree_1_la_SOURCES))

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -54,7 +54,7 @@ src/libostree/ostree-enumtypes.h: src/libostree/ostree-enumtypes.h.template $(EN
 	--template $< \
 	$(ENUM_TYPES) > $@.tmp && mv $@.tmp $@
 
-src/libostree/ostree-enumtypes.c: src/libostree/ostree-enumtypes.c.template $(ENUM_TYPES)
+src/libostree/ostree-enumtypes.c: src/libostree/ostree-enumtypes.c.template src/libostree/ostree-enumtypes.h $(ENUM_TYPES)
 	$(AM_V_GEN) $(GLIB_MKENUMS) \
 	--template $< \
 	$(ENUM_TYPES) > $@.tmp && mv $@.tmp $@

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -278,7 +278,7 @@ ostree_validate_remote_name (const char  *remote_name,
 
 /**
  * ostree_validate_collection_id:
- * @rev: (nullable): A collection ID
+ * @collection_id: (nullable): A collection ID
  * @error: Error
  *
  * Check whether the given @collection_id is valid. Return an error if it is

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5539,8 +5539,11 @@ check_remote_matches_collection_id (OstreeRepo  *repo,
   return g_str_equal (remote_collection_id, collection_id);
 }
 
+/* FIXME: Export this to bindings once OstreeRemote is properly registered as
+ * a boxed type.
+ */
 /**
- * ostree_repo_resolve_keyring_for_collection:
+ * ostree_repo_resolve_keyring_for_collection: (skip)
  * @self: an #OstreeRepo
  * @collection_id: the collection ID to look up a keyring for
  * @cancellable: (nullable): a #GCancellable, or %NULL


### PR DESCRIPTION
I'd like to use the experimental APIs from python, but `g-ir-scanner` isn't currently including them. Do that and fix up a couple other issues seen along the way.