### PR TITLE
tests: Don't symlink rofiles-fuse if it's disabled

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -41,7 +41,7 @@ AM_TESTS_ENVIRONMENT += OT_SKIP_READDIR_RAND=1 G_SLICE=always-malloc
 endif
 
 uninstalled_test_data = tests/ostree-symlink-stamp tests/ostree-prepare-root-symlink-stamp \
-			tests/ostree-remount-symlink-stamp tests/rofiles-fuse-symlink-stamp
+			tests/ostree-remount-symlink-stamp
 
 dist_uninstalled_test_scripts = tests/test-symbols.sh tests/coccinelle.sh
 
@@ -143,6 +143,7 @@ endif
 
 if BUILDOPT_FUSE
 _installed_or_uninstalled_test_scripts += tests/test-rofiles-fuse.sh
+uninstalled_test_data += tests/rofiles-fuse-symlink-stamp
 else
 EXTRA_DIST += tests/test-rofiles-fuse.sh
 endif


### PR DESCRIPTION
Creating the symlink will cause make to try to build rofiles-fuse, which
will fail if it's disabled. Normally I wouldn't disable rofiles-fuse,
but it's triggering a hang in our ARM Xenial builder's kernel in splice.
I'm sure that's fuse's fault, but for now I just need to disable
rofiles-fuse there and found --disable-rofiles-fuse didn't actually
work.