### PR TITLE
grub-generator: If OSTREE_BOOT_PARTITION is not set, default to /boot

### DIFF
--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -61,7 +61,12 @@ read_config()
 
 populate_menu()
 {
-    boot_prefix="${OSTREE_BOOT_PARTITION}"
+    # Default to /boot if OSTREE_BOOT_PARTITION is not set
+    if [ -z ${OSTREE_BOOT_PARTITION+x} ]; then
+        boot_prefix="/boot"
+    else
+        boot_prefix="${OSTREE_BOOT_PARTITION}"
+    fi
     for config in $(ls ${entries_path}); do
         read_config ${config}
         menu="${menu}menuentry '${title}' {\n"

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -61,7 +61,7 @@ read_config()
 
 populate_menu()
 {
-    # Default to /boot if OSTREE_BOOT_PARTITION is not set and /boot and / are on the save device
+    # Default to /boot if OSTREE_BOOT_PARTITION is not set and /boot and / are on the same device
     if [ -z ${OSTREE_BOOT_PARTITION+x} ] && [ $(df / /boot|awk '{print $1}'|uniq|wc -l) -eq 2 ]; then
         boot_prefix="/boot"
     else

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -61,8 +61,8 @@ read_config()
 
 populate_menu()
 {
-    # Default to /boot if OSTREE_BOOT_PARTITION is not set
-    if [ -z ${OSTREE_BOOT_PARTITION+x} ]; then
+    # Default to /boot if OSTREE_BOOT_PARTITION is not set and /boot and / are on the save device
+    if [ -z ${OSTREE_BOOT_PARTITION+x} ] && [ $(df / /boot|awk '{print $1}'|uniq|wc -l) -eq 2 ]; then
         boot_prefix="/boot"
     else
         boot_prefix="${OSTREE_BOOT_PARTITION}"

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -61,8 +61,8 @@ read_config()
 
 populate_menu()
 {
-    # Default to /boot if OSTREE_BOOT_PARTITION is not set and /boot and / are on the same device
-    if [ -z ${OSTREE_BOOT_PARTITION+x} ] && [ $(df / /boot|awk '{print $1}'|uniq|wc -l) -eq 2 ]; then
+    # Default to /boot if OSTREE_BOOT_PARTITION is not set and /boot is on the same device than ostree/repo
+    if [ -z ${OSTREE_BOOT_PARTITION+x} ] && [ -d /boot/ostree ] && [ -d /ostree/repo ] && [ $(stat -c '%d' /boot/ostree) -eq $(stat -c '%d' /ostree/repo) ]; then
         boot_prefix="/boot"
     else
         boot_prefix="${OSTREE_BOOT_PARTITION}"


### PR DESCRIPTION
## Summary of the issue
Unable to boot with grub after deploying a new image with ostree admin

## Description
I'm using Yocto/poky and [meta-updater](https://github.com/advancedtelematic/meta-updater).

After pulling the new generated ostree repository, I deploy it on the target device.

Everything goes fine but with the grub config generated. It generates a wrong config because `OSTREE_BOOT_PARTITION` is not set when i run the following from the terminal on the device:
```
ostree admin deploy --os=poky my-remote:genericx86-64
```

This generates a config where the kernel and initramfs files point to a non existent path at ```/ostree/poky-c24b509436e2f75d9e2f8b6491b7f6b3d1007ed8d67328fdf03508314c6bd5a1/vmlinuz ``` when the right path should be ```/boot/ostree/poky-c24b509436e2f75d9e2f8b6491b7f6b3d1007ed8d67328fdf03508314c6bd5a1/vmlinuz```
