### PR TITLE
build: Use --output parameter for glib-mkenums to avoid tmp file switch

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -52,12 +52,14 @@ ENUM_TYPES += $(srcdir)/src/libostree/ostree-fetcher.h
 src/libostree/ostree-enumtypes.h: src/libostree/ostree-enumtypes.h.template $(ENUM_TYPES)
 	$(AM_V_GEN) $(GLIB_MKENUMS) \
 	--template $< \
-	$(ENUM_TYPES) > $@.tmp && mv $@.tmp $@
+	--output $@ \
+	$(ENUM_TYPES)
 
 src/libostree/ostree-enumtypes.c: src/libostree/ostree-enumtypes.c.template src/libostree/ostree-enumtypes.h $(ENUM_TYPES)
 	$(AM_V_GEN) $(GLIB_MKENUMS) \
 	--template $< \
-	$(ENUM_TYPES) > $@.tmp && mv $@.tmp $@
+	--output $@ \
+	$(ENUM_TYPES)
 
 nodist_libostree_1_la_SOURCES = \
 	src/libostree/ostree-enumtypes.h \


### PR DESCRIPTION
Avoid renaming through a temporary file by using the --output parameter
for glib-mkenums, which handles this internally.

This introduces no functional changes.

Signed-off-by: Philip Withnall <withnall@endlessm.com>