### PR TITLE
deltas: Don't try to rollsum/bsdiff .xz files

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation-analysis.c
+++ b/src/libostree/ostree-repo-static-delta-compilation-analysis.c
@@ -232,8 +232,15 @@ sizename_is_delta_candidate (OstreeDeltaContentSizeNames *sizename)
        * but it's not clear to me that's a major win; we'd still need to
        * maintain a list of compression formats, and this doesn't require
        * allocation.
+       * NB: We explicitly don't have .gz here in case someone might be
+       * using --rsyncable for that.
        */
-      if (g_str_has_suffix (name, ".xz"))
+      const char *dot = g_strrchr (name, '.');
+      if (!dot)
+        continue;
+      const char *extension = dot+1;
+      /* Don't add .gz here, see above */
+      if (g_str_equal (extension, "xz") || g_str_equal (extension, "bz2"))
         return FALSE;
     }
 
@@ -301,7 +308,6 @@ _ostree_delta_compute_similar_objects (OstreeRepo                 *repo,
       const guint64 max_threshold = to_sizenames->size *
         (1.0+similarity_percent_threshold/100.0);
 
-      /* Don't build candidates for the empty object */
       if (!sizename_is_delta_candidate (to_sizenames))
         continue;
 

--- a/src/libostree/ostree-repo-static-delta-compilation-analysis.c
+++ b/src/libostree/ostree-repo-static-delta-compilation-analysis.c
@@ -235,7 +235,7 @@ sizename_is_delta_candidate (OstreeDeltaContentSizeNames *sizename)
        * NB: We explicitly don't have .gz here in case someone might be
        * using --rsyncable for that.
        */
-      const char *dot = g_strrchr (name, '.');
+      const char *dot = strrchr (name, '.');
       if (!dot)
         continue;
       const char *extension = dot+1;


### PR DESCRIPTION
Fedora switched to 'xz' compress kernel modules, and recently
[RHEL7 did too](https://bugzilla.redhat.com/show_bug.cgi?id=1367496).
This compression defeats bsdiff.

While we have a "rollsum-able" test, we don't have a "bsdiff-able" test as it'd
be very expensive (we'd have to bsdiff, then apply it and compare the result).

Let's do the tactical quick fix here and just not try to delta files ending in
`.xz.`. This avoids us using bsdiff pointlessly for over 4000 files, which is
quite a notable speed increase for generating deltas.