### PR TITLE
bin/summary: Fix --raw option

### DIFF
--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -210,7 +210,7 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
             return FALSE;
         }
     }
-  else if (opt_view)
+  else if (opt_view || opt_raw)
     {
       g_autoptr(GBytes) summary_data = NULL;
 

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -55,7 +55,7 @@ assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp)
 echo "ok view summary"
 
 # Check the summary can be viewed raw too.
-${OSTREE} summary --view --raw > raw-summary.txt
+${OSTREE} summary --raw > raw-summary.txt
 assert_file_has_content_literal raw-summary.txt "('main', ("
 assert_file_has_content_literal raw-summary.txt "('other', ("
 assert_file_has_content_literal raw-summary.txt "{'ostree.summary.last-modified': <uint64"


### PR DESCRIPTION
I wanted to inspect a summary file the other day and was saddened to
find it was broken:

$ ostree summary --raw
error: No option specified; use -u to update summary

CC @pwithnall