### PR TITLE
More experimental bindings

### DIFF
--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -19,6 +19,8 @@ OstreeRemote
 ostree_remote_ref
 ostree_remote_unref
 ostree_remote_get_name
+<SUBSECTION Standard>
+ostree_remote_get_type
 </SECTION>
 
 <SECTION>

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -89,3 +89,8 @@ global:
   ostree_repo_finder_override_get_type;
   ostree_repo_finder_override_new;
 } LIBOSTREE_2017.12_EXPERIMENTAL;
+
+LIBOSTREE_2017.14_EXPERIMENTAL {
+global:
+  ostree_remote_get_type;
+} LIBOSTREE_2017.13_EXPERIMENTAL;

--- a/src/libostree/ostree-ref.h
+++ b/src/libostree/ostree-ref.h
@@ -48,7 +48,6 @@ typedef struct
   gchar *ref_name;  /* (not nullable) */
 } OstreeCollectionRef;
 
-#ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 GType ostree_collection_ref_get_type (void);
 
@@ -59,7 +58,6 @@ _OSTREE_PUBLIC
 OstreeCollectionRef *ostree_collection_ref_dup (const OstreeCollectionRef *ref);
 _OSTREE_PUBLIC
 void ostree_collection_ref_free (OstreeCollectionRef *ref);
-#endif
 
 _OSTREE_PUBLIC
 guint ostree_collection_ref_hash (gconstpointer ref);

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -47,14 +47,12 @@ G_BEGIN_DECLS
 typedef struct OstreeRemote OstreeRemote;
 #endif
 
-#ifndef __GI_SCANNER__
 _OSTREE_PUBLIC
 GType ostree_remote_get_type (void) G_GNUC_CONST;
 _OSTREE_PUBLIC
 OstreeRemote *ostree_remote_ref (OstreeRemote *remote);
 _OSTREE_PUBLIC
 void ostree_remote_unref (OstreeRemote *remote);
-#endif /* GI_SCANNER */
 
 _OSTREE_PUBLIC
 const gchar *ostree_remote_get_name (OstreeRemote *remote);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5612,11 +5612,8 @@ check_remote_matches_collection_id (OstreeRepo  *repo,
   return g_str_equal (remote_collection_id, collection_id);
 }
 
-/* FIXME: Export this to bindings once OstreeRemote is properly registered as
- * a boxed type.
- */
 /**
- * ostree_repo_resolve_keyring_for_collection: (skip)
+ * ostree_repo_resolve_keyring_for_collection:
  * @self: an #OstreeRepo
  * @collection_id: the collection ID to look up a keyring for
  * @cancellable: (nullable): a #GCancellable, or %NULL


### PR DESCRIPTION
This makes `OstreeRemote` and `OstreeCollectionRef` to be actually usable from bindings.

CC @pwithnall 