### PR TITLE
Slimmer repo locking

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -108,6 +108,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-xattrs.sh \
 	tests/test-auto-summary.sh \
 	tests/test-prune.sh \
+	tests/test-concurrency.py \
 	tests/test-refs.sh \
 	tests/test-demo-buildsystem.sh \
 	tests/test-switchroot.sh \

--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -93,6 +93,9 @@ ostree_repo_finder_override_get_type
 OstreeRepoLockType
 ostree_repo_lock_push
 ostree_repo_lock_pop
+OstreeRepoAutoLock
+ostree_repo_auto_lock_push
+ostree_repo_auto_lock_cleanup
 ostree_repo_get_collection_id
 ostree_repo_set_collection_id
 ostree_validate_collection_id

--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -90,6 +90,9 @@ ostree_repo_finder_override_get_type
 
 <SECTION>
 <FILE>ostree-misc-experimental</FILE>
+OstreeRepoLockType
+ostree_repo_lock_push
+ostree_repo_lock_pop
 ostree_repo_get_collection_id
 ostree_repo_set_collection_id
 ostree_validate_collection_id

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -94,6 +94,8 @@ LIBOSTREE_2017.14_EXPERIMENTAL {
 global:
   ostree_remote_get_type;
   ostree_remote_get_url;
+  ostree_repo_auto_lock_cleanup;
+  ostree_repo_auto_lock_push;
   ostree_repo_lock_pop;
   ostree_repo_lock_push;
 } LIBOSTREE_2017.13_EXPERIMENTAL;

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -94,4 +94,6 @@ LIBOSTREE_2017.14_EXPERIMENTAL {
 global:
   ostree_remote_get_type;
   ostree_remote_get_url;
+  ostree_repo_lock_pop;
+  ostree_repo_lock_push;
 } LIBOSTREE_2017.13_EXPERIMENTAL;

--- a/src/libostree/ostree-autocleanups.h
+++ b/src/libostree/ostree-autocleanups.h
@@ -59,6 +59,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSysrootUpgrader, g_object_unref)
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (OstreeRepoCommitTraverseIter, ostree_repo_commit_traverse_iter_clear)
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, ostree_repo_auto_lock_cleanup)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeCollectionRef, ostree_collection_ref_free)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeCollectionRefv, ostree_collection_ref_freev, NULL)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRemote, ostree_remote_unref)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1304,6 +1304,8 @@ ostree_repo_scan_hardlinks (OstreeRepo    *self,
  *
  * Multithreading: This function is *not* MT safe; only one transaction can be
  * active at a time.
+ *
+ * This function takes a shared lock on the @self repository.
  */
 gboolean
 ostree_repo_prepare_transaction (OstreeRepo     *self,
@@ -1315,6 +1317,11 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
   g_return_val_if_fail (self->in_transaction == FALSE, FALSE);
 
   memset (&self->txn.stats, 0, sizeof (OstreeRepoTransactionStats));
+
+  self->txn_locked = ostree_repo_lock_push (self, OSTREE_REPO_LOCK_SHARED,
+                                            cancellable, error);
+  if (!self->txn_locked)
+    return FALSE;
 
   self->in_transaction = TRUE;
   if (self->min_free_space_percent > 0)
@@ -1836,6 +1843,13 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
   if (!ot_ensure_unlinked_at (self->repo_dir_fd, "transaction", 0))
     return FALSE;
 
+  if (self->txn_locked)
+    {
+      if (!ostree_repo_lock_pop (self, cancellable, error))
+        return FALSE;
+      self->txn_locked = FALSE;
+    }
+
   if (out_stats)
     *out_stats = self->txn.stats;
 
@@ -1875,6 +1889,13 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
   glnx_release_lock_file (&self->commit_stagedir_lock);
 
   self->in_transaction = FALSE;
+
+  if (self->txn_locked)
+    {
+      if (!ostree_repo_lock_pop (self, cancellable, error))
+        return FALSE;
+      self->txn_locked = FALSE;
+    }
 
   return TRUE;
 }

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -602,6 +602,7 @@ write_content_object (OstreeRepo         *self,
                       GCancellable       *cancellable,
                       GError            **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Writing content object", error);
   g_return_val_if_fail (expected_checksum || out_csum, FALSE);
 
   if (g_cancellable_set_error_if_cancelled (cancellable, error))
@@ -844,8 +845,7 @@ write_content_object (OstreeRepo         *self,
                                         uid, gid, mode,
                                         xattrs,
                                         cancellable, error))
-        return glnx_prefix_error (error, "Writing object %s.%s", actual_checksum,
-                                  ostree_object_type_to_string (OSTREE_OBJECT_TYPE_FILE));
+        return FALSE;
     }
 
   /* Update statistics */
@@ -886,6 +886,8 @@ adopt_and_commit_regfile (OstreeRepo   *self,
                           GCancellable *cancellable,
                           GError      **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Commit regfile (adopt)", error);
+
   g_assert (G_IN_SET (self->mode, OSTREE_REPO_MODE_BARE, OSTREE_REPO_MODE_BARE_USER_ONLY));
   g_autoptr(GBytes) header = _ostree_file_header_new (finfo, xattrs);
 
@@ -981,6 +983,8 @@ write_metadata_object (OstreeRepo         *self,
                        GCancellable       *cancellable,
                        GError            **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Writing metadata object", error);
+
   g_return_val_if_fail (expected_checksum || out_csum, FALSE);
 
   if (g_cancellable_set_error_if_cancelled (cancellable, error))

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -37,6 +37,8 @@ G_BEGIN_DECLS
 #define _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS 8
 #define _OSTREE_MAX_OUTSTANDING_DELTAPART_REQUESTS 2
 
+#define _OSTREE_DEFAULT_LOCK_TIMEOUT_SECONDS 30
+
 /* In most cases, writing to disk should be much faster than
  * fetching from the network, so we shouldn't actually hit
  * this. But if using pipelining and e.g. pulling over LAN
@@ -157,6 +159,7 @@ struct OstreeRepo {
   guint64 tmp_expiry_seconds;
   gchar *collection_id;
   gboolean add_remotes_config_dir; /* Add new remotes in remotes.d dir */
+  gint lock_timeout_seconds;
 
   OstreeRepo *parent_repo;
 };
@@ -435,6 +438,23 @@ _ostree_repo_get_remote_inherited (OstreeRepo  *self,
                                    GError     **error);
 
 #ifndef OSTREE_ENABLE_EXPERIMENTAL_API
+
+/* All the locking APIs below are duplicated in ostree-repo.h. Remove the ones
+ * here once it's no longer experimental.
+ */
+
+typedef enum {
+  OSTREE_REPO_LOCK_SHARED,
+  OSTREE_REPO_LOCK_EXCLUSIVE
+} OstreeRepoLockType;
+
+gboolean      ostree_repo_lock_push (OstreeRepo          *self,
+                                     OstreeRepoLockType   lock_type,
+                                     GCancellable        *cancellable,
+                                     GError             **error);
+gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
+                                    GCancellable  *cancellable,
+                                    GError       **error);
 
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 gboolean      ostree_repo_set_collection_id (OstreeRepo   *self,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -122,6 +122,7 @@ struct OstreeRepo {
 
   GMutex txn_lock;
   OstreeRepoTxn txn;
+  gboolean txn_locked;
 
   GMutex cache_lock;
   guint dirmeta_cache_refcount;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -456,6 +456,15 @@ gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
                                     GCancellable  *cancellable,
                                     GError       **error);
 
+typedef OstreeRepo OstreeRepoAutoLock;
+
+OstreeRepoAutoLock * ostree_repo_auto_lock_push (OstreeRepo          *self,
+                                                 OstreeRepoLockType   lock_type,
+                                                 GCancellable        *cancellable,
+                                                 GError             **error);
+void          ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, ostree_repo_auto_lock_cleanup)
+
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 gboolean      ostree_repo_set_collection_id (OstreeRepo   *self,
                                              const gchar  *collection_id,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1797,6 +1797,7 @@ repo_create_at_internal (int             dfd,
                          GCancellable   *cancellable,
                          GError        **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Creating repo", error);
    struct stat stbuf;
   /* We do objects/ last - if it exists we do nothing and exit successfully */
   const char *state_dirs[] = { "tmp", "extensions", "state",

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -131,6 +131,24 @@ gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
                                     GCancellable  *cancellable,
                                     GError       **error);
 
+/**
+ * OstreeRepoAutoLock: (skip)
+ *
+ * This is simply an alias to #OstreeRepo used for automatic lock cleanup.
+ * See ostree_repo_auto_lock_push() for its intended usage.
+ *
+ * Since: 2017.14
+ */
+typedef OstreeRepo OstreeRepoAutoLock;
+
+_OSTREE_PUBLIC
+OstreeRepoAutoLock * ostree_repo_auto_lock_push (OstreeRepo          *self,
+                                                 OstreeRepoLockType   lock_type,
+                                                 GCancellable        *cancellable,
+                                                 GError             **error);
+_OSTREE_PUBLIC
+void          ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
+
 _OSTREE_PUBLIC
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 _OSTREE_PUBLIC

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -107,6 +107,30 @@ OstreeRepo *  ostree_repo_create_at (int             dfd,
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
 
+/**
+ * OstreeRepoLockType:
+ * @OSTREE_REPO_LOCK_SHARED: A shared lock
+ * @OSTREE_REPO_LOCK_EXCLUSIVE: An exclusive lock
+ *
+ * The type of repository lock to acquire.
+ *
+ * Since: 2017.14
+ */
+typedef enum {
+  OSTREE_REPO_LOCK_SHARED,
+  OSTREE_REPO_LOCK_EXCLUSIVE
+} OstreeRepoLockType;
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_lock_push (OstreeRepo          *self,
+                                     OstreeRepoLockType   lock_type,
+                                     GCancellable        *cancellable,
+                                     GError             **error);
+_OSTREE_PUBLIC
+gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
+                                    GCancellable  *cancellable,
+                                    GError       **error);
+
 _OSTREE_PUBLIC
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 _OSTREE_PUBLIC

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+from __future__ import print_function
+import os
+import sys
+import shutil
+import subprocess
+from multiprocessing import cpu_count
+
+def fatal(msg):
+    sys.stderr.write(msg)
+    sys.stderr.write('\n')
+    sys.exit(1)
+
+# Create 20 files with content based on @dname + a serial, basically to have
+# different files with different checksums.
+def mktree(dname, serial=0):
+    print('Creating tree', dname, file=sys.stderr)
+    os.mkdir(dname, 0755)
+    for v in xrange(20):
+        with open('{}/{}'.format(dname, v), 'w') as f:
+            f.write('{} {} {}\n'.format(dname, serial, v))
+
+subprocess.check_call(['ostree', '--repo=repo', 'init', '--mode=bare'])
+# like the bit in libtest, but let's do it unconditionally since it's simpler,
+# and we don't need xattr coverage for this
+with open('repo/config', 'a') as f:
+    f.write('disable-xattrs=true\n')
+
+def commit(v):
+    tdir='tree{}'.format(v)
+    cmd = ['ostree', '--repo=repo', 'commit', '--fsync=0', '-b', tdir, '--tree=dir='+tdir]
+    proc = subprocess.Popen(cmd)
+    print('PID {}'.format(proc.pid), *cmd, file=sys.stderr)
+    return proc
+def prune():
+    cmd = ['ostree', '--repo=repo', 'prune', '--refs-only']
+    proc = subprocess.Popen(cmd)
+    print('PID {}:'.format(proc.pid), *cmd, file=sys.stderr)
+    return proc
+
+def wait_check(proc):
+    pid = proc.pid
+    proc.wait()
+    if proc.returncode != 0:
+        sys.stderr.write("process {} exited with code {}\n".format(proc.pid, proc.returncode))
+        return False
+    else:
+        sys.stderr.write('PID {} exited OK\n'.format(pid))
+        return True
+
+print("1..2")
+
+def run(n_committers, n_pruners):
+    # The number of committers needs to be even since we only create half as
+    # many trees
+    n_committers += n_committers % 2
+
+    committers = set()
+    pruners = set()
+
+    print('n_committers', n_committers, 'n_pruners', n_pruners, file=sys.stderr)
+    n_trees = n_committers / 2
+    for v in xrange(n_trees):
+        mktree('tree{}'.format(v))
+
+    for v in xrange(n_committers):
+        committers.add(commit(v / 2))
+    for v in xrange(n_pruners):
+        pruners.add(prune())
+
+    failed = False
+    for committer in committers:
+        if not wait_check(committer):
+            failed = True
+    for pruner in pruners:
+        if not wait_check(pruner):
+            failed = True
+    if failed:
+        fatal('A child process exited abnormally')
+
+    for v in xrange(n_trees):
+        shutil.rmtree('tree{}'.format(v))
+
+# No concurrent pruning
+run(cpu_count()/2 + 2, 0)
+print("ok no concurrent prunes")
+
+run(cpu_count()/2 + 4, 3)
+print("ok concurrent prunes")


### PR DESCRIPTION
This is a slimmed down version of the locking in #1292. It contains just the locking push/pop interfaces and internal locking for transactions and pruning. This should hopefully be easier to review and merge and start testing how the locking actually affects real life use cases.

I still intend to add more of the features in #1292, but will wait on review of this PR. Most of the comments in #1292 have been addressed here. I'll add comments back on that PR where applicable.