### PR TITLE
Fix some tmpdir races

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5004,7 +5004,16 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
                                          error))
         return FALSE;
       if (!did_lock)
-        continue;
+        {
+          /* We raced and someone else already locked the newly created
+           * directory. Free the resources here and then mark it as
+           * uninitialized so glnx_tmpdir_cleanup doesn't delete the directory
+           * when new_tmpdir goes out of scope.
+           */
+          glnx_tmpdir_unset (&new_tmpdir);
+          new_tmpdir.initialized = FALSE;
+          continue;
+        }
 
       g_debug ("Using new tmpdir %s", new_tmpdir.path);
       ret_tmpdir = new_tmpdir; /* Transfer ownership */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4980,6 +4980,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
 
       /* We found an existing tmpdir which we managed to lock */
       g_debug ("Reusing tmpdir %s", dent->d_name);
+      reusing_dir = TRUE;
       ret_tmpdir.src_dfd = tmpdir_dfd;
       ret_tmpdir.fd = glnx_steal_fd (&target_dfd);
       ret_tmpdir.path = g_strdup (dent->d_name);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4955,7 +4955,8 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
       if (!glnx_opendirat (dfd_iter.fd, dent->d_name, FALSE,
                            &target_dfd, &local_error))
         {
-          if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY))
+          if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY) ||
+              g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
             continue;
           else
             {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4979,6 +4979,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
       (void)futimens (target_dfd, NULL);
 
       /* We found an existing tmpdir which we managed to lock */
+      g_debug ("Reusing tmpdir %s", dent->d_name);
       ret_tmpdir.src_dfd = tmpdir_dfd;
       ret_tmpdir.fd = glnx_steal_fd (&target_dfd);
       ret_tmpdir.path = g_strdup (dent->d_name);
@@ -5003,6 +5004,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
       if (!did_lock)
         continue;
 
+      g_debug ("Using new tmpdir %s", new_tmpdir.path);
       ret_tmpdir = new_tmpdir; /* Transfer ownership */
       new_tmpdir.initialized = FALSE;
     }


### PR DESCRIPTION
Running the `test-concurrency.py` script from #1343 shows some races with processes trying to reuse existing tmpdirs. I think there might still be a race lingering, but this makes my stress test run for much longer.