### PR TITLE
Check commit ref bindings with ostree fsck

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -101,6 +101,7 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-repo-checkout.c \
 	src/libostree/ostree-repo-commit.c \
 	src/libostree/ostree-repo-pull.c \
+	src/libostree/ostree-repo-pull-private.h \
 	src/libostree/ostree-repo-libarchive.c \
 	src/libostree/ostree-repo-prune.c \
 	src/libostree/ostree-repo-refs.c \

--- a/apidoc/Makefile.am
+++ b/apidoc/Makefile.am
@@ -83,6 +83,7 @@ IGNORE_HFILES= \
 	ostree-metalink.h \
 	ostree-repo-file-enumerator.h \
 	ostree-repo-private.h \
+	ostree-repo-pull-private.h \
 	ostree-repo-static-delta-private.h \
 	ostree-sysroot-private.h \
 	ostree-tls-cert-interaction.h \

--- a/bash/ostree
+++ b/bash/ostree
@@ -963,6 +963,7 @@ _ostree_fsck() {
         --add-tombstones
         --delete
         --quiet -q
+        --verify-back-refs
     "
 
     local options_with_args="

--- a/man/ostree-fsck.xml
+++ b/man/ostree-fsck.xml
@@ -85,6 +85,17 @@ Boston, MA 02111-1307, USA.
                    Add tombstone commit for referenced but missing commits.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--verify-back-refs</option></term>
+                <listitem><para>
+                   Verify that all the refs listed in a commit’s ref-bindings
+                   point to that commit. This cannot be used in repositories
+                   where the target of refs is changed over time as new commits
+                   are added, but can be used in repositories which are
+                   regenerated from scratch for each commit.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/src/libostree/ostree-cmdprivate.c
+++ b/src/libostree/ostree-cmdprivate.c
@@ -22,6 +22,7 @@
 #include "ostree-cmdprivate.h"
 #include "ostree-repo-private.h"
 #include "ostree-core-private.h"
+#include "ostree-repo-pull-private.h"
 #include "ostree-repo-static-delta-private.h"
 #include "ostree-sysroot.h"
 #include "ostree-bootloader-grub2.h"
@@ -48,7 +49,8 @@ ostree_cmd__private__ (void)
     impl_ostree_generate_grub2_config,
     _ostree_repo_static_delta_dump,
     _ostree_repo_static_delta_query_exists,
-    _ostree_repo_static_delta_delete
+    _ostree_repo_static_delta_delete,
+    _ostree_repo_verify_bindings
   };
 
   return &table;

--- a/src/libostree/ostree-cmdprivate.h
+++ b/src/libostree/ostree-cmdprivate.h
@@ -31,6 +31,7 @@ typedef struct {
   gboolean (* ostree_static_delta_dump) (OstreeRepo *repo, const char *delta_id, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_query_exists) (OstreeRepo *repo, const char *delta_id, gboolean *out_exists, GCancellable *cancellable, GError **error);
   gboolean (* ostree_static_delta_delete) (OstreeRepo *repo, const char *delta_id, GCancellable *cancellable, GError **error);
+  gboolean (* ostree_repo_verify_bindings) (const char *collection_id, const char *ref_name, GVariant *commit, GError **error);
 } OstreeCmdPrivateVTable;
 
 /* Note this not really "public", we just export the symbol, but not the header */

--- a/src/libostree/ostree-repo-pull-private.h
+++ b/src/libostree/ostree-repo-pull-private.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include "ostree-core.h"
+
+G_BEGIN_DECLS
+
+gboolean
+_ostree_repo_verify_bindings (const char  *collection_id,
+                              const char  *ref_name,
+                              GVariant    *commit,
+                              GError     **error);
+
+G_END_DECLS

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1523,7 +1523,7 @@ _ostree_repo_verify_bindings (const char  *collection_id,
         return TRUE;
 
       return glnx_throw (error,
-                         "expected commit metadata to have ref "
+                         "Expected commit metadata to have ref "
                          "binding information, found none");
     }
 
@@ -1552,7 +1552,7 @@ _ostree_repo_verify_bindings (const char  *collection_id,
               refs_str = "no refs";
             }
 
-          return glnx_throw (error, "commit has no requested ref ‘%s’ "
+          return glnx_throw (error, "Commit has no requested ref ‘%s’ "
                              "in ref binding metadata (%s)",
                              ref_name, refs_str);
         }
@@ -1567,11 +1567,11 @@ _ostree_repo_verify_bindings (const char  *collection_id,
                              "&s",
                              &collection_id_binding))
         return glnx_throw (error,
-                           "expected commit metadata to have collection ID "
+                           "Expected commit metadata to have collection ID "
                            "binding information, found none");
       if (!g_str_equal (collection_id_binding, collection_id))
         return glnx_throw (error,
-                           "commit has collection ID ‘%s’ in collection binding "
+                           "Commit has collection ID ‘%s’ in collection binding "
                            "metadata, while the remote it came from has "
                            "collection ID ‘%s’",
                            collection_id_binding, collection_id);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1476,6 +1476,8 @@ get_remote_repo_collection_id (OtPullData *pull_data)
 }
 #endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
 
+#endif  /* HAVE_LIBCURL_OR_LIBSOUP */
+
 /**
  * _ostree_repo_verify_bindings:
  * @collection_id: (nullable): Locally specified collection ID for the remote
@@ -1580,6 +1582,8 @@ _ostree_repo_verify_bindings (const char  *collection_id,
 
   return TRUE;
 }
+
+#ifdef HAVE_LIBCURL_OR_LIBSOUP
 
 /* Look at a commit object, and determine whether there are
  * more things to fetch.

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -32,6 +32,7 @@
 
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
+#include "ostree-repo-pull-private.h"
 #include "ostree-repo-static-delta-private.h"
 #include "ostree-metalink.h"
 #include "ostree-fetcher-util.h"
@@ -1475,30 +1476,38 @@ get_remote_repo_collection_id (OtPullData *pull_data)
 }
 #endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
 
-/* Verify the ref and collection bindings.
+/**
+ * _ostree_repo_verify_bindings:
+ * @collection_id: (nullable): Locally specified collection ID for the remote
+ *    the @commit was retrieved from, or %NULL if none is configured
+ * @ref_name: (nullable): Ref name the commit was retrieved using, or %NULL if
+ *    the commit was retrieved by checksum
+ * @commit: Commit data to check
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Verify the ref and collection bindings.
  *
  * The ref binding is verified only if it exists. But if we have the
- * collection ID specified in the remote configuration then the ref
- * binding must exist, otherwise the verification will fail. Parts of
- * the verification can be skipped by passing NULL to the requested_ref
- * parameter (in case we requested a checksum directly, without looking it up
- * from a ref).
+ * collection ID specified in the remote configuration (@collection_id is
+ * non-%NULL) then the ref binding must exist, otherwise the verification will
+ * fail. Parts of the verification can be skipped by passing %NULL to the
+ * @ref_name parameter (in case we requested a checksum directly, without
+ * looking it up from a ref).
  *
  * The collection binding is verified only when we have collection ID
  * specified in the remote configuration. If it is specified, then the
  * binding must exist and must be equal to the remote repository
  * collection ID.
+ *
+ * Returns: %TRUE if bindings are correct, %FALSE otherwise
+ * Since: 2017.14
  */
-static gboolean
-verify_bindings (OtPullData                 *pull_data,
-                 GVariant                   *commit,
-                 const OstreeCollectionRef  *requested_ref,
-                 GError                    **error)
+gboolean
+_ostree_repo_verify_bindings (const char  *collection_id,
+                              const char  *ref_name,
+                              GVariant    *commit,
+                              GError     **error)
 {
-  g_autofree char *remote_collection_id = NULL;
-#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
-  remote_collection_id = get_remote_repo_collection_id (pull_data);
-#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
   g_autoptr(GVariant) metadata = g_variant_get_child_value (commit, 0);
   g_autofree const char **refs = NULL;
   if (!g_variant_lookup (metadata,
@@ -1510,7 +1519,7 @@ verify_bindings (OtPullData                 *pull_data,
        * we certainly will not verify the collection binding in the
        * commit.
        */
-      if (remote_collection_id == NULL)
+      if (collection_id == NULL)
         return TRUE;
 
       return glnx_throw (error,
@@ -1518,9 +1527,9 @@ verify_bindings (OtPullData                 *pull_data,
                          "binding information, found none");
     }
 
-  if (requested_ref != NULL)
+  if (ref_name != NULL)
     {
-      if (!g_strv_contains ((const char *const *) refs, requested_ref->ref_name))
+      if (!g_strv_contains ((const char *const *) refs, ref_name))
         {
           g_autoptr(GString) refs_dump = g_string_new (NULL);
           const char *refs_str;
@@ -1545,27 +1554,27 @@ verify_bindings (OtPullData                 *pull_data,
 
           return glnx_throw (error, "commit has no requested ref ‘%s’ "
                              "in ref binding metadata (%s)",
-                             requested_ref->ref_name, refs_str);
+                             ref_name, refs_str);
         }
     }
 
-  if (remote_collection_id != NULL)
+  if (collection_id != NULL)
     {
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
-      const char *collection_id;
+      const char *collection_id_binding;
       if (!g_variant_lookup (metadata,
                              OSTREE_COMMIT_META_KEY_COLLECTION_BINDING,
                              "&s",
-                             &collection_id))
+                             &collection_id_binding))
         return glnx_throw (error,
                            "expected commit metadata to have collection ID "
                            "binding information, found none");
-      if (!g_str_equal (collection_id, remote_collection_id))
+      if (!g_str_equal (collection_id_binding, collection_id))
         return glnx_throw (error,
                            "commit has collection ID ‘%s’ in collection binding "
                            "metadata, while the remote it came from has "
                            "collection ID ‘%s’",
-                           collection_id, remote_collection_id);
+                           collection_id_binding, collection_id);
 #endif
     }
 
@@ -1626,7 +1635,13 @@ scan_commit_object (OtPullData                 *pull_data,
   /* If ref is non-NULL then the commit we fetched was requested through the
    * branch, otherwise we requested a commit checksum without specifying a branch.
    */
-  if (!verify_bindings (pull_data, commit, ref, error))
+  g_autofree char *remote_collection_id = NULL;
+#ifdef OSTREE_ENABLE_EXPERIMENTAL_API
+  remote_collection_id = get_remote_repo_collection_id (pull_data);
+#endif  /* OSTREE_ENABLE_EXPERIMENTAL_API */
+  if (!_ostree_repo_verify_bindings (remote_collection_id,
+                                     (ref != NULL) ? ref->ref_name : NULL,
+                                     commit, error))
     return glnx_prefix_error (error, "Commit %s", checksum);
 
   if (pull_data->timestamp_check)

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -726,13 +726,17 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
  * @self: Repo
  * @refspec_prefix: (allow-none): Only list refs which match this prefix
  * @out_all_refs: (out) (element-type utf8 utf8) (transfer container):
- *    Mapping from ref to checksum
+ *    Mapping from refspec to checksum
  * @cancellable: Cancellable
  * @error: Error
  *
  * If @refspec_prefix is %NULL, list all local and remote refspecs,
  * with their current values in @out_all_refs.  Otherwise, only list
  * refspecs which have @refspec_prefix as a prefix.
+ *
+ * @out_all_refs will be returned as a mapping from refspecs (including the
+ * remote name) to checksums. If @refspec_prefix is non-%NULL, it will be
+ * removed as a prefix from the hash table keys.
  */
 gboolean
 ostree_repo_list_refs (OstreeRepo       *self,
@@ -752,16 +756,18 @@ ostree_repo_list_refs (OstreeRepo       *self,
  * @self: Repo
  * @refspec_prefix: (allow-none): Only list refs which match this prefix
  * @out_all_refs: (out) (element-type utf8 utf8) (transfer container):
- *    Mapping from ref to checksum
+ *    Mapping from refspec to checksum
  * @flags: Options controlling listing behavior
  * @cancellable: Cancellable
  * @error: Error
  *
  * If @refspec_prefix is %NULL, list all local and remote refspecs,
  * with their current values in @out_all_refs.  Otherwise, only list
- * refspecs which have @refspec_prefix as a prefix.  Differently from
- * ostree_repo_list_refs(), the prefix will not be removed from the ref
- * name.
+ * refspecs which have @refspec_prefix as a prefix.
+ *
+ * @out_all_refs will be returned as a mapping from refspecs (including the
+ * remote name) to checksums. Differently from ostree_repo_list_refs(), the
+ * @refspec_prefix will not be removed from the refspecs in the hash table.
  */
 gboolean
 ostree_repo_list_refs_ext (OstreeRepo                 *self,

--- a/src/libostree/ostree-repo-static-delta-private.h
+++ b/src/libostree/ostree-repo-static-delta-private.h
@@ -128,11 +128,6 @@ _ostree_static_delta_part_open (GInputStream   *part_in,
                                 GCancellable *cancellable,
                                 GError      **error);
 
-gboolean _ostree_static_delta_dump (OstreeRepo     *repo,
-                                    const char *delta_id,
-                                    GCancellable   *cancellable,
-                                    GError        **error);
-
 typedef struct {
   guint n_ops_executed[OSTREE_STATIC_DELTA_N_OPS];
 } OstreeDeltaExecuteStats;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -378,13 +378,11 @@ compare_strings (gconstpointer a, gconstpointer b)
 static void
 add_ref_binding (GVariantBuilder *metadata_builder)
 {
-  if (opt_orphan)
-    return;
-
-  g_assert_nonnull (opt_branch);
+  g_assert (opt_branch != NULL || opt_orphan);
 
   g_autoptr(GPtrArray) refs = g_ptr_array_new ();
-  g_ptr_array_add (refs, opt_branch);
+  if (opt_branch != NULL)
+    g_ptr_array_add (refs, opt_branch);
   for (char **iter = opt_bind_refs; iter != NULL && *iter != NULL; ++iter)
     g_ptr_array_add (refs, *iter);
   g_ptr_array_sort (refs, compare_strings);

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -189,9 +189,16 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
   gpointer key, value;
   g_hash_table_iter_init (&hash_iter, all_refs);
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
-    if (!fsck_commit_for_ref (repo, value, NULL, key,
-                              &found_corruption, cancellable, error))
-      return FALSE;
+    {
+      const char *refspec = key;
+      const char *checksum = value;
+      g_autofree char *ref_name = NULL;
+      if (!ostree_parse_refspec (refspec, NULL, &ref_name, error))
+        return FALSE;
+      if (!fsck_commit_for_ref (repo, checksum, NULL, ref_name,
+                                &found_corruption, cancellable, error))
+        return FALSE;
+    }
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
   if (!opt_quiet)

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -159,6 +159,10 @@ fsck_commit_for_ref (OstreeRepo    *repo,
         return glnx_prefix_error (error, "Loading commit for ref %s", ref_name);
     }
 
+  /* Check its bindings. */
+  if (!ostree_cmd__private__ ()->ostree_repo_verify_bindings (collection_id, ref_name, commit, error))
+    return glnx_prefix_error (error, "Commit %s", checksum);
+
   return TRUE;
 }
 

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -37,6 +37,8 @@ assert_not_reached () {
 # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
 if locale -a | grep C.UTF-8 >/dev/null; then
     export LC_ALL=C.UTF-8
+elif locale -a | grep C.utf8 >/dev/null; then
+    export LC_ALL=C.utf8
 else
     export LC_ALL=C
 fi

--- a/tests/test-fsck-collections.sh
+++ b/tests/test-fsck-collections.sh
@@ -21,12 +21,28 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..2'
+echo '1..11'
 
 cd ${test_tmpdir}
 
-# Check that fsck detects errors with refs which have collection IDs (i.e. refs in refs/mirrors).
-set_up_repo() {
+# Create a new repository with one ref with the repository’s collection ID, and
+# one ref with a different collection ID (which should be in refs/mirrors).
+set_up_repo_with_collection_id() {
+  rm -rf repo files
+
+  mkdir repo
+  ostree_repo_init repo --collection-id org.example.Collection
+
+  mkdir files
+  pushd files
+  ${CMD_PREFIX} ostree --repo=../repo commit -s "Commit 1" -b ref1 > ../ref1-checksum
+  ${CMD_PREFIX} ostree --repo=../repo commit -s "Commit 2" --orphan --bind-ref ref2 --add-metadata-string=ostree.collection-binding=org.example.Collection2 > ../ref2-checksum
+  ${CMD_PREFIX} ostree --repo=../repo refs --collections --create=org.example.Collection2:ref2 $(cat ../ref2-checksum)
+  popd
+}
+
+# Create a new repository with one ref and no collection IDs.
+set_up_repo_without_collection_id() {
   rm -rf repo files
 
   mkdir repo
@@ -34,12 +50,12 @@ set_up_repo() {
 
   mkdir files
   pushd files
-  ${CMD_PREFIX} ostree --repo=../repo commit -s "Commit 1" -b original-ref > ../original-ref-checksum
+  ${CMD_PREFIX} ostree --repo=../repo commit -s "Commit 3" -b ref3 --bind-ref ref4 > ../ref3-checksum
+  ${CMD_PREFIX} ostree --repo=../repo refs --create=ref4 $(cat ../ref3-checksum)
   popd
-  ${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collection:some-ref $(cat original-ref-checksum)
 }
 
-set_up_repo
+set_up_repo_with_collection_id
 
 # fsck at this point should succeed
 ${CMD_PREFIX} ostree fsck --repo=repo > fsck
@@ -47,9 +63,9 @@ assert_file_has_content fsck "^Validating refs in collections...$"
 
 # Drop the commit the ref points to, and drop the original ref so that fsck doesn’t prematurely fail on that.
 find repo/objects -name '*.commit' -delete -print | wc -l > commitcount
-assert_file_has_content commitcount "^1$"
+assert_file_has_content commitcount "^2$"
 
-rm repo/refs/heads/original-ref
+rm repo/refs/heads/ref1
 
 # fsck should now fail
 if ${CMD_PREFIX} ostree fsck --repo=repo > fsck; then
@@ -62,7 +78,7 @@ echo "ok 1 fsck-collections"
 
 # Try fsck in an old repository where refs/mirrors doesn’t exist to begin with.
 # It should succeed.
-set_up_repo
+set_up_repo_with_collection_id
 rm -rf repo/refs/mirrors
 
 ${CMD_PREFIX} ostree fsck --repo=repo > fsck
@@ -70,3 +86,122 @@ assert_file_has_content fsck "^Validating refs...$"
 assert_file_has_content fsck "^Validating refs in collections...$"
 
 echo "ok 2 fsck-collections in old repository"
+
+# Test that fsck detects commits which are pointed to by refs, but which don’t
+# list those refs in their ref-bindings.
+set_up_repo_with_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --create=new-ref $(cat ref1-checksum)
+
+# fsck should now fail
+if ${CMD_PREFIX} ostree fsck --repo=repo > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Commit has no requested ref ‘new-ref’ in ref binding metadata (‘ref1’)"
+assert_file_has_content fsck "^Validating refs...$"
+
+echo "ok 3 fsck detects missing ref bindings"
+
+# And the same where the ref is a collection–ref.
+set_up_repo_with_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collection2:new-ref $(cat ref1-checksum)
+
+# fsck should now fail
+if ${CMD_PREFIX} ostree fsck --repo=repo > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Commit has no requested ref ‘new-ref’ in ref binding metadata (‘ref1’)"
+assert_file_has_content fsck "^Validating refs...$"
+assert_file_has_content fsck "^Validating refs in collections...$"
+
+echo "ok 4 fsck detects missing collection–ref bindings"
+
+# Check that a ref with a different collection ID but the same ref name is caught.
+set_up_repo_with_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collection2:ref1 $(cat ref1-checksum)
+
+# fsck should now fail
+if ${CMD_PREFIX} ostree fsck --repo=repo > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Commit has collection ID ‘org.example.Collection’ in collection binding metadata, while the remote it came from has collection ID ‘org.example.Collection2’"
+assert_file_has_content fsck "^Validating refs...$"
+assert_file_has_content fsck "^Validating refs in collections...$"
+
+echo "ok 5 fsck detects missing collection–ref bindings"
+
+# Check that a commit with ref bindings which aren’t pointed to by refs is OK.
+set_up_repo_with_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --delete ref1
+
+# fsck at this point should succeed
+${CMD_PREFIX} ostree fsck --repo=repo > fsck
+assert_file_has_content fsck "^Validating refs in collections...$"
+
+echo "ok 6 fsck ignores unreferenced ref bindings"
+
+# …but it’s not OK if we pass --verify-back-refs to fsck.
+if ${CMD_PREFIX} ostree fsck --repo=repo --verify-back-refs > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Collection–ref (org.example.Collection, ref1) in bindings for commit .* does not exist"
+assert_file_has_content fsck "^Validating refs...$"
+assert_file_has_content fsck "^Validating refs in collections...$"
+
+echo "ok 7 fsck ignores unreferenced ref bindings"
+
+#
+# Now repeat most of the above tests with a repository without collection IDs.
+#
+
+set_up_repo_without_collection_id
+
+# fsck at this point should succeed
+${CMD_PREFIX} ostree fsck --repo=repo > fsck
+assert_file_has_content fsck "^Validating refs in collections...$"
+
+# Drop the commit the ref points to, and drop the original ref so that fsck doesn’t prematurely fail on that.
+find repo/objects -name '*.commit' -delete -print | wc -l > commitcount
+assert_file_has_content commitcount "^1$"
+
+rm repo/refs/heads/ref3
+
+# fsck should now fail
+if ${CMD_PREFIX} ostree fsck --repo=repo > fsck; then
+    assert_not_reached "fsck unexpectedly succeeded after deleting commit!"
+fi
+assert_file_has_content fsck "^Validating refs...$"
+
+echo "ok 8 fsck-collections"
+
+# Test that fsck detects commits which are pointed to by refs, but which don’t
+# list those refs in their ref-bindings.
+set_up_repo_without_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --create=new-ref $(cat ref3-checksum)
+
+# fsck should now fail
+if ${CMD_PREFIX} ostree fsck --repo=repo > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Commit has no requested ref ‘new-ref’ in ref binding metadata (‘ref3’, ‘ref4’)"
+assert_file_has_content fsck "^Validating refs...$"
+
+echo "ok 9 fsck detects missing ref bindings"
+
+# Check that a commit with ref bindings which aren’t pointed to by refs is OK.
+set_up_repo_without_collection_id
+${CMD_PREFIX} ostree --repo=repo refs --delete ref3
+
+# fsck at this point should succeed
+${CMD_PREFIX} ostree fsck --repo=repo > fsck
+assert_file_has_content fsck "^Validating refs...$"
+
+echo "ok 10 fsck ignores unreferenced ref bindings"
+
+# …but it’s not OK if we pass --verify-back-refs to fsck.
+if ${CMD_PREFIX} ostree fsck --repo=repo --verify-back-refs > fsck 2> fsck-error; then
+    assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
+fi
+assert_file_has_content fsck-error "Ref ‘ref3’ in bindings for commit .* does not exist"
+assert_file_has_content fsck "^Validating refs...$"
+
+echo "ok 11 fsck ignores unreferenced ref bindings"


### PR DESCRIPTION
If constructing complex repositories with many refs (in our particular case, for Endless OS), it’s possible to accidentally omit some ref bindings from some commits, or add too many ref bindings to others. `ostree fsck` seems like the right place to catch that kind of error, so add support for checking commit binding metadata there.

The branch checks some things unconditionally (the things which would cause `ostree pull` to error out), and hides other checks behind a new `--verify-back-refs` option which instructs `ostree fsck` to check that each ref listed in a commit’s ref bindings points to that commit (and not to another commit which also lists that ref in its ref bindings).

@dbnicholson might want to take a look at this if he gets time.