### PR TITLE
fetcher/curl: Stop using CURLOPT_LOW_SPEED_TIME/_LIMIT

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -788,8 +788,13 @@ initiate_next_curl_request (FetcherRequest *req,
   curl_easy_setopt (req->easy, CURLOPT_PROGRESSFUNCTION, prog_cb);
   curl_easy_setopt (req->easy, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt (req->easy, CURLOPT_CONNECTTIMEOUT, 30L);
-  curl_easy_setopt (req->easy, CURLOPT_LOW_SPEED_LIMIT, 1L);
-  curl_easy_setopt (req->easy, CURLOPT_LOW_SPEED_TIME, 30L);
+  /* We used to set CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME
+   * here, but see https://github.com/ostreedev/ostree/issues/878#issuecomment-347228854
+   * basically those options don't play well with HTTP2 at the moment
+   * where we can have lots of outstanding requests.  Further,
+   * we could implement that functionality at a higher level
+   * more consistently too.
+   */
 
   /* closure bindings -> task */
   curl_easy_setopt (req->easy, CURLOPT_PRIVATE, task);

--- a/tests/test-pull-mirrorlist.sh
+++ b/tests/test-pull-mirrorlist.sh
@@ -60,7 +60,7 @@ cat > ${test_tmpdir}/ostree-srv/mirrorlist <<EOF
 
 # comment with empty lines around
 
-http://example.com/nonexistent
+$(cat ${test_tmpdir}/content_mirror1-address)/ostree/non-existent-repo
 
 $(cat ${test_tmpdir}/content_mirror1-address)/ostree/gnomerepo
 $(cat ${test_tmpdir}/content_mirror2-address)/ostree/gnomerepo


### PR DESCRIPTION
They don't play nicely currently with HTTP2 where we may
have lots of requests queued.

https://github.com/ostreedev/ostree/issues/878#issuecomment-347228854

In practice anyways I think issues here are better solved on a higher level -
e.g. apps today can use an overall timeout on pulls and if they exceed the limit
set the cancellable.