### PR TITLE
lib/commit: Use direct repo writes if fsync is disabled

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -38,13 +38,14 @@
 #include "ostree-checksum-input-stream.h"
 #include "ostree-varint.h"
 
-/* In most cases, we write into a staging dir for commit, but we also allow
- * direct writes into objects/ for e.g. hardlink imports.
+/* If fsync is enabled and we're in a txn, we write into a staging dir for
+ * commit, but we also allow direct writes into objects/ for e.g. hardlink
+ * imports.
  */
 static int
 commit_dest_dfd (OstreeRepo *self)
 {
-  if (self->in_transaction)
+  if (self->in_transaction && !self->disable_fsync)
     return self->commit_stagedir.fd;
   else
     return self->objects_dir_fd;


### PR DESCRIPTION
For situations where fsync is disabled, there's basically
no reason to do the whole "staging directory" dance.  Just
write directly into the repo.

Today I use `fsync=false` for my build/cache repos.

I briefly considered not allocating a tmpdir at all
in this case, but we actually do want the txn tmpdir
for the non-`O_TMPFILE` case.

Part of https://github.com/ostreedev/ostree/issues/1184