### PR TITLE
tests/delta-crosscheck: Disable fsync

### DIFF
--- a/manual-tests/static-delta-generate-crosscheck.sh
+++ b/manual-tests/static-delta-generate-crosscheck.sh
@@ -43,6 +43,7 @@ assert_streq() {
 
 validate_delta_options() {
     ostree --repo=testrepo init --mode=bare-user
+    echo 'fsync=false' >> testrepo/config
     ostree --repo=testrepo remote add --set=gpg-verify=false local file://${repo}
     ostree --repo=${repo} static-delta generate $@ --from=${from} --to=${to}
     ostree --repo=${repo} summary -u


### PR DESCRIPTION
I was running this recently to test the last delta write changes, and this
helps. We should add an option to repo-init to make this easier at some point.