### PR TITLE
Release 2017.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ m4_define([year_version], [2017])
 m4_define([release_version], [14])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,8 +18,9 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2017.14 {
-} LIBOSTREE_2017.13;
+
+LIBOSTREE_2017.15 {
+} LIBOSTREE_2017.14;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -442,6 +442,9 @@ global:
   ostree_repo_checkout_at_options_set_devino;
 } LIBOSTREE_2017.12;
 
+LIBOSTREE_2017.14 {
+} LIBOSTREE_2017.13;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -52,7 +52,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-f8c387ff263f46ac5b8f56c05d37385fb0001a0494998925fd5e992399360386  ${released_syms}
+1e2c6b529bc2d940ff8969eaf0377d78d472d41ec2a2fc96e1c79efd7b95d241  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
Time to cut a new release, we've got the libcurl cleanup ordering patch which
several people have hit, along with safe early fixes for tmpdir cleanup. Let's
try to land the locking PR early next cycle.