### PR TITLE
README.md: Link to BuildStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ projects.
 where OSTree was born - as a high performance continuous delivery/testing
 system for GNOME.
 
+The [BuildStream](https://gitlab.com/BuildStream/buildstream) build and
+integration tool uses libostree as a caching system to store and share
+built artifacts.
+
 Building
 --------
 


### PR DESCRIPTION
This is an example of a tool using libostree to cache and share
build results.