### PR TITLE
Add public API for fsck, use it before loading metadata

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -348,6 +348,7 @@ ostree_repo_import_object_from_with_trust
 ostree_repo_import_archive_to_mtree
 ostree_repo_export_tree_to_archive
 ostree_repo_delete_object
+ostree_repo_fsck_object
 OstreeRepoCommitFilterResult
 OstreeRepoCommitFilter
 OstreeRepoCommitModifier

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,6 +20,7 @@
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 
 LIBOSTREE_2017.15 {
+  ostree_repo_fsck_object;
 } LIBOSTREE_2017.14;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -650,9 +650,16 @@ gboolean      ostree_repo_import_object_from_with_trust (OstreeRepo           *s
 _OSTREE_PUBLIC
 gboolean      ostree_repo_delete_object (OstreeRepo           *self,
                                          OstreeObjectType      objtype,
-                                         const char           *sha256, 
+                                         const char           *sha256,
                                          GCancellable         *cancellable,
                                          GError              **error);
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_fsck_object (OstreeRepo           *self,
+                                       OstreeObjectType      objtype,
+                                       const char           *sha256,
+                                       GCancellable         *cancellable,
+                                       GError              **error);
 
 /** 
  * OstreeRepoCommitFilterResult:

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -183,7 +183,7 @@ if ! skip_one_without_user_xattrs; then
         if ${CMD_PREFIX} ostree --repo=cacherepo fsck 2>err.txt; then
             fatal "corrupt repo fsck?"
         fi
-        assert_file_has_content err.txt "corrupted.*${checksum}"
+        assert_file_has_content err.txt "Corrupted.*${checksum}"
         rm ostree-srv/corruptrepo -rf
         ostree_repo_init ostree-srv/corruptrepo --mode=archive
         ${CMD_PREFIX} ostree --repo=ostree-srv/corruptrepo pull-local cacherepo main

--- a/tests/test-corruption.sh
+++ b/tests/test-corruption.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+# Copyright (C) 2011,2017 Colin Walters <walters@verbum.org>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..3"
+echo "1..4"
 
 . $(dirname $0)/libtest.sh
 
@@ -34,6 +34,18 @@ chmod o-x firstfile
 $OSTREE fsck -q
 
 echo "ok chmod"
+
+cd ${test_tmpdir}
+rm repo files -rf
+setup_test_repository "bare"
+rev=$($OSTREE rev-parse test2)
+echo -n > repo/objects/${rev:0:2}/${rev:2}.commit
+if $OSTREE fsck -q 2>err.txt; then
+    fatal "fsck unexpectedly succeeded"
+fi
+assert_file_has_content_literal err.txt "Corrupted commit object; checksum expected"
+
+echo "ok metadata checksum"
 
 cd ${test_tmpdir}
 rm repo files -rf

--- a/tests/test-corruption.sh
+++ b/tests/test-corruption.sh
@@ -29,7 +29,9 @@ setup_test_repository "bare"
 $OSTREE checkout test2 checkout-test2
 cd checkout-test2
 chmod o+x firstfile
-$OSTREE fsck -q && (echo 1>&2 "fsck unexpectedly succeeded"; exit 1)
+if $OSTREE fsck -q; then
+    fatal "fsck unexpectedly succeeded"
+fi
 chmod o-x firstfile
 $OSTREE fsck -q
 
@@ -54,7 +56,9 @@ rm checkout-test2 -rf
 $OSTREE checkout test2 checkout-test2
 cd checkout-test2
 chmod o+x firstfile
-$OSTREE fsck -q --delete && (echo 1>&2 "fsck unexpectedly succeeded"; exit 1)
+if $OSTREE fsck -q --delete; then
+    fatal "fsck unexpectedly succeeded"
+fi
 
 echo "ok chmod"
 

--- a/tests/test-pull-corruption.sh
+++ b/tests/test-pull-corruption.sh
@@ -76,7 +76,7 @@ if ! skip_one_without_user_xattrs; then
     if ${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo fsck 2>err.txt; then
         assert_not_reached "fsck with corrupted commit worked?"
     fi
-    assert_file_has_content err.txt "corrupted object ${corruptrev}\.commit"
+    assert_file_has_content_literal err.txt "Corrupted commit object; checksum expected='${corruptrev}' actual='${rev}'"
 
     # Do a pull-local; this should succeed since we don't verify checksums
     # for local repos by default.


### PR DESCRIPTION
A while ago I did `truncate -s 0 /path/to/repo/00/123.commit`, and expected a
checksum error, but I actually got a validation error due to us loading the
commit into a variant and trying to parse out the parent checksum, etc.

I first started by changing the `load_and_fsck_one_object()` function to
checksum before loading, but the problem is that we do a traverse of all objects
first. Fixing this is going to require an `OSTREE_REPO_COMMIT_TRAVER_FLAG_FSCK`
or something.

In the meantime at least though, let's add a public API to fsck a single object
which *does* checksum cleanly before parsing the object, and change the `fsck`
command to use it.

We then change the fsck binary to do this while iterating over the refs
and finding the commit object.  This way we'll at least get a checksum
first for commit objects, even if not dirtree/dirmeta.