### PR TITLE
lib/repo: Properly list remotes of parent repos

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1791,7 +1791,7 @@ _ostree_repo_remote_list (OstreeRepo *self,
   g_mutex_unlock (&self->remotes_lock);
 
   if (self->parent_repo)
-    _ostree_repo_remote_list (self, out);
+    _ostree_repo_remote_list (self->parent_repo, out);
 }
 
 /**

--- a/tests/test-remote-add.sh
+++ b/tests/test-remote-add.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..13'
+echo '1..14'
 
 setup_test_repository "bare"
 $OSTREE remote add origin http://example.com/ostree/gnome
@@ -62,6 +62,18 @@ assert_file_has_content list.txt "http://example.com/ostree/gnome"
 assert_file_has_content list.txt "http://another.com/repo"
 assert_file_has_content list.txt "http://another-noexist.example.com/anotherrepo"
 echo "ok remote list with urls"
+
+cd ${test_tmpdir}
+rm -rf parent-repo
+ostree_repo_init parent-repo
+$OSTREE config set core.parent ${test_tmpdir}/parent-repo
+${CMD_PREFIX} ostree --repo=parent-repo remote add --no-gpg-verify parent-remote http://parent-remote.example.com/parent-remote
+$OSTREE remote list > list.txt
+assert_file_has_content list.txt "origin"
+assert_file_has_content list.txt "another"
+assert_file_has_content list.txt "another-noexist"
+assert_file_has_content list.txt "parent-remote"
+echo "ok remote list with parent repo remotes"
 
 $OSTREE remote delete another
 echo "ok remote delete"


### PR DESCRIPTION
This commit fixes an infinite loop that happens if you try to list the
remotes of a repo that has a parent repo set. It also adds a unit test
to ensure the right behavior, which is that both the child remotes and
parent remotes are listed.