### PR TITLE
lib/commit: Use more direct path for regfile commits

### DIFF
--- a/src/libotutil/ot-checksum-instream.c
+++ b/src/libotutil/ot-checksum-instream.c
@@ -66,6 +66,16 @@ OtChecksumInstream *
 ot_checksum_instream_new (GInputStream    *base,
                           GChecksumType    checksum_type)
 {
+  return ot_checksum_instream_new_with_start (base, checksum_type, NULL, 0);
+}
+
+/* Initialize a checksum stream with starting state from data */
+OtChecksumInstream *
+ot_checksum_instream_new_with_start (GInputStream   *base,
+                                     GChecksumType   checksum_type,
+                                     const guint8   *buf,
+                                     size_t          len)
+{
   OtChecksumInstream *stream;
 
   g_return_val_if_fail (G_IS_INPUT_STREAM (base), NULL);
@@ -77,6 +87,8 @@ ot_checksum_instream_new (GInputStream    *base,
   /* For now */
   g_assert (checksum_type == G_CHECKSUM_SHA256);
   ot_checksum_init (&stream->priv->checksum);
+  if (buf)
+    ot_checksum_update (&stream->priv->checksum, buf, len);
 
   return (OtChecksumInstream*) (stream);
 }

--- a/src/libotutil/ot-checksum-instream.h
+++ b/src/libotutil/ot-checksum-instream.h
@@ -51,6 +51,8 @@ struct _OtChecksumInstreamClass
 GType          ot_checksum_instream_get_type     (void) G_GNUC_CONST;
 
 OtChecksumInstream * ot_checksum_instream_new          (GInputStream   *stream, GChecksumType   checksum);
+OtChecksumInstream * ot_checksum_instream_new_with_start (GInputStream   *stream, GChecksumType   checksum,
+                                                          const guint8 *buf, size_t len);
 
 char * ot_checksum_instream_get_string (OtChecksumInstream *stream);
 


### PR DESCRIPTION
In the non-`CONSUME` path for regfiles (which happens currently for
`bare-user`), we go to a lot of contortions to make an "object stream",
only to immediately parse it again.

Fixing this will also enable the `G_IS_FILE_DESCRIPTOR_BASED()` fast path in
commit, since the input stream will actually reference the file descriptor and
not be an `_OstreeChainInputStream`.

There's a slight concern here in that we're no longer checksumming *literally*
the object stream passed in for the stream case, but I mention in the comment,
the data should be the same, and if it's not somehow we're not adding risk,
since the checksum is still covering the data we actually care about.

Prep for further changes to break up the `write_content_object()` path into
separate paths for archive, as well as regfile vs symlink in non-archive.