### PR TITLE
build-sys: Add --disable-http2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,15 @@ AS_IF([test x$with_curl != xno ], [
 ], [with_soup_default=check])
 AM_CONDITIONAL(USE_CURL, test x$with_curl != xno)
 if test x$with_curl = xyes; then OSTREE_FEATURES="$OSTREE_FEATURES libcurl"; fi
+AC_ARG_ENABLE(http2,
+AS_HELP_STRING([--disable-http2],
+  [Disable use of http2 (default: no)]),,
+  [enable_http2=yes])
+AS_IF([test x$enable_http2 != xno ], [
+  AC_DEFINE([BUILDOPT_HTTP2], 1, [Define if we enable http2])
+], [
+  OSTREE_FEATURES="$OSTREE_FEATURES no-http2"
+])
 
 dnl When bumping the libsoup-2.4 dependency, remember to bump
 dnl SOUP_VERSION_MIN_REQUIRED and SOUP_VERSION_MAX_ALLOWED in
@@ -556,6 +565,7 @@ AC_OUTPUT
 
 echo "
     libostree $VERSION ($release_build_type)
+    features: $OSTREE_FEATURES
     ===============
 
 

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -771,6 +771,7 @@ initiate_next_curl_request (FetcherRequest *req,
    * there are numerous HTTP/2 fixes since the original version in
    * libcurl 7.43.0.
    */
+#ifdef BUILDOPT_HTTP2
   if (!(self->config_flags & OSTREE_FETCHER_FLAGS_DISABLE_HTTP2))
     {
 #if CURL_AT_LEAST_VERSION(7, 51, 0)
@@ -782,6 +783,7 @@ initiate_next_curl_request (FetcherRequest *req,
       curl_easy_setopt (req->easy, CURLOPT_PIPEWAIT, 1L);
 #endif
     }
+#endif
   curl_easy_setopt (req->easy, CURLOPT_WRITEFUNCTION, write_cb);
   if (g_getenv ("OSTREE_DEBUG_HTTP"))
     curl_easy_setopt (req->easy, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
I may punt and use this in Fedora at least for now until we have time to debug
the issues.