### PR TITLE
bin/commit: Support creating "unbound" commits

### DIFF
--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -37,6 +37,7 @@ static char *opt_body_file;
 static gboolean opt_editor;
 static char *opt_parent;
 static gboolean opt_orphan;
+static gboolean opt_no_bindings;
 static char **opt_bind_refs;
 static char *opt_branch;
 static char *opt_statoverride_file;
@@ -90,6 +91,7 @@ static GOptionEntry options[] = {
   { "editor", 'e', 0, G_OPTION_ARG_NONE, &opt_editor, "Use an editor to write the commit message", NULL },
   { "branch", 'b', 0, G_OPTION_ARG_STRING, &opt_branch, "Branch", "BRANCH" },
   { "orphan", 0, 0, G_OPTION_ARG_NONE, &opt_orphan, "Create a commit without writing a ref", NULL },
+  { "no-bindings", 0, 0, G_OPTION_ARG_NONE, &opt_no_bindings, "Do not write any ref bindings", NULL },
   { "bind-ref", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_bind_refs, "Add a ref to ref binding commit metadata", "BRANCH" },
   { "tree", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_trees, "Overlay the given argument as a tree", "dir=PATH or tar=TARFILE or ref=COMMIT" },
   { "add-metadata-string", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_metadata_strings, "Add a key/value pair to metadata", "KEY=VALUE" },
@@ -745,9 +747,12 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
     {
       gboolean update_summary;
       guint64 timestamp;
-      g_autoptr(GVariant) old_metadata = g_steal_pointer (&metadata);
 
-      fill_bindings (repo, old_metadata, &metadata);
+      if (!opt_no_bindings)
+        {
+          g_autoptr(GVariant) old_metadata = g_steal_pointer (&metadata);
+          fill_bindings (repo, old_metadata, &metadata);
+        }
 
       if (!opt_timestamp)
         {

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((77 + ${extra_basic_tests:-0}))"
+echo "1..$((78 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -766,6 +766,16 @@ assert_file_has_content test2-meta "uint64 42"
 $OSTREE show --print-detached-metadata-key=SIGNATURE test2 > test2-meta
 assert_file_has_content test2-meta "HANCOCK"
 echo "ok metadata commit with strings"
+
+cd ${test_tmpdir}
+$OSTREE show --print-metadata-key=ostree.ref-binding test2 > test2-ref-binding
+assert_file_has_content test2-ref-binding 'test2'
+
+$OSTREE commit ${COMMIT_ARGS} -b test2-unbound --no-bindings --tree=dir=${test_tmpdir}/checkout-test2
+if $OSTREE show --print-metadata-key=ostree.ref-binding; then
+    fatal "ref bindings found with --no-bindings?"
+fi
+echo "ok refbinding"
 
 if ! skip_one_without_user_xattrs; then
     cd ${test_tmpdir}


### PR DESCRIPTION
We had this basically forced on in the CLI; down the line I'd really like to
make this an API option to commit or so, but given that we found a use case in
the rpm-ostree test suite for "unbound" commits, let's support creating them
from the cmdline.

See: https://github.com/ostreedev/ostree/pull/1379