### PR TITLE
bin/refs: Disallow aliases to remote refs

### DIFF
--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -223,6 +223,8 @@ static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellab
 
       if (opt_alias)
         {
+          if (remote)
+            return glnx_throw (error, "Cannot create alias to remote ref: %s", remote);
           if (!ostree_repo_set_alias_ref_immediate (repo, remote, ref, refspec_prefix,
                                                     cancellable, error))
             goto out;

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 setup_fake_remote_repo1 "archive"
 
-echo '1..5'
+echo '1..6'
 
 cd ${test_tmpdir}
 mkdir repo
@@ -186,3 +186,10 @@ assert_file_has_content_literal refs.txt 'exampleos/x86_64/stable/server -> exam
 ${CMD_PREFIX} ostree --repo=repo summary -u
 
 echo "ok ref symlink"
+
+# https://github.com/ostreedev/ostree/issues/1342
+if ${CMD_PREFIX} ostree --repo=repo refs -A exampleos/x86_64/27/server --create=exampleos:exampleos/x86_64/stable/server 2>err.txt; then
+    fatal "Created alias ref to remote?"
+fi
+assert_file_has_content_literal err.txt 'Cannot create alias to remote ref'
+echo "ok ref no alias remote"


### PR DESCRIPTION
It can't really work in general; the client and server would
have to agree on the name of the remote.

Closes: https://github.com/ostreedev/ostree/issues/1342