### PR TITLE
build-sys: Use -fno-strict-aliasing by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,8 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' -DLIBEXECDIR='"$(libexecdir)"' \
   -DOSTREE_GITREV='"$(OSTREE_GITREV)"' \
 	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,50)' \
 	-DSOUP_VERSION_MIN_REQUIRED=SOUP_VERSION_2_40 '-DSOUP_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,48)'
-AM_CFLAGS += -std=gnu99 $(WARN_CFLAGS)
+# For strict aliasing, see https://bugzilla.gnome.org/show_bug.cgi?id=791622
+AM_CFLAGS += -std=gnu99 -fno-strict-aliasing $(WARN_CFLAGS)
 AM_DISTCHECK_CONFIGURE_FLAGS += \
 	--enable-gtk-doc \
 	--enable-man \

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -Werror=incompatible-pointer-types \
   -Werror=misleading-indentation \
   -Werror=missing-include-dirs -Werror=aggregate-return \
+  -Wstrict-aliasing=2 \
   -Werror=unused-result \
 ])])
 AC_SUBST(WARN_CFLAGS)


### PR DESCRIPTION
See discussion in https://bugzilla.gnome.org/show_bug.cgi?id=791622

This is what e.g. systemd, the Linux kernel, and lots of other projects do. It's
astonishingly hard to reliably get right; the optimization IMO only really
matters for truly high performance inner loops, but if you're doing
that kind of stuff today you're probably doing it on a GPU anyways.