### PR TITLE
lib/pull: Add more information into journal from pull

### DIFF
--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1260,3 +1260,17 @@ _ostree_fetcher_bytes_transferred (OstreeFetcher       *self)
 
   return ret;
 }
+
+
+OstreeFetcherHTTPVersions
+_ostree_fetcher_get_http_versions (OstreeFetcher *self)
+{
+  return 0;
+}
+
+char **
+_ostree_fetcher_get_journal_info (OstreeFetcher *self)
+{
+  /* I'm doing the libcurl implementation first */
+  return NULL;
+}

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -60,6 +60,12 @@ typedef enum {
   OSTREE_FETCHER_REQUEST_LINKABLE = (1 << 2),
 } OstreeFetcherRequestFlags;
 
+typedef enum {
+  OSTREE_FETCHER_HTTP_1_0 = (1 << 0),
+  OSTREE_FETCHER_HTTP_1_1 = (1 << 1),
+  OSTREE_FETCHER_HTTP_2_0 = (1 << 2),
+} OstreeFetcherHTTPVersions;
+
 void
 _ostree_fetcher_uri_free (OstreeFetcherURI *uri);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OstreeFetcherURI, _ostree_fetcher_uri_free)
@@ -144,6 +150,9 @@ gboolean _ostree_fetcher_request_to_membuf_finish (OstreeFetcher *self,
                                                    GBytes       **out_buf,
                                                    GError       **error);
 
+OstreeFetcherHTTPVersions _ostree_fetcher_get_http_versions (OstreeFetcher *self);
+
+char **_ostree_fetcher_get_journal_info (OstreeFetcher *self);
 
 G_END_DECLS
 


### PR DESCRIPTION
Things like which HTTP version are in use for obvious reasons.
I also want to log the TLS negotation summary.

Extra data that libcurl handliy provides like DNS lookup time
is injected into the journal as key/values separate from the log.