### PR TITLE
build: Fix typo in -Wparentheses warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -Werror=switch \
   -Werror=overflow \
   -Werror=int-conversion \
-  -Werror=parenthesis \
+  -Werror=parentheses \
   -Werror=undef \
   -Werror=incompatible-pointer-types \
   -Werror=misleading-indentation \


### PR DESCRIPTION
GCC supports -Wparentheses, not -Wparenthesis.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-parentheses

Signed-off-by: Philip Withnall <withnall@endlessm.com>