### PR TITLE
lib/pull: allways include ostree-repo-pull-private.h

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -27,12 +27,12 @@
 #include "libglnx.h"
 #include "ostree.h"
 #include "otutil.h"
+#include "ostree-repo-pull-private.h"
 
 #ifdef HAVE_LIBCURL_OR_LIBSOUP
 
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
-#include "ostree-repo-pull-private.h"
 #include "ostree-repo-static-delta-private.h"
 #include "ostree-metalink.h"
 #include "ostree-fetcher-util.h"


### PR DESCRIPTION
Allways include ostree-repo-pull-private.h to get rid of the following
build error when HAVE_LIBCURL_OR_LIBSOUP is not defined:

src/libostree/ostree-repo-pull.c:1493:1: error: no previous prototype
for '_ostree_repo_verify_bindings' [-Werror=missing-prototypes]

Signed-off-by: Marcus Folkesson <marcus.folkesson@gmail.com>