### PR TITLE
build-sys: Link with -ldl for rust build

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -53,7 +53,6 @@ tests:
 
 context: f26-rust
 inherit: true
-required: false
 container:
     image: registry.fedoraproject.org/fedora:26
 env:
@@ -68,7 +67,6 @@ tests:
 
 context: f26-gnutls
 inherit: true
-required: true
 container:
     image: registry.fedoraproject.org/fedora:26
 env:

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -202,6 +202,10 @@ libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(
 libostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions $(addprefix $(wl_versionscript_arg),$(symbol_files))
 libostree_1_la_LIBADD = libotutil.la libglnx.la libbsdiff.la libostree-kernel-args.la $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) \
                         $(OT_DEP_LZMA_LIBS) $(OT_DEP_ZLIB_LIBS) $(OT_DEP_CRYPTO_LIBS)
+# Some change between rust-1.21.0-1.fc27 and rust-1.22.1-1.fc27.x86_64
+if ENABLE_RUST
+libostree_1_la_LIBADD += -ldl
+endif
 libostree_1_la_LIBADD += $(bupsplitpath)
 EXTRA_libostree_1_la_DEPENDENCIES = $(symbol_files)
 


### PR DESCRIPTION
I didn't dive into this too much, it looks like something in rust changed that
broke our build. Probably libstd gained a dependency on `-ldl` or so, and that's
handled by cargo? Anyways linking against it isn't going to hurt.