### PR TITLE
tests: Assert that byte-order is swapped on LE but not BE CPUs

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -130,7 +130,13 @@ experimental_test_scripts = \
 	tests/test-summary-collections.sh \
 	tests/test-pull-collections.sh \
 	$(NULL)
-test_extra_programs = $(NULL)
+test_extra_programs = \
+	tests/get-byte-order \
+	$(NULL)
+
+tests_get_byte_order_SOURCES = tests/get-byte-order.c
+tests_get_byte_order_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS)
+tests_get_byte_order_LDADD = $(GLIB_LIBS)
 
 tests_repo_finder_mount_SOURCES = tests/repo-finder-mount.c
 tests_repo_finder_mount_CFLAGS = $(common_tests_cflags)

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -759,8 +759,20 @@ $OSTREE show --print-metadata-key=FOO test2 > test2-meta
 assert_file_has_content test2-meta "BAR"
 $OSTREE show --print-metadata-key=KITTENS test2 > test2-meta
 assert_file_has_content test2-meta "CUTE"
+
 $OSTREE show --print-metadata-key=SOMENUM test2 > test2-meta
-assert_file_has_content test2-meta "uint64 3026418949592973312"
+case "$("${test_builddir}/get-byte-order")" in
+    (4321)
+        assert_file_has_content test2-meta "uint64 42"
+        ;;
+    (1234)
+        assert_file_has_content test2-meta "uint64 3026418949592973312"
+        ;;
+    (*)
+        fatal "neither little-endian nor big-endian?"
+        ;;
+esac
+
 $OSTREE show -B --print-metadata-key=SOMENUM test2 > test2-meta
 assert_file_has_content test2-meta "uint64 42"
 $OSTREE show --print-detached-metadata-key=SIGNATURE test2 > test2-meta

--- a/tests/get-byte-order.c
+++ b/tests/get-byte-order.c
@@ -1,0 +1,12 @@
+/* Helper for OSTree tests: return host byte order */
+
+#include "config.h"
+
+#include <glib.h>
+
+int
+main (void)
+{
+  g_print ("%d\n", G_BYTE_ORDER);
+  return 0;
+}


### PR DESCRIPTION
Closes: #1392
Signed-off-by: Simon McVittie <smcv@collabora.com>

---

I'm still not sure I understand why the "obvious" code path through `commit --add-metadata` and `show` byteswaps the metadata - I would have expected that ostree would either define the metadata to be stored in a standardized byte order (in which case machines of the other byte order should byteswap during commit and byteswap back during show), or define the metadata to be stored in the host byte order of the machine that is expected to consume the tree, or store a byte-order indicator. But this does seem to work on both x86_64 (LE) and s390x (BE).