### PR TITLE
grub2: Exit gracefully if there's no system ostree repository

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -17,8 +17,12 @@
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330,
 # Boston, MA 02111-1307, USA.
 
-# Gracefully exit if ostree is not installed
+# Gracefully exit if ostree is not installed, or there's
+# no system repository initialized.
 if ! which ostree >/dev/null 2>/dev/null; then
+    exit 0
+fi
+if ! test -d /ostree/repo; then
     exit 0
 fi
 


### PR DESCRIPTION
Apparently there testing systems that literally install *all*
packages.  Having `ostree-grub2` currently causes grub2 to fail
on a non-ostree managed system.  Let's just gracefully exit
if there's no system repository.

https://bugzilla.redhat.com/show_bug.cgi?id=1532668