### PR TITLE
Support for booting without initramfs (rebased)

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -116,6 +116,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-pull-mirrorlist.sh \
 	tests/test-summary-update.sh \
 	tests/test-summary-view.sh \
+	tests/test-no-initramfs.sh \
 	$(NULL)
 
 experimental_test_scripts = \

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -28,7 +28,7 @@ entries_path=$(dirname $new_grub2_cfg)/entries
 
 read_config()
 {
-    config_file=${entries_path}/${1}
+    config_file=${1}
     title=""
     initrd=""
     options=""
@@ -67,11 +67,13 @@ populate_menu()
     else
         boot_prefix="${OSTREE_BOOT_PARTITION}"
     fi
-    for config in $(ls ${entries_path}); do
+    for config in $(ls $entries_path/*.conf); do
         read_config ${config}
         menu="${menu}menuentry '${title}' {\n"
         menu="${menu}\t linux ${boot_prefix}${linux} ${options}\n"
-        menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+        if [ -n "${initrd}" ] ; then
+            menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+        fi
         menu="${menu}}\n\n"
     done
     # The printf command seems to be more reliable across shells for special character (\n, \t) evaluation

--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# To use a custom script for generating grub.cfg, set the --with-grub2-mkconfig=no
-# configure switch when configuring and building OSTree.
+# The builtin grub.cfg generator.
 #
 # This script is called by ostree/src/libostree/ostree-bootloader-grub2.c whenever
 # boot loader configuration file needs to be updated. It can be used as a template

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -102,10 +102,16 @@ main(int argc, char *argv[])
   struct stat stbuf;
   int we_mounted_proc = 0;
 
-  if (argc < 2)
-    root_arg = "/";
+  if (getpid() == 1)
+    {
+      root_arg = "/";
+    }
   else
-    root_arg = argv[1];
+    {
+      if (argc < 2)
+        err (EXIT_FAILURE, "usage: ostree-prepare-root SYSROOT");
+      root_arg = argv[1];
+    }
 
   if (stat ("/proc/cmdline", &stbuf) < 0)
     {

--- a/tests/test-no-initramfs.sh
+++ b/tests/test-no-initramfs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+. $(dirname $0)/libtest.sh
+
+echo "1..3"
+
+setup_os_repository "archive-z2" "uboot"
+
+cd ${test_tmpdir}
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=rootfs --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+
+echo "ok deployment with initramfs"
+
+cd ${test_tmpdir}/osdata/boot
+rm -f initramfs* vmlinuz*
+echo "the kernel only" > vmlinuz-3.6.0
+bootcsum=$(cat vmlinuz-3.6.0 | sha256sum | cut -f 1 -d ' ')
+mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
+cd -
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+
+echo "ok switching to bootdir with no initramfs"
+
+cd ${test_tmpdir}/osdata/boot
+rm -f initramfs* vmlinuz*
+echo "the kernel" > vmlinuz-3.6.0
+echo "initramfs to assist the kernel" > initramfs-3.6.0
+bootcsum=$(cat vmlinuz-3.6.0 initramfs-3.6.0 | sha256sum | cut -f 1 -d ' ')
+mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
+mv initramfs-3.6.0 initramfs-3.6.0-${bootcsum}
+cd -
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+
+echo "ok switching from no initramfs to initramfs enabled sysroot"
+

--- a/tests/test-no-initramfs.sh
+++ b/tests/test-no-initramfs.sh
@@ -2,7 +2,7 @@
 
 . $(dirname $0)/libtest.sh
 
-echo "1..3"
+echo "1..7"
 
 setup_os_repository "archive-z2" "uboot"
 
@@ -17,36 +17,62 @@ assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'in
 
 echo "ok deployment with initramfs"
 
-cd ${test_tmpdir}/osdata/boot
-rm -f initramfs* vmlinuz*
-echo "the kernel only" > vmlinuz-3.6.0
-bootcsum=$(cat vmlinuz-3.6.0 | sha256sum | cut -f 1 -d ' ')
-mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
-cd -
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
-${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
-${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+pull_test_tree() {
+    kernel_contents=$1
+    initramfs_contents=$2
 
-echo "ok switching to bootdir with no initramfs"
+    printf "TEST SETUP:\n    kernel: %s\n    initramfs: %s\n    layout: %s\n" \
+        "$kernel_contents" "$initramfs_contents" "$layout"
 
-cd ${test_tmpdir}/osdata/boot
-rm -f initramfs* vmlinuz*
-echo "the kernel" > vmlinuz-3.6.0
-echo "initramfs to assist the kernel" > initramfs-3.6.0
-bootcsum=$(cat vmlinuz-3.6.0 initramfs-3.6.0 | sha256sum | cut -f 1 -d ' ')
-mv vmlinuz-3.6.0 vmlinuz-3.6.0-${bootcsum}
-mv initramfs-3.6.0 initramfs-3.6.0-${bootcsum}
-cd -
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
-${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
-${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+    rm -rf ${test_tmpdir}/osdata/usr/lib/modules/3.6.0/{initramfs.img,vmlinuz} \
+           ${test_tmpdir}/osdata/usr/lib/ostree-boot \
+           ${test_tmpdir}/osdata/boot
+    if [ "$layout" = "/usr/lib/modules" ]; then
+        # Fedora compatible layout
+        cd ${test_tmpdir}/osdata/usr/lib/modules/3.6.0
+        echo -n "$kernel_contents" > vmlinuz
+        [ -n "$initramfs_contents" ] && echo -n "$initramfs_contents" > initramfs.img
+    elif [ "$layout" = "/usr/lib/ostree-boot" ] || [ "$layout" = "/boot" ]; then
+        # "Legacy" layout
+        mkdir -p "${test_tmpdir}/osdata/$layout"
+        cd "${test_tmpdir}/osdata/$layout"
+        bootcsum=$(echo -n "$kernel_contents$initramfs_contents" \
+                   | sha256sum | cut -f 1 -d ' ')
+        echo -n "$kernel_contents" > vmlinuz-${bootcsum}
+        [ -n "$initramfs_contents" ] && echo -n "$initramfs_contents" > initramfs-${bootcsum}
+    else
+        exit 1
+    fi
+    cd -
+    ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --tree=dir=osdata/ -b testos/buildmaster/x86_64-runtime
+    ${CMD_PREFIX} ostree pull testos:testos/buildmaster/x86_64-runtime
+}
 
-echo "ok switching from no initramfs to initramfs enabled sysroot"
+get_key_from_bootloader_conf() {
+    conffile=$1
+    key=$2
 
+    assert_file_has_content "$conffile" "^$key"
+    awk "/^$key/ { print \$2 }" "$conffile"
+}
+
+for layout in /usr/lib/modules /usr/lib/ostree-boot /boot;
+do
+    pull_test_tree "the kernel only"
+    ${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmaster/x86_64-runtime
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+
+    echo "ok switching to bootdir with no initramfs layout=$layout"
+
+    pull_test_tree "the kernel" "initramfs to assist the kernel"
+    ${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmaster/x86_64-runtime
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+    assert_file_has_content sysroot/boot/$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-testos-0.conf "initrd") "initramfs to assist the kernel"
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+
+    echo "ok switching from no initramfs to initramfs enabled sysroot layout=$layout"
+done


### PR DESCRIPTION
This is #442 rebased and with some additional tests.  We've been using this patch successfully for over a year in combination with #215 and some others.