### PR TITLE
bin/commit: add --keep-metadata option

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -783,6 +783,7 @@ _ostree_commit() {
     local options_with_args="
         --add-detached-metadata-string
         --add-metadata-string
+        --keep-metadata
         --bind-ref
         --body -m
         --body-file -F

--- a/bash/ostree
+++ b/bash/ostree
@@ -783,6 +783,7 @@ _ostree_commit() {
     local options_with_args="
         --add-detached-metadata-string
         --add-metadata-string
+        --add-metadata
         --keep-metadata
         --bind-ref
         --body -m

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((78 + ${extra_basic_tests:-0}))"
+echo "1..$((79 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -778,6 +778,18 @@ assert_file_has_content test2-meta "uint64 42"
 $OSTREE show --print-detached-metadata-key=SIGNATURE test2 > test2-meta
 assert_file_has_content test2-meta "HANCOCK"
 echo "ok metadata commit with strings"
+
+$OSTREE commit ${COMMIT_ARGS} -b test2 --tree=ref=test2 \
+   --add-detached-metadata-string=SIGNATURE=HANCOCK \
+  --keep-metadata=KITTENS --keep-metadata=SOMENUM
+if $OSTREE show --print-metadata-key=FOO test2; then
+  assert_not_reached "FOO was kept without explicit --keep-metadata?"
+fi
+$OSTREE show --print-metadata-key=KITTENS test2 > test2-meta
+assert_file_has_content test2-meta "CUTE"
+$OSTREE show -B --print-metadata-key=SOMENUM test2 > test2-meta
+assert_file_has_content test2-meta "uint64 42"
+echo "ok keep metadata from parent"
 
 cd ${test_tmpdir}
 $OSTREE show --print-metadata-key=ostree.ref-binding test2 > test2-ref-binding


### PR DESCRIPTION
Clients of libostree such as rpm-ostree make extensive use of the
`ostree commit -b foo --tree=ref=foo` pattern in their tests, e.g. to
simulate an update.

What I'm trying to solve here is that it's often the case that we want
to keep metadata from the previous commit without having to be too
verbose (i.e. reading from the parent, then passing it as an argument).

The new `--keep-metadata` switch makes this really easy. I intend to use
this in the rpm-ostree testsuite to make sure we always carry over the
`source-title` metadata as well as during set up for tests that require
`rpmostree.rpmdb.pkglist` metadata.

I initially implemented this in a small wrapper script that uses the API
directly, though we make use of so many other `ostree commit` functions
that it'd require re-implementing a lot of it.