### PR TITLE
lib/fetcher: Add version to USER_AGENT string

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -714,7 +714,7 @@ initiate_next_curl_request (FetcherRequest *req,
     curl_easy_setopt (req->easy, CURLOPT_URL, uri);
   }
 
-  curl_easy_setopt (req->easy, CURLOPT_USERAGENT, "ostree ");
+  curl_easy_setopt (req->easy, CURLOPT_USERAGENT, OSTREE_FETCHER_USERAGENT_STRING);
   if (self->extra_headers)
     curl_easy_setopt (req->easy, CURLOPT_HTTPHEADER, self->extra_headers);
 

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -479,7 +479,7 @@ ostree_fetcher_session_thread (gpointer data)
   g_main_context_push_thread_default (mainctx);
 
   /* We retain ownership of the SoupSession reference. */
-  closure->session = soup_session_async_new_with_options (SOUP_SESSION_USER_AGENT, "ostree ",
+  closure->session = soup_session_async_new_with_options (SOUP_SESSION_USER_AGENT, OSTREE_FETCHER_USERAGENT_STRING,
                                                           SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
                                                           SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
                                                           SOUP_SESSION_ADD_FEATURE_BY_TYPE, SOUP_TYPE_REQUESTER,

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -25,6 +25,12 @@
 
 G_BEGIN_DECLS
 
+/* We used to only send "ostree/" but now include the version
+ * https://github.com/ostreedev/ostree/issues/1405
+ * This came up in allowing Fedora infrastructure to work around a libcurl bug with HTTP2.
+ */
+#define OSTREE_FETCHER_USERAGENT_STRING (PACKAGE_NAME "/" PACKAGE_VERSION)
+
 static inline gboolean
 _ostree_fetcher_tmpf_from_flags (OstreeFetcherRequestFlags flags,
                                  int                       dfd,


### PR DESCRIPTION
This came up in allowing Fedora infrastructure to work around a libcurl bug with
HTTP2: https://pagure.io/atomic-wg/issue/405

Closes: https://github.com/ostreedev/ostree/issues/1405