### PR TITLE
Add a --finders option to find-remotes

### DIFF
--- a/tests/test-find-remotes.sh
+++ b/tests/test-find-remotes.sh
@@ -86,7 +86,7 @@ assert_file_has_content local-mirror/refs/mirrors/org.example.OsCollection/os/am
 
 for repo in local local-mirror; do
     # Try finding an update for an existing branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.AppsCollection app1 > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.AppsCollection app1 > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/apps-collection$"
     assert_file_has_content find "^ - Keyring: apps-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.AppsCollection, app1) = $(cat app1-checksum)$"
@@ -94,7 +94,7 @@ for repo in local local-mirror; do
     assert_not_file_has_content find "^No results.$"
 
     # Find several updates for several existing branches.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.AppsCollection app1 org.example.OsCollection os/amd64/master > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.AppsCollection app1 org.example.OsCollection os/amd64/master > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/apps-collection$"
     assert_file_has_content find "^ - Keyring: apps-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.AppsCollection, app1) = $(cat app1-checksum)$"
@@ -105,7 +105,7 @@ for repo in local local-mirror; do
     assert_not_file_has_content find "^No results.$"
 
     # Find some updates and a new branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.AppsCollection app1 org.example.AppsCollection app2 org.example.OsCollection os/amd64/master > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.AppsCollection app1 org.example.AppsCollection app2 org.example.OsCollection os/amd64/master > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/apps-collection$"
     assert_file_has_content find "^ - Keyring: apps-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.AppsCollection, app1) = $(cat app1-checksum)$"
@@ -117,7 +117,7 @@ for repo in local local-mirror; do
     assert_not_file_has_content find "^No results.$"
 
     # Find an update and a non-existent branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.AppsCollection app1 org.example.AppsCollection not-an-app > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.AppsCollection app1 org.example.AppsCollection not-an-app > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/apps-collection$"
     assert_file_has_content find "^ - Keyring: apps-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.AppsCollection, not-an-app) = (not found)$"
@@ -128,20 +128,20 @@ for repo in local local-mirror; do
     assert_not_file_has_content find "^No results.$"
 
     # Do all the above, but pull this time.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.AppsCollection app1 > pull || true
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.AppsCollection app1 > pull || true
     assert_file_has_content pull "^1/1 refs were found.$"
     assert_file_has_content pull "^Pulled 1/1 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
     assert_ref $repo app1 $(cat app1-checksum)
 
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.AppsCollection app1 org.example.OsCollection os/amd64/master > pull
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.AppsCollection app1 org.example.OsCollection os/amd64/master > pull
     assert_file_has_content pull "^2/2 refs were found.$"
     assert_file_has_content pull "^Pulled 2/2 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
     assert_ref $repo app1 $(cat app1-checksum)
     assert_ref $repo os/amd64/master $(cat os-checksum)
 
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.AppsCollection app1 org.example.AppsCollection app2 org.example.OsCollection os/amd64/master > pull
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.AppsCollection app1 org.example.AppsCollection app2 org.example.OsCollection os/amd64/master > pull
     assert_file_has_content pull "^3/3 refs were found.$"
     assert_file_has_content pull "^Pulled 3/3 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
@@ -149,7 +149,7 @@ for repo in local local-mirror; do
     assert_ref $repo app2 $(cat app2-checksum)
     assert_ref $repo os/amd64/master $(cat os-checksum)
 
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.AppsCollection app1 org.example.AppsCollection not-an-app > pull
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.AppsCollection app1 org.example.AppsCollection not-an-app > pull
     assert_file_has_content pull "^1/2 refs were found.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
     assert_ref $repo app1 $(cat app1-checksum)
@@ -164,7 +164,7 @@ ${CMD_PREFIX} ostree --repo=os-collection summary --update --gpg-homedir=${TEST_
 
 for repo in local-mirror; do
     # Try finding an update for that branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.OsCollection os/amd64/master > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.OsCollection os/amd64/master > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/os-collection$"
     assert_file_has_content find "^ - Keyring: os-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.OsCollection, os/amd64/master) = $(cat os-checksum-2)$"
@@ -172,7 +172,7 @@ for repo in local-mirror; do
     assert_not_file_has_content find "^No results.$"
 
     # Pull it.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.OsCollection os/amd64/master > pull || true
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.OsCollection os/amd64/master > pull || true
     assert_file_has_content pull "^1/1 refs were found.$"
     assert_file_has_content pull "^Pulled 1/1 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
@@ -191,7 +191,7 @@ ${CMD_PREFIX} ostree --repo=local remote add os-remote-local-mirror file://$(pwd
 
 for repo in local; do
     # Try finding an update for that branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.OsCollection os/amd64/master > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.OsCollection os/amd64/master > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/os-collection$"
     assert_file_has_content find "^ - Keyring: os-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.OsCollection, os/amd64/master) = $(cat os-checksum-2)$"
@@ -202,7 +202,7 @@ for repo in local; do
     assert_not_file_has_content find "^No results.$"
 
     # Pull it.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.OsCollection os/amd64/master > pull || true
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.OsCollection os/amd64/master > pull || true
     assert_file_has_content pull "^1/1 refs were found.$"
     assert_file_has_content pull "^Pulled 1/1 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"
@@ -218,7 +218,7 @@ ${CMD_PREFIX} ostree --repo=os-collection summary --update --gpg-homedir=${TEST_
 
 for repo in local; do
     # Try finding an update for that branch.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes org.example.OsCollection os/amd64/master > find
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config org.example.OsCollection os/amd64/master > find
     assert_file_has_content find "^Result [0-9]\+: file://$(pwd)/os-collection$"
     assert_file_has_content find "^ - Keyring: os-remote.trustedkeys.gpg$"
     assert_file_has_content find "^    - (org.example.OsCollection, os/amd64/master) = $(cat os-checksum-3)$"
@@ -226,7 +226,7 @@ for repo in local; do
     assert_not_file_has_content find "^No results.$"
 
     # Pull it.
-    ${CMD_PREFIX} ostree --repo=$repo find-remotes --pull org.example.OsCollection os/amd64/master > pull || true
+    ${CMD_PREFIX} ostree --repo=$repo find-remotes --finders=config --pull org.example.OsCollection os/amd64/master > pull || true
     assert_file_has_content pull "^1/1 refs were found.$"
     assert_file_has_content pull "^Pulled 1/1 refs successfully.$"
     assert_not_file_has_content pull "Failed to pull some refs from the remotes"

--- a/tests/test-repo-finder-mount-integration.sh
+++ b/tests/test-repo-finder-mount-integration.sh
@@ -109,12 +109,12 @@ for fs_type in ext4 vfat; do
     ostree_repo_init peer-repo_$fs_type
     ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type remote add remote1 file://just-here-for-the-keyring --collection-id org.example.Collection1 --gpg-import="${test_tmpdir}/gpghome/key1.asc"
 
-    ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type find-remotes org.example.Collection1 test-1 > find-results
+    ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type find-remotes --finders=mount org.example.Collection1 test-1 > find-results
     assert_not_file_has_content find-results "^No results.$"
     assert_file_has_content find-results "^Result 0: file://${usb_mount}"
     assert_file_has_content find-results "(org.example.Collection1, test-1) = $(cat ref1-checksum)$"
 
-    ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type find-remotes --pull org.example.Collection1 test-1 > pull-results
+    ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type find-remotes --finders=mount --pull org.example.Collection1 test-1 > pull-results
     assert_file_has_content pull-results "^Pulled 1/1 refs successfully.$"
 
     ${CMD_PREFIX} ostree --repo=peer-repo_$fs_type refs --collections > refs


### PR DESCRIPTION
Endless' OBS build of ostree stopped working when we started compiling with Avahi; hence this PR.