### PR TITLE
tests/libtest-core: support multiple literal checks

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -112,9 +112,12 @@ assert_file_has_content () {
 }
 
 assert_file_has_content_literal () {
-    if ! grep -q -F -e "$2" "$1"; then
-        _fatal_print_file "$1" "File '$1' doesn't match fixed string list '$2'"
-    fi
+    fpath=$1; shift
+    for s in "$@"; do
+        if ! grep -q -F -e "$s" "$fpath"; then
+            _fatal_print_file "$fpath" "File '$fpath' doesn't match fixed string list '$s'"
+        fi
+    done
 }
 
 assert_file_has_mode () {


### PR DESCRIPTION
`grep` supports checking multiple fixed strings separated by newlines,
but it's mostly just easier to pass them as separate arguments, so let's
support that. This is now at parity with the similar
`assert_file_has_content`.