### PR TITLE
Add support for devicetree files alongside the kernel and initramfs

### DIFF
--- a/docs/manual/atomic-upgrades.md
+++ b/docs/manual/atomic-upgrades.md
@@ -95,7 +95,7 @@ collected at any point.
 ## The /ostree/boot directory
 
 However, we want to optimize for the case where the set of
-kernel/initramfs pairs is the same between both the old and new
+kernel/initramfs/devicetree sets is the same between both the old and new
 deployment lists.  This happens when doing an upgrade that does not
 include the kernel; think of a simple translation update.  OSTree
 optimizes for this case because on some systems `/boot` may be on a

--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -53,10 +53,11 @@ paths, which are `vmlinuz(-.*)?-$checksum` in either `/boot` or `/usr/lib/ostree
 The checksum should be a SHA256 hash of the kernel contents; it must be
 pre-computed before storing the kernel in the repository.  Optionally,
 the directory can also contain an initramfs, stored as
-`initramfs(-.*)?-$checksum`.  If this exists, the checksum must include
-both the kernel and initramfs contents.  OSTree will use this to
-determine which kernels are shared.  The rationale for this is to avoid
-computing checksums on the client by default.
+`initramfs(-.*)?-$checksum` and/or a device tree, stored as
+`devicetree(-.*)?-$checksum`.  If an initramfs or devicetree exist,
+the checksum must include all of the kernel, initramfs and devicetree contents.
+OSTree will use this to determine which kernels are shared.  The rationale for
+this is to avoid computing checksums on the client by default.
 
 The deployment should not have a traditional UNIX `/etc`; instead, it
 should include `/usr/etc`.  This is the "default configuration".  When

--- a/src/libostree/ostree-bootloader-syslinux.c
+++ b/src/libostree/ostree-bootloader-syslinux.c
@@ -95,6 +95,10 @@ append_config_from_loader_entries (OstreeBootloaderSyslinux  *self,
       if (val)
         g_ptr_array_add (new_lines, g_strdup_printf ("\tINITRD %s", val));
 
+      val = ostree_bootconfig_parser_get (config, "devicetree");
+      if (val)
+        g_ptr_array_add (new_lines, g_strdup_printf ("\tDEVICETREE %s", val));
+
       val = ostree_bootconfig_parser_get (config, "options");
       if (val)
         g_ptr_array_add (new_lines, g_strdup_printf ("\tAPPEND %s", val));


### PR DESCRIPTION
Much like the (optional) initramfs at `/usr/lib/ostree-boot/initramfs-<SHA256>` or `/usr/lib/modules/$kver/initramfs` you can now optionally include a flattened devicetree (.dtb) file alongside the kernel at `/usr/lib/ostree-boot/devicetree-<SHA256>` or `/usr/lib/modules/$kver/devicetree`.

This is useful for embedded ARM systems which need the devicetree file
loaded by the bootloader for the kernel to discover and initialise
hardware.  See https://en.wikipedia.org/wiki/Device_tree for more
information.

This patch was mostly produced by copy-pasting code for initramfs handling
and renaming `s/initramfs/devicetree/g`.  It's not beautiful, but it is
fairly straightforward.

It may be useful to extend device-tree support in a number ways in the
future.  Device trees dependant on many details of the hardware they
support.  This makes them unlike kernels, which may support many different
hardware variants as long as the instruction-set matches.  This means that
a ostree tree created with a device-tree in this manner will only boot on
a single model of hardware.  This is sufficient for my purposes, but may
not be for others'.

I've tested this on my NVidia Tegra TK1 device which has u-boot running
in syslinux-compatible mode.

Note: if #1404 is merged before this this PR will have to be updated - and vice-versa.