### PR TITLE
Release 2018.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,11 @@ dnl If doing a final release, remember to follow the instructions to
 dnl update libostree-released.sym from libostree-devel.sym, and update the checksum
 dnl in test-symbols.sh, and also set is_release_build=yes below.  Then make
 dnl another post-release commit to bump the version, and set is_release_build=no.
-m4_define([year_version], [2017])
-m4_define([release_version], [16])
+m4_define([year_version], [2018])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,8 +18,8 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2017.16 {
-} LIBOSTREE_2017.15;
+LIBOSTREE_2018.2 {
+} LIBOSTREE_2018.1;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -451,6 +451,9 @@ LIBOSTREE_2017.15 {
   ostree_break_hardlink;
 } LIBOSTREE_2017.14;
 
+LIBOSTREE_2018.1 {
+} LIBOSTREE_2017.15;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -52,7 +52,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-3dbe0aa610c7229050f4a651fd18893742f8a24c34f3e25bf807ff98fbfc7f72  ${released_syms}
+e880ade1f3b4cc7587dc1a7a30059ab1d5287484ee70843f1bb4f258fbec677c  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
In particular I'd like to get the `--copyup` changes out for an rpm-ostree
release that will use them. But there are other good changes here, and let's
keep up a regular release train 🚄 in general.