### PR TITLE
WIP: deploy: Attempt accelerated deploy by updating old deploy

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -58,6 +58,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-basic-user.sh \
 	tests/test-basic-user-only.sh \
 	tests/test-basic-root.sh \
+	tests/test-checkout-update.sh \
 	tests/test-pull-subpath.sh \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \

--- a/bash/ostree
+++ b/bash/ostree
@@ -704,6 +704,7 @@ _ostree_checkout() {
     local options_with_args="
         --from-file
         --fsync
+        --replace
         --repo
         --subpath
     "
@@ -713,6 +714,10 @@ _ostree_checkout() {
     case "$prev" in
         --from-file)
             __ostree_compreply_all_files
+            return 0
+            ;;
+        --replace)
+            __ostree_compreply_commits
             return 0
             ;;
         --repo|--subpath)

--- a/man/ostree-checkout.xml
+++ b/man/ostree-checkout.xml
@@ -57,7 +57,13 @@ Boston, MA 02111-1307, USA.
         <title>Description</title>
 
         <para>
-            Checks out the given commit into the filesystem under directory DESTINATION.  If DESTINATION is not specified, the COMMIT will become the destination checkout target.  If COMMIT destination already exists, command will error unless <option>--union</option> option is selected.
+            Checks out the given commit into the filesystem under directory
+            DESTINATION.  If DESTINATION is not specified, the COMMIT will
+            become the destination checkout target.  If COMMIT destination
+            already exists, command will error unless one of the
+            <option>--union</option>, <option>--union-add</option>,
+            <option>--union-identical</option> or <option>--replace</option>
+            options are selected.
         </para>
     </refsect1>
 
@@ -104,6 +110,15 @@ Boston, MA 02111-1307, USA.
                 if a file would be replaced with a different file. Add new files
                 and directories, ignore identical files, and keep existing
                 directories. Requires <literal>-H</literal>.</para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--replace</option>="COMMIT"</term>
+
+                <listitem><para>
+                    Assume that the <literal>DESTINATION</literal> already has
+                    this commit checked out in it and modify it in-place.
+                </para></listitem>
             </varlistentry>
 
             <varlistentry>

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -838,8 +838,6 @@ file_iter_clear(FileDirectoryIter *self) {
   CLEAR (self);
 }
 
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(FileDirectoryIter, file_iter_clear);
-
 static FileDentry*
 file_iter_next(FileDirectoryIter* self)
 {
@@ -933,6 +931,84 @@ dir_diff_iter_next(DirDiffIter* self)
     }
   else
     self->item.after = NULL;
+  return &self->item;
+}
+
+/*
+ * Diff a list files:
+ */
+
+typedef struct {
+  const char *name;
+  char *before_checksum;
+  char *after_checksum;
+} FileDiffItem;
+
+typedef struct {
+  FileDirectoryIter before_iter;
+  FileDirectoryIter after_iter;
+  int last_cmp;
+  FileDiffItem item;
+} FileDiffIter;
+
+static FileDiffIter
+file_diff_iter_init(GVariant *before_dirtree, GVariant *after_dirtree) {
+  FileDiffIter self;
+  CLEAR(&self);
+  self.before_iter = file_iter_init(before_dirtree);
+  self.after_iter = file_iter_init(after_dirtree);
+  return self;
+}
+
+static void
+file_diff_iter_clear(FileDiffIter *self) {
+  file_iter_clear (&self->before_iter);
+  file_iter_clear (&self->after_iter);
+  CLEAR(&self->item);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(FileDiffIter, file_diff_iter_clear);
+
+static int
+file_entry_cmp_by_name(FileDentry* before, FileDentry* after)
+{
+  /* NULL comes after all items as it's the list terminator */
+  if ((!before || !before->name) && (!after || !after->name))
+    return -2;
+  else if (!after || !after->name)
+    return -1;
+  else if (!before || !before->name)
+    return 1;
+  else
+    return MAX(-1, MIN(1, strcmp (before->name, after->name)));
+}
+
+static FileDiffItem*
+file_diff_iter_next(FileDiffIter* self)
+{
+  if (self->last_cmp == 0 || self->last_cmp == -1)
+    file_iter_next(&self->before_iter);
+  if (self->last_cmp == 0 || self->last_cmp == 1)
+    file_iter_next(&self->after_iter);
+
+  self->last_cmp = file_entry_cmp_by_name(&self->before_iter.entry,
+                                          &self->after_iter.entry);
+  if (self->last_cmp == -2)
+    return NULL;
+  if (self->last_cmp == 0 || self->last_cmp == -1)
+    {
+      self->item.name = self->before_iter.entry.name;
+      self->item.before_checksum = self->before_iter.entry.checksum;
+    }
+  else
+    self->item.before_checksum = NULL;
+  if (self->last_cmp == 0 || self->last_cmp == 1)
+    {
+      self->item.name = self->after_iter.entry.name;
+      self->item.after_checksum = self->after_iter.entry.checksum;
+    }
+  else
+    self->item.after_checksum = NULL;
   return &self->item;
 }
 
@@ -1071,24 +1147,40 @@ checkout_tree_at_recurse (OstreeRepo                        *self,
           return FALSE;
   }
 
+  {
+    g_auto(DirDiffIter) iter = dir_diff_iter_init(orig_dirtree, dirtree);
+    DirDiffItem* diff;
+    while ((diff = dir_diff_iter_next(&iter)))
+      if (!diff->after)
+        if (!glnx_shutil_rm_rf_at (destination_dfd, diff->name, cancellable, error))
+          return FALSE;
+  }
+
   /* Process files in this subdir */
   {
-    g_auto(FileDirectoryIter) iter = file_iter_init(dirtree);
-    FileDentry* file;
-    while ((file = file_iter_next(&iter)))
+    g_auto(FileDiffIter) iter = file_diff_iter_init(orig_dirtree, dirtree);
+    FileDiffItem* diff;
+    while ((diff = file_diff_iter_next(&iter)))
       {
-        const size_t origlen = selabel_path_buf ? selabel_path_buf->len : 0;
-        if (selabel_path_buf)
-          g_string_append (selabel_path_buf, file->name);
+        if (diff->after_checksum && diff->before_checksum &&
+            strcmp(diff->after_checksum, diff->before_checksum) == 0)
+          /* File is unchanged */
+          continue;
+        else if (diff->after_checksum)
+          {
+            const size_t origlen = selabel_path_buf ? selabel_path_buf->len : 0;
+            if (selabel_path_buf)
+              g_string_append (selabel_path_buf, diff->name);
 
-        if (!checkout_one_file_at (self, options, state,
-                                   file->checksum,
-                                   destination_dfd, file->name,
-                                   cancellable, error))
-          return FALSE;
+            if (!checkout_one_file_at (self, options, state,
+                                       diff->after_checksum,
+                                       destination_dfd, diff->name,
+                                       cancellable, error))
+              return FALSE;
 
-        if (selabel_path_buf)
-          g_string_truncate (selabel_path_buf, origlen);
+            if (selabel_path_buf)
+              g_string_truncate (selabel_path_buf, origlen);
+          }
       }
   }
 

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -227,6 +227,7 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
             case OSTREE_REPO_CHECKOUT_OVERWRITE_NONE:
               return glnx_throw_errno_prefix (error, "symlinkat");
             case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES:
+            case OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE:
               {
                 /* For unioning, we further bifurcate a bit; for the "process whiteouts"
                  * mode which is really "Docker/OCI", we need to match their semantics
@@ -324,6 +325,7 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
         case OSTREE_REPO_CHECKOUT_OVERWRITE_NONE:
           /* Handled above */
           break;
+        case OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE:
         case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES:
           /* Special case OCI/Docker - see similar code in checkout_file_hardlink()
            * and above for symlinks.
@@ -441,6 +443,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
           break;
         case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES:
         case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL:
+        case OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE:
           {
             /* In both union-files and union-identical, see if the src/target are
              * already hardlinked.  If they are, we're done.
@@ -487,7 +490,8 @@ checkout_file_hardlink (OstreeRepo                          *self,
               }
             if (is_identical)
               ret_result = HARDLINK_RESULT_SKIP_EXISTED;
-            else if (options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES)
+            else if (options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES ||
+                     options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE)
               {
                 char *tmpname = strdupa ("checkout-union-XXXXXX");
                 /* Make a link with a temp name */
@@ -1022,7 +1026,7 @@ file_diff_iter_next(FileDiffIter* self)
  * @destination_name: Use this name for tree
  * @dirtree_checksum: dirtree checksum of the tree being checked out
  * @dirmeta_checksum: dirmeta checksum of the tree being checked out
- * @orig_dirtree_checksum:
+ * @orig_dirtree_checksum: Used when overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -1106,6 +1110,11 @@ checkout_tree_at_recurse (OstreeRepo                        *self,
           case OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES:
           case OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL:
             did_exist = TRUE;
+            break;
+          /* When replacing we pretend that we created the directory to ensure
+             the xattrs get updated. */
+          case OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE:
+            did_exist = FALSE;
             break;
           }
       }
@@ -1329,9 +1338,22 @@ checkout_tree_at (OstreeRepo                        *self,
   g_assert_cmpint (g_file_info_get_file_type (source_info), ==, G_FILE_TYPE_DIRECTORY);
   const char *dirtree_checksum = ostree_repo_file_tree_get_contents_checksum (source);
   const char *dirmeta_checksum = ostree_repo_file_tree_get_metadata_checksum (source);
+  const char *overwrite_update_dirtree_checksum = NULL;
+  char csum_buf[OSTREE_SHA256_STRING_LEN+1];
+  if (options->overwrite_update_from_checksum) {
+    g_autoptr(GVariant) commit = NULL;
+    if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT,
+                                   options->overwrite_update_from_checksum,
+                                   &commit, error))
+      return FALSE;
+    g_autoptr(GVariant) dirtree_v = g_variant_get_child_value (commit, 6);
+    _ostree_checksum_inplace_from_bytes_v (dirtree_v, csum_buf);
+    overwrite_update_dirtree_checksum = csum_buf;
+  }
   return checkout_tree_at_recurse (self, options, &state, destination_parent_fd,
                                    destination_name,
-                                   dirtree_checksum, dirmeta_checksum, NULL,
+                                   dirtree_checksum, dirmeta_checksum,
+                                   overwrite_update_dirtree_checksum,
                                    cancellable, error);
 }
 
@@ -1480,6 +1502,8 @@ ostree_repo_checkout_at (OstreeRepo                        *self,
   /* union identical requires hardlink mode */
   g_return_val_if_fail (!(options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL &&
                           !options->no_copy_fallback), FALSE);
+  g_return_val_if_fail ((options->overwrite_mode == OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE) ==
+                        !!options->overwrite_update_from_checksum, FALSE);
 
   g_autoptr(GFile) commit_root = (GFile*) _ostree_repo_file_new_for_commit (self, commit, error);
   if (!commit_root)

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -860,15 +860,15 @@ file_iter_next(FileDirectoryIter* self)
 }
 
 /*
- * checkout_tree_at:
+ * checkout_tree_at_recurse:
  * @self: Repo
- * @mode: Options controlling all files
+ * @options: Options controlling all files
  * @state: Any state we're carrying through
  * @overwrite_mode: Whether or not to overwrite files
  * @destination_parent_fd: Place tree here
  * @destination_name: Use this name for tree
- * @source: Source tree
- * @source_info: Source info
+ * @dirtree_checksum: dirtree checksum of the tree being checked out
+ * @dirmeta_checksum: dirmeta checksum of the tree being checked out
  * @cancellable: Cancellable
  * @error: Error
  *

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -744,6 +744,68 @@ checkout_one_file_at (OstreeRepo                        *repo,
   return TRUE;
 }
 
+#pragma GCC diagnostic ignored "-Waggregate-return"
+
+/* It can be easy to pass the wrong size to memset */
+#define CLEAR(p) memset((p), 0, sizeof(*(p)))
+
+/*
+ * Iterate through the directories in a dirtree
+ */
+typedef struct {
+  const char *name;
+  char dirtree_checksum[OSTREE_SHA256_STRING_LEN+1];
+  char dirmeta_checksum[OSTREE_SHA256_STRING_LEN+1];
+} DirDentry;
+
+typedef struct {
+  GVariantIter viter;
+  GVariant* dir_subdirs;
+
+  DirDentry entry;
+} DirDirectoryIter;
+
+static DirDirectoryIter
+dir_iter_init(GVariant *dirtree) {
+  DirDirectoryIter self;
+  CLEAR(&self);
+  if (dirtree)
+    {
+      self.dir_subdirs = g_variant_get_child_value (dirtree, 1);
+      g_variant_iter_init (&self.viter, self.dir_subdirs);
+    }
+  return self;
+}
+
+static void
+dir_iter_clear(DirDirectoryIter *self) {
+  if (self->dir_subdirs)
+    g_variant_unref(self->dir_subdirs);
+  CLEAR(self);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(DirDirectoryIter, dir_iter_clear);
+
+static DirDentry*
+dir_iter_next(DirDirectoryIter* self)
+{
+  g_autoptr(GVariant) subdirtree_csum_v = NULL;
+  g_autoptr(GVariant) subdirmeta_csum_v = NULL;
+
+  if (!self->dir_subdirs || !g_variant_iter_next (
+      &self->viter, "(&s@ay@ay)", &self->entry.name,
+      &subdirtree_csum_v, &subdirmeta_csum_v))
+    {
+      CLEAR(&self->entry);
+      return NULL;
+    }
+
+  _ostree_checksum_inplace_from_bytes_v (subdirtree_csum_v, self->entry.dirtree_checksum);
+  _ostree_checksum_inplace_from_bytes_v (subdirmeta_csum_v, self->entry.dirmeta_checksum);
+
+  return &self->entry;
+}
+
 /*
  * checkout_tree_at:
  * @self: Repo
@@ -888,29 +950,22 @@ checkout_tree_at_recurse (OstreeRepo                        *self,
   }
 
   /* Process subdirectories */
-  { g_autoptr(GVariant) dir_subdirs = g_variant_get_child_value (dirtree, 1);
-    const char *dname;
-    g_autoptr(GVariant) subdirtree_csum_v = NULL;
-    g_autoptr(GVariant) subdirmeta_csum_v = NULL;
-    GVariantIter viter;
-    g_variant_iter_init (&viter, dir_subdirs);
-    while (g_variant_iter_loop (&viter, "(&s@ay@ay)", &dname,
-                                &subdirtree_csum_v, &subdirmeta_csum_v))
+  {
+    g_auto(DirDirectoryIter) iter = dir_iter_init(dirtree);
+    DirDentry* subdir;
+    while ((subdir = dir_iter_next(&iter)))
       {
         const size_t origlen = selabel_path_buf ? selabel_path_buf->len : 0;
         if (selabel_path_buf)
           {
-            g_string_append (selabel_path_buf, dname);
+            g_string_append (selabel_path_buf, subdir->name);
             g_string_append_c (selabel_path_buf, '/');
           }
 
-        char subdirtree_checksum[OSTREE_SHA256_STRING_LEN+1];
-        _ostree_checksum_inplace_from_bytes_v (subdirtree_csum_v, subdirtree_checksum);
-        char subdirmeta_checksum[OSTREE_SHA256_STRING_LEN+1];
-        _ostree_checksum_inplace_from_bytes_v (subdirmeta_csum_v, subdirmeta_checksum);
         if (!checkout_tree_at_recurse (self, options, state,
-                                       destination_dfd, dname,
-                                       subdirtree_checksum, subdirmeta_checksum,
+                                       destination_dfd, subdir->name,
+                                       subdir->dirtree_checksum,
+                                       subdir->dirmeta_checksum,
                                        cancellable, error))
           return FALSE;
 

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -921,12 +921,14 @@ typedef enum {
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES: When layering checkouts, unlink() and replace existing files, but do not modify existing directories (unless whiteouts are enabled, then directories are replaced)
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES: Only add new files/directories
  * @OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL: Like UNION_FILES, but error if files are not identical (requires hardlink checkouts)
+ * @OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE: Update an existing checkout.  Set OstreeRepoCheckoutAtOptions::overwrite_update_from_checksum.
  */
 typedef enum {
   OSTREE_REPO_CHECKOUT_OVERWRITE_NONE = 0,
   OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES = 1,
   OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES = 2, /* Since: 2017.3 */
   OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL = 3, /* Since: 2017.11 */
+  OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE = 4, /* Since: 2018.1 */
 } OstreeRepoCheckoutOverwriteMode;
 
 _OSTREE_PUBLIC
@@ -967,7 +969,8 @@ typedef struct {
   OstreeRepoDevInoCache *devino_to_csum_cache;
 
   int unused_ints[6];
-  gpointer unused_ptrs[5];
+  gpointer unused_ptrs[4];
+  const char *overwrite_update_from_checksum; /* Since: 2018.1 */
   OstreeSePolicy *sepolicy; /* Since: 2017.6 */
   const char *sepolicy_prefix;
 } OstreeRepoCheckoutAtOptions;

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -279,6 +279,12 @@ cleanup_old_deployments (OstreeSysroot       *self,
       g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (self, deployment);
       g_autofree char *origin_relpath = ostree_deployment_get_origin_relpath (deployment);
 
+      g_autofree char *deploy_wip = g_strdup_printf (
+          "ostree/deploy/%s/deploy-wip",
+          ostree_deployment_get_osname (deployment));
+      if (!glnx_shutil_rm_rf_at (self->sysroot_fd, deploy_wip, cancellable, error))
+        return FALSE;
+
       if (!g_hash_table_lookup (active_deployment_dirs, deployment_path))
         {
           struct stat stbuf;

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -109,6 +109,138 @@ list_all_deployment_directories (OstreeSysroot       *self,
 }
 
 static gboolean
+deploy_cache_get_tree (OstreeSysroot  *self,
+                       const char     *osname,
+                       char          **csum_out,
+                       gboolean       *exists_out,
+                       GCancellable   *cancellable,
+                       GError        **error)
+{
+  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  g_autofree char *cachepath = g_strdup_printf (
+      "ostree/deploy/%s/cache", osname);
+  gboolean exists;
+  if (!ot_dfd_iter_init_allow_noent (self->sysroot_fd, cachepath, &dfd_iter, &exists, error))
+    return FALSE;
+  if (!exists)
+    {
+      *exists_out = FALSE;
+      return TRUE;
+    }
+
+  while (TRUE)
+    {
+      struct dirent *dent;
+
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
+        return FALSE;
+      if (dent == NULL)
+        break;
+
+      if (dent->d_type != DT_DIR)
+        continue;
+
+      g_autoptr(GError) csum_err = NULL;
+      g_autofree char *csum = g_path_get_basename (dent->d_name);
+      if (ostree_validate_structureof_checksum_string (csum, &csum_err))
+        {
+          if (csum_out)
+            *csum_out = g_steal_pointer(&csum);
+          *exists_out = TRUE;
+          return TRUE;
+        }
+      else
+        {
+          g_printerr ("Warning: Deploy cache dirname %s "
+                      "is not valid checksum: %s\n", dent->d_name,
+                      csum_err->message);
+        }
+    }
+  *exists_out = FALSE;
+  return TRUE;
+}
+
+gboolean
+_ostree_sysroot_deploy_cache_steal_tree (OstreeSysroot *self,
+                                         const char    *osname,
+                                         int            dest_fd,
+                                         const char    *destination,
+                                         char         **csum_out,
+                                         gboolean      *exists_out,
+                                         GCancellable  *cancellable,
+                                         GError       **error)
+{
+  g_autofree char *csum = NULL;
+  gboolean exists;
+  if (!deploy_cache_get_tree (self, osname, &csum, &exists, cancellable, error))
+    return FALSE;
+  if (!exists)
+    {
+      *exists_out = FALSE;
+      return TRUE;
+    }
+
+  g_autofree char *relpath = g_strdup_printf (
+      "ostree/deploy/%s/cache/%s", osname, csum);
+
+  g_autoptr(OstreeRepo) repo = NULL;
+  if (!ostree_sysroot_get_repo (self, &repo, cancellable, error))
+    return FALSE;
+  g_autofree char *ref = g_strdup_printf (
+      "ostree/deploy_cache/%s", osname);
+  if (!ostree_repo_set_ref_immediate (repo, NULL, ref, NULL, cancellable, error))
+    return FALSE;
+
+  if (!glnx_renameat(self->sysroot_fd, relpath, dest_fd, destination,
+                     error))
+    return FALSE;
+
+  *csum_out = g_steal_pointer (&csum);
+  *exists_out = TRUE;
+  return TRUE;
+}
+
+static gboolean
+deploy_cache_try_ingest(OstreeSysroot       *self,
+                        OstreeDeployment    *deployment,
+                        GCancellable        *cancellable,
+                        GError             **error)
+{
+  const char *osname = ostree_deployment_get_osname (deployment);
+  gboolean exists = FALSE;
+  g_autofree char *old_csum = NULL;
+  if (!deploy_cache_get_tree (self, osname, &old_csum, &exists, cancellable, error))
+    return FALSE;
+  if (exists)
+    return TRUE;
+
+  g_autofree char *cachepath = g_strdup_printf (
+      "ostree/deploy/%s/cache", osname);
+  if (!glnx_shutil_mkdir_p_at(self->sysroot_fd, cachepath, 0700, cancellable, error))
+    return FALSE;
+
+  const char* csum = ostree_deployment_get_csum (deployment);
+  g_autofree char *injested_path = g_strdup_printf ("%s/%s", cachepath, csum);
+
+  if (!glnx_renameat (self->sysroot_fd,
+                      ostree_sysroot_get_deployment_dirpath(self, deployment),
+                      self->sysroot_fd,
+                      injested_path,
+                      error))
+    return FALSE;
+
+  g_autoptr(OstreeRepo) repo = NULL;
+  if (!ostree_sysroot_get_repo (self, &repo, cancellable, error))
+    return FALSE;
+  g_autofree char *ref = g_strdup_printf (
+      "ostree/deploy_cache/%s", osname);
+  if (!ostree_repo_set_ref_immediate (repo, NULL, ref, csum, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
 parse_bootdir_name (const char *name,
                     char      **out_osname,
                     char      **out_csum)
@@ -307,6 +439,8 @@ cleanup_old_deployments (OstreeSysroot       *self,
           /* This deployment wasn't referenced, so delete it */
           if (!_ostree_linuxfs_fd_alter_immutable_flag (deployment_fd, FALSE,
                                                         cancellable, error))
+            return FALSE;
+          if (!deploy_cache_try_ingest (self, deployment, cancellable, error))
             return FALSE;
           if (!glnx_shutil_rm_rf_at (self->sysroot_fd, origin_relpath, cancellable, error))
             return FALSE;

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -518,10 +518,19 @@ checkout_deployment_tree (OstreeSysroot     *sysroot,
   if (!glnx_shutil_rm_rf_at (osdeploy_dfd, checkout_target_name, cancellable, error))
     return FALSE;
 
+  g_autofree char *checkout_target_tempname = g_strdup_printf (
+      "ostree/deploy/%s/deploy-wip", osname);
+  if (!glnx_shutil_rm_rf_at (sysroot->sysroot_fd, checkout_target_tempname, cancellable, error))
+    return FALSE;
+
   OstreeRepoCheckoutAtOptions checkout_opts = { 0, };
-  if (!ostree_repo_checkout_at (repo, &checkout_opts, osdeploy_dfd,
-                                checkout_target_name, csum,
+  if (!ostree_repo_checkout_at (repo, &checkout_opts, sysroot->sysroot_fd,
+                                checkout_target_tempname, csum,
                                 cancellable, error))
+    return FALSE;
+
+  if (!glnx_renameat (sysroot->sysroot_fd, checkout_target_tempname,
+                      osdeploy_dfd, checkout_target_name, error))
     return FALSE;
 
   glnx_autofd int ret_fd = -1;

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -491,6 +491,42 @@ merge_configuration_from (OstreeSysroot    *sysroot,
   return TRUE;
 }
 
+static gboolean
+try_update_old_deployment(OstreeSysroot               *sysroot,
+                          OstreeRepo                  *repo,
+                          const char                  *osname,
+                          int                          osdeploy_dfd,
+                          const char                  *checkout_target_tempname,
+                          GCancellable                *cancellable,
+                          GError                     **error)
+{
+  g_autoptr(OstreeDeployment) old_deployment = NULL;
+
+  g_autofree char * csum = NULL;
+  gboolean exists = FALSE;
+  if (!_ostree_sysroot_deploy_cache_steal_tree (
+        sysroot, osname, osdeploy_dfd, checkout_target_tempname, &csum, &exists,
+        cancellable, error))
+    return FALSE;
+  if (!exists)
+    return FALSE;
+
+  g_autofree char *old_etc = g_strdup_printf ("%s/etc", checkout_target_tempname);
+  if (!glnx_shutil_rm_rf_at (osdeploy_dfd, old_etc, cancellable, error))
+    return FALSE;
+
+  OstreeRepoCheckoutAtOptions checkout_opts = { 0, };
+  checkout_opts.overwrite_update_from_checksum = csum;
+  checkout_opts.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE;
+
+  if (!ostree_repo_checkout_at (repo, &checkout_opts, osdeploy_dfd,
+                                checkout_target_tempname, csum,
+                                cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
 /* Look up @revision in the repository, and check it out in
  * /ostree/deploy/OS/deploy/${treecsum}.${deployserial}.
  * A dfd for the result is returned in @out_deployment_dfd.
@@ -503,8 +539,9 @@ checkout_deployment_tree (OstreeSysroot     *sysroot,
                           GCancellable      *cancellable,
                           GError           **error)
 {
+  const char *osname = ostree_deployment_get_osname (deployment);
   g_autofree char *osdeploy_path = g_strconcat (
-      "ostree/deploy/", ostree_deployment_get_osname (deployment), "/deploy", NULL);
+      "ostree/deploy/", osname, "/deploy", NULL);
   if (!glnx_shutil_mkdir_p_at (sysroot->sysroot_fd, osdeploy_path, 0775, cancellable, error))
     return FALSE;
 
@@ -523,11 +560,26 @@ checkout_deployment_tree (OstreeSysroot     *sysroot,
   if (!glnx_shutil_rm_rf_at (sysroot->sysroot_fd, checkout_target_tempname, cancellable, error))
     return FALSE;
 
-  OstreeRepoCheckoutAtOptions checkout_opts = { 0, };
-  if (!ostree_repo_checkout_at (repo, &checkout_opts, sysroot->sysroot_fd,
-                                checkout_target_tempname, csum,
-                                cancellable, error))
-    return FALSE;
+  g_autoptr(GError) olddeploy_err = NULL;
+  if (!try_update_old_deployment(sysroot, repo, osname, sysroot->sysroot_fd,
+                                 checkout_target_tempname, cancellable,
+                                 &olddeploy_err))
+    {
+      if (olddeploy_err)
+        g_printerr("Reusing old deployment failed: %s.  Falling back to "
+                   "fresh deploy\n", olddeploy_err->message);
+
+      if (!glnx_shutil_rm_rf_at (sysroot->sysroot_fd, checkout_target_tempname,
+                                 cancellable, error))
+        return FALSE;
+
+      /* Updating an old deployment failed, try a fresh one */
+      OstreeRepoCheckoutAtOptions checkout_opts = { 0, };
+      if (!ostree_repo_checkout_at (repo, &checkout_opts, sysroot->sysroot_fd,
+                                    checkout_target_tempname, csum,
+                                    cancellable, error))
+        return FALSE;
+    }
 
   if (!glnx_renameat (sysroot->sysroot_fd, checkout_target_tempname,
                       osdeploy_dfd, checkout_target_name, error))

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -120,4 +120,13 @@ gboolean _ostree_sysroot_cleanup_internal (OstreeSysroot *sysroot,
                                            GCancellable  *cancellable,
                                            GError       **error);
 
+gboolean _ostree_sysroot_deploy_cache_steal_tree (OstreeSysroot *self,
+                                                  const char    *osname,
+                                                  int            dest_dfd,
+                                                  const char    *destination,
+                                                  char         **csum_out,
+                                                  gboolean      *exists_out,
+                                                  GCancellable  *cancellable,
+                                                  GError       **error);
+
 G_END_DECLS

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -37,6 +37,7 @@ static char *opt_subpath;
 static gboolean opt_union;
 static gboolean opt_union_add;
 static gboolean opt_union_identical;
+static char *opt_update;
 static gboolean opt_whiteouts;
 static gboolean opt_from_stdin;
 static char *opt_from_file;
@@ -74,6 +75,7 @@ static GOptionEntry options[] = {
   { "union-add", 0, 0, G_OPTION_ARG_NONE, &opt_union_add, "Keep existing files/directories, only add new", NULL },
   { "union-identical", 0, 0, G_OPTION_ARG_NONE, &opt_union_identical, "When layering checkouts, error out if a file would be replaced with a different version, but add new files and directories", NULL },
   { "whiteouts", 0, 0, G_OPTION_ARG_NONE, &opt_whiteouts, "Process 'whiteout' (Docker style) entries", NULL },
+  { "update", 0, 0, G_OPTION_ARG_STRING, &opt_update, "Assume that the DESTINATION already has ORIG_COMMIT  checked out - modify it in-place to be the same as COMMIT", "ORIG_COMMIT" },
   { "allow-noent", 0, 0, G_OPTION_ARG_NONE, &opt_allow_noent, "Do nothing if specified path does not exist", NULL },
   { "from-stdin", 0, 0, G_OPTION_ARG_NONE, &opt_from_stdin, "Process many checkouts from standard input", NULL },
   { "from-file", 0, 0, G_OPTION_ARG_STRING, &opt_from_file, "Process many checkouts from input file", "FILE" },
@@ -100,7 +102,8 @@ process_one_checkout (OstreeRepo           *repo,
    * convenient infrastructure for testing C APIs with data.
    */
   if (opt_disable_cache || opt_whiteouts || opt_require_hardlinks ||
-      opt_union_add || opt_force_copy || opt_bareuseronly_dirs || opt_union_identical)
+      opt_union_add || opt_force_copy || opt_bareuseronly_dirs ||
+      opt_union_identical || opt_update)
     {
       OstreeRepoCheckoutAtOptions options = { 0, };
 
@@ -125,12 +128,20 @@ process_one_checkout (OstreeRepo           *repo,
                        "Cannot specify both --union-add and --union-identical ");
           goto out;
         }
+      if (opt_update && (opt_union || opt_union_add || opt_union_identical))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Cannot combine --replace with --union, "
+                       "--union-identical or --union-add");
+          goto out;
+        }
       if (opt_require_hardlinks && opt_force_copy)
         {
           glnx_throw (error, "Cannot specify both --require-hardlinks and --force-copy");
           goto out;
         }
-      else if (opt_union)
+
+      if (opt_union)
         options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
       else if (opt_union_add)
         options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES;
@@ -143,6 +154,15 @@ process_one_checkout (OstreeRepo           *repo,
               goto out;
             }
           options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL;
+        }
+      else if (opt_update)
+        {
+          options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UPDATE;
+          char *checksum;
+          if (!ostree_repo_resolve_rev (repo, opt_update, FALSE, &checksum,
+                                        error))
+            goto out;
+          options.overwrite_update_from_checksum = checksum;
         }
       if (opt_whiteouts)
         options.process_whiteouts = TRUE;

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -104,7 +104,7 @@ assert_not_has_dir sysroot/boot/loader.1
 # But swap subbootversion
 assert_has_dir sysroot/ostree/boot.0.0
 assert_not_has_dir sysroot/ostree/boot.0.1
-assert_ostree_deployment_refs 0/0/{0,1}
+assert_ostree_deployment_refs 0/0/{0,1} deploy_cache/testos
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -119,7 +119,7 @@ assert_has_file sysroot/boot/loader/entries/ostree-testos-1.conf
 assert_has_file sysroot/boot/loader/entries/ostree-otheros-0.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/deploy/otheros/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
-assert_ostree_deployment_refs 1/1/{0,1,2}
+assert_ostree_deployment_refs 1/1/{0,1,2} deploy_cache/testos
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -133,7 +133,7 @@ assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.2/etc/os-rele
 assert_has_file sysroot/boot/loader/entries/ostree-testos-2.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.3/etc/os-release 'NAME=TestOS'
 ${CMD_PREFIX} ostree admin status
-assert_ostree_deployment_refs 0/1/{0,1,2,3}
+assert_ostree_deployment_refs 0/1/{0,1,2,3} deploy_cache/testos
 validate_bootloader
 
 echo "ok fourth deploy (retain)"

--- a/tests/test-admin-deploy-clean.sh
+++ b/tests/test-admin-deploy-clean.sh
@@ -32,6 +32,6 @@ export rev
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin undeploy 0
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo refs > refs.txt
-assert_not_file_has_content refs.txt '^ostree/'
+assert_not_file_has_content refs.txt '^ostree/[0-9]'
 
 echo "ok deploy + undeploy repo prune"

--- a/tests/test-checkout-update.sh
+++ b/tests/test-checkout-update.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Copyright (C) 2018 William Manley <will@williammanley.net>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..2"
+
+#### Test setup: Create some interesting trees
+
+setup_test_repository bare
+
+mkdir pristine
+cd pristine
+
+mkdir a
+echo basic >a/file
+
+mkdir b
+echo basic >b/file
+echo repo >b/another_file
+ln -s file b/a_symlink
+mkdir b/a_directory
+mkdir b/another_directory
+echo hello b/another_directory/a_file
+
+cp -r b c
+echo new_text >b/file
+
+# d is b with the file types all messed up:
+mkdir d
+mkdir d/file
+echo basic >d/file/not_really
+ln -s file d/another_file
+echo hah >d/a_directory
+mkdir b/another_directory/a_file
+echo "something else" >b/another_directory/a_file/contents
+
+cd ..
+
+$OSTREE commit -b pristine/a --tree=dir=pristine/a
+$OSTREE commit -b pristine/b --tree=dir=pristine/b
+$OSTREE commit -b pristine/c --tree=dir=pristine/c
+$OSTREE commit -b pristine/d --tree=dir=pristine/d
+
+rm -rf pristine
+
+##############
+
+check_update_identical() {
+    commit_a=$1
+    commit_b=$2
+
+    printf "\n\n### Test transitioning from %s to %s\n\n" "$commit_a" "$commit_b" >&2
+    d=$(mktemp -d -p .)
+    $OSTREE checkout $commit_a $d/a >&2
+    $OSTREE checkout $commit_b $d/b >&2
+    echo Expecting $commit_a: >&2
+    find $d/a >&2
+    echo to become $commit_b: >&2
+    find $d/b >&2
+    $OSTREE diff $commit_a $commit_b >&2
+    $OSTREE checkout --update=$commit_a $commit_b $d/a >&2
+    diff -r $d/a $d/b || fail >&2
+}
+
+check_update_identical pristine/a pristine/a
+check_update_identical pristine/b pristine/b
+check_update_identical pristine/c pristine/c
+check_update_identical pristine/d pristine/d
+
+echo "ok Check overwriting checkout with no changes"
+
+check_update_identical pristine/a pristine/b
+check_update_identical pristine/b pristine/a
+check_update_identical pristine/b pristine/c
+check_update_identical pristine/c pristine/b
+check_update_identical pristine/c pristine/d
+check_update_identical pristine/d pristine/c
+
+echo "ok Check overwriting checkout with changes"


### PR DESCRIPTION
...rather than doing a complete fresh checkout.

Currently on our (embedded) system with slow eMMC disk it takes 1m40s to do
a deploy (~150000 files). Ideally if only one or two files have changed it
should be nearly instantaneous - suitable for interactive development. This
should also reduce eMMC wear.

After applying these patches (and with `--no-prune` #1418) it takes <2s to do a deploy - a 50x-100x speedup.

We store unpacked container images as part of our rootfs.  Checkouts with O(number of changes) rather than O(number of files) is going to be more and more important for us as we add more containers.

On any failure we fall back to doing a full deploy.

This builds on top of #1408.  Although it's not ready I've raised this PR to solicit opinion.

TODO:

- [ ] Merge #1408 and rebase
- [ ] Only take `/usr` from old deploys - rather than removing `/etc`
- [ ] `syncfs` before moving deployment into final directory.
- [ ] Get tests to pass
- [ ] Add expicit new tests for this feature.