### PR TITLE
bin/delta: Fix compilation with relative subdirs --filename

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1370,7 +1370,6 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
   g_autoptr(GVariant) detached = NULL;
   gboolean inline_parts;
   guint endianness = G_BYTE_ORDER;
-  glnx_autofd int tmp_dfd = -1;
   builder.parts = g_ptr_array_new_with_free_func ((GDestroyNotify)ostree_static_delta_part_builder_unref);
   builder.fallback_objects = g_ptr_array_new_with_free_func ((GDestroyNotify)g_variant_unref);
   g_auto(GLnxTmpfile) descriptor_tmpf = { 0, };

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1416,36 +1416,13 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
                                  &to_commit, error))
     goto out;
 
-  if (opt_filename)
-    {
-      g_autofree char *dnbuf = g_strdup (opt_filename);
-      const char *dn = dirname (dnbuf);
-      if (!glnx_opendirat (AT_FDCWD, dn, TRUE, &tmp_dfd, error))
-        goto out;
-    }
-  else
-    {
-      tmp_dfd = fcntl (self->tmp_dir_fd, F_DUPFD_CLOEXEC, 3);
-      if (tmp_dfd < 0)
-        {
-          glnx_set_error_from_errno (error);
-          goto out;
-        }
-    }
-
-  builder.parts_dfd = tmp_dfd;
   builder.delta_opts = delta_opts;
 
-  /* Ignore optimization flags */
-  if (!generate_delta_lowlatency (self, from, to, delta_opts, &builder,
-                                  cancellable, error))
-    goto out;
-
   if (opt_filename)
     {
       g_autofree char *dnbuf = g_strdup (opt_filename);
       const char *dn = dirname (dnbuf);
-      descriptor_name = g_strdup (opt_filename);
+      descriptor_name = g_strdup (glnx_basename (opt_filename));
 
       if (!glnx_opendirat (AT_FDCWD, dn, TRUE, &descriptor_dfd, error))
         goto out;
@@ -1463,6 +1440,12 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
 
       descriptor_name = g_strdup (basename (descriptor_relpath));
     }
+  builder.parts_dfd = descriptor_dfd;
+
+  /* Ignore optimization flags */
+  if (!generate_delta_lowlatency (self, from, to, delta_opts, &builder,
+                                  cancellable, error))
+    goto out;
 
   if (!glnx_open_tmpfile_linkable_at (descriptor_dfd, ".", O_WRONLY | O_CLOEXEC,
                                       &descriptor_tmpf, error))

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -123,8 +123,9 @@ fi
 
 ostree_repo_init temp-repo --mode=archive
 ${CMD_PREFIX} ostree --repo=temp-repo pull-local repo
-${CMD_PREFIX} ostree --repo=temp-repo static-delta generate --empty --to=${newrev} --filename=some.delta
-assert_has_file some.delta
+mkdir tmpsubdir
+${CMD_PREFIX} ostree --repo=temp-repo static-delta generate --empty --to=${newrev} --filename=tmpsubdir/some.delta
+assert_has_file tmpsubdir/some.delta
 ${CMD_PREFIX} ostree --repo=temp-repo static-delta list > delta-list.txt
 assert_file_has_content delta-list.txt 'No static deltas'
 rm temp-repo -rf


### PR DESCRIPTION
Currently we were parsing `opt_filename` twice...I dug through
the history a bit and it looks like it may have been an accident
from refactoring.

What we're fixing here concretely is that using relative subdirectories
like `--filename somesubdir/foo` broke because we were incorrectly
passing the `somesubdir/` again.

Closes: #1423