### PR TITLE
docs: Dual license under CC BY-SA and the GFDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,10 @@ Contributing
 ------------
 
 See [Contributing](CONTRIBUTING.md).
+
+
+Licensing
+-------
+
+The license for the *code* of libostree can be found in [COPYING](COPYING).
+The license for the *documentation* of libostree is: `SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/adapting-existing.md
+++ b/docs/manual/adapting-existing.md
@@ -166,3 +166,6 @@ Then to actually deploy this tree for the next boot:
 
 This is essentially what [rpm-ostree](https://github.com/projectatomic/rpm-ostree/)
 does to support its [package layering model](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#package-layering).
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/atomic-upgrades.md
+++ b/docs/manual/atomic-upgrades.md
@@ -116,3 +116,6 @@ so just like `/boot`, it has a version of `0` or `1` appended.
 Each bootloader entry has a special `ostree=` argument which refers to
 one of these symbolic links.  This is parsed at runtime in the
 initramfs.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/buildsystem-and-repos.md
+++ b/docs/manual/buildsystem-and-repos.md
@@ -183,3 +183,6 @@ ostree --repo=repo static-delta generate exampleos/x86_64/standard
 
 Next, see [Repository Management](repository-management.md) for the
 next steps in managing content in OSTree repositories.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/deployment.md
+++ b/docs/manual/deployment.md
@@ -96,3 +96,6 @@ deployment.
 At present, not all bootloaders implement the BootLoaderSpec, so
 OSTree contains code for some of these to regenerate native config
 files (such as `/boot/syslinux/syslinux.conf`) based on the entries.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/formats.md
+++ b/docs/manual/formats.md
@@ -182,3 +182,6 @@ For these types of objects, the delta superblock contains an array of
 "fallback objects".  These objects aren't included in the delta
 parts - the client simply fetches them from the underlying `.filez`
 object.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/introduction.md
+++ b/docs/manual/introduction.md
@@ -115,3 +115,6 @@ Finally, each deployment has its own writable copy of the
 configuration store `/etc`.  On upgrade, OSTree will
 perform a basic 3-way diff, and apply any local changes to the
 new copy, while leaving the old untouched.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/related-projects.md
+++ b/docs/manual/related-projects.md
@@ -353,3 +353,6 @@ was intended to address this, but it was not adopted in the end for v2.
 The [Balena](https://github.com/resin-os/balena) project forks Docker and aims
 to even use Docker/OCI format for the root filesystem, and adds wire deltas
 using librsync.  See also [discussion on  libostree-list](https://mail.gnome.org/archives/ostree-list/2017-December/msg00002.html).
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/repo.md
+++ b/docs/manual/repo.md
@@ -143,3 +143,6 @@ the only way to provide GPG signatures (transitively) on deltas.
 If a repository administrator creates a summary file, they must
 thereafter run `ostree summary -u` to update it whenever a ref is
 updated or a static delta is generated.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`

--- a/docs/manual/repository-management.md
+++ b/docs/manual/repository-management.md
@@ -240,3 +240,6 @@ That will truncate the history older than 6 months.  Deleted commits
 will have "tombstone markers" added so that you know they were
 explicitly deleted, but all content in them (that is not referenced by
 a still retained commit) will be garbage collected.
+
+###### Licensing for this document:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`


### PR DESCRIPTION
Originating issue:  https://github.com/ostreedev/ostree/issues/1431

Mailing list post: https://mail.gnome.org/archives/ostree-list/2018-January/msg00004.html

---

This will allow the text to be used in Wikipedia for example; it
also just makes more sense for documentation than the LGPLv2+.