### PR TITLE
switchroot: Ensure /sysroot is set to "private" propagation

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -244,6 +244,17 @@ main(int argc, char *argv[])
         err (EXIT_FAILURE, "failed to MS_MOVE %s to %s", deploy_path, root_mountpoint);
     }
 
+  /* The /sysroot mount needs to be private to avoid having a mount for e.g. /var/cache
+   * also propagate to /sysroot/ostree/deploy/$stateroot/var/cache
+   *
+   * Now in reality, today this is overridden by systemd: the *actual* way we fix this up
+   * is in ostree-remount.c.  But let's do it here to express the semantics we want
+   * at the very start (perhaps down the line systemd will have compile/runtime option
+   * to say that the initramfs environment did everything right from the start).
+   */
+  if (mount ("none", "sysroot", NULL, MS_PRIVATE, NULL) < 0)
+    err (EXIT_FAILURE, "remounting 'sysroot' private");
+
   if (getpid() == 1)
     {
       execl ("/sbin/init", "/sbin/init", NULL);

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -44,6 +44,15 @@ main(int argc, char *argv[])
   struct stat stbuf;
   int i;
 
+  /* The /sysroot mount needs to be private to avoid having a mount for e.g. /var/cache
+   * also propagate to /sysroot/ostree/deploy/$stateroot/var/cache
+   *
+   * Today systemd remounts / (recursively) as shared, so we're undoing that as early
+   * as possible.  See also a copy of this in ostree-prepare-root.c.
+   */
+  if (mount ("none", "/sysroot", NULL, MS_REC | MS_PRIVATE, NULL) < 0)
+    perror ("warning: While remounting /sysroot MS_PRIVATE");
+
   if (path_is_on_readonly_fs ("/"))
     {
       /* If / isn't writable, don't do any remounts; we don't want


### PR DESCRIPTION
Downstream BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1498281

This came up as a problem with `oci-umount` which was trying to ensure some host
mounts like `/var/lib/containers` don't leak into privileged containers.  But
since our `/sysroot` mount wasn't private we also got a copy there.

We should have done this from the very start - it makes `findmnt` way, way less
ugly and is just the obviously right thing to do, will possibly create world
peace etc.