### PR TITLE
Introduce new type PAYLOAD_LINK

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -145,6 +145,13 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>payload-link-threshold</varname></term>
+        <listitem><para>An integer value that specifies a minimum file size for creating
+        a payload link.  By default it is disabled.
+        </para></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1239,6 +1239,8 @@ ostree_object_type_to_string (OstreeObjectType objtype)
       return "tombstone-commit";
     case OSTREE_OBJECT_TYPE_COMMIT_META:
       return "commitmeta";
+    case OSTREE_OBJECT_TYPE_PAYLOAD_LINK:
+      return "payload-link";
     default:
       g_assert_not_reached ();
       return NULL;
@@ -1266,6 +1268,8 @@ ostree_object_type_from_string (const char *str)
     return OSTREE_OBJECT_TYPE_TOMBSTONE_COMMIT;
   else if (!strcmp (str, "commitmeta"))
     return OSTREE_OBJECT_TYPE_COMMIT_META;
+  else if (!strcmp (str, "payload-link"))
+    return OSTREE_OBJECT_TYPE_PAYLOAD_LINK;
   g_assert_not_reached ();
   return 0;
 }
@@ -2122,6 +2126,7 @@ _ostree_validate_structureof_metadata (OstreeObjectType objtype,
       break;
     case OSTREE_OBJECT_TYPE_TOMBSTONE_COMMIT:
     case OSTREE_OBJECT_TYPE_COMMIT_META:
+    case OSTREE_OBJECT_TYPE_PAYLOAD_LINK:
       /* TODO */
       break;
     case OSTREE_OBJECT_TYPE_FILE:

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -68,6 +68,7 @@ G_BEGIN_DECLS
  * @OSTREE_OBJECT_TYPE_COMMIT: Toplevel object, refers to tree and dirmeta for root
  * @OSTREE_OBJECT_TYPE_TOMBSTONE_COMMIT: Toplevel object, refers to a deleted commit
  * @OSTREE_OBJECT_TYPE_COMMIT_META: Detached metadata for a commit
+ * @OSTREE_OBJECT_TYPE_PAYLOAD_LINK: Symlink to a .file given its checksum on the payload only.
  *
  * Enumeration for core object types; %OSTREE_OBJECT_TYPE_FILE is for
  * content, the other types are metadata.
@@ -79,6 +80,7 @@ typedef enum {
   OSTREE_OBJECT_TYPE_COMMIT = 4,              /* .commit */
   OSTREE_OBJECT_TYPE_TOMBSTONE_COMMIT = 5,    /* .commit-tombstone */
   OSTREE_OBJECT_TYPE_COMMIT_META = 6,         /* .commitmeta */
+  OSTREE_OBJECT_TYPE_PAYLOAD_LINK = 7,         /* .payload-link */
 } OstreeObjectType;
 
 /**
@@ -94,7 +96,7 @@ typedef enum {
  *
  * Last valid object type; use this to validate ranges.
  */
-#define OSTREE_OBJECT_TYPE_LAST OSTREE_OBJECT_TYPE_COMMIT_META
+#define OSTREE_OBJECT_TYPE_LAST OSTREE_OBJECT_TYPE_PAYLOAD_LINK
 
 /**
  * OSTREE_DIRMETA_GVARIANT_FORMAT:

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -53,6 +53,9 @@ G_BEGIN_DECLS
 #define OSTREE_SUMMARY_COLLECTION_ID "ostree.summary.collection-id"
 #define OSTREE_SUMMARY_COLLECTION_MAP "ostree.summary.collection-map"
 
+#define _OSTREE_PAYLOAD_LINK_PREFIX "../"
+#define _OSTREE_PAYLOAD_LINK_PREFIX_LEN (sizeof (_OSTREE_PAYLOAD_LINK_PREFIX) - 1)
+
 /* Well-known keys for the additional metadata field in a commit in a ref entry
  * in a summary file. */
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
@@ -161,6 +164,8 @@ struct OstreeRepo {
   gchar *collection_id;
   gboolean add_remotes_config_dir; /* Add new remotes in remotes.d dir */
   gint lock_timeout_seconds;
+  guint64 payload_link_threshold;
+  gint fs_support_reflink; /* The underlying filesystem has support for ioctl (FICLONE..) */
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -237,14 +237,6 @@ _ostree_repo_ensure_loose_objdir_at (int             dfd,
                                      GCancellable   *cancellable,
                                      GError        **error);
 
-gboolean
-_ostree_repo_find_object (OstreeRepo           *self,
-                          OstreeObjectType      objtype,
-                          const char           *checksum,
-                          GFile               **out_stored_path,
-                          GCancellable         *cancellable,
-                          GError             **error);
-
 GFile *
 _ostree_repo_get_commit_metadata_loose_path (OstreeRepo        *self,
                                              const char        *checksum);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2827,6 +2827,15 @@ reload_core_config (OstreeRepo          *self,
       return FALSE;
   }
 
+  { g_autofree char *payload_threshold = NULL;
+
+    if (!ot_keyfile_get_value_with_default (self->config, "core", "payload-link-threshold", "-1",
+                                            &payload_threshold, error))
+      return FALSE;
+
+    self->payload_link_threshold = g_ascii_strtoull (payload_threshold, NULL, 10);
+  }
+
   return TRUE;
 }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3278,6 +3278,8 @@ list_loose_objects_at (OstreeRepo             *self,
         objtype = OSTREE_OBJECT_TYPE_DIR_META;
       else if (strcmp (dot, ".commit") == 0)
         objtype = OSTREE_OBJECT_TYPE_COMMIT;
+      else if (strcmp (dot, ".payload-link") == 0)
+        objtype = OSTREE_OBJECT_TYPE_PAYLOAD_LINK;
       else
         continue;
 

--- a/tests/installed/itest-payload-link.sh
+++ b/tests/installed/itest-payload-link.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libinsttest.sh
+
+echo "1..1"
+
+cd /var/srv
+mkdir repo
+ostree --repo=repo init --mode=archive
+echo -e '[archive]\nzlib-level=1\n' >> repo/config
+host_nonremoteref=$(echo ${host_refspec} | sed 's,[^:]*:,,')
+ostree --repo=repo pull-local /ostree/repo ${host_commit}
+ostree --repo=repo refs ${host_commit} --create=${host_nonremoteref}
+
+run_tmp_webserver $(pwd)/repo
+
+origin=$(cat ${test_tmpdir}/httpd-address)
+
+cleanup() {
+    cd ${oldpwd}
+    umount mnt || true
+    test -n "${blkdev}" && losetup -d ${blkdev} || true
+    rm -rf mnt testblk.img
+}
+oldpwd=`pwd`
+trap cleanup EXIT
+
+mkdir mnt
+truncate -s 2G testblk.img
+if ! blkdev=$(losetup --find --show $(pwd)/testblk.img); then
+    echo "ok # SKIP not run when cannot setup loop device"
+    exit 0
+fi
+
+mkfs.xfs -m reflink=1 ${blkdev}
+
+mount ${blkdev} mnt
+
+test_tmpdir=$(pwd)/mnt
+cd ${test_tmpdir}
+
+touch a
+if cp --reflink a b; then
+    mkdir repo
+    ostree --repo=repo init
+    ostree config --repo=repo set core.payload-link-threshold 0
+    ostree --repo=repo remote add origin --set=gpg-verify=false ${origin}
+    ostree --repo=repo pull --disable-static-deltas origin ${host_nonremoteref}
+    if test `find repo -name '*.payload-link' | wc -l` = 0; then
+        fatal ".payload-link files not found"
+    fi
+
+    find repo -name '*.payload-link' | while read i;
+    do
+        payload_checksum=$(basename $(dirname $i))$(basename $i .payload-link)
+        payload_checksum_calculated=$(sha256sum $(readlink -f $i) | cut -d ' ' -f 1)
+        if test $payload_checksum != $payload_checksum_calculated; then
+            fatal ".payload-link has the wrong checksum"
+        fi
+    done
+    echo "ok pull creates .payload-link"
+else
+    echo "ok # SKIP no reflink support in the file system"
+fi


### PR DESCRIPTION
It is used to keep track of the payload checksum for files stored in the repository.
   
The goal is that files having the same payload but different xattrs can take advantage of reflinks where supported.

More details here: https://mail.gnome.org/archives/ostree-list/2018-January/msg00012.html