### PR TITLE
deploy: SELinux-relabel installed kernel/initramfs data

### DIFF
--- a/tests/installed/itest-deploy-selinux.sh
+++ b/tests/installed/itest-deploy-selinux.sh
@@ -29,4 +29,13 @@ for file in fstab passwd exports hostname sysctl.conf yum.repos.d \
     assert_streq "${current}" "${new}"
 done
 
+# This captures all of the boot entries; it'd be slightly annoying
+# to try to figure out the accurate one, so let's just ensure that at least
+# one entry is boot_t.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1536991
+ls -Z /boot/ostree/*/ > bootlsz.txt
+assert_file_has_content_literal bootlsz.txt 'system_u:object_r:boot_t:s0 vmlinuz-'
+assert_file_has_content_literal bootlsz.txt 'system_u:object_r:boot_t:s0 initramfs-'
+
+# Cleanup
 ostree admin undeploy 0


### PR DESCRIPTION
When we changed around the kernel location in rpm-ostree, we
started installing the kernel into `/boot` as `modules_object_t`,
and the current policy didn't permit that.  For maximum compatibility,
relabel installed kernel/initramfs/dtb as `boot_t`.

https://bugzilla.redhat.com/show_bug.cgi?id=1536991