### PR TITLE
switchroot: Fix split source/build directory

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -45,7 +45,7 @@ if BUILDOPT_USE_STATIC_COMPILER
 ostree_boot_SCRIPTS = ostree-prepare-root
 
 ostree-prepare-root : $(ostree_prepare_root_SOURCES)
-	$(STATIC_COMPILER) -o $@ -static $(ostree_prepare_root_SOURCES) $(AM_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
+	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(AM_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_prepare_root_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot


### PR DESCRIPTION
If you have split source and build directories, then building
static ostree-prepare-root fails to find the source files.

https://github.com/ostreedev/ostree/issues/1429