### PR TITLE
repo: Create uncompressed-object-cache dir dynamically

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3029,18 +3029,6 @@ ostree_repo_open (OstreeRepo    *self,
   if (!ostree_repo_reload_config (self, cancellable, error))
     return FALSE;
 
-  /* TODO - delete this */
-  if (self->mode == OSTREE_REPO_MODE_ARCHIVE && self->enable_uncompressed_cache)
-    {
-      if (!glnx_shutil_mkdir_p_at (self->repo_dir_fd, "uncompressed-objects-cache", 0755,
-                                   cancellable, error))
-        return FALSE;
-      if (!glnx_opendirat (self->repo_dir_fd, "uncompressed-objects-cache", TRUE,
-                           &self->uncompressed_objects_dir_fd,
-                           error))
-        return FALSE;
-    }
-
   self->inited = TRUE;
   return TRUE;
 }

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -42,6 +42,9 @@ else
     fi
 fi
 
+# This should be dynamic now
+assert_not_has_dir repo/uncompressed-objects-cache
+
 validate_checkout_basic() {
     (cd $1;
      assert_has_file firstfile


### PR DESCRIPTION
Having the `uncompressed-object-cache` directory in `archive` repos by default
is clutter; the functionality should be considered deprecated.

Now we only create the directory if we're doing a checkout with the cache
enabled.