### PR TITLE
core: Add API (and standard concept for) content checksum

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -149,6 +149,7 @@ ostree_validate_structureof_dirtree
 ostree_validate_structureof_dirmeta
 ostree_commit_get_parent
 ostree_commit_get_timestamp
+ostree_commit_get_content_checksum
 ostree_check_version
 </SECTION>
 

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,7 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2018.2 {
+  ostree_commit_get_content_checksum;
 } LIBOSTREE_2018.1;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -521,6 +521,9 @@ _OSTREE_PUBLIC
 guint64  ostree_commit_get_timestamp         (GVariant  *commit_variant);
 
 _OSTREE_PUBLIC
+gchar *  ostree_commit_get_content_checksum  (GVariant  *commit_variant);
+
+_OSTREE_PUBLIC
 gboolean ostree_check_version (guint required_year, guint required_release);
 
 G_END_DECLS

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -126,6 +126,8 @@ dump_commit (GVariant            *variant,
   str = format_timestamp (timestamp, &local_error);
   if (!str)
     errx (1, "Failed to read commit: %s", local_error->message);
+  g_autofree char *contents = ostree_commit_get_content_checksum (variant) ?: "<invalid commit>";
+  g_print ("ContentChecksum:  %s\n", contents);
   g_print ("Date:  %s\n", str);
 
   if ((version = ot_admin_checksum_version (variant)))

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((81 + ${extra_basic_tests:-0}))"
+echo "1..$((82 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -751,6 +751,16 @@ $OSTREE show test4 > show-output
 assert_file_has_content show-output "Third commit"
 assert_file_has_content show-output "commit $checksum"
 echo "ok show full output"
+
+grep -E -e '^ContentChecksum' show-output > previous-content-checksum.txt
+cd $test_tmpdir/checkout-test2
+checksum=$($OSTREE commit ${COMMIT_ARGS} -b test4 -s "Another commit with different subject")
+cd ${test_tmpdir}
+$OSTREE show test4 | grep -E -e '^ContentChecksum' > new-content-checksum.txt
+if ! diff -u previous-content-checksum.txt new-content-checksum.txt; then
+    fatal "content checksum differs"
+fi
+echo "ok content checksum"
 
 cd $test_tmpdir/checkout-test2
 checksum1=$($OSTREE commit ${COMMIT_ARGS} -b test5 -s "First commit")


### PR DESCRIPTION
There are a few cases for knowing whether a commit has identical
content to another commit.  Some people want to do a "promotion workflow",
where the content of a commit on a tesitng branch is then "promoted"
to a production branch with `ostree commit --tree=ref`.

Another use case I just hit in rpm-ostree deals with
[jigdo](https://github.com/projectatomic/rpm-ostree/issues/1081) where we're
importing RPMs on both the client and server, and will be using the
content checksum, since the client/server cases inject different metadata
into the commit object.

Closes: https://github.com/ostreedev/ostree/issues/1315