### PR TITLE
fetcher/soup: Drop outdated max queue size assertion

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -866,12 +866,6 @@ _ostree_fetcher_request_async (OstreeFetcher         *self,
   initiate_next_curl_request (req, task);
 
   g_hash_table_add (self->outstanding_requests, g_steal_pointer (&task));
-
-  /* Sanity check, I added * 2 just so we don't abort if something odd happens,
-   * but we do want to abort if we're asked to do obviously too many requests.
-   */
-  g_assert_cmpint (g_hash_table_size (self->outstanding_requests), <,
-                   _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS * 2);
 }
 
 void


### PR DESCRIPTION
Since f4d1334e19ce3ab2f8872b1e28da52044f559401 the primary pull code maintains a
maximum queue. In that commit message I said `Note that I kept an assertion.`.
But I think this is wrong since while it covers a lot of the normal cases, if
one is e.g. trying to fetch a ton of refs, the primary pull code doesn't yet
queue those.  While it'd be nice to queue those, it isn't worth carrying
an extra assertion just in the libsoup side.

Closes: https://github.com/ostreedev/ostree/issues/1451