### PR TITLE
Make tests compatible with Python 3

### DIFF
--- a/tests/bootloader-entries-crosscheck.py
+++ b/tests/bootloader-entries-crosscheck.py
@@ -38,8 +38,8 @@ def fatal(msg):
     sys.stderr.write('\n')
     sys.exit(1)
 
-def compare_entries_descending(a, b):
-    return int(b['version']) - int(a['version'])
+def entry_get_version(entry):
+    return int(entry['version'])
 
 def get_ostree_option(optionstring):
     for o in optionstring.split():
@@ -65,7 +65,7 @@ for fname in os.listdir(loaderpath):
             v = line[s+1:]
             entry[k] = v
         entries.append(entry)
-    entries.sort(compare_entries_descending)
+    entries.sort(key=entry_get_version, reverse=True)
 
 # Parse SYSLINUX config
 with open(syslinuxpath) as f:

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -17,6 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+from __future__ import division
 from __future__ import print_function
 import os
 import sys
@@ -78,12 +79,12 @@ def run(n_committers, n_pruners):
     pruners = set()
 
     print('n_committers', n_committers, 'n_pruners', n_pruners, file=sys.stderr)
-    n_trees = n_committers / 2
+    n_trees = n_committers // 2
     for v in range(n_trees):
         mktree('tree{}'.format(v))
 
     for v in range(n_committers):
-        committers.add(commit(v / 2))
+        committers.add(commit(v // 2))
     for v in range(n_pruners):
         pruners.add(prune())
 
@@ -101,8 +102,8 @@ def run(n_committers, n_pruners):
         shutil.rmtree('tree{}'.format(v))
 
 # No concurrent pruning
-run(cpu_count()/2 + 2, 0)
+run(cpu_count() // 2 + 2, 0)
 print("ok no concurrent prunes")
 
-run(cpu_count()/2 + 4, 3)
+run(cpu_count() // 2 + 4, 3)
 print("ok concurrent prunes")

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -34,7 +34,7 @@ def fatal(msg):
 def mktree(dname, serial=0):
     print('Creating tree', dname, file=sys.stderr)
     os.mkdir(dname, 0o755)
-    for v in xrange(20):
+    for v in range(20):
         with open('{}/{}'.format(dname, v), 'w') as f:
             f.write('{} {} {}\n'.format(dname, serial, v))
 
@@ -79,12 +79,12 @@ def run(n_committers, n_pruners):
 
     print('n_committers', n_committers, 'n_pruners', n_pruners, file=sys.stderr)
     n_trees = n_committers / 2
-    for v in xrange(n_trees):
+    for v in range(n_trees):
         mktree('tree{}'.format(v))
 
-    for v in xrange(n_committers):
+    for v in range(n_committers):
         committers.add(commit(v / 2))
-    for v in xrange(n_pruners):
+    for v in range(n_pruners):
         pruners.add(prune())
 
     failed = False
@@ -97,7 +97,7 @@ def run(n_committers, n_pruners):
     if failed:
         fatal('A child process exited abnormally')
 
-    for v in xrange(n_trees):
+    for v in range(n_trees):
         shutil.rmtree('tree{}'.format(v))
 
 # No concurrent pruning

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -33,7 +33,7 @@ def fatal(msg):
 # different files with different checksums.
 def mktree(dname, serial=0):
     print('Creating tree', dname, file=sys.stderr)
-    os.mkdir(dname, 0755)
+    os.mkdir(dname, 0o755)
     for v in xrange(20):
         with open('{}/{}'.format(dname, v), 'w') as f:
             f.write('{} {} {}\n'.format(dname, serial, v))


### PR DESCRIPTION
Because Python 2 reaches EOL in 2020, which is within the projected security-support lifetime of Ubuntu 18.04 and Debian 10, there's an effort within Debian to replace Python 2 with Python 3 as much as possible.

ostree currently uses Python 2 for some tests, but this pull request makes it compatible with Python 3. I believe this would be necessary in Arch Linux, where `/usr/bin/python` is Python 3, if Arch Linux routinely ran the ostree test suite (which it seems they don't).

In Debian we're using an additional patch to switch the Python 2 tests to Python 3, which isn't included in this pull request, but I'm happy to open another one afterwards (or add it to this one) if you're interested: https://salsa.debian.org/debian/ostree/blob/debian/master/debian/patches/debian/Use-Python-3-for-tests.patch