### PR TITLE
Use Python 3 for tests

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -16,7 +16,14 @@ pkg_install sudo which attr fuse strace \
 if test -n "${CI_PKGS:-}"; then
     pkg_install ${CI_PKGS}
 fi
-pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang
+pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang \
+                  python3-PyYAML
+(. /etc/os-release;
+ if test "${ID}" = "centos"; then
+     rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+     pkg_install python34{,-PyYAML}
+ fi
+)
 
 # Default libcurl on by default in fedora unless libsoup is enabled
 if sh -c '. /etc/os-release; test "${ID}" = fedora'; then

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -110,7 +110,7 @@ case "$ci_distro" in
             libcurl4-openssl-dev \
             procps \
             zlib1g-dev \
-            python-yaml \
+            python{,3}-yaml \
             ${NULL}
 
         if [ "$ci_in_docker" = yes ]; then

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -110,7 +110,7 @@ case "$ci_distro" in
             libcurl4-openssl-dev \
             procps \
             zlib1g-dev \
-            python{,3}-yaml \
+            python3-yaml \
             ${NULL}
 
         if [ "$ci_in_docker" = yes ]; then

--- a/tests/bootloader-entries-crosscheck.py
+++ b/tests/bootloader-entries-crosscheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (C) 2015 Red Hat
 #

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -28,7 +28,7 @@ extra_basic_tests=5
 . $(dirname $0)/basic-test.sh
 
 $CMD_PREFIX ostree --version > version.yaml
-python -c 'import yaml; yaml.safe_load(open("version.yaml"))'
+python3 -c 'import yaml; yaml.safe_load(open("version.yaml"))'
 echo "ok yaml version"
 
 # Reset things so we don't inherit a lot of state from earlier tests

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>
 #


### PR DESCRIPTION
As requested on #1457, here's the patch I used in Debian to run all tests in a version of Python that is not approaching EOL.

An alternative to this would be to use `$(PYTHON)` as populated by `configure.ac`, but to work for the installed-tests that would require messing around with `.in` files and I'm not sure whether that's really worth the effort.