### PR TITLE
lib/repo-finder-mount: Fix path to flatpak repo

### DIFF
--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -439,7 +439,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
         {
           ".ostree/repo",
           "ostree/repo",
-          "var/lib/flatpak",
+          "var/lib/flatpak/repo",
         };
 
       for (i = 0; i < G_N_ELEMENTS (well_known_repos); i++)


### PR DESCRIPTION
OstreeRepoFinderMount checks mounts for a few well-known directories
such as "ostree/repo" and ".ostree/repo" to try to find remotes. One of
the hard-coded directories is "var/lib/flatpak" but that's the flatpak
directory, not the ostree repo used by flatpak, which is at
"var/lib/flatpak/repo". So this commit changes the path so the repo can
be found.

For recent versions of Endless, flatpak uses /ostree/repo as its
repository, so this commit won't make a difference there. But it may
help on other operating systems.