### PR TITLE
lib/sysroot: Fix retrieving non-booted pending deployment

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1202,6 +1202,10 @@ ostree_sysroot_query_deployments_for (OstreeSysroot     *self,
     {
       OstreeDeployment *deployment = self->deployments->pdata[i];
 
+      /* Ignore deployments not for this osname */
+      if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
+          continue;
+
       /* Is this deployment booted?  If so, note we're past the booted */
       if (self->booted_deployment != NULL &&
           ostree_deployment_equal (deployment, self->booted_deployment))
@@ -1209,10 +1213,6 @@ ostree_sysroot_query_deployments_for (OstreeSysroot     *self,
           found_booted = TRUE;
           continue;
         }
-
-      /* Ignore deployments not for this osname */
-      if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
-          continue;
 
       if (!found_booted && !ret_pending)
         ret_pending = g_object_ref (deployment);


### PR DESCRIPTION
If we're booted into a deployment, then any queries for the pending
merge deployment of a non-booted OS will fail due all of them being
considered rollback.

Fix this by filtering by `osname` *before* determining if we've crossed
the booted deployment yet.