### PR TITLE
lib/repo-finder-mount: Update comment about paths

### DIFF
--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -52,7 +52,7 @@
  * enumerated, and all OSTree repositories below it will be searched, in lexical
  * order, for the requested #OstreeCollectionRefs. The names of the directories
  * below `.ostree/repos.d` are irrelevant, apart from their lexical ordering.
- * The directories `.ostree/repo`, `ostree/repo` and `var/lib/flatpak`
+ * The directories `.ostree/repo`, `ostree/repo` and `var/lib/flatpak/repo`
  * will be searched after the others, if they exist.
  * Non-removable volumes are ignored.
  *


### PR DESCRIPTION
This updates the gtk-doc comment for OstreeRepoFinderMount to match the
correct flatpak repo path, which was fixed in commit 6db6268df.