### PR TITLE
lib: Fix memory leaks of OstreeRemote

### DIFF
--- a/src/libostree/ostree-repo-finder-config.c
+++ b/src/libostree/ostree-repo-finder-config.c
@@ -30,6 +30,7 @@
 #include <glib-object.h>
 #include <libglnx.h>
 
+#include "ostree-autocleanups.h"
 #include "ostree-remote-private.h"
 #include "ostree-repo.h"
 #include "ostree-repo-private.h"
@@ -176,7 +177,7 @@ ostree_repo_finder_config_resolve_async (OstreeRepoFinder                  *find
   while (g_hash_table_iter_next (&iter, (gpointer *) &remote_name, (gpointer *) &supported_ref_to_checksum))
     {
       g_autoptr(GError) local_error = NULL;
-      OstreeRemote *remote;
+      g_autoptr(OstreeRemote) remote = NULL;
 
       /* We don’t know what last-modified timestamp the remote has without
        * making expensive HTTP queries, so leave that information blank. We

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5695,7 +5695,7 @@ ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
     }
 
   if (keyring_remote != NULL)
-    return ostree_remote_ref (keyring_remote);
+    return keyring_remote;
   else
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5645,7 +5645,7 @@ ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
 {
   gsize i;
   g_auto(GStrv) remotes = NULL;
-  OstreeRemote *keyring_remote = NULL;
+  g_autoptr(OstreeRemote) keyring_remote = NULL;
 
   g_return_val_if_fail (OSTREE_IS_REPO (self), NULL);
   g_return_val_if_fail (ostree_validate_collection_id (collection_id, NULL), NULL);
@@ -5680,6 +5680,7 @@ ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
             {
               g_debug ("%s: Ignoring remote ‘%s’ as it has no keyring configured.",
                        G_STRFUNC, remotes[i]);
+              g_clear_object (&keyring_remote);
               continue;
             }
 
@@ -5695,7 +5696,7 @@ ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
     }
 
   if (keyring_remote != NULL)
-    return keyring_remote;
+    return g_steal_pointer (&keyring_remote);
   else
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4914,7 +4914,7 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
       g_autofree char *gpgkeypath = NULL;
       /* Add the remote's keyring file if it exists. */
 
-      OstreeRemote *remote;
+      g_autoptr(OstreeRemote) remote = NULL;
 
       remote = _ostree_repo_get_remote_inherited (self, remote_name, error);
       if (remote == NULL)
@@ -4936,8 +4936,6 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
 
       if (gpgkeypath)
         _ostree_gpg_verifier_add_key_ascii_file (verifier, gpgkeypath);
-
-      ostree_remote_unref (remote);
     }
 
   if (add_global_keyring_dir)


### PR DESCRIPTION
The _ostree_repo_get_remote() and _ostree_repo_get_remote_inherited()
methods transfer ownership of the returned OstreeRemote to the caller,
so this commit fixes a few call sites that weren't properly freeing it.