### PR TITLE
prune: Error if --static-deltas-only without --delete-commit

### DIFF
--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -174,6 +174,15 @@ ostree_builtin_prune (int argc, char **argv, OstreeCommandInvocation *invocation
         else if (!delete_commit (repo, opt_delete_commit, cancellable, error))
           return FALSE;
     }
+  else
+    {
+      /* In the future we should make this useful, but for now let's
+       * error out since what we were doing before was very misleading.
+       * https://github.com/ostreedev/ostree/issues/1479
+       */
+      if (opt_static_deltas_only)
+        return glnx_throw (error, "--static-deltas-only requires --delete-commit; see https://github.com/ostreedev/ostree/issues/1479");
+    }
 
   OstreeRepoPruneFlags pruneflags = 0;
   if (opt_refs_only)

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -134,9 +134,10 @@ assert_file_has_content deltascount "^1$"
 ${CMD_PREFIX} ostree --repo=repo static-delta generate test
 ${CMD_PREFIX} ostree --repo=repo static-delta list | wc -l > deltascount
 assert_file_has_content deltascount "^2$"
-${CMD_PREFIX} ostree --repo=repo prune --static-deltas-only --keep-younger-than="October 20 2015"
-${CMD_PREFIX} ostree --repo=repo static-delta list | wc -l > deltascount
-assert_file_has_content deltascount "^1$"
+if ${CMD_PREFIX} ostree --repo=repo prune --static-deltas-only --keep-younger-than="October 20 2015" 2>err.txt; then
+    fatal "pruned deltas only"
+fi
+assert_file_has_content_literal err.txt "--static-deltas-only requires --delete-commit"
 
 echo "ok prune"
 


### PR DESCRIPTION
The original changes here apparently had the *idea* that `--static-deltas-only`
would be useful in general, but we never implemented that.  The current
situation where it's ignored unless `--delete-commit` is specified is
very misleading and I can easily see it leading to data loss for people.

Let's error out until we have a chance to make it actually useful.

Related: https://github.com/ostreedev/ostree/issues/1479