### PR TITLE
repo/refs: Clean up error prefixing

### DIFF
--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -617,6 +617,8 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
                                  GCancellable     *cancellable,
                                  GError          **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Listing refs", error);
+
   g_autofree char *remote = NULL;
   g_autofree char *ref_prefix = NULL;
 
@@ -1029,10 +1031,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
     {
       if (!glnx_opendirat (self->repo_dir_fd, "refs/heads", TRUE,
                            &dfd, error))
-        {
-          g_prefix_error (error, "Opening %s: ", "refs/heads");
-          return FALSE;
-        }
+        return FALSE;
     }
   else if (remote == NULL && ref->collection_id != NULL)
     {
@@ -1041,10 +1040,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
       /* refs/mirrors might not exist in older repositories, so create it. */
       if (!glnx_shutil_mkdir_p_at_open (self->repo_dir_fd, "refs/mirrors", 0777,
                                         &refs_mirrors_dfd, cancellable, error))
-        {
-          g_prefix_error (error, "Opening %s: ", "refs/mirrors");
-          return FALSE;
-        }
+        return FALSE;
 
       if (rev != NULL)
         {
@@ -1063,10 +1059,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
 
       if (!glnx_opendirat (self->repo_dir_fd, "refs/remotes", TRUE,
                            &refs_remotes_dfd, error))
-        {
-          g_prefix_error (error, "Opening %s: ", "refs/remotes");
-          return FALSE;
-        }
+        return FALSE;
 
       if (rev != NULL)
         {
@@ -1207,6 +1200,8 @@ ostree_repo_list_collection_refs (OstreeRepo                 *self,
                                   GCancellable               *cancellable,
                                   GError                     **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Listing refs", error);
+
   g_return_val_if_fail (OSTREE_IS_REPO (self), FALSE);
   g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((82 + ${extra_basic_tests:-0}))"
+echo "1..$((83 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -475,6 +475,17 @@ echo "ok commit skiplist"
 cd ${test_tmpdir}
 $OSTREE prune
 echo "ok prune didn't fail"
+
+# https://github.com/ostreedev/ostree/issues/1467
+cd ${test_tmpdir}
+mv repo/refs/remotes{,.orig}
+if $OSTREE refs --list >/dev/null 2>err.txt; then
+    fatal "listed refs without remotes dir?"
+fi
+assert_file_has_content err.txt 'Listing refs.*opendir.*No such file or directory'
+mv repo/refs/remotes{.orig,}
+$OSTREE refs --list >/dev/null
+echo "ok refs enoent error"
 
 cd ${test_tmpdir}
 # Verify we can't cat dirs


### PR DESCRIPTION
Add some "function global" prefixing in line with what we do in
other places now, and drop the "manual filename" prefixing that
is no longer necessary since
https://github.com/GNOME/libglnx/commit/23f7df15006f14ddc3bc2ddee690f7f8604c3ebe

Closes: https://github.com/ostreedev/ostree/issues/1467