### PR TITLE
pull: Do not pass cancellable when aborting a transaction

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2153,6 +2153,12 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
                                GCancellable   *cancellable,
                                GError        **error)
 {
+  /* Always ignore the cancellable to avoid the chance that, if it gets
+   * canceled, the transaction may not be fully cleaned up.
+   * See https://github.com/ostreedev/ostree/issues/1491 .
+   */
+  cancellable = NULL;
+
   /* Note early return */
   if (!self->in_transaction)
     return TRUE;


### PR DESCRIPTION
**Please check https://github.com/ostreedev/ostree/issues/1491 first!**

In ostree_repo_pull_with_options, if we pass a cancellable to
ostree_repo_abort_transaction, and that cancellable has been canceled
already, then the abort call will never reach the point where it resets
the needed flags. So the next time an operation is prepared (i.e. a pull
is attempted), it will fail because it believes it already has a pending
transaction.

To fix this we pass the cancellable as NULL. An alternative fix could be
to just check the state of the cancellable before passing it to the
abort operation, but this will not prevent the aforementioned situation
from happening.