### PR TITLE
lib/fetcher: Allow clients to append to User-Agent

### DIFF
--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -114,6 +114,9 @@ void _ostree_fetcher_set_tls_database (OstreeFetcher *self,
 void _ostree_fetcher_set_extra_headers (OstreeFetcher *self,
                                         GVariant      *extra_headers);
 
+void _ostree_fetcher_set_extra_user_agent (OstreeFetcher *self,
+                                           const char    *extra_user_agent);
+
 guint64 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self);
 
 void _ostree_fetcher_request_to_tmpfile (OstreeFetcher         *self,

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -41,6 +41,7 @@ static gboolean opt_bareuseronly_files;
 static char** opt_subpaths;
 static char** opt_http_headers;
 static char* opt_cache_dir;
+static char* opt_append_user_agent;
 static int opt_depth = 0;
 static int opt_frequency = 0;
 static char* opt_url;
@@ -69,6 +70,8 @@ static GOptionEntry options[] = {
    { "update-frequency", 0, 0, G_OPTION_ARG_INT, &opt_frequency, "Sets the update frequency, in milliseconds (0=1000ms) (default: 0)", "FREQUENCY" },
    { "localcache-repo", 'L', 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_localcache_repos, "Add REPO as local cache source for objects during this pull", "REPO" },
    { "timestamp-check", 'T', 0, G_OPTION_ARG_NONE, &opt_timestamp_check, "Require fetched commits to have newer timestamps", NULL },
+   /* let's leave this hidden for now; we just need it for tests */
+   { "append-user-agent", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_append_user_agent, "Append string to user agent", NULL },
    { NULL }
  };
 
@@ -332,6 +335,10 @@ ostree_builtin_pull (int argc, char **argv, OstreeCommandInvocation *invocation,
         g_variant_builder_add (&builder, "{s@v}", "http-headers",
                                g_variant_new_variant (g_variant_builder_end (&hdr_builder)));
       }
+
+    if (opt_append_user_agent)
+      g_variant_builder_add (&builder, "{s@v}", "append-user-agent",
+                             g_variant_new_variant (g_variant_new_string (opt_append_user_agent)));
 
     if (!opt_dry_run)
       {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -234,10 +234,9 @@ ostree_repo_init() {
 # The original one; use setup_fake_remote_repo2 for newer code,
 # down the line we'll try to port tests.
 setup_fake_remote_repo1() {
-    mode=$1
-    commit_opts=${2:-}
-    args=${3:-}
-    shift
+    mode=$1; shift
+    commit_opts=${1:-}
+    [ $# -eq 0 ] || shift
     oldpwd=`pwd`
     mkdir ostree-srv
     cd ostree-srv
@@ -263,7 +262,7 @@ setup_fake_remote_repo1() {
     mkdir ${test_tmpdir}/httpd
     cd httpd
     ln -s ${test_tmpdir}/ostree-srv ostree
-    ${OSTREE_HTTPD} --autoexit --log-file $(pwd)/httpd.log --daemonize -p ${test_tmpdir}/httpd-port $args
+    ${OSTREE_HTTPD} --autoexit --log-file $(pwd)/httpd.log --daemonize -p ${test_tmpdir}/httpd-port "$@"
     port=$(cat ${test_tmpdir}/httpd-port)
     echo "http://127.0.0.1:${port}" > ${test_tmpdir}/httpd-address
     cd ${oldpwd} 

--- a/tests/test-remote-cookies.sh
+++ b/tests/test-remote-cookies.sh
@@ -27,7 +27,8 @@ echo '1..4'
 . $(dirname $0)/libtest.sh
 
 setup_fake_remote_repo1 "archive" "" \
-  "--expected-cookies foo=bar --expected-cookies baz=badger"
+  --expected-cookies foo=bar \
+  --expected-cookies baz=badger
 
 assert_fail (){ 
   if $@; then


### PR DESCRIPTION
We do already have `http-headers`, which potentially could be used to
allow clients to completely override the field, but it seems like the
more common use case is simply to append.