### PR TITLE
main, status: Factor out deployment printing into helper

### DIFF
--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -141,15 +141,10 @@ main (int    argc,
 
   if (error != NULL)
     {
-      int is_tty = isatty (1);
-      const char *prefix = "";
-      const char *suffix = "";
-      if (is_tty)
-        {
-          prefix = "\x1b[31m\x1b[1m"; /* red, bold */
-          suffix = "\x1b[22m\x1b[0m"; /* bold off, color reset */
-        }
-      g_printerr ("%serror: %s%s\n", prefix, suffix, error->message);
+      g_printerr ("%s%serror:%s%s %s\n",
+                  ot_get_red_start (), ot_get_bold_start (),
+                  ot_get_bold_end (), ot_get_red_end (),
+                  error->message);
     }
 
   return ret;

--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -680,15 +680,10 @@ main (int    argc,
 
   if (!run (argc, argv, cancellable, &error))
     {
-      int is_tty = isatty (1);
-      const char *prefix = "";
-      const char *suffix = "";
-      if (is_tty)
-        {
-          prefix = "\x1b[31m\x1b[1m"; /* red, bold */
-          suffix = "\x1b[22m\x1b[0m"; /* bold off, color reset */
-        }
-      g_printerr ("%serror: %s%s\n", prefix, suffix, error->message);
+      g_printerr ("%s%serror:%s%s %s\n",
+                  ot_get_red_start (), ot_get_bold_start (),
+                  ot_get_bold_end (), ot_get_red_end (),
+                  error->message);
       return 1;
     }
 

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -91,3 +91,19 @@ gboolean ostree_ensure_repo_writable (OstreeRepo *repo, GError **error);
 void ostree_print_gpg_verify_result (OstreeGpgVerifyResult *result);
 
 gboolean ot_enable_tombstone_commits (OstreeRepo *repo, GError **error);
+
+/* Copied from rpm-ostree's rpmostree-libbuiltin.h */
+#define TERM_ESCAPE_SEQUENCE(type,seq)          \
+  static inline const char* ot_get_##type (void) { \
+    if (glnx_stdout_is_tty ())                  \
+      return seq;                               \
+    return "";                                  \
+  }
+
+TERM_ESCAPE_SEQUENCE(red_start,  "\x1b[31m")
+TERM_ESCAPE_SEQUENCE(red_end,    "\x1b[22m")
+TERM_ESCAPE_SEQUENCE(bold_start, "\x1b[1m")
+TERM_ESCAPE_SEQUENCE(bold_end,   "\x1b[0m")
+
+#undef TERM_ESCAPE_SEQUENCE
+

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -106,4 +106,3 @@ TERM_ESCAPE_SEQUENCE(bold_start, "\x1b[1m")
 TERM_ESCAPE_SEQUENCE(bold_end,   "\x1b[0m")
 
 #undef TERM_ESCAPE_SEQUENCE
-


### PR DESCRIPTION
Prep for staged deployments; they won't be in the primary deployment
list, and we want to print them first.

Also pull in some code from rpm-ostree for the red/bold bits and use
that tree-wide.

Update submodule: libglnx