### PR TITLE
switchroot: Ensure /run/ostree-booted is created even without initramfs

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -104,4 +104,19 @@ read_proc_cmdline_ostree (void)
   return ret;
 }
 
+/* This is an API for other projects to determine whether or not the
+ * currently running system is ostree-controlled.
+ */
+static inline void
+touch_run_ostree (void)
+{
+  int fd = open ("/run/ostree-booted", O_CREAT | O_WRONLY | O_NOCTTY | O_CLOEXEC, 0640);
+  /* We ignore failures here in case /run isn't mounted...not much we
+   * can do about that, but we don't want to fail.
+   */
+  if (fd == -1)
+    return;
+  (void) close (fd);
+}
+
 #endif /* __OSTREE_MOUNT_UTIL_H_ */

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -46,6 +46,16 @@ main(int argc, char *argv[])
   struct stat stbuf;
   int i;
 
+  /* See comments in ostree-prepare-root.c for this.
+   *
+   * This service is triggered via
+   * ConditionKernelCommandLine=ostree
+   * but it's a lot easier for various bits of userspace to check for
+   * a file versus parsing the kernel cmdline.  So let's ensure
+   * the stamp file is created here too.
+   */
+  touch_run_ostree ();
+
   /* The /sysroot mount needs to be private to avoid having a mount for e.g. /var/cache
    * also propagate to /sysroot/ostree/deploy/$stateroot/var/cache
    *


### PR DESCRIPTION
See https://mail.gnome.org/archives/ostree-list/2018-March/msg00012.html

If ostree-prepare-root is run as pid 1 (i.e we're not using an initramfs), then
anything we write outside the target sysroot (such as `/run/ostree-booted`) will
be lost.

Since `ostree-remount.service` runs fairly early in boot, and is triggered via
`ConditionKernelCommandLine=ostree`, we can just touch the file there in
addition.