### PR TITLE
lib/deltas: Squash some GCC maybe-uninitialized warnings

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -241,14 +241,8 @@ finish_part (OstreeStaticDeltaBuilder *builder, GError **error)
     g_variant_builder_add_value (&xattr_builder, part_builder->xattrs->pdata[j]);
 
   {
-    g_autoptr(GBytes) payload_b;
-    g_autoptr(GBytes) operations_b;
-
-    payload_b = g_string_free_to_bytes (part_builder->payload);
-    part_builder->payload = NULL;
-
-    operations_b = g_string_free_to_bytes (part_builder->operations);
-    part_builder->operations = NULL;
+    g_autoptr(GBytes) payload_b = g_string_free_to_bytes (g_steal_pointer (&part_builder->payload));
+    g_autoptr(GBytes) operations_b = g_string_free_to_bytes (g_steal_pointer (&part_builder->operations));
 
     delta_part_content = g_variant_new ("(a(uuu)aa(ayay)@ay@ay)",
                                         &mode_builder, &xattr_builder,

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -38,10 +38,8 @@ _ostree_static_delta_parse_checksum_array (GVariant      *array,
                                            guint         *out_n_checksums,
                                            GError       **error)
 {
-  gsize n = g_variant_n_children (array);
-  guint n_checksums;
-
-  n_checksums = n / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN;
+  const gsize n = g_variant_n_children (array);
+  const guint n_checksums = n / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN;
 
   if (G_UNLIKELY(n > (G_MAXUINT32/OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN) ||
                  (n_checksums * OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN) != n))
@@ -166,8 +164,8 @@ _ostree_repo_static_delta_part_have_all_objects (OstreeRepo             *repo,
                                                  GCancellable           *cancellable,
                                                  GError                **error)
 {
-  guint8 *checksums_data;
-  guint n_checksums;
+  guint8 *checksums_data = NULL;
+  guint n_checksums = 0;
   gboolean have_object = TRUE;
 
   if (!_ostree_static_delta_parse_checksum_array (checksum_array,


### PR DESCRIPTION
These show up in the RPM build, I didn't yet try to figure out why we're not
reproducing them outside of that.