### PR TITLE
 Release 2018.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl update libostree-released.sym from libostree-devel.sym, and update the check
 dnl in test-symbols.sh, and also set is_release_build=yes below.  Then make
 dnl another post-release commit to bump the version, and set is_release_build=no.
 m4_define([year_version], [2018])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ m4_define([year_version], [2018])
 m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,7 +18,7 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2018.4 {
+LIBOSTREE_2018.5 {
 } LIBOSTREE_2018.3;
 
 /* Stub section for the stable release *after* this development one; don't


### PR DESCRIPTION
A quick turnaround to include one PR: #1508
"switchroot: Ensure /run/ostree-booted is created even without initramfs"

This fixes ostree when booting without an initramfs.  Thanks to @akiernan for the
bug report and helping review the fix!  I'm working on enhancing
the test suite, which will help in adding some coverage here.

Also for this release I'm going to avoid adding a "stub" symbol section
to the `-released.sym` file; I don't believe it's necessary.