### PR TITLE
tests/installed: Fix TESTS= being empty

### DIFF
--- a/tests/installed/run.sh
+++ b/tests/installed/run.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 for tn in ${dn}/itest-*.sh; do
-    if [ -n "${TESTS+ }" ]; then
+    if [ -n "${TESTS:-}" ]; then
       tbn=$(basename "$tn" .sh)
       tbn=" ${tbn#itest-} "
       if [[ " $TESTS " != *$tbn* ]]; then


### PR DESCRIPTION
I broke this in https://github.com/ostreedev/ostree/pull/1509/commits/9b55aaea6f34b7094c44932a3c2e1cf2d54634fd
I'd obviously tested *setting* it locally worked, but I didn't test that
not having it set ran all the tests.

I don't understand why we were doing the `+ ` pattern before; let's
just check if it's empty.