### PR TITLE
lib/repo-pull: Improve error message when no summary is found

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5784,6 +5784,13 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,
   if (!ostree_repo_remote_get_gpg_verify_summary (self, name, &gpg_verify_summary, error))
     goto out;
 
+  if (gpg_verify_summary && summary == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "No remote summary found (check that the configured URL is correct)");
+      goto out;
+    }
+
   if (gpg_verify_summary && signatures == NULL)
     {
       g_set_error (error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5787,7 +5787,7 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,
   if (gpg_verify_summary && summary == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "No remote summary found (check that the configured URL is correct)");
+                   "GPG verification enabled, but no summary found (check that the configured URL in remote config is correct)");
       goto out;
     }
 


### PR DESCRIPTION
In ostree_repo_remote_fetch_summary_with_options(), if no summary is
found on the server and summary verification is enabled, the error
message implies that it's the summary signature that's missing, which is
misleading. This commit adds a more specific error message for the case
of a missing summary, which has the side effect of explicitly checking
for the case that signatures != NULL && summary == NULL after
repo_remote_fetch_summary(), even though that should never happen.

One effect of this is that if you run "flatpak remote-add" with an
incorrect URL you get a more helpful error message, and similarly for
other flatpak operations and other users of ostree.