### PR TITLE
Don't write to parent repo

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -777,8 +777,6 @@ _try_clone_from_payload_link (OstreeRepo   *self,
           return TRUE;
         }
     }
-  if (self->parent_repo)
-    return _try_clone_from_payload_link (self->parent_repo, payload_checksum, file_info, tmpf, cancellable, error);
 
   return TRUE;
 }


### PR DESCRIPTION
In _try_clone_from_payload_link, don't try to do the clone in the
parent repo, because we don't want to modify that. parent repos are
typically used when you want a shared, immutable base.

For example in flatpak, the parent repo is the system repo which you
don't have write access to, so any modification to it will fail with
EACCES, making it impossible to install via the system helper.