### PR TITLE
ci: Drop patches when building RPM

### DIFF
--- a/ci/libpaprci/Makefile.dist-packaging
+++ b/ci/libpaprci/Makefile.dist-packaging
@@ -30,7 +30,7 @@ srpm: dist-snapshot
     origdir=$$(pwd); \
 	  cd $(DISTGIT_NAME) && \
 		git stash && git pull -r && \
-	  sed -i -e "s,^Version:.*,Version: $(GITREV_FOR_PKG)," $(DISTGIT_NAME).spec && \
+	  sed -i -e '/^Patch/d' -e "s,^Version:.*,Version: $(GITREV_FOR_PKG)," $(DISTGIT_NAME).spec && \
     rm -f *.src.rpm && \
 	  $(mypath)/rpmbuild-cwd -bs $(DISTGIT_NAME).spec && mv *.src.rpm $${origdir}; \
 	fi


### PR DESCRIPTION
Things fell over when downstream added a patch we had already merged
upstream.