### PR TITLE
ci: turn gating back on for most testsuites

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -28,6 +28,10 @@ artifacts:
 
 # This suite skips the RPMs and does the build+unit tests in a container
 inherit: false
+branches:
+    - master
+    - auto
+    - try
 container:
   image: registry.fedoraproject.org/fedora:27
 context: f27-primary


### PR DESCRIPTION
Somehow, this slipped through in #1513. We weren't inheriting anymore,
so `branches` defaulted back to just `master`. This means we weren't
gating on most of the containerized builds anymore. Ouch!

It'd make sense to teach PAPR to allow some defaults across all
testsuites, even in the `inherit: false` case. Though it's tempting to
also just change the hardcoded PAPR default to those branches since our
use of Homu + PAPR at this point is pretty ubiquitous, and it doesn't
really hurt for the ones that don't use it.