### PR TITLE
Don't scan uncompressed_objects_dir if it doesn't exist

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1438,7 +1438,8 @@ scan_loose_devino (OstreeRepo                     *self,
         return FALSE;
     }
 
-  if (self->mode == OSTREE_REPO_MODE_ARCHIVE)
+  if (self->mode == OSTREE_REPO_MODE_ARCHIVE &&
+      self->uncompressed_objects_dir_fd != -1)
     {
       if (!scan_one_loose_devino (self, self->uncompressed_objects_dir_fd, devino_cache,
                                   cancellable, error))


### PR DESCRIPTION
A newly created archive-mode repository won't have a uncompressed-objects-cache
directory, and uncompressed_objects_dir is -1 to flag that. The special meaning of
-1 meaning "cwd" for libglnx means that the current directory was scanned as
if it was an objects directory, producing unexpected results, especially if there
were any two-letter files/subdirs in the current directory.

This fixes a regression from https://github.com/ostreedev/ostree/commit/88d27fb3f1bb4102fddc74e77276011f6ee365ec

I didn't examine the source code to see if there were any other places where uncompressed_objects_dir is used blindly.