### PR TITLE
avahi: Don't complain with g_warning if the daemon wasn't running

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -1437,9 +1437,15 @@ ostree_repo_finder_avahi_start (OstreeRepoFinderAvahi  *self,
 
   if (client == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Failed to create finder client: %s",
-                   avahi_strerror (failure));
+      if (failure == AVAHI_ERR_NO_DAEMON)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     "Avahi daemon is not running: %s",
+                     avahi_strerror (failure));
+      else
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                     "Failed to create finder client: %s",
+                     avahi_strerror (failure));
+
       return;
     }
 


### PR DESCRIPTION
This is a normal case when running unit tests in client code
on continuous integration infrastructure. When those tests are
running they will set G_DEBUG=fatal-warnings which will cause
the program to abort if a warning is emitted. Instead, emit
a debug message if the problem was that we couldn't connect to
the daemon.

---

Upstreaming a patch from @smspillaz which we’ve been carrying in Endless OS for a little while.