### PR TITLE
fsck: Only print "marking commit partial" once

### DIFF
--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -99,9 +99,16 @@ fsck_one_object (OstreeRepo            *repo,
               for (i = 0; parent_commits[i] != NULL; i++)
                 {
                   const char *parent_commit = parent_commits[i];
-                  g_printerr ("Marking commit %s as partial\n", parent_commit);
-                  if (!ostree_repo_mark_commit_partial (repo, parent_commit, TRUE, error))
+                  OstreeRepoCommitState state;
+                  if (!ostree_repo_load_commit (repo, parent_commit, NULL,
+                                                &state, error))
                     return FALSE;
+                  if ((state & OSTREE_REPO_COMMIT_STATE_PARTIAL) == 0)
+                    {
+                      g_printerr ("Marking commit as partial: %s\n", parent_commit);
+                      if (!ostree_repo_mark_commit_partial (repo, parent_commit, TRUE, error))
+                        return FALSE;
+                    }
                 }
             }
         }

--- a/tests/installed/nondestructive/itest-pull.sh
+++ b/tests/installed/nondestructive/itest-pull.sh
@@ -35,11 +35,12 @@ echo "ok pull"
 # fsck marks commits partial
 # https://github.com/ostreedev/ostree/pull/1533
 for d in $(find bare-repo/objects/ -maxdepth 1 -type d); do
-    (find ${d} -name '*.file' || true) | head -20 | xargs rm -vf
+    (find ${d} -name '*.file' || true) | head -20 | xargs rm -f
 done
-if ostree --repo=bare-repo fsck; then
+if ostree --repo=bare-repo fsck |& tee fsck.txt; then
     fatal "fsck unexpectedly succeeded"
 fi
+assert_streq $(grep -cE -e 'Marking commit as partial' fsck.txt) "1"
 ostree --repo=bare-repo pull origin ${host_nonremoteref}
 # Don't need a full fsck here
 ostree --repo=bare-repo ls origin:${host_nonremoteref} >/dev/null

--- a/tests/test-corruption.sh
+++ b/tests/test-corruption.sh
@@ -105,7 +105,7 @@ if $OSTREE fsck -q 2>err.txt; then
     assert_not_reached "fsck unexpectedly succeeded"
 fi
 assert_file_has_content_literal err.txt "Object missing:"
-assert_file_has_content_literal err.txt "Marking commit $rev as partial"
+assert_file_has_content_literal err.txt "Marking commit as partial: $rev"
 assert_has_file repo/state/${rev}.commitpartial
 
 echo "ok missing file"
@@ -125,7 +125,7 @@ if $OSTREE fsck -q --delete 2>err.txt; then
     assert_not_reached "fsck unexpectedly succeeded"
 fi
 assert_file_has_content_literal err.txt "Corrupted file object;"
-assert_file_has_content_literal err.txt "Marking commit $rev as partial"
+assert_file_has_content_literal err.txt "Marking commit as partial: $rev"
 assert_has_file repo/state/${rev}.commitpartial
 
 echo "ok corrupt file"


### PR DESCRIPTION
Let's only print if the commit isn't already partial; this
addresses a spam of "marking commit partial" from fsck.