### PR TITLE
tests/installed: bump reboot timeout to 180s

### DIFF
--- a/tests/installed/execute_batch.yml
+++ b/tests/installed/execute_batch.yml
@@ -19,4 +19,4 @@
     loop_var: "async_result_item"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 240
+  retries: 300


### PR DESCRIPTION
We've been seeing a lot of CI test failures due to ansible timing out
waiting for the host to come back up after a reboot.