### PR TITLE
ci: Temporary libgcrypt workaround for older kernels

### DIFF
--- a/ci/libpaprci/libbuild.sh
+++ b/ci/libpaprci/libbuild.sh
@@ -66,6 +66,10 @@ pkg_builddep() {
         if rpm -q gpgme | grep -q gpgme-1.9.0-6.fc27; then
             dnf install -y https://kojipkgs.fedoraproject.org//packages/gpgme/1.10.0/4.fc27/x86_64/{gpgme{,-devel},python{2,3}-gpg}-1.10.0-4.fc27.x86_64.rpm
         fi
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1542453
+        if rpm -q libgcrypt | grep -q libgcrypt-1.8.2-1.fc27; then
+            dnf install -y https://kojipkgs.fedoraproject.org//packages/libgcrypt/1.8.2/2.fc27/x86_64/libgcrypt-1.8.2-2.fc27.x86_64.rpm
+        fi
     else
         yum-builddep -y "$@"
     fi


### PR DESCRIPTION
I'm trying to get ostree tests to pass in OpenShift as part of our CI
move but I've been seeing lots of failures related to GPG tests. It
finally turned out to be because libgcrypt doesn't behave well on older
kernels that don't have `getrandom()` (the cluster is running on RHEL7).
Thankfully, there's a new build with a fix for this. Pull that in
manually until it gets into stable.

For more information, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1542453