### PR TITLE
ci: mark some ci testsuites as required again

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -32,6 +32,7 @@ branches:
     - master
     - auto
     - try
+required: true
 container:
   image: registry.fedoraproject.org/fedora:27
 context: f27-primary


### PR DESCRIPTION
Follow up to #1536; we are now running all the testsuites on merges, but
we weren't actually blocking on their success!