### PR TITLE
 ci: drop BDB1539 workaround 

### DIFF
--- a/ci/libpaprci/libbuild.sh
+++ b/ci/libpaprci/libbuild.sh
@@ -6,18 +6,7 @@ OS_ID=$(. /etc/os-release; echo $ID)
 OS_VERSION_ID=$(. /etc/os-release; echo $VERSION_ID)
 
 pkg_upgrade() {
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1483553
-    local ecode=0
-    yum -y distro-sync 2>err.txt || ecode=$?
-    if test ${ecode} '!=' 0 && grep -q -F -e "BDB1539 Build signature doesn't match environment" err.txt; then
-        rpm --rebuilddb
-        yum -y distro-sync
-    else
-        if test ${ecode} '!=' 0; then
-            cat err.txt
-            exit ${ecode}
-        fi
-    fi
+    yum -y distro-sync
 }
 
 make() {


### PR DESCRIPTION
For reason I don't quite understand, running the PAPR testsuites in OCP
sometimes gets hit with:

```
Running transaction
Failed to obtain the transaction lock (logged in as: root).
```

This is reminiscent of the overlay2 librpm compat issues[1], except that
AFAICT, this OCP instance is running on devicemapper. Yet, this patch
does fix the issue for me. (I initially had it specifically touch
`/var/lib/rpm/Packages`, but nope, that doesn't work).

https://bugzilla.redhat.com/show_bug.cgi?id=1213602