### PR TITLE
lib/repo: Enable locking by default, make API non-experimental

### DIFF
--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -90,12 +90,6 @@ ostree_repo_finder_override_get_type
 
 <SECTION>
 <FILE>ostree-misc-experimental</FILE>
-OstreeRepoLockType
-ostree_repo_lock_push
-ostree_repo_lock_pop
-OstreeRepoAutoLock
-ostree_repo_auto_lock_push
-ostree_repo_auto_lock_cleanup
 ostree_repo_get_collection_id
 ostree_repo_set_collection_id
 ostree_validate_collection_id

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -94,8 +94,4 @@ LIBOSTREE_2017.14_EXPERIMENTAL {
 global:
   ostree_remote_get_type;
   ostree_remote_get_url;
-  ostree_repo_auto_lock_cleanup;
-  ostree_repo_auto_lock_push;
-  ostree_repo_lock_pop;
-  ostree_repo_lock_push;
 } LIBOSTREE_2017.13_EXPERIMENTAL;

--- a/src/libostree/ostree-autocleanups.h
+++ b/src/libostree/ostree-autocleanups.h
@@ -61,7 +61,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSysrootUpgrader, g_object_unref)
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (OstreeRepoCommitTraverseIter, ostree_repo_commit_traverse_iter_clear)
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, ostree_repo_auto_lock_cleanup)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeCollectionRef, ostree_collection_ref_free)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeCollectionRefv, ostree_collection_ref_freev, NULL)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRemote, ostree_remote_unref)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1567,8 +1567,8 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
 
   memset (&self->txn.stats, 0, sizeof (OstreeRepoTransactionStats));
 
-  self->txn_locked = ostree_repo_lock_push (self, OSTREE_REPO_LOCK_SHARED,
-                                            cancellable, error);
+  self->txn_locked = _ostree_repo_lock_push (self, OSTREE_REPO_LOCK_SHARED,
+                                             cancellable, error);
   if (!self->txn_locked)
     return FALSE;
 
@@ -2136,7 +2136,7 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
 
   if (self->txn_locked)
     {
-      if (!ostree_repo_lock_pop (self, cancellable, error))
+      if (!_ostree_repo_lock_pop (self, cancellable, error))
         return FALSE;
       self->txn_locked = FALSE;
     }
@@ -2189,7 +2189,7 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
 
   if (self->txn_locked)
     {
-      if (!ostree_repo_lock_pop (self, cancellable, error))
+      if (!_ostree_repo_lock_pop (self, cancellable, error))
         return FALSE;
       self->txn_locked = FALSE;
     }

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -435,34 +435,36 @@ _ostree_repo_get_remote_inherited (OstreeRepo  *self,
                                    const char  *name,
                                    GError     **error);
 
-#ifndef OSTREE_ENABLE_EXPERIMENTAL_API
-
-/* All the locking APIs below are duplicated in ostree-repo.h. Remove the ones
- * here once it's no longer experimental.
+/* Locking APIs are currently private.
+ * See https://github.com/ostreedev/ostree/pull/1555
  */
-
 typedef enum {
   OSTREE_REPO_LOCK_SHARED,
   OSTREE_REPO_LOCK_EXCLUSIVE
 } OstreeRepoLockType;
 
-gboolean      ostree_repo_lock_push (OstreeRepo          *self,
+gboolean      _ostree_repo_lock_push (OstreeRepo          *self,
                                      OstreeRepoLockType   lock_type,
                                      GCancellable        *cancellable,
                                      GError             **error);
-gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
-                                    GCancellable  *cancellable,
-                                    GError       **error);
+gboolean      _ostree_repo_lock_pop (OstreeRepo    *self,
+                                     GCancellable  *cancellable,
+                                     GError       **error);
 
 typedef OstreeRepo OstreeRepoAutoLock;
 
-OstreeRepoAutoLock * ostree_repo_auto_lock_push (OstreeRepo          *self,
-                                                 OstreeRepoLockType   lock_type,
-                                                 GCancellable        *cancellable,
-                                                 GError             **error);
-void          ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, ostree_repo_auto_lock_cleanup)
+OstreeRepoAutoLock * _ostree_repo_auto_lock_push (OstreeRepo          *self,
+                                                  OstreeRepoLockType   lock_type,
+                                                  GCancellable        *cancellable,
+                                                  GError             **error);
+void          _ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, _ostree_repo_auto_lock_cleanup)
 
+#ifndef OSTREE_ENABLE_EXPERIMENTAL_API
+
+/* These APIs are duplicated in the public headers when doing an
+ * experimental-API build.
+ */
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 gboolean      ostree_repo_set_collection_id (OstreeRepo   *self,
                                              const gchar  *collection_id,

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -201,8 +201,7 @@ ostree_repo_prune_static_deltas (OstreeRepo *self, const char *commit,
                                  GError           **error)
 {
   g_autoptr(OstreeRepoAutoLock) lock =
-    ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable,
-                                error);
+    _ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable, error);
   if (!lock)
     return FALSE;
 
@@ -340,8 +339,7 @@ ostree_repo_prune (OstreeRepo        *self,
                    GError           **error)
 {
   g_autoptr(OstreeRepoAutoLock) lock =
-    ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable,
-                                error);
+    _ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable, error);
   if (!lock)
     return FALSE;
 
@@ -452,8 +450,7 @@ ostree_repo_prune_from_reachable (OstreeRepo        *self,
                                   GError           **error)
 {
   g_autoptr(OstreeRepoAutoLock) lock =
-    ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable,
-                                error);
+    _ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE, cancellable, error);
   if (!lock)
     return FALSE;
 

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -109,48 +109,6 @@ OstreeRepo *  ostree_repo_create_at (int             dfd,
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
 
-/**
- * OstreeRepoLockType:
- * @OSTREE_REPO_LOCK_SHARED: A shared lock
- * @OSTREE_REPO_LOCK_EXCLUSIVE: An exclusive lock
- *
- * The type of repository lock to acquire.
- *
- * Since: 2017.14
- */
-typedef enum {
-  OSTREE_REPO_LOCK_SHARED,
-  OSTREE_REPO_LOCK_EXCLUSIVE
-} OstreeRepoLockType;
-
-_OSTREE_PUBLIC
-gboolean      ostree_repo_lock_push (OstreeRepo          *self,
-                                     OstreeRepoLockType   lock_type,
-                                     GCancellable        *cancellable,
-                                     GError             **error);
-_OSTREE_PUBLIC
-gboolean      ostree_repo_lock_pop (OstreeRepo    *self,
-                                    GCancellable  *cancellable,
-                                    GError       **error);
-
-/**
- * OstreeRepoAutoLock: (skip)
- *
- * This is simply an alias to #OstreeRepo used for automatic lock cleanup.
- * See ostree_repo_auto_lock_push() for its intended usage.
- *
- * Since: 2017.14
- */
-typedef OstreeRepo OstreeRepoAutoLock;
-
-_OSTREE_PUBLIC
-OstreeRepoAutoLock * ostree_repo_auto_lock_push (OstreeRepo          *self,
-                                                 OstreeRepoLockType   lock_type,
-                                                 GCancellable        *cancellable,
-                                                 GError             **error);
-_OSTREE_PUBLIC
-void          ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
-
 _OSTREE_PUBLIC
 const gchar * ostree_repo_get_collection_id (OstreeRepo   *self);
 _OSTREE_PUBLIC

--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -44,7 +44,6 @@ subprocess.check_call(['ostree', '--repo=repo', 'init', '--mode=bare'])
 # and we don't need xattr coverage for this
 with open('repo/config', 'a') as f:
     f.write('disable-xattrs=true\n')
-    f.write('locking=true\n')
 
 def commit(v):
     tdir='tree{}'.format(v)


### PR DESCRIPTION
The code has been sitting around for a while but since I disabled
it by default, I doubt anyone is really using it or relying on it.

This patch makes the existing APIs public, and turns on locking
by default.  Conceptually these are two distinct things, and we
may actually want to split up the patches.

I don't think this will break anyone, but it's hard to say for sure.
It's also going to be hard to find out until we actually release
I suspect...

But anyone who is broken should be able to add `locking=false` into
their repo config.

On the APIs - I'm a bit concerned about the interactions over time
between libostree's use of the API and any apps that start using it.
For example, if an app specifies a SHARED lock in their code, then
later internally we decide to temporarily grab an `EXCLUSIVE`, but the
app had a second thread/process that was `EXCLUSIVE` already, and
that process was waiting on the first bit of code, then we could
deadlock. I can't think of a real world situation where this would happen
yet though.