### PR TITLE
lib/deploy: Also compare deployment csum versions

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -491,7 +491,7 @@ os_repository_new_commit ()
 
     echo "content iteration ${content_iteration}" > usr/bin/content-iteration
 
-    version=$(date "+%Y%m%d.${content_iteration}")
+    export version=$(date "+%Y%m%d.${content_iteration}")
 
     ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" -b $branch -s "Build"
     cd ${test_tmpdir}


### PR DESCRIPTION
When comparing deployments to determine whether we need a new
bootversion, we should also check whether the commit "version" metadata
is the same. Otherwise, we may end up with the a bootconfig whose
`title` includes a version that doesn't match the one from the
deployment checksum.

Closes: projectatomic/rpm-ostree#1343