### PR TITLE
deploy: Return staged deployment

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2736,6 +2736,7 @@ ostree_sysroot_stage_tree (OstreeSysroot     *self,
   if (!ostree_sysroot_load (self, cancellable, error))
     return FALSE;
 
+  ot_transfer_out_value (out_new_deployment, &deployment);
   return TRUE;
 }
 

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -178,12 +178,14 @@ ot_admin_builtin_deploy (int argc, char **argv, OstreeCommandInvocation *invocat
       if (!ostree_sysroot_stage_tree (sysroot, opt_osname, revision, origin, merge_deployment,
                                       kargs_strv, &new_deployment, cancellable, error))
         return FALSE;
+      g_assert (new_deployment);
     }
   else
     {
       if (!ostree_sysroot_deploy_tree (sysroot, opt_osname, revision, origin, merge_deployment,
                                        kargs_strv, &new_deployment, cancellable, error))
         return FALSE;
+      g_assert (new_deployment);
 
       OstreeSysrootSimpleWriteDeploymentFlags flags = OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NO_CLEAN;
       if (opt_retain)


### PR DESCRIPTION
Today rpm-ostree has some code to run a "sanitycheck" on a deployment.
I had initially deleted that when adapting it to use the staging code,
but I realized it should work fine; we just won't see the merged
config, but that's OK.

When I readded that code it started crashing because we didn't
actually return the new deployment object.  We'll gain some coverage
here as I'll land the code to have rpm-ostree use staging, then bump
the rpm-ostree tests here.