### PR TITLE
man/ostree: Document --repo option a bit more

### DIFF
--- a/man/ostree-init.xml
+++ b/man/ostree-init.xml
@@ -69,13 +69,24 @@ Boston, MA 02111-1307, USA.
         <variablelist>
             <varlistentry>
                 <term><option>--mode</option>="MODE"</term>
-                <listitem><para> Initialize repository in given mode
-                (<literal>bare</literal>, <literal>bare-user</literal>,
-                <literal>archive</literal>). The default is
-                <literal>bare</literal>. Note that for
-                <literal>archive</literal> the repository configuration file
-                will actually have <literal>archive-z2</literal>, as that's the
-                historical name.</para></listitem>
+                <listitem><para>
+                    Initialize repository in given mode
+                    (<literal>bare</literal>, <literal>bare-user</literal>,
+                    <literal>bare-user-only</literal>, <literal>archive</literal>).
+                    The default is <literal>bare</literal>. Note that for
+                    <literal>archive</literal> the repository configuration file
+                    will actually have <literal>archive-z2</literal>, as that's
+                    the historical name.</para>
+
+                    <para>See the manual for differences between these modes.
+                    Briefly, <literal>bare</literal> mode stores files as they
+                    are, so they can be directly hardlinked,
+                    <literal>bare-user</literal> uses extended attributes to
+                    store ownership and xattr information, allowing non-root
+                    operations, <literal>bare-user-only</literal> does not store
+                    ownership information, and <literal>archive</literal> stores
+                    files compressed, to be served over the network.
+                </para></listitem>
             </varlistentry>
 
             <varlistentry>

--- a/man/ostree.xml
+++ b/man/ostree.xml
@@ -111,14 +111,14 @@ Boston, MA 02111-1307, USA.
                 <term><option>--repo</option></term>
 
                 <listitem><para>
-                    For most commands,
-                    when run as non-root, repository is
-                    required.  If
-                    <command>ostree</command> is run as
-                    root, it is assumed operations will be
-                    performed on the
-                    <filename>/sysroot/ostree/repo</filename>
-                    repository.
+                    For most commands, a repository is
+                    required.  If unspecified, the current
+                    directory is used if it appears to be an
+                    OSTree repository. If it isn't, either
+                    the <envar>OSTREE_REPO</envar>
+                    environment variable is used, or the
+                    system repository located at
+                    <filename>/sysroot/ostree/repo</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/src/ostree/ot-builtin-init.c
+++ b/src/ostree/ot-builtin-init.c
@@ -38,7 +38,7 @@ static char *opt_collection_id = NULL;
  */
 
 static GOptionEntry options[] = {
-  { "mode", 0, 0, G_OPTION_ARG_STRING, &opt_mode, "Initialize repository in given mode (bare, archive)", NULL },
+  { "mode", 0, 0, G_OPTION_ARG_STRING, &opt_mode, "Initialize repository in given mode (bare, bare-user, bare-user-only, archive)", NULL },
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id,
     "Globally unique ID for this repository as an collection of refs for redistribution to other repositories", "COLLECTION-ID" },

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -46,7 +46,7 @@ static GOptionEntry global_entries[] = {
 };
 
 static GOptionEntry repo_entry[] = {
-  { "repo", 0, 0, G_OPTION_ARG_FILENAME, &opt_repo, "Path to OSTree repository (defaults to /sysroot/ostree/repo)", "PATH" },
+  { "repo", 0, 0, G_OPTION_ARG_FILENAME, &opt_repo, "Path to OSTree repository (defaults to current directory or /sysroot/ostree/repo)", "PATH" },
   { NULL }
 };
 


### PR DESCRIPTION
This new information is already mostly part of `ostree.repo(5)`, though
let's put it in `ostree(1)` as well since that's where the switch is
officially documented.