### PR TITLE
build: Don't distribute Bison-generated parser in dist tarballs

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -52,6 +52,9 @@ ostree_SOURCES = src/ostree/main.c \
 	src/ostree/ot-editor.c \
 	src/ostree/ot-editor.h \
 	src/ostree/parse-datetime.h \
+	$(NULL)
+
+nodist_ostree_SOURCES = \
 	src/ostree/parse-datetime.c \
 	$(NULL)
 


### PR DESCRIPTION
We already build it from source, but the generated code is in the dist tarball anyway.