### PR TITLE
repo: Add checksum to error message opening unreadable object

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3550,6 +3550,9 @@ _ostree_repo_load_file_bare (OstreeRepo         *self,
       return FALSE;
     }
 
+  const char *errprefix = glnx_strjoina ("Opening content object ", checksum);
+  GLNX_AUTO_PREFIX_ERROR (errprefix, error);
+
   struct stat stbuf;
   glnx_autofd int fd = -1;
   g_autofree char *ret_symlink = NULL;
@@ -3590,7 +3593,7 @@ _ostree_repo_load_file_bare (OstreeRepo         *self,
     }
 
   if (!(S_ISREG (stbuf.st_mode) || S_ISLNK (stbuf.st_mode)))
-    return glnx_throw (error, "Not a regular file or symlink: %s", loose_path_buf);
+    return glnx_throw (error, "Not a regular file or symlink");
 
   /* In the non-bare-user case, gather symlink info if requested */
   if (self->mode != OSTREE_REPO_MODE_BARE_USER

--- a/tests/installed/nondestructive/itest-bare-unit.sh
+++ b/tests/installed/nondestructive/itest-bare-unit.sh
@@ -24,7 +24,7 @@ date
 
 # Test error message when opening a non-world-readable object
 # https://github.com/ostreedev/ostree/issues/1562
-rm repo -rf
+rm repo files -rf
 chmod a+rx .
 ostree --repo=repo init --mode=bare
 mkdir files
@@ -37,3 +37,5 @@ if setpriv --reuid bin --regid bin --clear-groups ostree --repo=repo cat testbra
     fatal "Listed unreadable object as non-root"
 fi
 assert_file_has_content err.txt "Opening content object.*openat: Permission denied"
+
+date

--- a/tests/installed/nondestructive/itest-bare-unit.sh
+++ b/tests/installed/nondestructive/itest-bare-unit.sh
@@ -21,3 +21,24 @@ trap _tmpdir_cleanup EXIT
 /usr/libexec/installed-tests/libostree/test-basic.sh
 /usr/libexec/installed-tests/libostree/test-basic-c
 date
+
+# Test error message when opening a non-world-readable object
+# https://github.com/ostreedev/ostree/issues/1562
+rm repo -rf
+chmod a+rx .
+ostree --repo=repo init --mode=bare
+mkdir files
+touch files/unreadable
+chmod 0 files/unreadable
+ostree --repo=repo commit -b testbranch --tree=dir=files
+# We should be able to read as non-root due to CAP_DAC_OVERRIDE
+ostree --repo=repo ls testbranch >/dev/null
+cat >upriv.sh <<EOF
+#!/bin/bash
+set -xeuo pipefail
+ostree --repo=testclone
+EOF
+if setpriv --reuid bin --regid bin --clear-groups ostree --repo=repo cat testbranch /unreadable 2>err.txt; then
+    fatal "Listed unreadable object as non-root"
+fi
+assert_file_has_content err.txt "Opening content object.*openat: Permission denied"

--- a/tests/installed/nondestructive/itest-bare-unit.sh
+++ b/tests/installed/nondestructive/itest-bare-unit.sh
@@ -31,13 +31,8 @@ mkdir files
 touch files/unreadable
 chmod 0 files/unreadable
 ostree --repo=repo commit -b testbranch --tree=dir=files
-# We should be able to read as non-root due to CAP_DAC_OVERRIDE
-ostree --repo=repo ls testbranch >/dev/null
-cat >upriv.sh <<EOF
-#!/bin/bash
-set -xeuo pipefail
-ostree --repo=testclone
-EOF
+# We should be able to read as root due to CAP_DAC_OVERRIDE
+ostree --repo=repo cat testbranch /unreadable >/dev/null
 if setpriv --reuid bin --regid bin --clear-groups ostree --repo=repo cat testbranch /unreadable 2>err.txt; then
     fatal "Listed unreadable object as non-root"
 fi


### PR DESCRIPTION
This would have debugged trying to do a pull as non-root from
a sysroot repository.  See for example:
https://github.com/ostreedev/ostree/issues/1562