### PR TITLE
lib/deploy: Do post-ops when removing staged commit

### DIFF
--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -4,13 +4,14 @@
 - name: Write staged-deploy commit
   shell: |
     ostree --repo=/ostree/repo commit --parent="${commit}" -b staged-deploy --tree=ref="${commit}" --no-bindings
+    newcommit=$(ostree rev-parse staged-deploy)
     orig_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
     ostree admin deploy --stage staged-deploy
     new_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
     assert_not_streq "${orig_mtime}" "${new_mtime}"
     test -f /run/ostree/staged-deployment
     ostree refs | grep -E -e '^ostree/' | while read ref; do
-      if test "$(ostree rev-parse ${ref})" = "${commit}"; then
+      if test "$(ostree rev-parse ${ref})" = "${newcommit}"; then
         touch deployment-ref-found
       fi
     done

--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -4,8 +4,18 @@
 - name: Write staged-deploy commit
   shell: |
     ostree --repo=/ostree/repo commit --parent="${commit}" -b staged-deploy --tree=ref="${commit}" --no-bindings
+    orig_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
     ostree admin deploy --stage staged-deploy
+    new_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
+    assert_not_streq "${orig_mtime}" "${new_mtime}"
     test -f /run/ostree/staged-deployment
+    ostree refs | grep -E -e '^ostree/' | while read ref; do
+      if test "$(ostree rev-parse ${ref})" = "${commit}"; then
+        touch deployment-ref-found
+      fi
+    done
+    test -f deployment-ref-found
+    rm deployment-ref-found
   environment:
     commit: "{{ rpmostree_status['deployments'][0]['checksum'] }}"
 - include_tasks: ../tasks/reboot.yml


### PR DESCRIPTION
These are further fixes based on running more of the rpm-ostree
test suite.

When dropping the staged deployment, we do need to do the
"post operations" such as bumping the sysroot mtime, so that
clients know something changed.  We also need to regenerate
the deployment refs.  And of course do a sysroot reload.

Also, add a "base cleanup" after creating a staged deployment
which also regenerates the refs.