### PR TITLE
deploy: Use fdatasync() for new kernel/initramfs by default

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -128,7 +128,7 @@ install_into_boot (OstreeSePolicy *sepolicy,
                                                     error))
             return FALSE;
           return glnx_file_copy_at (src_dfd, src_subpath, NULL, dest_dfd, dest_subpath,
-                                    GLNX_FILE_COPY_NOXATTRS,
+                                    GLNX_FILE_COPY_NOXATTRS | GLNX_FILE_COPY_DATASYNC,
                                     cancellable, error);
         }
       else


### PR DESCRIPTION
While we do a `syncfs()` plus `FIFREEZE/THAW` for `/boot`, that
only comes during deployment finalization.

The code here today generally assumes that if the file exists
it's been fully written.  So let's do a `fdatasync()` before
we do the `rename()`.

This just came out of looking through the code while working
on deployment staging.  In that scenario there's a much larger
window between when we copy the kernel/initramfs and when we
sync `/boot`.