### PR TITLE
lib: Use `Locking:` term in docs

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1551,10 +1551,9 @@ ostree_repo_scan_hardlinks (OstreeRepo    *self,
  * on a single `OstreeRepo` instance as long as their lifetime is bounded by the
  * transaction.
  *
+ * Locking: Acquires a `shared` lock; release via commit or abort
  * Multithreading: This function is *not* MT safe; only one transaction can be
  * active at a time.
- *
- * This function takes a shared lock on the @self repository.
  */
 gboolean
 ostree_repo_prepare_transaction (OstreeRepo     *self,
@@ -2080,6 +2079,7 @@ ostree_repo_set_collection_ref_immediate (OstreeRepo                 *self,
  * Note that if multiple threads are performing writes, all such threads must
  * have terminated before this function is invoked.
  *
+ * Locking: Releases `shared` lock acquired by `ostree_repo_prepare_transaction()`
  * Multithreading: This function is *not* MT safe; only one transaction can be
  * active at a time.
  */

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -193,7 +193,7 @@ _ostree_repo_prune_tmp (OstreeRepo *self,
  * targeting that commit; otherwise any static delta of non existing commits are
  * deleted.
  *
- * This function takes an exclusive lock on the @self repository.
+ * Locking: exclusive
  */
 gboolean
 ostree_repo_prune_static_deltas (OstreeRepo *self, const char *commit,
@@ -326,7 +326,7 @@ repo_prune_internal (OstreeRepo        *self,
  * statistics on objects that would be deleted, without actually
  * deleting them.
  *
- * This function takes an exclusive lock on the @self repository.
+ * Locking: exclusive
  */
 gboolean
 ostree_repo_prune (OstreeRepo        *self,
@@ -438,7 +438,7 @@ ostree_repo_prune (OstreeRepo        *self,
  * The %OSTREE_REPO_PRUNE_FLAGS_NO_PRUNE flag may be specified to just determine
  * statistics on objects that would be deleted, without actually deleting them.
  *
- * This function takes an exclusive lock on the @self repository.
+ * Locking: exclusive
  */
 gboolean
 ostree_repo_prune_from_reachable (OstreeRepo        *self,


### PR DESCRIPTION
This is easier to `git grep` etc. versus ad-hoc English.  Although
we still have some English for the prepare_transaction/commit which
acquire/release in separate phases.