### PR TITLE
README: Tweak licensing description

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Licensing
 
 The licensing for the *code* of libostree can be canonically found in the individual files;
 and the overall status in the [COPYING](https://github.com/ostreedev/ostree/blob/master/COPYING)
-file in the source. Currently, that's LGPLv2+.
+file in the source.  Currently, that's LGPLv2+.  This also covers the man pages and API docs.
 
-The license for the *documentation* of libostree is: `SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`
+The license for the manual documentation in the `doc/` directory is:
+`SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`
+This is intended to allow use by Wikipedia and other projects.
+
+In general, files should have a `SPDX-License-Identifier` and that is canonical.


### PR DESCRIPTION
Basically it wasn't clear that the man pages and API doc
remain LGPLv2.

Closes: https://github.com/ostreedev/ostree/issues/1456