### PR TITLE
repo: handle GPG_ERR_AMBIGUOUS_NAME in sign_data

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4640,6 +4640,10 @@ sign_data (OstreeRepo     *self,
   if (gpgme_err_code (err) == GPG_ERR_EOF)
     return glnx_throw (error, "No gpg key found with ID %s (homedir: %s)", key_id,
                        homedir ? homedir : "<default>");
+  else if (gpgme_err_code (err) == GPG_ERR_AMBIGUOUS_NAME) {
+    return glnx_throw (error, "gpg key id %s ambiguous (homedir: %s). Try the fingerprint instead", key_id,
+                       homedir ? homedir : "<default>");
+   }
   else if (err != GPG_ERR_NO_ERROR)
     return ot_gpgme_throw (err, error, "Unable to lookup key ID %s", key_id);
 


### PR DESCRIPTION
This should give a more insightful error message if the user provides
a UID which is present on multiple keys.
This happens if you have an old key in your keyring which you are not
actively using any more, e.g. because it is too old.  You still have
your old keys in your keyring, because you want to read old email
encrypted for that key, though.

The gpgme function used by ostree right now complains if a UID is found
on multiple keys:
https://www.gnupg.org/documentation/manuals/gpgme/Listing-Keys.html#index-gpgme_005fget_005fkey
The used API is too simple for that use case.

Note that it would be nicer if ostree picked the only valid signing key out
of the available keys rather than using the simplistic gpgme_get_key
function.  It be nicer, of course, if there was such a gpgme function.