### PR TITLE
ci: Drop str hotpatch

### DIFF
--- a/tests/installed/provision.sh
+++ b/tests/installed/provision.sh
@@ -6,7 +6,3 @@ dn=$(dirname $0)
 
 pkg_upgrade
 pkg_install git rsync openssh-clients ansible standard-test-roles
-
-# "Hot patch" this to pick up https://pagure.io/standard-test-roles/pull-request/152
-# so we get parallelism
-cd /usr/share/ansible/inventory && curl -L -O https://pagure.io/standard-test-roles/raw/master/f/inventory/standard-inventory-qcow2


### PR DESCRIPTION
The change we want is in the current Fedora repos, and git master
is broken:

> qemu-system-x86_64: -vnc :1: Failed to start VNC server: Failed to bind socket: Address already in use

 https://pagure.io/standard-test-roles/pull-request/186#comment-52440