### PR TITLE
lib/sysroot: Add OSTREE_EX_STAGE_DEPLOYMENTS environment variable 

### DIFF
--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -644,21 +644,37 @@ ostree_sysroot_upgrader_deploy (OstreeSysrootUpgrader  *self,
                                 GError                **error)
 {
   g_autoptr(OstreeDeployment) new_deployment = NULL;
-  if (!ostree_sysroot_deploy_tree (self->sysroot, self->osname,
-                                   self->new_revision,
-                                   self->origin,
-                                   self->merge_deployment,
-                                   NULL,
-                                   &new_deployment,
-                                   cancellable, error))
-    return FALSE;
 
-  if (!ostree_sysroot_simple_write_deployment (self->sysroot, self->osname,
-                                               new_deployment,
-                                               self->merge_deployment,
-                                               0,
-                                               cancellable, error))
-    return FALSE;
+  /* Experimental flag to enable staging */
+  if (getenv ("OSTREE_EX_STAGE_DEPLOYMENTS"))
+    {
+      if (!ostree_sysroot_stage_tree (self->sysroot, self->osname,
+                                      self->new_revision,
+                                      self->origin,
+                                      self->merge_deployment,
+                                      NULL,
+                                      &new_deployment,
+                                      cancellable, error))
+        return FALSE;
+    }
+  else
+    {
+      if (!ostree_sysroot_deploy_tree (self->sysroot, self->osname,
+                                       self->new_revision,
+                                       self->origin,
+                                       self->merge_deployment,
+                                       NULL,
+                                       &new_deployment,
+                                       cancellable, error))
+        return FALSE;
+
+      if (!ostree_sysroot_simple_write_deployment (self->sysroot, self->osname,
+                                                   new_deployment,
+                                                   self->merge_deployment,
+                                                   0,
+                                                   cancellable, error))
+        return FALSE;
+    }
 
   return TRUE;
 }

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -78,7 +78,8 @@ assert_ostree_deployment_refs 1/1/0
 ${CMD_PREFIX} ostree admin status
 echo "ok layout"
 
-if ${CMD_PREFIX} ostree admin deploy --stage --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
+assert_file_has_content_literal err.txt "Cannot stage a deployment when not currently booted into an OSTree system"
+if env OSTREE_EX_STAGE_DEPLOYMENTS=1 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
     fatal "staged when not booted"
 fi
 assert_file_has_content_literal err.txt "Cannot stage a deployment when not currently booted into an OSTree system"

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((24 + ${extra_admin_tests:-0}))"
+echo "1..$((25 + ${extra_admin_tests:-0}))"
 
 function validate_bootloader() {
     cd ${test_tmpdir};
@@ -78,8 +78,7 @@ assert_ostree_deployment_refs 1/1/0
 ${CMD_PREFIX} ostree admin status
 echo "ok layout"
 
-assert_file_has_content_literal err.txt "Cannot stage a deployment when not currently booted into an OSTree system"
-if env OSTREE_EX_STAGE_DEPLOYMENTS=1 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
+if ${CMD_PREFIX} ostree admin deploy --stage --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
     fatal "staged when not booted"
 fi
 assert_file_has_content_literal err.txt "Cannot stage a deployment when not currently booted into an OSTree system"
@@ -216,6 +215,11 @@ validate_bootloader
 echo "ok upgrade bare"
 
 os_repository_new_commit
+if env OSTREE_EX_STAGE_DEPLOYMENTS=1 ${CMD_PREFIX} ostree admin upgrade --os=testos 2>err.txt; then
+    fatal "staged when not booted"
+fi
+echo "ok upgrade failed when staged"
+
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos file://$(pwd)/testos-repo testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 origrev=${rev}

--- a/tests/installed/destructive-ansible.yml
+++ b/tests/installed/destructive-ansible.yml
@@ -9,10 +9,7 @@
     tests: "."
   tasks:
     - import_tasks: tasks/disable-all-rpmmd-repos.yml
-    - import_tasks: tasks/query-host.yml
-    - set_fact:
-        rpmostree_initial_deployment: "{{ rpmostree_status[\"deployments\"][0] }}"
     - import_tasks: tasks/install-git.yml
       when: use_git_build
-
+    - import_tasks: tasks/query-host.yml
     - import_tasks: destructive/staged-deploy.yml

--- a/tests/installed/destructive-ansible.yml
+++ b/tests/installed/destructive-ansible.yml
@@ -8,6 +8,7 @@
     use_git_build: True
     tests: "."
   tasks:
+    - import_tasks: tasks/disable-all-rpmmd-repos.yml
     - import_tasks: tasks/query-host.yml
     - set_fact:
         rpmostree_initial_deployment: "{{ rpmostree_status[\"deployments\"][0] }}"

--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -27,16 +27,31 @@
 - name: Check that deploy-staged service worked
   shell: |
     set -xeuo pipefail
+    rpm-ostree status
     # Assert that the previous boot had a journal entry for it
     journalctl -b "-1" -u ostree-finalize-staged.service | grep -q -e 'Transaction complete'
     # And there should not be a staged deployment
     test '!' -f /run/ostree/staged-deployment
-- name: Rollback
-  shell: rpm-ostree rollback
-- include_tasks: ../tasks/reboot.yml
-- shell: |
+
+- name: Upgrade with staging
+  shell: |
     set -xeuo pipefail
+    test '!' -f /run/ostree/staged-deployment
+    ostree admin deploy --stage staged-deploy
+    test -f /run/ostree/staged-deployment
+    origcommit=$(ostree rev-parse staged-deploy)
+    cd /ostree/repo/tmp
+    ostree checkout -H "${origcommit}" t
+    ostree commit --no-bindings --parent="${origcommit}" -b staged-deploy -I --consume t
+    newcommit=$(ostree rev-parse staged-deploy)
+    env OSTREE_EX_STAGE_DEPLOYMENTS=1 ostree admin upgrade >out.txt
+    test -f /run/ostree/staged-deployment
+    # Debating bouncing back out to Ansible for this
+    firstdeploycommit=$(rpm-ostree status |grep 'Commit:' |head -1|sed -e 's,^ *Commit: *,,')
+    test "${firstdeploycommit}" = "${newcommit}"
+    # Cleanup
     rpm-ostree cleanup -rp
+- import_tasks: ../tasks/query-host.yml
 
 # Ensure we can unstage
 - name: Write staged-deploy commit, then unstage
@@ -50,8 +65,6 @@
     ostree admin status > status.txt
     grep -vqFe '(staged)' status.txt
     test '!' -f /run/ostree/staged-deployment
-  environment:
-    commit: "{{ rpmostree_status['deployments'][0]['checksum'] }}"
 
 - name: Staged should be overwritten by non-staged
   shell: |

--- a/tests/installed/tasks/disable-all-rpmmd-repos.yml
+++ b/tests/installed/tasks/disable-all-rpmmd-repos.yml
@@ -1,0 +1,5 @@
+- name: Disable all rpmmd repos
+  shell: |
+    for x in /etc/yum.repos.d/*.repo; do
+      sed -i -e 's,^enabled=,enabled=0,g' $x
+    done

--- a/tests/installed/tasks/install-git.yml
+++ b/tests/installed/tasks/install-git.yml
@@ -8,7 +8,8 @@
   synchronize: src=build/x86_64/ dest=/root/x86_64/ archive=yes
 - name: Install RPMs
   shell: rpm-ostree override replace /root/x86_64/*.rpm
-- include_tasks: ../tasks/reboot.yml
+- import_tasks: ../tasks/reboot.yml
+- import_tasks: ../tasks/query-host.yml
 - command: ostree --version
   register: ostree_new_version
 - set_fact:

--- a/tests/installed/tasks/query-host.yml
+++ b/tests/installed/tasks/query-host.yml
@@ -1,4 +1,5 @@
-- command: rpm-ostree status --json
+- name: Load status json
+  command: rpm-ostree status --json
   changed_when: False
   register: rpmostree_status_json
 - set_fact:


### PR DESCRIPTION
I feel like I'm drowning in a pile of experimental-but-almost-stable
features...

Anyways, since we made the feature opt-in in rpm-ostree in
https://github.com/projectatomic/rpm-ostree/pull/1352
let's mirror that a bit here with an environment variable so people
can play with it more easily.

The tests needed some tweaks; specifically we need to reload the
status fact after making changes.  I'm still a bit uncertain
about the Ansible-as-tests.

But we add an upgrade test that uses the new environment variable.