### PR TITLE
u-boot: add support for devicetree

### DIFF
--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -140,6 +140,10 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
       if (val)
         g_ptr_array_add (new_lines, g_strdup_printf ("ramdisk_image%s=%s", index_suffix, val));
 
+      val = ostree_bootconfig_parser_get (config, "devicetree");
+      if (val)
+        g_ptr_array_add (new_lines, g_strdup_printf ("fdt_file%s=%s", index_suffix, val));
+
       val = ostree_bootconfig_parser_get (config, "options");
       if (val)
         {


### PR DESCRIPTION
Likewise the corresponding support for syslinux introduced by commit
c5112c25e4519835c4cd53f4350c1b2f2a477746, this one enables writing devicetree
filename into the uEnv.txt environment file for u-boot.

Since u-boot does not strictly defines variable names, here 'fdt_file' was
chosen as it appear to be one the most frequently adopted names in u-boot
default environments. Outer boot logic should of course comply with this choice
and use $fdt_file as the device tree file name to pass to boot commands.

This was tested on a custom board booting with u-boot.