### PR TITLE
More useful ostree fsck

### DIFF
--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -31,6 +31,7 @@
 
 static gboolean opt_quiet;
 static gboolean opt_delete;
+static gboolean opt_all;
 static gboolean opt_add_tombstones;
 static gboolean opt_verify_bindings;
 static gboolean opt_verify_back_refs;
@@ -43,6 +44,7 @@ static gboolean opt_verify_back_refs;
 static GOptionEntry options[] = {
   { "add-tombstones", 0, 0, G_OPTION_ARG_NONE, &opt_add_tombstones, "Add tombstones for missing commits", NULL },
   { "quiet", 'q', 0, G_OPTION_ARG_NONE, &opt_quiet, "Only print error messages", NULL },
+  { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_all, "Don't stop on first error", NULL },
   { "delete", 0, 0, G_OPTION_ARG_NONE, &opt_delete, "Remove corrupted objects", NULL },
   { "verify-bindings", 0, 0, G_OPTION_ARG_NONE, &opt_verify_bindings, "Verify ref bindings", NULL },
   { "verify-back-refs", 0, 0, G_OPTION_ARG_NONE, &opt_verify_back_refs, "Verify back-references (implies --verify-bindings)", NULL },
@@ -93,6 +95,11 @@ fsck_one_object (OstreeRepo            *repo,
               g_printerr ("%s\n", temp_error->message);
               (void) ostree_repo_delete_object (repo, objtype, checksum, cancellable, NULL);
               object_missing = TRUE;
+            }
+          else if (opt_all)
+            {
+              *out_found_corruption = TRUE;
+              g_printerr ("%s\n", temp_error->message);
             }
           else
             {

--- a/tests/test-corruption.sh
+++ b/tests/test-corruption.sh
@@ -104,7 +104,7 @@ assert_not_has_file repo/state/${rev}.commitpartial
 if $OSTREE fsck -q 2>err.txt; then
     assert_not_reached "fsck unexpectedly succeeded"
 fi
-assert_file_has_content_literal err.txt "Object missing:"
+assert_file_has_content_literal err.txt "Object missing"
 assert_file_has_content_literal err.txt "Marking commit as partial: $rev"
 assert_has_file repo/state/${rev}.commitpartial
 


### PR DESCRIPTION
This adds a --all option to not stop on the first error, and prints out what commits each corrupted object is in.