### PR TITLE
Support retrying downloads if they transiently fail

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -337,19 +337,7 @@ check_multi_info (OstreeFetcher *fetcher)
           curl_easy_getinfo (easy, CURLINFO_RESPONSE_CODE, &response);
           if (!is_file && !(response >= 200 && response < 300))
             {
-              GIOErrorEnum giocode;
-
-              /* TODO - share with soup */
-              switch (response)
-                {
-                case 404:
-                case 403:
-                case 410:
-                  giocode = G_IO_ERROR_NOT_FOUND;
-                  break;
-                default:
-                  giocode = G_IO_ERROR_FAILED;
-                }
+              GIOErrorEnum giocode = _ostree_fetcher_http_status_code_to_io_error (response);
 
               if (req->idx + 1 == req->mirrorlist->len)
                 {

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1086,8 +1086,8 @@ on_request_sent (GObject        *object,
                   code = G_IO_ERROR_BROKEN_PIPE;
 #else
                   code = G_IO_ERROR_CONNECTION_CLOSED;
-                  break;
 #endif
+                  break;
                 default:
                   code = _ostree_fetcher_http_status_code_to_io_error (msg->status_code);
                   break;

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1070,18 +1070,12 @@ on_request_sent (GObject        *object,
                 soup_uri_to_string (soup_request_get_uri (pending->request), FALSE);
 
               GIOErrorEnum code;
+
               switch (msg->status_code)
                 {
-                case SOUP_STATUS_NOT_FOUND:
-                case SOUP_STATUS_FORBIDDEN:
-                case SOUP_STATUS_GONE:
-                  code = G_IO_ERROR_NOT_FOUND;
-                  break;
+                /* These statuses are internal to libsoup, and not standard HTTP ones: */
                 case SOUP_STATUS_CANCELLED:
                   code = G_IO_ERROR_CANCELLED;
-                  break;
-                case SOUP_STATUS_REQUEST_TIMEOUT:
-                  code = G_IO_ERROR_TIMED_OUT;
                   break;
                 case SOUP_STATUS_CANT_RESOLVE:
                 case SOUP_STATUS_CANT_CONNECT:
@@ -1092,10 +1086,11 @@ on_request_sent (GObject        *object,
                   code = G_IO_ERROR_BROKEN_PIPE;
 #else
                   code = G_IO_ERROR_CONNECTION_CLOSED;
-#endif
                   break;
+#endif
                 default:
-                  code = G_IO_ERROR_FAILED;
+                  code = _ostree_fetcher_http_status_code_to_io_error (msg->status_code);
+                  break;
                 }
 
               {

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1072,10 +1072,27 @@ on_request_sent (GObject        *object,
               GIOErrorEnum code;
               switch (msg->status_code)
                 {
-                case 404:
-                case 403:
-                case 410:
+                case SOUP_STATUS_NOT_FOUND:
+                case SOUP_STATUS_FORBIDDEN:
+                case SOUP_STATUS_GONE:
                   code = G_IO_ERROR_NOT_FOUND;
+                  break;
+                case SOUP_STATUS_CANCELLED:
+                  code = G_IO_ERROR_CANCELLED;
+                  break;
+                case SOUP_STATUS_REQUEST_TIMEOUT:
+                  code = G_IO_ERROR_TIMED_OUT;
+                  break;
+                case SOUP_STATUS_CANT_RESOLVE:
+                case SOUP_STATUS_CANT_CONNECT:
+                  code = G_IO_ERROR_HOST_NOT_FOUND;
+                  break;
+                case SOUP_STATUS_IO_ERROR:
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+                  code = G_IO_ERROR_BROKEN_PIPE;
+#else
+                  code = G_IO_ERROR_CONNECTION_CLOSED;
+#endif
                   break;
                 default:
                   code = G_IO_ERROR_FAILED;

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -218,3 +218,22 @@ _ostree_fetcher_should_retry_request (const GError *error,
 
   return FALSE;
 }
+
+/* Convert a HTTP status code representing an error from libsoup or libcurl to
+ * a #GIOError. This will return %G_IO_ERROR_FAILED if the status code is
+ * unknown or otherwise unhandled. */
+GIOError
+_ostree_fetcher_http_status_code_to_io_error (guint status_code)
+{
+  switch (status_code)
+    {
+    case 403:  /* SOUP_STATUS_FORBIDDEN */
+    case 404:  /* SOUP_STATUS_NOT_FOUND */
+    case 410:  /* SOUP_STATUS_GONE */
+      return G_IO_ERROR_NOT_FOUND;
+    case 408:  /* SOUP_STATUS_REQUEST_TIMEOUT */
+      return G_IO_ERROR_TIMED_OUT;
+    default:
+      return G_IO_ERROR_FAILED;
+    }
+}

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -52,15 +52,15 @@ fetch_uri_sync_on_complete (GObject        *object,
   data->done = TRUE;
 }
 
-gboolean
-_ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher  *fetcher,
-                                            GPtrArray     *mirrorlist,
-                                            const char     *filename,
-                                            OstreeFetcherRequestFlags flags,
-                                            GBytes         **out_contents,
-                                            guint64        max_size,
-                                            GCancellable   *cancellable,
-                                            GError         **error)
+static gboolean
+_ostree_fetcher_mirrored_request_to_membuf_once  (OstreeFetcher              *fetcher,
+                                                  GPtrArray                  *mirrorlist,
+                                                  const char                 *filename,
+                                                  OstreeFetcherRequestFlags   flags,
+                                                  GBytes                    **out_contents,
+                                                  guint64                     max_size,
+                                                  GCancellable               *cancellable,
+                                                  GError                    **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GMainContext) mainctx = NULL;
@@ -108,11 +108,42 @@ _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher  *fetcher,
   return ret;
 }
 
+gboolean
+_ostree_fetcher_mirrored_request_to_membuf  (OstreeFetcher              *fetcher,
+                                             GPtrArray                  *mirrorlist,
+                                             const char                 *filename,
+                                             OstreeFetcherRequestFlags   flags,
+                                             guint                       n_network_retries,
+                                             GBytes                    **out_contents,
+                                             guint64                     max_size,
+                                             GCancellable               *cancellable,
+                                             GError                    **error)
+{
+  g_autoptr(GError) local_error = NULL;
+  guint n_retries_remaining = n_network_retries;
+
+  do
+    {
+      g_clear_error (&local_error);
+      if (_ostree_fetcher_mirrored_request_to_membuf_once (fetcher, mirrorlist,
+                                                           filename, flags,
+                                                           out_contents, max_size,
+                                                           cancellable, &local_error))
+        return TRUE;
+    }
+  while (_ostree_fetcher_should_retry_request (local_error, n_retries_remaining--));
+
+  g_assert (local_error != NULL);
+  g_propagate_error (error, g_steal_pointer (&local_error));
+  return FALSE;
+}
+
 /* Helper for callers who just want to fetch single one-off URIs */
 gboolean
 _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
                                        OstreeFetcherURI *uri,
                                        OstreeFetcherRequestFlags flags,
+                                       guint          n_network_retries,
                                        GBytes         **out_contents,
                                        guint64        max_size,
                                        GCancellable   *cancellable,
@@ -121,7 +152,7 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   g_autoptr(GPtrArray) mirrorlist = g_ptr_array_new ();
   g_ptr_array_add (mirrorlist, uri); /* no transfer */
   return _ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist, NULL, flags,
-                                                     out_contents, max_size,
+                                                     n_network_retries, out_contents, max_size,
                                                      cancellable, error);
 }
 
@@ -143,4 +174,47 @@ _ostree_fetcher_journal_failure (const char *remote_name,
                    "OSTREE_URL=%s", url,
                    NULL);
 #endif
+}
+
+/* Check whether a particular operation should be retried. This is entirely
+ * based on how it failed (if at all) last time, and whether the operation has
+ * some retries left. The retry count is set when the operation is first
+ * created, and must be decremented by the caller. (@n_retries_remaining == 0)
+ * will always return %FALSE from this function.
+ *
+ * FIXME: In future, we may decide to use transient failures like this as a hint
+ * to prioritise other mirrors for a particular pull operation (for example). */
+gboolean
+_ostree_fetcher_should_retry_request (const GError *error,
+                                      guint         n_retries_remaining)
+{
+  if (error == NULL)
+    g_debug ("%s: error: unset, n_retries_remaining: %u",
+             G_STRFUNC, n_retries_remaining);
+  else
+    g_debug ("%s: error: %u:%u %s, n_retries_remaining: %u",
+             G_STRFUNC, error->domain, error->code, error->message,
+             n_retries_remaining);
+
+  if (error == NULL || n_retries_remaining == 0)
+    return FALSE;
+
+  /* Return TRUE for transient errors. */
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE) ||
+#else
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+#endif
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
+    {
+      g_debug ("Should retry request (remaining: %u retries), due to transient error: %s",
+               n_retries_remaining, error->message);
+      return TRUE;
+    }
+
+  return FALSE;
 }

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -78,6 +78,8 @@ void _ostree_fetcher_journal_failure (const char *remote_name,
 gboolean _ostree_fetcher_should_retry_request (const GError *error,
                                                guint         n_retries_remaining);
 
+GIOError _ostree_fetcher_http_status_code_to_io_error (guint status_code);
+
 G_END_DECLS
 
 #endif

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -56,6 +56,7 @@ gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
                                                      GPtrArray     *mirrorlist,
                                                      const char    *filename,
                                                      OstreeFetcherRequestFlags flags,
+                                                     guint          n_network_retries,
                                                      GBytes         **out_contents,
                                                      guint64        max_size,
                                                      GCancellable   *cancellable,
@@ -64,6 +65,7 @@ gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
 gboolean _ostree_fetcher_request_uri_to_membuf (OstreeFetcher *fetcher,
                                                 OstreeFetcherURI *uri,
                                                 OstreeFetcherRequestFlags flags,
+                                                guint          n_network_retries,
                                                 GBytes         **out_contents,
                                                 guint64        max_size,
                                                 GCancellable   *cancellable,
@@ -73,6 +75,8 @@ void _ostree_fetcher_journal_failure (const char *remote_name,
                                       const char *url,
                                       const char *msg);
 
+gboolean _ostree_fetcher_should_retry_request (const GError *error,
+                                               guint         n_retries_remaining);
 
 G_END_DECLS
 

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -48,7 +48,8 @@ GType   _ostree_metalink_get_type (void) G_GNUC_CONST;
 OstreeMetalink *_ostree_metalink_new (OstreeFetcher  *fetcher,
                                       const char     *requested_file,
                                       guint64         max_size,
-                                      OstreeFetcherURI *uri);
+                                      OstreeFetcherURI *uri,
+                                      guint             n_network_retries);
 
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         OstreeFetcherURI      **out_target_uri,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1119,6 +1119,7 @@ content_fetch_on_complete (GObject        *object,
     }
 
  out:
+  g_assert (pull_data->n_outstanding_content_fetches > 0);
   pull_data->n_outstanding_content_fetches--;
 
   if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
@@ -1168,6 +1169,7 @@ on_metadata_written (GObject           *object,
   queue_scan_one_metadata_object_c (pull_data, csum, objtype, fetch_data->path, 0, fetch_data->requested_ref);
 
  out:
+  g_assert (pull_data->n_outstanding_metadata_write_requests > 0);
   pull_data->n_outstanding_metadata_write_requests--;
   fetch_object_data_free (fetch_data);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1309,7 +1309,9 @@ meta_fetch_on_complete (GObject           *object,
  out:
   g_assert (pull_data->n_outstanding_metadata_fetches > 0);
   pull_data->n_outstanding_metadata_fetches--;
-  pull_data->n_fetched_metadata++;
+
+  if (local_error == NULL)
+    pull_data->n_fetched_metadata++;
 
   if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
     enqueue_one_object_request_s (pull_data, g_steal_pointer (&fetch_data));
@@ -1395,7 +1397,9 @@ static_deltapart_fetch_on_complete (GObject           *object,
  out:
   g_assert (pull_data->n_outstanding_deltapart_fetches > 0);
   pull_data->n_outstanding_deltapart_fetches--;
-  pull_data->n_fetched_deltaparts++;
+
+  if (local_error == NULL)
+    pull_data->n_fetched_deltaparts++;
 
   if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
     enqueue_one_static_delta_part_request_s (pull_data, g_steal_pointer (&fetch_data));
@@ -2628,7 +2632,9 @@ on_superblock_fetched (GObject   *src,
  out:
   g_assert (pull_data->n_outstanding_metadata_fetches > 0);
   pull_data->n_outstanding_metadata_fetches--;
-  pull_data->n_fetched_metadata++;
+
+  if (local_error == NULL)
+    pull_data->n_fetched_metadata++;
 
   /* FIXME: This should check _ostree_fetcher_should_retry_request(). */
   check_outstanding_requests_handle_error (pull_data, &local_error);


### PR DESCRIPTION
Here’s a branch which adds support for retrying each network request in a pull operation if it fails with a transient error (like a socket timeout).

Static delta superblocks are currently not supported because they aren’t queued (that’s a separate issue). If this PR is accepted, I’ll put together another one to add queuing support for them, and remove the FIXME added in this one.

One issue which remains in my testing (using qdisc to increase latency and randomly drop packets) is that DNS queries fail a lot. That’s https://github.com/ostreedev/ostree/issues/894, and isn’t addressed in this PR. In real life, I would expect DNS queries to fail quite a lot less often than HTTP requests (since they’re tiny), but this does warrant further investigation.

I haven’t added tests to the branch because I have no idea how to write a unit test which reliably triggers this error handling path, short of writing a mock `GSocket` implementation and plumbing that in (which would result in a *huge* test harness). Suggestions welcome.

https://github.com/ostreedev/ostree/issues/878