### PR TITLE
bash-completion: Don't add a space after files and directories

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -87,10 +87,12 @@ __ostree_compreply_all_options() {
 }
 
 __ostree_compreply_all_files() {
+    compopt -o nospace
     COMPREPLY+=( $( compgen -f "$cur" ) )
 }
 
 __ostree_compreply_dirs_only() {
+    compopt -o nospace
     COMPREPLY+=( $( compgen -d "$cur" ) )
 }
 


### PR DESCRIPTION
Currently if ostree is completing a file or directory for you it adds a
space to the end, but this is an inconvenience when it's an intermediate
directory in a tree. It's better to let the user add the space after the
final directory, so this commit changes the bash completion to avoid
adding a space when completing files or directories.