### PR TITLE
Cleanup current boot's staging dir if we hit min-free-space-* condition

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -522,6 +522,7 @@ _ostree_repo_bare_content_commit (OstreeRepo                 *self,
       const fsblkcnt_t object_blocks = (st_buf.st_size / self->txn.blocksize) + 1;
       if (object_blocks > self->txn.max_blocks)
         {
+          self->emergency_cleanup = TRUE;
           g_mutex_unlock (&self->txn_lock);
           g_autofree char *formatted_required = g_format_size (st_buf.st_size);
           if (self->min_free_space_percent > 0)
@@ -924,6 +925,7 @@ write_content_object (OstreeRepo         *self,
       if (object_blocks > self->txn.max_blocks)
         {
           guint64 bytes_required = (guint64)object_blocks * self->txn.blocksize;
+          self->emergency_cleanup = TRUE;
           g_mutex_unlock (&self->txn_lock);
           g_autofree char *formatted_required = g_format_size (bytes_required);
           if (self->min_free_space_percent > 0)
@@ -1623,6 +1625,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
     return FALSE;
 
   self->in_transaction = TRUE;
+  self->emergency_cleanup = FALSE;
   if (self->min_free_space_percent >= 0 || self->min_free_space_mb >= 0)
     {
       struct statvfs stvfsbuf;
@@ -1638,6 +1641,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
       else
         {
           guint64 bytes_required = bfree * self->txn.blocksize;
+          self->emergency_cleanup = TRUE;
           g_mutex_unlock (&self->txn_lock);
           g_autofree char *formatted_free = g_format_size (bytes_required);
           if (self->min_free_space_percent > 0)
@@ -1783,9 +1787,10 @@ cleanup_txn_dir (OstreeRepo   *self,
 
   /* If however this is the staging directory for the *current*
    * boot, then don't delete it now - we may end up reusing it, as
-   * is the point.
+   * is the point. Delete *only if* we have hit min-free-space* checks
+   * as we don't want to hold onto caches in that case.
    */
-  if (g_str_has_prefix (path, self->stagedir_prefix))
+  if (g_str_has_prefix (path, self->stagedir_prefix) && !self->emergency_cleanup)
     return TRUE; /* Note early return */
 
   /* But, crucially we can now clean up staging directories

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2229,10 +2229,6 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
   if (!self->in_transaction)
     return TRUE;
 
-  /* Do not propagate failures from cleanup_tmpdir() immediately, as we want
-   * to clean up the rest of the internal transaction state first. */
-  cleanup_tmpdir (self, cancellable, &cleanup_error);
-
   if (self->loose_object_devino_hash)
     g_hash_table_remove_all (self->loose_object_devino_hash);
 
@@ -2241,6 +2237,10 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
 
   glnx_tmpdir_unset (&self->commit_stagedir);
   glnx_release_lock_file (&self->commit_stagedir_lock);
+
+  /* Do not propagate failures from cleanup_tmpdir() immediately, as we want
+   * to clean up the rest of the internal transaction state first. */
+  cleanup_tmpdir (self, cancellable, &cleanup_error);
 
   self->in_transaction = FALSE;
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -152,7 +152,7 @@ struct OstreeRepo {
   gid_t target_owner_gid;
   guint min_free_space_percent; /* See the min-free-space-percent config option */
   guint64 min_free_space_mb; /* See the min-free-space-size config option */
-  gboolean emergency_cleanup;
+  gboolean cleanup_stagedir;
 
   guint test_error_flags; /* OstreeRepoTestErrorFlags */
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -152,6 +152,7 @@ struct OstreeRepo {
   gid_t target_owner_gid;
   guint min_free_space_percent; /* See the min-free-space-percent config option */
   guint64 min_free_space_mb; /* See the min-free-space-size config option */
+  gboolean emergency_cleanup;
 
   guint test_error_flags; /* OstreeRepoTestErrorFlags */
 


### PR DESCRIPTION
If the pull failed due to lack of free space error, it is
not recommended to hold onto partial caches (in repo/tmp) which
can leave the disk-space full. Low-level free disk space error
reporing is not reliable so we alternatively check for free space
using fstatfs(). Hence, we keep partial caches only if free space is
above a certain threshold. This can be controlled by cache-threshold
config parameter.