### PR TITLE
.gitmodules: Update URL for libglnx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libglnx"]
 	path = libglnx
-	url = https://git.gnome.org/browse/libglnx
+	url = https://gitlab.gnome.org/GNOME/libglnx.git
 [submodule "bsdiff"]
 	path = bsdiff
 	url = https://github.com/mendsley/bsdiff


### PR DESCRIPTION
Same thing as https://github.com/projectatomic/rpm-ostree/pull/1374.
Otherwise we get an annoying "warning: redirecting to" message.

Update submodule: libglnx