### PR TITLE
switchroot: Allow letting ostree-prepare-root mount /var

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -31,6 +31,8 @@
 #include <fcntl.h>
 #include <string.h>
 
+#define INITRAMFS_MOUNT_VAR "/run/ostree/initramfs-mount-var"
+
 static inline int
 path_is_on_readonly_fs (char *path)
 {

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -155,7 +155,7 @@ main(int argc, char *argv[])
   /* In the systemd case, this is handled by ostree-system-generator by default */
 #ifndef HAVE_SYSTEMD_AND_LIBMOUNT
   /* file in /run can override that behaviour */
-  if (lstat ("/run/ostree-mount-deployment-var", &stbuf) < 0)
+  if (lstat (INITRAMFS_MOUNT_VAR, &stbuf) < 0)
     mount_var = false;
 #endif
 

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -49,6 +49,13 @@ main(int argc, char *argv[])
       exit (EXIT_SUCCESS);
   }
 
+  /* We conflict with the magic ostree-mount-deployment-var file for ostree-prepare-root */
+  { struct stat stbuf;
+    if (fstatat (AT_FDCWD, "/run/ostree-mount-deployment-var", &stbuf, 0) == 0)
+      exit (EXIT_SUCCESS);
+  }
+
+
   if (argc > 1 && argc != 4)
     errx (EXIT_FAILURE, "This program takes three or no arguments");
 

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -51,10 +51,13 @@ main(int argc, char *argv[])
 
   /* We conflict with the magic ostree-mount-deployment-var file for ostree-prepare-root */
   { struct stat stbuf;
-    if (fstatat (AT_FDCWD, "/run/ostree-mount-deployment-var", &stbuf, 0) == 0)
-      exit (EXIT_SUCCESS);
+    if (fstatat (AT_FDCWD, INITRAMFS_MOUNT_VAR, &stbuf, 0) == 0)
+      {
+        if (unlinkat (AT_FDCWD, INITRAMFS_MOUNT_VAR, 0) < 0)
+          err (EXIT_FAILURE, "Can't unlink " INITRAMFS_MOUNT_VAR);
+        exit (EXIT_SUCCESS);
+      }
   }
-
 
   if (argc > 1 && argc != 4)
     errx (EXIT_FAILURE, "This program takes three or no arguments");


### PR DESCRIPTION
In some scenarios, it might make sense to let `ostree-prepare-root` do
the `/var` mount from the state root as before. For example, one may
want to do some system configuration before the switch root. This of
course comes at the expense of supporting `/var` as a mount point in
`/etc/fstab`.