### PR TITLE
Makefile-libostree.am: Drop Makefile dependency

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -28,7 +28,7 @@ if ENABLE_RUST
 bupsplitpath = @abs_top_builddir@/target/@RUST_TARGET_SUBDIR@/libbupsplit_rs.a
 BUPSPLIT_RUST_SRCS = rust/src/bupsplit.rs
 EXTRA_DIST += $(BUPSPLIT_RUST_SRCS)
-$(bupsplitpath): Makefile $(BUPSPLIT_RUST_SRCS)
+$(bupsplitpath): $(BUPSPLIT_RUST_SRCS)
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=@abs_top_builddir@/target cargo build --verbose $(CARGO_RELEASE_ARGS)
 else
 bupsplitpath = libbupsplit.la


### PR DESCRIPTION
For some reason, this is causing `cargo build` to execute both during a
`make` and a `make install`. This in turn is causing problems on my
system since I'm using `rustup`, so `sudo make install` fails to find
`cargo` in the more restricted `PATH`.

Looking at the librsvg code as an example, I also don't see this
dependency. It seems like any `make` command implicitly depends on
making sure the various Automake makefiles are up to date anyway?