### PR TITLE
lib/archive: Tell g-ir-scanner to ignore the private libarchive bits

### DIFF
--- a/src/libostree/ostree-libarchive-private.h
+++ b/src/libostree/ostree-libarchive-private.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+/* Private, not for introspection */
+#ifndef __GI_SCANNER__
+
 #include "config.h"
 
 #include <gio/gio.h>
@@ -64,3 +67,5 @@ ot_open_archive_read (const char *path, GError **error)
 #endif
 
 G_END_DECLS
+
+#endif


### PR DESCRIPTION
Squashes this warning:
```
src/libostree/ostree-libarchive-private.h:46: syntax error, unexpected typedef-name in '  g_autoptr(OtAutoArchiveRead) a = archive_read_new ();' at 'OtAutoArchiveRead'
```