### PR TITLE
Drop "ostree trivial-httpd" CLI, move to tests directory

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -37,12 +37,6 @@ ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 \
 ostree-pull.1 ostree-refs.1 ostree-remote.1 ostree-reset.1 \
 ostree-rev-parse.1 ostree-show.1 ostree-sign.1 ostree-summary.1 \
 ostree-static-delta.1
-if USE_LIBSOUP_OR_LIBSOUP3
-man1_files += ostree-trivial-httpd.1
-else
-# We still want to distribute the source, even if we are not building it
-EXTRA_DIST += man/ostree-trivial-httpd.xml
-endif
 
 if BUILDOPT_FUSE
 man1_files += rofiles-fuse.1

--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -142,13 +142,6 @@ ostree_SOURCES += src/ostree/ot-builtin-pull.c
 endif
 
 if USE_LIBSOUP_OR_LIBSOUP3
-# Eventually once we stop things from using this, we should support disabling this
-ostree_SOURCES += src/ostree/ot-builtin-trivial-httpd.c
-pkglibexec_PROGRAMS += ostree-trivial-httpd
-ostree_trivial_httpd_SOURCES = src/ostree/ostree-trivial-httpd.c
-ostree_trivial_httpd_CFLAGS = $(ostree_bin_shared_cflags) $(OT_INTERNAL_SOUP_CFLAGS)
-ostree_trivial_httpd_LDADD = $(ostree_bin_shared_ldadd) $(OT_INTERNAL_SOUP_LIBS)
-
 if !USE_CURL
 # This is necessary for the cookie jar bits
 ostree_CFLAGS += $(OT_INTERNAL_SOUP_CFLAGS)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -273,6 +273,13 @@ _installed_or_uninstalled_test_programs += \
 	$(NULL)
 endif
 
+if USE_LIBSOUP_OR_LIBSOUP3
+test_extra_programs += ostree-trivial-httpd
+ostree_trivial_httpd_SOURCES = src/ostree/ostree-trivial-httpd.c
+ostree_trivial_httpd_CFLAGS = $(common_tests_cflags) $(OT_INTERNAL_SOUP_CFLAGS)
+ostree_trivial_httpd_LDADD = $(common_tests_ldadd) $(OT_INTERNAL_SOUP_LIBS)
+endif
+
 if USE_AVAHI
 test_programs += tests/test-repo-finder-avahi
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -212,14 +212,6 @@ AS_IF([test x$with_soup = xyes || test x$with_soup3 = xyes], [
   AC_DEFINE([HAVE_LIBSOUP_OR_LIBSOUP3], 1, [Define if we have libsoup.pc or libsoup3.pc])
 ])
 
-AC_ARG_ENABLE(trivial-httpd-cmdline,
-  [AS_HELP_STRING([--enable-trivial-httpd-cmdline],
-  [Continue to support "ostree trivial-httpd" [default=no]])],,
-  enable_trivial_httpd_cmdline=no)
-AS_IF([test x$enable_trivial_httpd_cmdline = xyes],
-  [AC_DEFINE([BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE], 1, [Define if we are enabling ostree trivial-httpd entrypoint])]
-)
-
 AS_IF([test x$with_curl = xyes && test x$with_soup = xno && test x$with_soup3 = xno], [
   AC_MSG_WARN([Curl enabled, but libsoup is not; libsoup is needed for tests (make check, etc.)])
 ])
@@ -686,7 +678,6 @@ echo "
     introspection:                                $found_introspection
     rofiles-fuse:                                 $enable_rofiles_fuse
     HTTP backend:                                 $fetcher_backend
-    \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
     fs-verity:                                    $ac_cv_header_linux_fsverity_h
     cryptographic checksums:                      $with_crypto

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -76,9 +76,6 @@ static OstreeCommand commands[] = {
   { "static-delta", OSTREE_BUILTIN_FLAG_NONE, ostree_builtin_static_delta,
     "Static delta related commands" },
   { "summary", OSTREE_BUILTIN_FLAG_NONE, ostree_builtin_summary, "Manage summary metadata" },
-#if defined(HAVE_LIBSOUP_OR_LIBSOUP3) && defined(BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE)
-  { "trivial-httpd", OSTREE_BUILTIN_FLAG_NONE, ostree_builtin_trivial_httpd, NULL },
-#endif
   { NULL }
 };
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -180,18 +180,9 @@ if test -n "${OT_TESTS_VALGRIND:-}"; then
     CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
 fi
 
-if test -n "${OSTREE_UNINSTALLED:-}"; then
-    OSTREE_HTTPD=${OSTREE_UNINSTALLED}/ostree-trivial-httpd
-else
-    # trivial-httpd is now in $libexecdir by default, which we don't
-    # know at this point. Fortunately, libtest.sh is also in
-    # $libexecdir, so make an educated guess. If it's not found, assume
-    # it's still runnable as "ostree trivial-httpd".
-    if [ -x "${test_srcdir}/../../libostree/ostree-trivial-httpd" ]; then
-        OSTREE_HTTPD="${CMD_PREFIX} ${test_srcdir}/../../libostree/ostree-trivial-httpd"
-    else
-        OSTREE_HTTPD="${CMD_PREFIX} ostree trivial-httpd"
-    fi
+OSTREE_HTTPD="${G_TEST_BUILDDIR}/ostree-trivial-httpd"
+if ! [ -x "${OSTREE_HTTPD}" ]; then
+    fatal "Failed to find ${OSTREE_HTTPD}"
 fi
 
 files_are_hardlinked() {


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/issues/1593

Basically this makes it easier for people packaging, as the trivial-httpd
is only for tests, and this way the binary will live with the tests.

Also at this point nothing should depend on `ostree trivial-httpd`.