### PR TITLE
avahi: Fail immediately if we can't talk to D-Bus or Avahi

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -1432,8 +1432,7 @@ ostree_repo_finder_avahi_start (OstreeRepoFinderAvahi  *self,
 
   g_assert (self->client == NULL);
 
-  client = avahi_client_new (avahi_glib_poll_get (self->poll),
-                             AVAHI_CLIENT_NO_FAIL,
+  client = avahi_client_new (avahi_glib_poll_get (self->poll), 0,
                              client_cb, self, &failure);
 
   if (client == NULL)


### PR DESCRIPTION
We special-case AVAHI_ERR_NO_DAEMON to not cause warnings, but if
we pass AVAHI_CLIENT_NO_FAIL to avahi_client_new, we never actually
see AVAHI_ERR_NO_DAEMON. Instead, we will get AVAHI_ERR_BAD_STATE
when we try to use the client.

Bug: https://github.com/ostreedev/ostree/issues/1618
Signed-off-by: Simon McVittie <smcv@debian.org>

---

This is what I've applied in Debian for now to cope with #1618. It's one of two possible routes for solving that issue. The other would be rather more involved: if the `AvahiClient` can't immediately talk to Avahi, make all methods on the `OstreeRepoFinderAvahi` fail with `G_IO_ERROR_NOT_FOUND` or similar.