### PR TITLE
tests/installed: Wait a bit more for http.server

### DIFF
--- a/tests/installed/libinsttest.sh
+++ b/tests/installed/libinsttest.sh
@@ -58,7 +58,8 @@ run_tmp_webserver() {
     cd -
     child_pid=$!
 
-    for x in $(seq 15); do
+    for x in $(seq 60); do
+        echo "Waiting for web server ($x/60)..." >&2
         # Snapshot the output
         cp ${test_tmpdir}/httpd-output{,.tmp}
         # If it's non-empty, see whether it matches our regexp

--- a/tests/installed/libinsttest.sh
+++ b/tests/installed/libinsttest.sh
@@ -58,7 +58,7 @@ run_tmp_webserver() {
     cd -
     child_pid=$!
 
-    for x in $(seq 10); do
+    for x in $(seq 15); do
         # Snapshot the output
         cp ${test_tmpdir}/httpd-output{,.tmp}
         # If it's non-empty, see whether it matches our regexp
@@ -71,6 +71,12 @@ run_tmp_webserver() {
         fi
         sleep 1
     done
+
+    if [ ! -f ${test_tmpdir}/httpd-port ]; then
+      cat ${test_tmpdir}/httpd-output
+      fatal "can't start up httpd"
+    fi
+
     port=$(cat ${test_tmpdir}/httpd-port)
     echo "http://127.0.0.1:${port}" > ${test_tmpdir}/httpd-address
     echo "$child_pid" > ${test_tmpdir}/httpd-pid


### PR DESCRIPTION
And also print out the output if it still didn't start up in case there
are error messages hidden in there.

This should hopefully help with diagnosing the flakes we've been seeing
in starting it up.