### PR TITLE
ostree-grub-generator: sort BLS files by version instead of alphabeti…

### DIFF
--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -66,7 +66,7 @@ populate_menu()
     else
         boot_prefix="${OSTREE_BOOT_PARTITION}"
     fi
-    for config in $(ls $entries_path/*.conf); do
+    for config in $(ls -v $entries_path/*.conf); do
         read_config ${config}
         menu="${menu}menuentry '${title}' {\n"
         menu="${menu}\t linux ${boot_prefix}${linux} ${options}\n"


### PR DESCRIPTION
…cally

The ostree-grub-generator populates the grub.cfg menu entries using the
BLS config files. But it uses the ls command that by default sorts the
entries alphabetically, so the order won't be correct if there are more
than 10 deployments, i.e:

$ ls -1 /boot/loader/entries/
ostree-fedora-workstation-0.conf
ostree-fedora-workstation-10.conf
ostree-fedora-workstation-1.conf
...

So instead the -v option should be used to make ls use version sorting:

$ ls -1 -v /boot/loader/entries/
ostree-fedora-workstation-0.conf
ostree-fedora-workstation-1.conf
...
ostree-fedora-workstation-10.conf

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>