### PR TITLE
deploy: Change BootLoaderSpec filenames so they can be used for sorting

### DIFF
--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -66,7 +66,7 @@ populate_menu()
     else
         boot_prefix="${OSTREE_BOOT_PARTITION}"
     fi
-    for config in $(ls -v $entries_path/*.conf); do
+    for config in $(ls -v -r $entries_path/*.conf); do
         read_config ${config}
         menu="${menu}menuentry '${title}' {\n"
         menu="${menu}\t linux ${boot_prefix}${linux} ${options}\n"

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1628,8 +1628,9 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   g_assert_cmpstr (kernel_layout->bootcsum, ==, bootcsum);
   g_autofree char *bootcsumdir = g_strdup_printf ("ostree/%s-%s", osname, bootcsum);
   g_autofree char *bootconfdir = g_strdup_printf ("loader.%d/entries", new_bootversion);
-  g_autofree char *bootconf_name = g_strdup_printf ("ostree-%s-%d.conf", osname,
-                                   ostree_deployment_get_index (deployment));
+  g_autofree char *bootconf_name = g_strdup_printf ("ostree-%d-%s.conf",
+                                   n_deployments - ostree_deployment_get_index (deployment),
+                                   osname);
   if (!glnx_shutil_mkdir_p_at (boot_dfd, bootcsumdir, 0775, cancellable, error))
     return FALSE;
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -68,9 +68,9 @@ echo "ok --print-current-dir"
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
 assert_has_dir sysroot/ostree/boot.1.1
-assert_has_file sysroot/boot/loader/entries/ostree-testos-0.conf
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* quiet'
+assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* quiet'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/boot.1/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
@@ -96,7 +96,7 @@ assert_not_has_dir sysroot/ostree/boot.0.0
 assert_not_has_dir sysroot/ostree/boot.1.0
 assert_not_has_dir sysroot/ostree/boot.1.1
 # Ensure we propagated kernel arguments from previous deployment
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/boot.0/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
 assert_ostree_deployment_refs 0/1/{0,1}
@@ -123,8 +123,8 @@ ${CMD_PREFIX} ostree admin os-init otheros
 ${CMD_PREFIX} ostree admin deploy --os=otheros testos/buildmaster/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-testos-1.conf
-assert_has_file sysroot/boot/loader/entries/ostree-otheros-0.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
+assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/deploy/otheros/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
 assert_ostree_deployment_refs 1/1/{0,1,2}
@@ -136,9 +136,9 @@ echo "ok independent deploy"
 ${CMD_PREFIX} ostree admin deploy --retain --os=testos testos:testos/buildmaster/x86_64-runtime
 assert_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-testos-0.conf
+assert_has_file sysroot/boot/loader/entries/ostree-4-testos.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.2/etc/os-release 'NAME=TestOS'
-assert_has_file sysroot/boot/loader/entries/ostree-testos-2.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.3/etc/os-release 'NAME=TestOS'
 ${CMD_PREFIX} ostree admin status
 assert_ostree_deployment_refs 0/1/{0,1,2,3}
@@ -172,14 +172,14 @@ echo "ok deploy with modified /etc"
 for i in $(seq 4); do
   ${CMD_PREFIX} ostree admin undeploy 0
 done
-assert_has_file sysroot/boot/loader/entries/ostree-testos-0.conf
-assert_not_has_file sysroot/boot/loader/entries/ostree-testos-1.conf
-assert_not_has_file sysroot/boot/loader/entries/ostree-otheros-1.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
+assert_not_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
+assert_not_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
 ${CMD_PREFIX} ostree admin deploy --not-as-default --os=otheros testos:testos/buildmaster/x86_64-runtime
 assert_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-testos-0.conf
-assert_has_file sysroot/boot/loader/entries/ostree-otheros-1.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -188,9 +188,9 @@ echo "ok deploy --not-as-default"
 ${CMD_PREFIX} ostree admin deploy --retain-rollback --os=otheros testos:testos/buildmaster/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-otheros-0.conf
-assert_has_file sysroot/boot/loader/entries/ostree-testos-1.conf
-assert_has_file sysroot/boot/loader/entries/ostree-otheros-2.conf
+assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -265,7 +265,7 @@ echo "ok deploy with unknown OS"
 
 ${CMD_PREFIX} ostree admin deploy --os=testos --karg-append=console=/dev/foo --karg-append=console=/dev/bar testos:testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'console=/dev/foo.*console=/dev/bar'
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf 'console=/dev/foo.*console=/dev/bar'
 validate_bootloader
 
 echo "ok deploy with multiple kernel args"
@@ -275,7 +275,7 @@ os_repository_new_commit 0 "test upgrade multiple kernel args"
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 newrev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 assert_not_streq ${origrev} ${newrev}
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'console=/dev/foo.*console=/dev/bar'
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf 'console=/dev/foo.*console=/dev/bar'
 validate_bootloader
 
 echo "ok upgrade with multiple kernel args"

--- a/tests/test-admin-deploy-2.sh
+++ b/tests/test-admin-deploy-2.sh
@@ -71,9 +71,9 @@ oldversion=${version}
 # another commit with *same* bootcsum but *new* content
 os_repository_new_commit "1" "2"
 newversion=${version}
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf ${oldversion}
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf ${oldversion}
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf ${newversion}
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf ${newversion}
 
 echo "ok new version same bootcsum"
 

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -35,12 +35,12 @@ export rev
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=FOO=BAR --os=testos testos:testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=TESTARG=TESTVALUE --os=testos testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-1.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
 ${CMD_PREFIX} ostree admin deploy --karg=ANOTHERARG=ANOTHERVALUE --os=testos testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*ANOTHERARG=ANOTHERVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*ANOTHERARG=ANOTHERVALUE'
 
 echo "ok deploy with --karg, but same config"
 
@@ -51,7 +51,7 @@ for arg in $(cat /proc/cmdline); do
 	  ;;
 	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
 	   ;;
-	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf "options.*$arg"
 	   ;;
     esac
 done
@@ -62,8 +62,8 @@ ${CMD_PREFIX} ostree admin status
 ${CMD_PREFIX} ostree admin undeploy 0
 
 ${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=APPENDARG=VALAPPEND --karg-append=APPENDARG=2NDAPPEND testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 
 echo "ok deploy --karg-append"

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -38,8 +38,8 @@ for test_bootdir in "boot" "usr/lib/ostree-boot"; do
     ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
     rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
     ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* quiet'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* quiet'
     assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
     assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
     # kernel/initrams should also be in the tree's /boot with the checksum
@@ -64,7 +64,7 @@ cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
 # Note this bootcsum shouldn't be the modules one

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -34,25 +34,25 @@ ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-r
 
 ${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAR
 ${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAZ FOO=BIF TESTARG=TESTVALUE
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAZ .*FOO=BIF'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
 echo "ok instutil set-kargs (basic)"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge FOO=BAR
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAZ .*FOO=BIF .*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF .*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
 echo "ok instutil set-kargs --merge"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --replace=FOO=XXX
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=XXX'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*TESTARG=TESTVALUE'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=XXX'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
 echo "ok instutil set-kargs --replace"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --append=FOO=BAR --append=APPENDARG=VALAPPEND --append=APPENDARG=2NDAPPEND testos:testos/buildmaster/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*FOO=XXX.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=XXX.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
@@ -62,7 +62,7 @@ for arg in $(cat /proc/cmdline); do
 	   ;;
 	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
 	   ;;
-	*) assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "options.*$arg"
 	   ;;
     esac
 done

--- a/tests/test-admin-pull-deploy-split.sh
+++ b/tests/test-admin-pull-deploy-split.sh
@@ -46,13 +46,13 @@ ${CMD_PREFIX} ostree admin upgrade --os=testos --pull-only --os=testos > out.txt
 assert_not_file_has_content out.txt 'No update available'
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${parent_rev}.0
 assert_not_has_dir sysroot/ostree/deploy/testos/deploy/${rev}.0
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'TestOS 42 1.0.9'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'TestOS 42 1.0.9'
 assert_streq "${rev}" $(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 # Now, generate new content upstream; we shouldn't pull it
 os_repository_new_commit
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only --os=testos > out.txt
 assert_not_file_has_content out.txt 'No update available'
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'TestOS 42 1.0.10'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'TestOS 42 1.0.10'
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${parent_rev}.0
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${rev}.0
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only --os=testos > out.txt

--- a/tests/test-admin-upgrade-endoflife.sh
+++ b/tests/test-admin-upgrade-endoflife.sh
@@ -65,7 +65,7 @@ ${CMD_PREFIX} ostree admin upgrade --os=testos --pull-only
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only
 
 # Check we got redirected to the new branch
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "${bootcsum}"
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf "${bootcsum}"
 rev=$(${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo rev-parse testos/buildmaster/newbranch)
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/usr/bin/content-iteration "1"
 

--- a/tests/test-no-initramfs.sh
+++ b/tests/test-no-initramfs.sh
@@ -12,8 +12,8 @@ ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=fals
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=rootfs --os=testos testos:testos/buildmaster/x86_64-runtime
 
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'init='
 
 echo "ok deployment with initramfs"
 
@@ -63,28 +63,28 @@ for layout in /usr/lib/modules /usr/lib/ostree-boot /boot;
 do
     pull_test_tree "the kernel only"
     ${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmaster/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'rootwait'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
 
     echo "ok switching to bootdir with no initramfs layout=$layout"
 
     pull_test_tree "the kernel" "initramfs to assist the kernel"
     ${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmaster/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
-    assert_file_has_content sysroot/boot/$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-testos-0.conf "initrd") "initramfs to assist the kernel"
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'root=LABEL=rootfs'
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'rootwait'
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
+    assert_file_has_content sysroot/boot/$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2-testos.conf "initrd") "initramfs to assist the kernel"
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'root=LABEL=rootfs'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'rootwait'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
 
     echo "ok switching from no initramfs to initramfs enabled sysroot layout=$layout"
 
     pull_test_tree "the kernel" "" "my .dtb file"
     ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
 
-    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'init='
-    assert_file_has_content sysroot/boot/"$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-testos-0.conf 'devicetree')" "my .dtb file"
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'initrd'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
+    assert_file_has_content sysroot/boot/"$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2-testos.conf 'devicetree')" "my .dtb file"
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
 
     echo "ok switching from initramfs to no initramfs sysroot with devicetree layout=$layout"
 done


### PR DESCRIPTION
Currently the BLS snippets are named ostree-$ID-$VARIANT_ID-$index.conf,
but the BLS config files are actually sorted by using the version field
which is the inverse of the index.

In most places, _ostree_sysroot_read_boot_loader_configs() is used to
get the BLS files and this function already returns them sorted by the
version field. The only place where the index trailing number is used is
in the ostree-grub-generator script that lists the BLS files to populate
the grub config file.

But for some bootloaders the BLS filename is the criteria for sorting by
taking the filename as a string version. So on these bootloaders the BLS
entries will be listed in the reverse order.

To avoid that, change the BLS snippets filename to have the version field
instead of the index and also to have the version before deployment name.

Make the filenames to be of the form ostree-$version-$ID-$VARIANT_ID.conf
so the version is before the deployment name.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>