### PR TITLE
sysroot: Reject attempts to pin the staged deployment

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1894,7 +1894,8 @@ ostree_sysroot_deployment_unlock (OstreeSysroot     *self,
  * for e.g. older versions of libostree unaware of pinning to GC the deployment.
  *
  * This function does nothing and returns successfully if the deployment
- * is already in the desired pinning state.
+ * is already in the desired pinning state.  It is an error to try to pin
+ * the staged deployment (as it's not in the bootloader entries).
  *
  * Since: 2018.3
  */
@@ -1907,6 +1908,9 @@ ostree_sysroot_deployment_set_pinned (OstreeSysroot     *self,
   const gboolean current_pin = ostree_deployment_is_pinned (deployment);
   if (is_pinned == current_pin)
     return TRUE;
+
+  if (ostree_deployment_is_staged (deployment))
+    return glnx_throw (error, "Cannot pin staged deployment");
 
   g_autoptr(OstreeDeployment) deployment_clone = ostree_deployment_clone (deployment);
   GKeyFile *origin_clone = ostree_deployment_get_origin (deployment_clone);

--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -21,6 +21,10 @@
     done
     test -f deployment-ref-found
     rm deployment-ref-found
+    if ostree admin pin 0 2>err.txt; then
+      echo "Pinned staged deployment"; exit 1
+    fi
+    grep -qFe 'Cannot pin staged deployment' err.txt
   environment:
     commit: "{{ rpmostree_status['deployments'][0]['checksum'] }}"
 - include_tasks: ../tasks/reboot.yml


### PR DESCRIPTION
From https://github.com/projectatomic/rpm-ostree/pull/1434#discussion_r198936674

To support it we'd have to actually write it to disk, which...let's
not try that right now.