### PR TITLE
ci: exclude 'lib' from libsoup configure option

### DIFF
--- a/.papr-ex.yaml
+++ b/.papr-ex.yaml
@@ -99,7 +99,7 @@ required: true
 context: f28-libsoup
 
 env:
-  CONFIGOPTS: "--without-curl --without-openssl --with-libsoup"
+  CONFIGOPTS: "--without-curl --without-openssl --with-soup"
 
 tests:
   - ci/build-check.sh

--- a/.papr.yml
+++ b/.papr.yml
@@ -104,7 +104,7 @@ required: true
 context: f28-libsoup
 
 env:
-  CONFIGOPTS: "--without-curl --without-openssl --with-libsoup"
+  CONFIGOPTS: "--without-curl --without-openssl --with-soup"
 
 tests:
   - ci/build-check.sh


### PR DESCRIPTION
The option used by configure script is actually
--with-soup/--without-soup.

Signed-off-by: Marcus Folkesson <marcus.folkesson@gmail.com>