### PR TITLE
ci/flatpak: Fix to use built ostree version

### DIFF
--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -28,7 +28,6 @@ pkg_install sudo which attr fuse bison \
             libubsan libasan libtsan clang python2 \
             elfutils git gettext-devel libappstream-glib-devel hicolor-icon-theme \
             /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
-pkg_install_testing ostree-devel ostree
 pkg_install_builddeps flatpak
 # Now install ostree over the package version
 cd ${codedir}

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -3,24 +3,39 @@
 
 set -xeuo pipefail
 
-FLATPAK_TAG=master
+# Keep this pinned to avoid arbitrary change for now; it's also
+# good to test building older code against newer ostree as it helps
+# us notice any API breaks.
+FLATPAK_TAG=0.99.2
 
 dn=$(dirname $0)
 . ${dn}/libpaprci/libbuild.sh
 
 codedir=$(pwd)
 
-# Build and install ostree
+# Build ostree, but we don't install it yet
 cd ${codedir}
 ci/build.sh
-make install
 
 # Build flatpak
 tmpd=$(mktemp -d)
 cd ${tmpd}
 git clone --recursive --depth=1 -b ${FLATPAK_TAG} https://github.com/flatpak/flatpak
 cd ${tmpd}/flatpak
-ci/build.sh
+# This is a copy of flatpak/ci/build.sh, but we can't use that as we want to install
+# our built ostree over it.
+pkg_install sudo which attr fuse bison \
+            libubsan libasan libtsan clang python2 \
+            elfutils git gettext-devel libappstream-glib-devel hicolor-icon-theme \
+            /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
+pkg_install_testing ostree-devel ostree
+pkg_install_builddeps flatpak
+# Now install ostree over the package version
+cd ${codedir}
+make install
+cd -
+# And build flatpak
+build
 # We want to capture automake results from flatpak
 cleanup() {
     mv test-suite.log ${codedir} || true

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -28,7 +28,7 @@ pkg_install sudo which attr fuse bison \
             libubsan libasan libtsan clang python2 \
             elfutils git gettext-devel libappstream-glib-devel hicolor-icon-theme \
             /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
-pkg_install_builddeps flatpak
+pkg_builddep flatpak
 # Now install ostree over the package version
 cd ${codedir}
 make install


### PR DESCRIPTION
Noticed as part of a random failure in this PR:
https://github.com/ostreedev/ostree/pull/1655
that we weren't actually testing the version of ostree
we built in git.  Probably we should be generating RPMs but...later.