### PR TITLE
lib/repo: Minor fixes around min-free-space

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -126,10 +126,10 @@ Boston, MA 02111-1307, USA.
 
      <varlistentry>
         <term><varname>min-free-space-size</varname></term>
-        <listitem><para>Value (in MB, GB or TB) that specifies a minimum space (in blocks)
-        in the underlying filesystem to keep free. Also, note that min-free-space-percent
+        <listitem><para>Value (in MB, GB or TB) that specifies a minimum space in the
+        underlying filesystem to keep free. Also, note that min-free-space-percent
         and min-free-space-size are mutually exclusive. Examples of acceptable values:
-        500MB, 1GB etc.
+        500MB, 1GB etc. The default value is 0MB, which disables this check.
         </para></listitem>
       </varlistentry>
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2670,7 +2670,7 @@ min_free_space_size_validate_and_convert (OstreeRepo    *self,
 
   g_autoptr(GMatchInfo) match = NULL;
   if (!g_regex_match (regex, min_free_space_size_str, 0, &match))
-    return glnx_throw (error, "Failed to parse min-free-space-size parameter: '%s'", min_free_space_size_str);
+    return glnx_throw (error, "Failed to match '^[0-9]+[GMT]B$'");
 
   g_autofree char *size_str = g_match_info_fetch (match, 1);
   g_autofree char *unit = g_match_info_fetch (match, 2);
@@ -2693,10 +2693,7 @@ min_free_space_size_validate_and_convert (OstreeRepo    *self,
 
   guint64 min_free_space = g_ascii_strtoull (size_str, NULL, 10);
   if (shifts > 0 && g_bit_nth_lsf (min_free_space, 63 - shifts) != -1)
-    {
-      glnx_throw (error, "Integer overflow detected");
-      return FALSE;
-    }
+    return glnx_throw (error, "Integer overflow detected");
 
   self->min_free_space_mb = min_free_space << shifts;
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2670,7 +2670,7 @@ min_free_space_size_validate_and_convert (OstreeRepo    *self,
 
   g_autoptr(GMatchInfo) match = NULL;
   if (!g_regex_match (regex, min_free_space_size_str, 0, &match))
-    return glnx_prefix_error (error, "Failed to parse min-free-space-size parameter: '%s'", min_free_space_size_str);
+    return glnx_throw (error, "Failed to parse min-free-space-size parameter: '%s'", min_free_space_size_str);
 
   g_autofree char *size_str = g_match_info_fetch (match, 1);
   g_autofree char *unit = g_match_info_fetch (match, 2);
@@ -2691,7 +2691,14 @@ min_free_space_size_validate_and_convert (OstreeRepo    *self,
         g_assert_not_reached ();
     }
 
-  self->min_free_space_mb = g_ascii_strtoull (size_str, NULL, 10) << shifts;
+  guint64 min_free_space = g_ascii_strtoull (size_str, NULL, 10);
+  if (shifts > 0 && g_bit_nth_lsf (min_free_space, 63 - shifts) != -1)
+    {
+      glnx_throw (error, "Integer overflow detected");
+      return FALSE;
+    }
+
+  self->min_free_space_mb = min_free_space << shifts;
 
   return TRUE;
 }
@@ -2829,7 +2836,7 @@ reload_core_config (OstreeRepo          *self,
 
         /* Validate the string and convert the size to MBs */
         if (!min_free_space_size_validate_and_convert (self, min_free_space_size_str, error))
-          return glnx_throw (error, "Invalid min-free-space-size '%s'", min_free_space_size_str);
+          return glnx_prefix_error (error, "Invalid min-free-space-size '%s'", min_free_space_size_str);
       }
     else
       {


### PR DESCRIPTION
Summary:
* Remove a useless if condition in prepare_transaction()
* Fix glnx_throw error propagation
* Integer overflow check while parsing min-free-space-size config
* Documentation fixes