### PR TITLE
build: add soup to build process when configured with avahi

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -238,6 +238,13 @@ if USE_LIBSOUP
 libostree_1_la_SOURCES += src/libostree/ostree-fetcher-soup.c
 libostree_1_la_CFLAGS += $(OT_INTERNAL_SOUP_CFLAGS)
 libostree_1_la_LIBADD += $(OT_INTERNAL_SOUP_LIBS)
+else
+if USE_AVAHI
+libostree_1_la_SOURCES += src/libostree/ostree-soup-uri.h \
+	src/libostree/ostree-soup-uri.c \
+	src/libostree/ostree-soup-form.c \
+	$(NULL)
+endif
 endif
 endif
 


### PR DESCRIPTION
We need either libsoup or ostree-soup-* to support avahi.

Avoid getting these link errors:
    ./.libs/libostree-1.so: undefined reference to `soup_uri_set_path'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_new'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_free'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_set_scheme'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_to_string'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_set_host'
    ./.libs/libostree-1.so: undefined reference to `soup_uri_set_port'
    collect2: error: ld returned 1 exit status

Reproduce with:
    ./configure --with-avahi --without-soup

Signed-off-by: Marcus Folkesson <marcus.folkesson@gmail.com>