### PR TITLE
switchroot: Fix regression for separately mounted /var

### DIFF
--- a/tests/installed/destructive-ansible.yml
+++ b/tests/installed/destructive-ansible.yml
@@ -13,3 +13,4 @@
       when: use_git_build
     - import_tasks: tasks/query-host.yml
     - import_tasks: destructive/staged-deploy.yml
+    - import_tasks: destructive/var-mount.yml

--- a/tests/installed/destructive/var-mount.yml
+++ b/tests/installed/destructive/var-mount.yml
@@ -1,0 +1,13 @@
+# https://github.com/ostreedev/ostree/issues/1667
+- name: Set up /var as a mountpoint
+  shell: |
+    set -xeuo pipefail
+    cp -a /var /sysroot/myvar
+    touch /sysroot/myvar/somenewfile
+    echo '/sysroot/myvar /var none bind 0 0' >> /etc/fstab
+- include_tasks: ../tasks/reboot.yml
+- name: Check that /var mountpoint worked
+  shell: |
+    set -xeuo pipefail
+    systemctl status var.mount
+    test -f /var/somenewfile

--- a/tests/installed/playbook-run.sh
+++ b/tests/installed/playbook-run.sh
@@ -7,6 +7,10 @@ dn=$(cd $(dirname $0) && pwd)
 if ! test -d build; then
     mkdir -p build
     (cd build && ${dn}/../../ci/build-rpm.sh)
+else
+    # XXX: we should invalidate based on `git describe` or something
+    echo "NOTE: Re-using prebuilt RPMs:"
+    find build -name '*.rpm'
 fi
 
 # https://fedoraproject.org/wiki/CI/Tests

--- a/tests/installed/tasks/install-git.yml
+++ b/tests/installed/tasks/install-git.yml
@@ -8,6 +8,9 @@
   synchronize: src=build/x86_64/ dest=/root/x86_64/ archive=yes
 - name: Install RPMs
   shell: rpm-ostree override replace /root/x86_64/*.rpm
+# Regenerate to make sure new ostree binaries also make it to the initrd
+- name: Regenerate initramfs
+  shell: rpm-ostree initramfs --enable
 - import_tasks: ../tasks/reboot.yml
 - import_tasks: ../tasks/query-host.yml
 - command: ostree --version


### PR DESCRIPTION
I made a logical error in #1617 which resulted in the exact *opposite*
behaviour we want when `/var` is a separate mount.

Split this out and lower the number of negations to make it more obvious
that it's correct.

Closes: #1667