### PR TITLE
build: Use ostree_prepare_root_CPPFLAGS for ostree-prepare-root

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -45,7 +45,7 @@ if BUILDOPT_USE_STATIC_COMPILER
 ostree_boot_SCRIPTS = ostree-prepare-root
 
 ostree-prepare-root : $(ostree_prepare_root_SOURCES)
-	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(AM_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
+	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_prepare_root_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot


### PR DESCRIPTION
Swap from AM_CPPFLAGS to ostree_prepare_root_CPPFLAGS when compiling
ostree-prepare-root statically. This fixes a problem when you have
systemd and libmount, but only ostree_prepare_root_CPPFLAGS includes
-DHAVE_SYSTEMD_AND_LIBMOUNT=1.

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>