### PR TITLE
deploy: Retain staged by default

### DIFF
--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -70,7 +70,7 @@
     grep -vqFe '(staged)' status.txt
     test '!' -f /run/ostree/staged-deployment
 
-- name: Staged should be overwritten by non-staged
+- name: Staged should be overwritten by non-staged as first
   shell: |
     set -xeuo pipefail
     ostree admin deploy --stage staged-deploy
@@ -81,6 +81,20 @@
     grep -vqFe '(staged)' status.txt
     test '!' -f /run/ostree/staged-deployment
     ostree admin undeploy 0
+  environment:
+    commit: "{{ rpmostree_status['deployments'][0]['checksum'] }}"
+
+- name: Staged is retained when pushing rollback
+  shell: |
+    set -xeuo pipefail
+    ostree admin deploy --stage staged-deploy
+    test -f /run/ostree/staged-deployment
+    ostree admin deploy --retain-pending --not-as-default nonstaged-deploy
+    test -f /run/ostree/staged-deployment
+    ostree admin status > status.txt
+    grep -qFe '(staged)' status.txt
+    ostree admin undeploy 0
+    ostree admin undeploy 1
   environment:
     commit: "{{ rpmostree_status['deployments'][0]['checksum'] }}"
 


### PR DESCRIPTION
For `rpm-ostree ex livefs` we have a use case of pushing a rollback
deployment.  There's no reason this should require deleting the staged
deployment (and doing so actually breaks livefs which tries to access
it as a data source).

I was initially very conservative here, but I think it ends up
being fairly easy to retain the staged deployment.  We need to handle
two cases:

First, when the staged is *intentionally* deleted; here, we just need
to unlink the `/run` file, and then everything will be sync'd up after
reloading.

Second, (as in the livefs case) where we're retaining it,
e.g. adding a deployment to the end.  What I realized here is that
we can have the code keep `new_deployments` as view without staged,
and then when we do the final reload we'll end up re-reading it from
disk anyways.