### PR TITLE
switchroot: Move late /run/ostree-booted creation to ostree-system-ge…

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -210,8 +210,9 @@ main(int argc, char *argv[])
 
 
   /* We only stamp /run now if we're running in an initramfs, i.e. we're
-   * not pid 1.  Otherwise it's handled later via ostree-remount.service.
+   * not pid 1.  Otherwise it's handled later via ostree-system-generator.
    * https://mail.gnome.org/archives/ostree-list/2018-March/msg00012.html
+   * https://github.com/ostreedev/ostree/pull/1675
    */
   if (!running_as_pid1)
     touch_run_ostree ();

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -46,13 +46,8 @@ main(int argc, char *argv[])
   struct stat stbuf;
   int i;
 
-  /* See comments in ostree-prepare-root.c for this.
-   *
-   * This service is triggered via
-   * ConditionKernelCommandLine=ostree
-   * but it's a lot easier for various bits of userspace to check for
-   * a file versus parsing the kernel cmdline.  So let's ensure
-   * the stamp file is created here too.
+  /* When systemd is in use this is normally created via the generator, but
+   * we ensure it's created here as well for redundancy.
    */
   touch_run_ostree ();
 


### PR DESCRIPTION
…nerator

When ostree-prepare-root is pid 1, ostree-prepare-boot defers creation of
/run/ostree-booted, which we were doing in ostree-remount, but that's too
late if we need ostree-system-generator to bind /var. Move the creation
of the /run/ostree-booted marker to ostree-system-generator based on the
existence of the ostree= kernel command line argument (which matches the
condition that ostree-remount used).

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>