### PR TITLE
ostree commit: Add option --use-bare-user-xattrs

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -292,6 +292,10 @@ _ostree_repo_file_replace_contents (OstreeRepo    *self,
                                     GCancellable  *cancellable,
                                     GError       **error);
 
+GVariant  *
+_ostree_filemeta_to_stat (struct stat *stbuf,
+                          GBytes      *bytes);
+
 gboolean
 _ostree_repo_write_ref (OstreeRepo                 *self,
                         const char                 *remote,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3528,12 +3528,15 @@ load_metadata_internal (OstreeRepo       *self,
   return TRUE;
 }
 
-static GVariant  *
-filemeta_to_stat (struct stat *stbuf,
-                  GVariant   *metadata)
+GVariant  *
+_ostree_filemeta_to_stat (struct stat *stbuf,
+                          GBytes      *bytes)
 {
   guint32 uid, gid, mode;
   GVariant *xattrs;
+
+  g_autoptr(GVariant) metadata = g_variant_ref_sink (g_variant_new_from_bytes (
+        OSTREE_FILEMETA_GVARIANT_FORMAT, bytes, FALSE));
 
   g_variant_get (metadata, "(uuu@a(ayay))",
                  &uid, &gid, &mode, &xattrs);
@@ -3673,9 +3676,7 @@ _ostree_repo_load_file_bare (OstreeRepo         *self,
       if (bytes == NULL)
         return FALSE;
 
-      g_autoptr(GVariant) metadata = g_variant_ref_sink (g_variant_new_from_bytes (OSTREE_FILEMETA_GVARIANT_FORMAT,
-                                                                                   bytes, FALSE));
-      ret_xattrs = filemeta_to_stat (&stbuf, metadata);
+      ret_xattrs = _ostree_filemeta_to_stat (&stbuf, bytes);
       if (S_ISLNK (stbuf.st_mode))
         {
           if (out_symlink)

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -642,6 +642,7 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo    *r
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED: Emit an error if configured SELinux policy does not provide a label
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME: Delete added files/directories after commit; Since: 2017.13
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL: If a devino cache hit is found, skip modifier filters (non-directories only); Since: 2017.14
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_USE_BARE_USER_XATTRS: Get uid, gid, mode and xattrs from the user.ostreemeta xattr; Since: XXX
  */
 typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE = 0,
@@ -651,6 +652,7 @@ typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED = (1 << 3),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME = (1 << 4),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL = (1 << 5),
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_USE_BARE_USER_XATTRS = (1 << 6),
 } OstreeRepoCommitModifierFlags;
 
 /**

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -53,6 +53,7 @@ static gboolean opt_skip_if_unchanged;
 static gboolean opt_tar_autocreate_parents;
 static char *opt_tar_pathname_filter;
 static gboolean opt_no_xattrs;
+static gboolean opt_use_bare_user_xattrs;
 static char *opt_selinux_policy;
 static gboolean opt_canonical_permissions;
 static gboolean opt_consume;
@@ -105,6 +106,7 @@ static GOptionEntry options[] = {
   { "owner-gid", 0, 0, G_OPTION_ARG_INT, &opt_owner_gid, "Set file ownership group id", "GID" },
   { "canonical-permissions", 0, 0, G_OPTION_ARG_NONE, &opt_canonical_permissions, "Canonicalize permissions in the same way bare-user does for hardlinked files", NULL },
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Do not import extended attributes", NULL },
+  { "use-bare-user-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_use_bare_user_xattrs, "Set uid, gid, mode and xattrs according to the user.ostreemeta xattr on files", NULL },
   { "selinux-policy", 0, 0, G_OPTION_ARG_FILENAME, &opt_selinux_policy, "Set SELinux labels based on policy in root filesystem PATH (may be /)", "PATH" },
   { "link-checkout-speedup", 0, 0, G_OPTION_ARG_NONE, &opt_link_checkout_speedup, "Optimize for commits of trees composed of hardlinks into the repository", NULL },
   { "devino-canonical", 'I', 0, G_OPTION_ARG_NONE, &opt_devino_canonical, "Assume hardlinked objects are unmodified.  Implies --link-checkout-speedup", NULL },
@@ -534,6 +536,8 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
 
   if (opt_no_xattrs)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS;
+  if (opt_use_bare_user_xattrs)
+    flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_USE_BARE_USER_XATTRS;
   if (opt_consume)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME;
   if (opt_devino_canonical)
@@ -554,6 +558,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
       || opt_statoverride_file != NULL
       || opt_skiplist_file != NULL
       || opt_no_xattrs
+      || opt_use_bare_user_xattrs
       || opt_selinux_policy)
     {
       filter_data.mode_adds = mode_adds;

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -37,6 +37,7 @@ fi
 save_core() {
   if [ -e core ]; then
     cp core "$test_srcdir/core"
+    gdb -batch -ex bt "$test_builddir/../.libs/ostree" core
   fi
 }
 


### PR DESCRIPTION
For our build-system we have a [patched version of `fakeroot`][1] which
understands the `user.ostreemeta` xattr.  It's intended for use with
`ostree checkout --user-mode --require-hardlinks`.  When programs are run
with `LD_PRELOAD=libfakeroot...` they see the ownership and permissions
that ostree understands, rather than the real ones.

Our build system mostly consists of calls to:

    ostree checkout --user-mode --require-hardlinks $COMMIT root
    LD_PRELOAD=fakeroot <make some changes>
    ostree commit --tree=dir=root --link-checkout-speedup --devino-canonical

in the past this seemed to work fine but at some point I started losing the
setuid bit on `sudo`.  I suspect the previous behaviour was a bug.  This
commit makes the `ostreemeta` preserving behaviour explicit.

`--use-bare-user-xattrs` will currently be ignored when loading a commit
from a tarball.  This can be fixed in the future.

I originally considered implementing this inside `_ostree_repo_commit_modifier_apply` but we don't have access to the file fd to retrieve the xattrs from in there.  I considered using `g_file_info_get_attribute_data (info, "xattr::ostreemeta", ...)` but it GLib has no way of retrieving an attribute that may contain embedded NULs.

This may need a little bit more work (see TODO list below) but I wanted to raise it sooner rather than later to receive feedback.

I'm not super happy with the name

[1]: https://github.com/stb-tester/fakeroot/tree/ostree

**TODO:**

- [ ] Test xattrs in xattrs
- [ ] Decide on and test the precedence of `--canonical-permissions`, `--owner-uid`, `--owner-gid` and `--use-bare-user-xattrs`.  My feeling is that if the xattrs are present they should take precedence.