### PR TITLE
Release 2018.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ m4_define([year_version], [2018])
 m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl update libostree-released.sym from libostree-devel.sym, and update the check
 dnl in test-symbols.sh, and also set is_release_build=yes below.  Then make
 dnl another post-release commit to bump the version, and set is_release_build=no.
 m4_define([year_version], [2018])
-m4_define([release_version], [7])
+m4_define([release_version], [8])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,12 +18,6 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2018.7 {
-global:
-    ostree_mutable_tree_fill_empty_from_dirtree;
-    ostree_mutable_tree_new_from_checksum;
-    ostree_mutable_tree_check_error;
-} LIBOSTREE_2018.6;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,6 +18,8 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
+LIBOSTREE_2018.8 {
+} LIBOSTREE_2018.7;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the last number.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -527,6 +527,13 @@ global:
   ostree_validate_collection_id;
 } LIBOSTREE_2018.5;
 
+LIBOSTREE_2018.7 {
+global:
+    ostree_mutable_tree_fill_empty_from_dirtree;
+    ostree_mutable_tree_new_from_checksum;
+    ostree_mutable_tree_check_error;
+} LIBOSTREE_2018.6;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-0d9b42d7e6694a6875962e253c0ffc61f8363dfdfb78f41b843223708cae60d5  ${released_syms}
+611278b6081cbd34e365f3a7988e0c981644a828230973d7675a1a31ef09a0e3  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
As `min-free-space-size` patches got split up pre/post `2018.6` release, I am requesting another release for flatpak porting.