### PR TITLE
lib/repo: Allow min-free-space-size and -percent to co-exist

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -121,7 +121,10 @@ Boston, MA 02111-1307, USA.
         <term><varname>min-free-space-percent</varname></term>
         <listitem><para>Integer percentage value (0-99) that specifies a minimum
         percentage of total space (in blocks) in the underlying filesystem to
-        keep free. The default value is 3.</para></listitem>
+        keep free. The default value is 3.</para>
+        <para>In case this option is co-existing with min-free-space-size (see below),
+        it would be ignored and min-free-space-size check would be enforced instead.
+        </para></listitem>
       </varlistentry>
 
      <varlistentry>


### PR DESCRIPTION
Previously, we would error out if both of the options were mentioned
in the config file (even if one of them is disabled with 0). There
were few suggestions that this behavior was not quite right.

Therefore, instead of throwing error and exiting, it's preferred to
warn the user. Hence, the solution that worked out is:
* Allow both options to exist simulateneously
* Check each config's value and decide:
  * If both are present and are non-zero, warn the user. Also, prefer
    to use min-free-space-size over the another.
  * If both are absent, then use -percent=3% as fallback
  * Every other case is valid hence, no warning

https://phabricator.endlessm.com/T13698
(cherry picked from commit be68991cf80f0aa1da7d36ab6e1d2c4d6c7cd3fb)
Signed-off-by: Robert McQueen <rob@endlessm.com>