### PR TITLE
ci: Mark insttests as not required

### DIFF
--- a/.papr-ex.yaml
+++ b/.papr-ex.yaml
@@ -5,7 +5,7 @@ branches:
     - try
 
 context: FAH28-insttests
-required: true
+required: false
 
 container:
   image: registry.fedoraproject.org/fedora:28

--- a/.papr.yml
+++ b/.papr.yml
@@ -5,7 +5,7 @@ branches:
     - try
 
 context: FAH28-insttests
-required: true
+required: false
 
 # FIXME; temporary workaround
 # https://github.com/ostreedev/ostree/pull/1513#issuecomment-378784162


### PR DESCRIPTION
The reliablity has just not been what we need, and they haven't
yet caught any real bugs.  Until I can carve off some time to
truly make this reliable let's just mark it as not required.
I'd like to gather more statistics on the failure scenarios.