### PR TITLE
man/ostree.repo-config: Update min-free-space-size docs

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -121,18 +121,21 @@ Boston, MA 02111-1307, USA.
         <term><varname>min-free-space-percent</varname></term>
         <listitem><para>Integer percentage value (0-99) that specifies a minimum
         percentage of total space (in blocks) in the underlying filesystem to
-        keep free. The default value is 3.</para>
+        keep free. The default value is 3. This default value is enforced when none
+        of min-free-space-* options are set.</para>
         <para>In case this option is co-existing with min-free-space-size (see below),
-        it would be ignored and min-free-space-size check would be enforced instead.
+        and min-free-space-size is set to a non-zero value, min-free-space-percent
+        would be ignored and min-free-space-size check would be enforced instead.
         </para></listitem>
       </varlistentry>
 
      <varlistentry>
         <term><varname>min-free-space-size</varname></term>
         <listitem><para>Value (in MB, GB or TB) that specifies a minimum space in the
-        underlying filesystem to keep free. Also, note that min-free-space-percent
-        and min-free-space-size are mutually exclusive. Examples of acceptable values:
-        500MB, 1GB etc. The default value is 0MB, which disables this check.
+        underlying filesystem to keep free. Examples of acceptable values: 500MB, 1GB
+        etc.</para>
+        <para>In case this option is co-existing with min-free-space-percent (see above),
+        and set to a non-zero value, this option takes priority.
         </para></listitem>
       </varlistentry>
 


### PR DESCRIPTION
Now that it's possible to have both min-free-space-size and
min-free-space-percent set in a repo config, update the docs for
min-free-space-size to make the behavior clear.