### PR TITLE
Deprecate commit-update-summary and rename change-update-summary

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -94,7 +94,7 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
-        <term><varname>change-update-summary</varname></term>
+        <term><varname>auto-update-summary</varname></term>
         <listitem><para>Boolean value controlling whether or not to
         automatically update the summary file after any ref is added,
         removed, or updated. This covers a superset of the cases covered by

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -87,20 +87,20 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
-        <term><varname>commit-update-summary</varname></term>
-        <listitem><para>Boolean value controlling whether or not to
-        automatically update the summary file after a commit.  Defaults
-        to <literal>false</literal>.</para></listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term><varname>auto-update-summary</varname></term>
         <listitem><para>Boolean value controlling whether or not to
         automatically update the summary file after any ref is added,
-        removed, or updated. This covers a superset of the cases covered by
-        commit-update-summary, with the exception of orphan commits which
-        shouldn't affect the summary anyway. Defaults to <literal>false</literal>.
+        removed, or updated. Other modifications which may render a
+        summary file stale (like static deltas, or collection IDs) do
+        not currently trigger an auto-update.
         </para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>commit-update-summary</varname></term>
+        <listitem><para>This option is deprecated. Use
+        <literal>auto-update-summary</literal> instead, for which this
+        option is now an alias.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2195,18 +2195,20 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
   if (self->txn.refs)
     if (!_ostree_repo_update_refs (self, self->txn.refs, cancellable, error))
       return FALSE;
-  g_clear_pointer (&self->txn.refs, g_hash_table_destroy);
 
   if (self->txn.collection_refs)
     if (!_ostree_repo_update_collection_refs (self, self->txn.collection_refs, cancellable, error))
       return FALSE;
-  g_clear_pointer (&self->txn.collection_refs, g_hash_table_destroy);
 
   /* Update the summary if auto-update-summary is set, because doing so was
    * delayed for each ref change during the transaction.
    */
-  if (!_ostree_repo_maybe_regenerate_summary (self, cancellable, error))
+  if ((self->txn.refs || self->txn.collection_refs) &&
+      !_ostree_repo_maybe_regenerate_summary (self, cancellable, error))
     return FALSE;
+
+  g_clear_pointer (&self->txn.refs, g_hash_table_destroy);
+  g_clear_pointer (&self->txn.collection_refs, g_hash_table_destroy);
 
   self->in_transaction = FALSE;
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2202,7 +2202,7 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
       return FALSE;
   g_clear_pointer (&self->txn.collection_refs, g_hash_table_destroy);
 
-  /* Update the summary if change-update-summary is set, because doing so was
+  /* Update the summary if auto-update-summary is set, because doing so was
    * delayed for each ref change during the transaction.
    */
   if (!_ostree_repo_maybe_regenerate_summary (self, cancellable, error))

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -1158,17 +1158,10 @@ _ostree_repo_update_refs (OstreeRepo        *self,
                           GCancellable      *cancellable,
                           GError           **error)
 {
-  GHashTableIter hash_iter;
-  gpointer key, value;
-
-  g_hash_table_iter_init (&hash_iter, refs);
-  while (g_hash_table_iter_next (&hash_iter, &key, &value))
+  GLNX_HASH_TABLE_FOREACH_KV (refs, const char*, refspec, const char*, rev)
     {
-      const char *refspec = key;
-      const char *rev = value;
       g_autofree char *remote = NULL;
       g_autofree char *ref_name = NULL;
-
       if (!ostree_parse_refspec (refspec, &remote, &ref_name, error))
         return FALSE;
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5387,7 +5387,7 @@ summary_add_ref_entry (OstreeRepo       *self,
  *
  * It is regenerated automatically after a commit if
  * `core/commit-update-summary` is set, and automatically after any ref is
- * added, removed, or updated if `core/change-update-summary` is set.
+ * added, removed, or updated if `core/auto-update-summary` is set.
  *
  * If the `core/collection-id` key is set in the configuration, it will be
  * included as %OSTREE_SUMMARY_COLLECTION_ID in the summary file. Refs that
@@ -5593,23 +5593,21 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
   return TRUE;
 }
 
-/* Regenerate the summary if `core/change-update-summary` is set */
+/* Regenerate the summary if `core/auto-update-summary` is set */
 gboolean
 _ostree_repo_maybe_regenerate_summary (OstreeRepo    *self,
                                        GCancellable  *cancellable,
                                        GError       **error)
 {
-  gboolean update_summary;
+  gboolean auto_update_summary;
 
   if (!ot_keyfile_get_boolean_with_default (self->config, "core",
-                                            "change-update-summary", FALSE,
-                                            &update_summary, error))
+                                            "auto-update-summary", FALSE,
+                                            &auto_update_summary, error))
     return FALSE;
 
-  if (update_summary && !ostree_repo_regenerate_summary (self,
-                                                         NULL,
-                                                         cancellable,
-                                                         error))
+  if (auto_update_summary &&
+      !ostree_repo_regenerate_summary (self, NULL, cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -753,7 +753,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
   if (!skip_commit)
     {
       guint64 timestamp;
-      gboolean change_update_summary;
+      gboolean auto_update_summary;
 
       if (!opt_no_bindings)
         {
@@ -825,12 +825,12 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
         goto out;
 
       if (!ot_keyfile_get_boolean_with_default (ostree_repo_get_config (repo), "core",
-                                                "change-update-summary", FALSE,
-                                                &change_update_summary, error))
+                                                "auto-update-summary", FALSE,
+                                                &auto_update_summary, error))
         goto out;
 
       /* No need to update it again if we did for each ref change */
-      if (opt_orphan || !change_update_summary)
+      if (opt_orphan || !auto_update_summary)
         {
           gboolean commit_update_summary;
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -753,7 +753,6 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
   if (!skip_commit)
     {
       guint64 timestamp;
-      gboolean auto_update_summary;
 
       if (!opt_no_bindings)
         {
@@ -823,33 +822,6 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
 
       if (!ostree_repo_commit_transaction (repo, &stats, cancellable, error))
         goto out;
-
-      if (!ot_keyfile_get_boolean_with_default (ostree_repo_get_config (repo), "core",
-                                                "auto-update-summary", FALSE,
-                                                &auto_update_summary, error))
-        goto out;
-
-      /* No need to update it again if we did for each ref change */
-      if (opt_orphan || !auto_update_summary)
-        {
-          gboolean commit_update_summary;
-
-          /* The default for this option is FALSE, even for archive repos,
-           * because ostree supports multiple processes committing to the same
-           * repo (but different refs) concurrently, and in fact gnome-continuous
-           * actually does this.  In that context it's best to update the summary
-           * explicitly instead of automatically here. */
-          if (!ot_keyfile_get_boolean_with_default (ostree_repo_get_config (repo), "core",
-                                                    "commit-update-summary", FALSE,
-                                                    &commit_update_summary, error))
-            goto out;
-
-          if (commit_update_summary && !ostree_repo_regenerate_summary (repo,
-                                                                        NULL,
-                                                                        cancellable,
-                                                                        error))
-            goto out;
-        }
     }
   else
     {

--- a/tests/test-auto-summary.sh
+++ b/tests/test-auto-summary.sh
@@ -65,7 +65,7 @@ touch repo/summary.sig
 $OSTREE summary --update
 assert_not_has_file repo/summary.sig
 
-# Check that without change-update-summary set, adding, changing, or deleting a ref doesn't update the summary
+# Check that without auto-update-summary set, adding, changing, or deleting a ref doesn't update the summary
 $OSTREE summary --update
 OLD_MD5=$(md5sum repo/summary)
 $OSTREE commit -b test2 -s "A commit" test
@@ -80,8 +80,8 @@ $OSTREE refs --delete test
 
 assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
 
-# Check that with change-update-summary set, adding, changing, or deleting a ref updates the summary
-$OSTREE --repo=repo config set core.change-update-summary true
+# Check that with auto-update-summary set, adding, changing, or deleting a ref updates the summary
+$OSTREE --repo=repo config set core.auto-update-summary true
 
 $OSTREE summary --update
 OLD_MD5=$(md5sum repo/summary)


### PR DESCRIPTION
Minor follow-ups to #1681.
See individual commit messages.