### PR TITLE
ostree-remount.service: RemainAfterExit=yes

### DIFF
--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -31,6 +31,7 @@ Before=systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/lib/ostree/ostree-remount
 StandardInput=null
 StandardOutput=syslog


### PR DESCRIPTION
This is standard practice for units like this; e.g. it's what
`systemd-remount-fs.service` does.  I think it may be part of
or the whole cause for
https://github.com/projectatomic/rpm-ostree/issues/1471

I haven't reproduced the problem exactly but it seems to me that
if the unit starts and is GC'd, then when systemd goes to execute
a later unit it might end up restarting it.

A noticeable side effect of this is that `systemctl status ostree-remount`
exits with code `0` as expected.