### PR TITLE
Fix corrupted summary cache

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -61,7 +61,8 @@ G_BEGIN_DECLS
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
 
 typedef enum {
-  OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0)
+  OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0),
+  OSTREE_REPO_TEST_ERROR_INVALID_CACHE = (1 << 1),
 } OstreeRepoTestErrorFlags;
 
 struct OstreeRepoCommitModifier {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4037,10 +4037,20 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
             if (summary_from_cache)
               {
                 /* The cached summary doesn't match, fetch a new one and verify again */
+                if ((self->test_error_flags & OSTREE_REPO_TEST_ERROR_INVALID_CACHE) > 0)
+                  {
+                    g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                 "Remote %s cached summary invalid and "
+                                 "OSTREE_REPO_TEST_ERROR_INVALID_CACHE specified",
+                                 pull_data->remote_name);
+                    goto out;
+                  }
+                else
+                  g_debug ("Remote %s cached summary invalid, pulling new version",
+                           pull_data->remote_name);
+
                 summary_from_cache = FALSE;
                 g_clear_pointer (&bytes_summary, (GDestroyNotify)g_bytes_unref);
-                g_debug ("Remote %s cached summary invalid, pulling new version",
-                         pull_data->remote_name);
                 if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
                                                                  pull_data->meta_mirrorlist,
                                                                  "summary",

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3986,7 +3986,10 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       goto out;
 
     if (bytes_summary)
-      summary_from_cache = TRUE;
+      {
+        g_debug ("Loaded %s summary from cache", remote_name_or_baseurl);
+        summary_from_cache = TRUE;
+      }
 
     if (!pull_data->summary && !bytes_summary)
       {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1187,6 +1187,7 @@ ostree_repo_init (OstreeRepo *self)
   static gsize gpgme_initialized;
   const GDebugKey test_error_keys[] = {
     { "pre-commit", OSTREE_REPO_TEST_ERROR_PRE_COMMIT },
+    { "invalid-cache", OSTREE_REPO_TEST_ERROR_INVALID_CACHE },
   };
 
   if (g_once_init_enter (&gpgme_initialized))

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -245,7 +245,19 @@ cmp repo/tmp/cache/summaries/origin.sig ${test_tmpdir}/ostree-srv/gnomerepo/summ
 # cache before validating the signature. That would mean the cache would
 # have mismatched summary and signature and ostree would remain
 # deadlocked there until the remote published a new signature.
+#
+# First pull with OSTREE_REPO_TEST_ERROR=invalid-cache to see the
+# invalid cache is detected. Then pull again to check if it can be
+# recovered from.
 cp ${test_tmpdir}/ostree-srv/gnomerepo/summary.2 repo/tmp/cache/summaries/origin
+if OSTREE_REPO_TEST_ERROR=invalid-cache ${OSTREE} --repo=repo pull origin main 2>err.txt; then
+    assert_not_reached "Should have hit OSTREE_REPO_TEST_ERROR_INVALID_CACHE"
+fi
+assert_file_has_content err.txt "OSTREE_REPO_TEST_ERROR_INVALID_CACHE"
+assert_has_file repo/tmp/cache/summaries/origin
+assert_has_file repo/tmp/cache/summaries/origin.sig
+cmp repo/tmp/cache/summaries/origin ${test_tmpdir}/ostree-srv/gnomerepo/summary.2 >&2
+cmp repo/tmp/cache/summaries/origin.sig ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig.1 >&2
 ${OSTREE} --repo=repo pull origin main
 assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig


### PR DESCRIPTION
If the summary from the cache is used but it doesn't match the signature, fetch it again. While c4c2b5eb helps you from corrupting the summary cache, this helps you get out of it if you happen to get into that situation.

This also adds a couple tests for racing with remote summary updates that I wrote while trying to get to the bottom of this. We were still occasionally seeing this on our image builder, but I believe that's because it uses a cache repo that's used by different versions of ostree depending on what's being built.

This might fix flatpak/flatpak#1450.