### PR TITLE
ostree_repo_static_delta_generate: Fix leak

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1521,7 +1521,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
             goto out;
         }
 
-      g_variant_builder_add_value (part_headers, g_variant_ref (part_builder->header));
+      g_variant_builder_add_value (part_headers, part_builder->header);
 
       total_compressed_size += part_builder->compressed_size;
       total_uncompressed_size += part_builder->uncompressed_size;


### PR DESCRIPTION
There is no need to ref the argument of g_variant_builder_add_value