### PR TITLE
repo: remove outdated note from write_config() docs

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1441,12 +1441,10 @@ ostree_repo_copy_config (OstreeRepo *self)
 /**
  * ostree_repo_write_config:
  * @self: Repo
- * @new_config: Overwrite the config file with this data.  Do not change later!
+ * @new_config: Overwrite the config file with this data
  * @error: a #GError
  *
- * Save @new_config in place of this repository's config file.  Note
- * that @new_config should not be modified after - this function
- * simply adds a reference.
+ * Save @new_config in place of this repository's config file.
  */
 gboolean
 ostree_repo_write_config (OstreeRepo *self,


### PR DESCRIPTION
Since 9dc6ddce0848cf04b76fc1c673c8fc1a0f6f425a it has not been true that
'new_config' was simply ref'd: it's serialized, and then re-parsed into
a new GKeyFile.