### PR TITLE
ci: Bump rpm-ostree tag we build for tests

### DIFF
--- a/ci/rpmostree.sh
+++ b/ci/rpmostree.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 # Frozen to a tag for now to help predictability; it's
 # also useful to test building *older* versions since
 # that must work.
-RPMOSTREE_TAG=v2018.5
+RPMOSTREE_TAG=v2018.7
 
 dn=$(dirname $0)
 . ${dn}/libpaprci/libbuild.sh

--- a/ci/rpmostree.sh
+++ b/ci/rpmostree.sh
@@ -48,4 +48,4 @@ if ! make vmsync; then
     fatal "vmsync failed"
 fi
 # Now run tests; just a subset ⊂ for now to avoid CI overload
-make vmcheck TESTS="basic layering-basic"
+make vmcheck TESTS="layering-basic-1 layering-basic-2"


### PR DESCRIPTION
The latest rpm-ostree release no longer requires `python3-devel` so
`dnf builddep` here is no longer pulling it in, subsequently causing issues
when building an older rpm-ostree release. Let's just bump the release
tag so we don't have to also start keeping track of older dependencies.