### PR TITLE
docs: Add Contributing Tutorial to Mkdocs pages

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Instead do this:
           }
       }
 
-Contributing: Tutorial
-----------------------
+Contributing Tutorial
+---------------------
 
 For a detailed walk-through on building, modifying, and testing, see this [tutorial on how to start contributing to OSTree](contributing-tutorial.md).

--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -277,10 +277,8 @@ To find the IP address of a Vagrant VM, run `vagrant ssh-config` in the same dir
 
 6. Set `rsync` to sync changes in `/etc` and `/usr` from `<ostree-install-dir>/` on the host to the VM:
 
-    ```
-    $ rsync -av <ostree-install-dir>/etc/ root@<ip-address>:/etc
-    $ rsync -av <ostree-install-dir>/usr/ root@<ip-address>:/usr
-    ```
+        $ rsync -av <ostree-install-dir>/etc/ root@<ip-address>:/etc
+        $ rsync -av <ostree-install-dir>/usr/ root@<ip-address>:/usr
 
     Using option `-n` will execute the commands as a trial, which is helpful to list the files that will be synced.
 
@@ -436,7 +434,7 @@ When returning to work on a patch, it is recommended to update your fork with th
 
 If creating a new branch:
 
-```
+```bash
 $ git checkout master
 $ git pull upstream master
 $ git checkout -b <name-of-patch>
@@ -444,7 +442,7 @@ $ git checkout -b <name-of-patch>
 
 If continuing on a branch already created:
 
-```
+```bash
 $ git checkout <name-of-patch>
 $ git pull --rebase upstream master
 ```

--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -103,7 +103,7 @@ Make allows parallel execution of recipes. Use `make -j<N>` to speed up the buil
 
 See page 106 of the [GNU Make Manual](https://www.gnu.org/software/make/manual/make.pdf) for more information about the `--jobs` or `-j` option.
 
-## [Testing a Build](#testing-a-build)
+## Testing a Build
 
 It is best practice to build software (definitely including ostree) in a container or virtual machine first.
 
@@ -358,7 +358,7 @@ This will add a command which prints `Hello OSTree!` when `ostree hello-ostree` 
         $ ostree hello-ostree
         Hello OSTree!
 
-### [OSTree Tests](#ostree-tests)
+### OSTree Tests
 
 Tests for OSTree are done by shell scripting, by running OSTree commands and examining output. These steps will go through adding a test for `hello-ostree`.
 

--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -66,7 +66,7 @@ apt-get build-dep ostree
 
 ### OSTree Build Commands
 
-These are the basic commands to build OSTree. Depending on the OS that OSTree will be build for, the flags or options for `./autogen.sh` and `./configure` will vary.
+These are the basic commands to build OSTree. Depending on the OS that OSTree will be built for, the flags or options for `./autogen.sh` and `./configure` will vary.
 
 See `ostree-build.sh` in this tutorial below for specific commands to building OSTree for Fedora 28 and Fedora 28 Atomic Host.
 

--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -62,7 +62,7 @@ apt-get install build-essential && \
 apt-get build-dep ostree
 ```
 
-[build.sh](../ci/build.sh) will have a list of packages needed to build ostree.
+[build.sh](https://github.com/ostreedev/ostree/blob/master/ci/build.sh) will have a list of packages needed to build ostree.
 
 ### OSTree Build Commands
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: OSTree
 pages:
   - Home: 'index.md'
   - Contributing: 'CONTRIBUTING.md'
+  - Contributing Tutorial: 'contributing-tutorial.md'
   - Manual:
       - Introduction: 'manual/introduction.md'
       - Repository: 'manual/repo.md'


### PR DESCRIPTION
Follow-up PR to #1694 .

Adds an entry to `mkdocs.yml` to include `contributing-tutorial.md` in the Mkdocs build and display on readthedocs.io.

Displays as: https://rfairley-demo.readthedocs.io/en/latest/contributing-tutorial/ (on the same navigation level as CONTRIBUTING.md).

Also minor fixups on the tutorial file:
- use absolute link for `ci/build.sh` so readthedocs can link it
- title headings - remove last couple that were hyperlinked
- code highlighting - minor edits to display better on readthedocs