### PR TITLE
lib/fetcher-curl: Prefix fatal errors with full URL 

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -322,13 +322,12 @@ check_multi_info (OstreeFetcher *fetcher)
             {
               /* Handle file not found */
               g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                                       "%s",
-                                         curl_easy_strerror (curlres));
+                                       "%s", curl_easy_strerror (curlres));
             }
           else
             {
-              g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED, "[%u] %s",
-                                       curlres,
+              g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                       "While fetching %s: [%u] %s", eff_url, curlres,
                                        curl_easy_strerror (curlres));
               _ostree_fetcher_journal_failure (req->fetcher->remote_name,
                                                eff_url, curl_easy_strerror (curlres));

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -330,9 +330,8 @@ check_multi_info (OstreeFetcher *fetcher)
               g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED, "[%u] %s",
                                        curlres,
                                        curl_easy_strerror (curlres));
-              if (req->fetcher->remote_name)
-                _ostree_fetcher_journal_failure (req->fetcher->remote_name,
-                                                 eff_url, curl_easy_strerror (curlres));
+              _ostree_fetcher_journal_failure (req->fetcher->remote_name,
+                                               eff_url, curl_easy_strerror (curlres));
             }
         }
       else

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -172,6 +172,7 @@ _ostree_fetcher_journal_failure (const char *remote_name,
                    "MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_HTTP_FAILURE_ID),
                    "OSTREE_REMOTE=%s", remote_name,
                    "OSTREE_URL=%s", url,
+                   "PRIORITY=%i", LOG_ERR,
                    NULL);
 #endif
 }


### PR DESCRIPTION
Just include the whole URL that failed if libcurl failed with something
elementary like `CURLE_COULDNT_CONNECT` or `CURLE_COULDNT_RESOLVE_HOST`.

Closes: #1731