### PR TITLE
lib/commit: Don't copy xattrs for metadata objects

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -4315,11 +4315,12 @@ import_one_object_direct (OstreeRepo    *dest_repo,
         }
 
       /* Don't want to copy xattrs for archive repos, nor for
-       * bare-user-only.
+       * bare-user-only.  We also only do this for content
+       * objects.
        */
       const gboolean src_is_bare_or_bare_user =
         G_IN_SET (src_repo->mode, OSTREE_REPO_MODE_BARE, OSTREE_REPO_MODE_BARE_USER);
-      if (src_is_bare_or_bare_user)
+      if (src_is_bare_or_bare_user && !OSTREE_OBJECT_TYPE_IS_META(objtype))
         {
           g_autoptr(GVariant) xattrs = NULL;
 


### PR DESCRIPTION
Copying the xattrs on metadata objects is wrong in general, we
don't "own" them.  Notably this would fail in the situation of
doing a pull from e.g. a `bare-user` source to a destination
that was on a different mount point (so we couldn't hardlink),
and the source had e.g. a `security.selinux` attribute.

Closes: #1734