### PR TITLE
lib/repo: Validate lock-timeout-secs config

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2833,6 +2833,8 @@ reload_core_config (OstreeRepo          *self,
           return FALSE;
 
         self->lock_timeout_seconds = g_ascii_strtoll (lock_timeout_seconds, NULL, 10);
+        if (self->lock_timeout_seconds < REPO_LOCK_DISABLED);
+          return glnx_throw (error, "Invalid lock-timeout-secs '%s'", lock_timeout_seconds);
       }
   }
 


### PR DESCRIPTION
Now that we're correctly reading negative values for the
"lock-timeout-secs" config key, throw an error if it's not within the
range of values that have semantic meaning. This mirrors the behavior
when other config keys have invalid values.