### PR TITLE
boot: Add ostree-finalize-staged.path

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -39,7 +39,10 @@ endif
 
 if BUILDOPT_SYSTEMD
 systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
-	src/boot/ostree-remount.service src/boot/ostree-finalize-staged.service
+	src/boot/ostree-remount.service \
+	src/boot/ostree-finalize-staged.service \
+	src/boot/ostree-finalize-staged.path \
+	$(NULL)
 systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_systemdtmpfiles_DATA = src/boot/ostree-tmpfiles.conf
 

--- a/src/boot/ostree-finalize-staged.path
+++ b/src/boot/ostree-finalize-staged.path
@@ -1,0 +1,28 @@
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+# For some implementation discussion, see:
+# https://lists.freedesktop.org/archives/systemd-devel/2018-March/040557.html
+[Unit]
+Description=OSTree Monitor Staged Deployment
+Documentation=man:ostree(1)
+
+[Path]
+PathExists=/run/ostree/staged-deployment
+
+[Install]
+WantedBy=multi-user.target

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2761,6 +2761,10 @@ ostree_sysroot_stage_tree (OstreeSysroot     *self,
   if (booted_deployment == NULL)
     return glnx_throw (error, "Cannot stage a deployment when not currently booted into an OSTree system");
 
+  /* This is used by the testsuite to exercise the path unit, until it becomes the default
+   * (which is pending on the preset making it everywhere). */
+  if ((self->debug_flags & OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH) == 0)
+    {
   /* This is a bit of a hack.  When adding a new service we have to end up getting
    * into the presets for downstream distros; see e.g. https://src.fedoraproject.org/rpms/ostree/pull-request/7
    *
@@ -2773,6 +2777,11 @@ ostree_sysroot_stage_tree (OstreeSysroot     *self,
     return FALSE;
   if (!g_spawn_check_exit_status (estatus, error))
     return FALSE;
+    }
+  else
+    {
+      g_print ("test-staged-path: Not running `systemctl start`\n");
+    } /* OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH */
 
   g_autoptr(OstreeDeployment) deployment = NULL;
   if (!sysroot_initialize_deployment (self, osname, revision, origin, override_kernel_argv,

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -36,6 +36,9 @@ typedef enum {
   OSTREE_SYSROOT_DEBUG_NO_XATTRS = 1 << 1,
   /* https://github.com/ostreedev/ostree/pull/1049 */
   OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE = 1 << 2,
+  /* This is a temporary flag until we fully drop the explicit `systemctl start
+   * ostree-finalize-staged.service` so that tests can exercise the new path unit. */
+  OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH = 1 << 3,
 } OstreeSysrootDebugFlags;
 
 /**

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -189,6 +189,7 @@ ostree_sysroot_init (OstreeSysroot *self)
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },
     { "test-fifreeze", OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE },
     { "no-xattrs", OSTREE_SYSROOT_DEBUG_NO_XATTRS },
+    { "test-staged-path", OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH },
   };
 
   self->debug_flags = g_parse_debug_string (g_getenv ("OSTREE_SYSROOT_DEBUG"),

--- a/tests/installed/destructive/staged-deploy.yml
+++ b/tests/installed/destructive/staged-deploy.yml
@@ -1,16 +1,31 @@
 # Test the deploy --stage functionality; first, we stage a deployment
 # reboot, and validate that it worked.
 
+# for now, until the preset propagates down
+- name: Start up path unit
+  shell: |
+    set -xeuo pipefail
+    systemctl enable --now ostree-finalize-staged.path
 - name: Write staged-deploy commit
   shell: |
     set -xeuo pipefail
+    export OSTREE_SYSROOT_DEBUG="test-staged-path"
     cd /ostree/repo/tmp
     # https://github.com/ostreedev/ostree/issues/1569
     ostree checkout -H ${commit} t
     ostree commit --no-bindings --parent="${commit}" -b staged-deploy -I --consume t
     newcommit=$(ostree rev-parse staged-deploy)
     orig_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
-    ostree admin deploy --stage staged-deploy
+    systemctl show -p SubState ostree-finalize-staged.path | grep -q waiting
+    systemctl show -p ActiveState ostree-finalize-staged.service | grep -q inactive
+    systemctl show -p TriggeredBy ostree-finalize-staged.service | grep -q path
+    ostree admin deploy --stage staged-deploy | tee out.txt
+    if ! grep -q 'test-staged-path: Not running' out.txt; then
+      cat out.txt
+      exit 1
+    fi
+    systemctl show -p SubState ostree-finalize-staged.path | grep running
+    systemctl show -p ActiveState ostree-finalize-staged.service | grep active
     new_mtime=$(stat -c '%.Y' /sysroot/ostree/deploy)
     test "${orig_mtime}" != "${new_mtime}"
     test -f /run/ostree/staged-deployment


### PR DESCRIPTION
Rather than manually starting the `ostree-finalize-staged.service` unit,
we can leverage systemd's path units for this. It fits quite nicely too,
given that we already have a path we drop iif we have a staged
deployment.

---

I started on this thinking we somehow didn't have to change presets. But of course, we do still need a preset for *the path unit itself*. So anyway, just throwing this up here, since I do think overall that using a path unit is nicer, but this is now predicated on getting a preset added in distros (at least for rpm-ostree-based downstreams, we can just do like in #1482, for others... we'd need to mention it clearly in the release notes).