### PR TITLE
man/create-usb: Don't recommend summary updates

### DIFF
--- a/man/ostree-create-usb.xml
+++ b/man/ostree-create-usb.xml
@@ -83,11 +83,6 @@ Boston, MA 02111-1307, USA.
             USB mounts use signed per-repo and per-commit metadata instead of
             summary signatures.
         </para>
-        <para>
-            This command relies on the summary file in the source repo, so you
-            may want to run <command>ostree summary -u</command> before running
-            this command.
-        </para>
     </refsect1>
 
     <refsect1>


### PR DESCRIPTION
This commit removes the recommendation in the create-usb man page for
the user to update the summary in the source repo before using the
create-usb command. I'm not sure where I got the idea that create-usb
depends on a summary in the source repo. I went back to the first commit
that introduced the create-usb command and even using that a summary
isn't required, so it seems unlikely that this changed recently.

This is good news because the exclusive lock that's taken for summary
updates has been causing problems on Endless (due to other processes
having a lock for the duration of the 30 second acquire time out
period).