### PR TITLE
Don't delete refs having aliases

### DIFF
--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -192,6 +192,11 @@ done
 ${CMD_PREFIX} ostree --repo=repo refs -A > refs.txt
 assert_file_has_content_literal refs.txt 'exampleos/x86_64/stable/server -> exampleos/x86_64/27/server'
 
+# Test that we don't delete a ref having aliases
+if ${CMD_PREFIX} ostree --repo=repo refs --delete exampleos/x86_64/27/server; then
+    assert_not_reached "refs --delete unexpectedly succeeded in deleting a ref containing alias!"
+fi
+
 ${CMD_PREFIX} ostree --repo=repo summary -u
 
 echo "ok ref symlink"


### PR DESCRIPTION
Deleting a ref with aliases makes them dangling. In such
cases, display an error message to the user.

Fixes #1597

Signed-off-by: Sinny Kumari <sinny@redhat.com>