### PR TITLE
lib/sysroot-deploy: Write to journal when finalizing

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -19,6 +19,7 @@
 # https://lists.freedesktop.org/archives/systemd-devel/2018-March/040557.html
 [Unit]
 Description=OSTree Finalize Staged Deployment
+Documentation=man:ostree(1)
 ConditionPathExists=/run/ostree-booted
 DefaultDependencies=no
 

--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -31,6 +31,3 @@ Conflicts=final.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStop=/usr/bin/ostree admin finalize-staged
-
-[Install]
-WantedBy=multi-user.target

--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -17,6 +17,7 @@
 
 [Unit]
 Description=OSTree Prepare OS/
+Documentation=man:ostree(1)
 DefaultDependencies=no
 ConditionKernelCommandLine=ostree
 ConditionPathExists=/etc/initrd-release

--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -16,7 +16,8 @@
 # Boston, MA 02111-1307, USA.
 
 [Unit]
-Description=OSTree Remount OS/ bind mounts
+Description=OSTree Remount OS/ Bind Mounts
+Documentation=man:ostree(1)
 DefaultDependencies=no
 ConditionKernelCommandLine=ostree
 OnFailure=emergency.target


### PR DESCRIPTION
Write to the journal when starting to finalize a staged deployment.
Combined with the "Transaction completed" message we already emit, this
makes it easy later on to determine whether the operation was successful
by inspecting the journal. This will be used by `rpm-ostree status`.

I also cherry-picked some commits from #1740 here.