### PR TITLE
finalize-staged: Bump timeout to 5 minutes

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -32,3 +32,7 @@ Conflicts=final.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStop=/usr/bin/ostree admin finalize-staged
+# This is a quite long timeout intentionally; the failure mode
+# here is that people don't get an upgrade.  We need to handle
+# cases with slow rotational media, etc.
+TimeoutStopSec=5m


### PR DESCRIPTION
See https://github.com/projectatomic/rpm-ostree/issues/1568

Basically for people on e.g. rotational media, the default 90
second timeout can be too small.

We're in a tough situation here, because delaying shutdown
can be problematic too if the user is trying to shut down their
laptop to put in a backpack, etc.

There's potential optimizations here to make; I think we
could pre-copy the kernel/initramfs for example.

I suspect for some people the grub2 os-prober is a factor here too,
if that tries to e.g. inspect attached USB rotational hard drives.
But hopefully we'll get rid of that soon.