### PR TITLE
Allow disabling pulling from LAN/USB/Internet

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -298,6 +298,7 @@ ostree_repo_get_mode
 ostree_repo_get_min_free_space_bytes
 ostree_repo_get_config
 ostree_repo_get_dfd
+ostree_repo_get_repo_finders
 ostree_repo_hash
 ostree_repo_equal
 ostree_repo_copy_config

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -215,6 +215,20 @@ Boston, MA 02111-1307, USA.
         of -1 means block indefinitely. The default value is 30.
         </para></listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>repo-finders</varname></term>
+        <listitem><para>Semicolon separated default list of finders (sources
+        for refs) to use when pulling. This can be used to disable
+        pulling from mounted filesystems, peers on the local network,
+        or the Internet. However note that it only applies when a set
+        of finders isn't explicitly specified, either by a consumer of
+        libostree API or on the command line. Possible values:
+        <literal>config</literal>, <literal>lan</literal>, and
+        <literal>mount</literal> (or any combination thereof). If
+        unset, this defaults to <literal>config;lan;mount;</literal>.
+        </para></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -225,8 +225,9 @@ Boston, MA 02111-1307, USA.
         of finders isn't explicitly specified, either by a consumer of
         libostree API or on the command line. Possible values:
         <literal>config</literal>, <literal>lan</literal>, and
-        <literal>mount</literal> (or any combination thereof). If
-        unset, this defaults to <literal>config;lan;mount;</literal>.
+        <literal>mount</literal> (or any combination thereof). If unset, this
+        defaults to <literal>config;mount;</literal> (since the LAN finder is
+        costly).
         </para></listitem>
       </varlistentry>
     </variablelist>

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -21,6 +21,7 @@
 LIBOSTREE_2018.9 {
   ostree_mutable_tree_remove;
   ostree_repo_get_min_free_space_bytes;
+  ostree_repo_get_repo_finders;
 } LIBOSTREE_2018.7;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -168,6 +168,7 @@ struct OstreeRepo {
   gint lock_timeout_seconds;
   guint64 payload_link_threshold;
   gint fs_support_reflink; /* The underlying filesystem has support for ioctl (FICLONE..) */
+  gchar **repo_finders;
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2967,7 +2967,7 @@ reload_core_config (OstreeRepo          *self,
 
     /* Fall back to a default set of finders */
     if (configured_finders == NULL)
-      configured_finders = g_strsplit ("config;lan;mount", ";", -1);
+      configured_finders = g_strsplit ("config;mount", ";", -1);
 
     g_clear_pointer (&self->repo_finders, g_strfreev);
     self->repo_finders = g_steal_pointer (&configured_finders);

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -113,6 +113,9 @@ gboolean      ostree_repo_set_collection_id (OstreeRepo   *self,
                                              GError      **error);
 
 _OSTREE_PUBLIC
+const gchar * const * ostree_repo_get_repo_finders (OstreeRepo   *self);
+
+_OSTREE_PUBLIC
 GFile *       ostree_repo_get_path (OstreeRepo  *self);
 
 _OSTREE_PUBLIC


### PR DESCRIPTION
This branch has two patches, one to add a repo config option that can be used to disable `OstreeRepoFinders`, and one to disable pulling from the LAN unless explicitly enabled.