### PR TITLE
ostree-prepare-root.service: Run earlier in initrd

### DIFF
--- a/src/boot/dracut/module-setup.sh
+++ b/src/boot/dracut/module-setup.sh
@@ -36,7 +36,7 @@ depends() {
 install() {
     dracut_install /usr/lib/ostree/ostree-prepare-root
     inst_simple "${systemdsystemunitdir}/ostree-prepare-root.service"
-    mkdir -p "${initdir}${systemdsystemconfdir}/initrd-switch-root.target.wants"
+    mkdir -p "${initdir}${systemdsystemconfdir}/initrd-root-fs.target.wants"
     ln_r "${systemdsystemunitdir}/ostree-prepare-root.service" \
-        "${systemdsystemconfdir}/initrd-switch-root.target.wants/ostree-prepare-root.service"
+        "${systemdsystemconfdir}/initrd-root-fs.target.wants/ostree-prepare-root.service"
 }

--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -32,3 +32,4 @@ ExecStart=/usr/lib/ostree/ostree-prepare-root /sysroot
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog+console
+RemainAfterExit=yes

--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -22,9 +22,8 @@ DefaultDependencies=no
 ConditionKernelCommandLine=ostree
 ConditionPathExists=/etc/initrd-release
 OnFailure=emergency.target
-After=initrd-switch-root.target
-Before=initrd-switch-root.service
-Before=plymouth-switch-root.service
+After=sysroot.mount
+Before=initrd-root-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Previously, we were preparing the root very late in the boot process;
right before we switch root. The issue with that is that most services
in the initrd that run `After=initrd-root-fs.target` expect that
`/sysroot` already points to the rootfs we'll be pivoting to. Running
this late violates that assumption.

This patch fixes this by making `ostree-prepare-root.service` instead
run right after `sysroot.mount` (the physical sysroot mounted by
systemd) but still before `initrd-root-fs.target` (which is the target
signalling that `/sysroot` is now valid and ready).

This should make it easier to integrate OSTree with other initrd
services such as Ignition.

Related: dustymabe/ignition-dracut#20