### PR TITLE
remount: Refactor to helper function instead of loop

### DIFF
--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -39,13 +39,40 @@
 
 #include "ostree-mount-util.h"
 
+static void
+do_remount (const char *target)
+{
+  struct stat stbuf;
+  if (lstat (target, &stbuf) < 0)
+    return;
+  /* Silently ignore symbolic links; we expect these to point to
+   * /sysroot, and thus there isn't a bind mount there.
+   */
+  if (S_ISLNK (stbuf.st_mode))
+    return;
+  /* If not a mountpoint, skip it */
+  struct statvfs stvfsbuf;
+  if (statvfs (target, &stvfsbuf) == -1)
+    return;
+  /* If no read-only flag, skip it */
+  if ((stvfsbuf.f_flag & ST_RDONLY) == 0)
+    return;
+  /* It's a mounted, read-only fs; remount it */
+  if (mount (target, target, NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
+    {
+      /* Also ignore EINVAL - if the target isn't a mountpoint
+       * already, then assume things are OK.
+       */
+      if (errno != EINVAL)
+        err (EXIT_FAILURE, "failed to remount %s", target);
+    }
+  else
+    printf ("Remounted: %s\n", target);
+}
+
 int
 main(int argc, char *argv[])
 {
-  const char *remounts[] = { "/sysroot", "/var", NULL };
-  struct stat stbuf;
-  int i;
-
   /* When systemd is in use this is normally created via the generator, but
    * we ensure it's created here as well for redundancy.
    */
@@ -65,39 +92,11 @@ main(int argc, char *argv[])
       /* If / isn't writable, don't do any remounts; we don't want
        * to clear the readonly flag in that case.
        */
-
       exit (EXIT_SUCCESS);
     }
 
-  for (i = 0; remounts[i] != NULL; i++)
-    {
-      const char *target = remounts[i];
-      if (lstat (target, &stbuf) < 0)
-        continue;
-      /* Silently ignore symbolic links; we expect these to point to
-       * /sysroot, and thus there isn't a bind mount there.
-       */
-      if (S_ISLNK (stbuf.st_mode))
-        continue;
-      /* If not a mountpoint, skip it */
-      struct statvfs stvfsbuf;
-      if (statvfs (target, &stvfsbuf) == -1)
-        continue;
-      /* If no read-only flag, skip it */
-      if ((stvfsbuf.f_flag & ST_RDONLY) == 0)
-        continue;
-      /* It's a mounted, read-only fs; remount it */
-      if (mount (target, target, NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
-        {
-          /* Also ignore EINVAL - if the target isn't a mountpoint
-           * already, then assume things are OK.
-           */
-          if (errno != EINVAL)
-            err (EXIT_FAILURE, "failed to remount %s", target);
-        }
-      else
-        printf ("Remounted: %s\n", target);
-    }
+  do_remount ("/sysroot");
+  do_remount ("/var");
 
   exit (EXIT_SUCCESS);
 }


### PR DESCRIPTION
Prep for further work.  It was silly to use a loop on
a static array of two elements.