### PR TITLE
ostree/main: Prefix version with "v"

### DIFF
--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -354,7 +354,7 @@ ostree_option_context_parse (GOptionContext *context,
        * possible to parse */
       g_auto(GStrv) features = g_strsplit (OSTREE_FEATURES, " ", -1);
       g_print ("%s:\n", PACKAGE_NAME);
-      g_print (" Version: %s\n", PACKAGE_VERSION);
+      g_print (" Version: v%s\n", PACKAGE_VERSION);
       if (strlen (OSTREE_GITREV) > 0)
         g_print (" Git: %s\n", OSTREE_GITREV);
 #ifdef BUILDOPT_IS_DEVEL_BUILD

--- a/tests/test-remote-headers.sh
+++ b/tests/test-remote-headers.sh
@@ -27,6 +27,7 @@ echo '1..2'
 
 V=$($CMD_PREFIX ostree --version | \
   python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["libostree"]["Version"])')
+V=${V:1} # trim out the leading v
 
 setup_fake_remote_repo1 "archive" "" \
   --expected-header foo=bar \


### PR DESCRIPTION
Prefix the `Version` key in the YAML-compatible output of
`ostree --version` with `v` so that it's coerced to a string. The issue
with the previous approach in a nutshell:

```
In [5]: yaml.load("asdf: 2018.10")
Out[5]: {'asdf': 2018.1}
```

It's treating the version number as a floating-point. Now, this is
technically a backwards incompatible change, but given that the previous
approach is inherently broken for our needs, I don't see a way around
breaking it now.