### PR TITLE
Support mounting /sysroot (and /boot) read-only

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -55,7 +55,8 @@ ostree_remount_SOURCES = \
     src/switchroot/ostree-mount-util.h \
     src/switchroot/ostree-remount.c \
     $(NULL)
-ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) -Isrc/switchroot
+ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -Isrc/switchroot -I$(srcdir)/libglnx
+ostree_remount_LDADD = $(AM_LDFLAGS) $(OT_INTERNAL_GIO_UNIX_LIBS) libglnx.la
 
 if BUILDOPT_SYSTEMD
 ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD=1

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -499,6 +499,7 @@ ostree_sepolicy_get_type
 OstreeSysroot
 ostree_sysroot_new
 ostree_sysroot_new_default
+ostree_sysroot_initialize
 ostree_sysroot_get_path
 ostree_sysroot_load
 ostree_sysroot_load_if_changed
@@ -508,6 +509,8 @@ ostree_sysroot_lock_async
 ostree_sysroot_lock_finish
 ostree_sysroot_unlock
 ostree_sysroot_unload
+ostree_sysroot_set_mount_namespace_in_use
+ostree_sysroot_is_booted
 ostree_sysroot_get_fd
 ostree_sysroot_ensure_initialized
 ostree_sysroot_get_bootversion

--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -22,12 +22,12 @@ DefaultDependencies=no
 ConditionKernelCommandLine=ostree
 OnFailure=emergency.target
 Conflicts=umount.target
-After=-.mount
+# Run after core mounts
+After=-.mount var.mount
 After=systemd-remount-fs.service
+# But we run *before* most other core bootup services that need write access to /etc and /var
 Before=local-fs.target umount.target
-# Other early boot units that need to write to /var
 Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service
-# tmpfiles.d usually needs write access to a few places
 Before=systemd-tmpfiles-setup.service
 
 [Service]

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,9 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2019.7 {
+  ostree_sysroot_initialize;
+  ostree_sysroot_is_booted;
+  ostree_sysroot_set_mount_namespace_in_use;
 } LIBOSTREE_2019.6;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -28,6 +28,7 @@
 #ifdef HAVE_LIBMOUNT
 #include <libmount.h>
 #endif
+#include <sys/statvfs.h>
 #include <stdbool.h>
 #include "otutil.h"
 
@@ -189,8 +190,6 @@ _ostree_impl_system_generator (const char *ostree_cmdline,
                                "[Unit]\n"
                                "Documentation=man:ostree(1)\n"
                                "ConditionKernelCommandLine=!systemd.volatile\n"
-                               /* We need /sysroot mounted writable first */
-                               "After=ostree-remount.service\n"
                                "Before=local-fs.target\n"
                                "\n"
                                "[Mount]\n"

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -455,6 +455,9 @@ ostree_sysroot_cleanup_prune_repo (OstreeSysroot          *sysroot,
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
   const guint depth = 0; /* Historical default */
 
+  if (!_ostree_sysroot_ensure_writable (sysroot, error))
+    return FALSE;
+
   /* Hold an exclusive lock by default across gathering refs and doing
    * the prune.
    */
@@ -535,7 +538,10 @@ _ostree_sysroot_cleanup_internal (OstreeSysroot              *self,
                                   GError                    **error)
 {
   g_return_val_if_fail (OSTREE_IS_SYSROOT (self), FALSE);
-  g_return_val_if_fail (self->loaded, FALSE);
+  g_return_val_if_fail (self->loadstate == OSTREE_SYSROOT_LOAD_STATE_LOADED, FALSE);
+
+  if (!_ostree_sysroot_ensure_writable (self, error))
+    return FALSE;
 
   if (!cleanup_other_bootversions (self, cancellable, error))
     return glnx_prefix_error (error, "Cleaning bootversions");

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -40,6 +40,12 @@ typedef enum {
   OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH = 1 << 3,
 } OstreeSysrootDebugFlags;
 
+typedef enum {
+      OSTREE_SYSROOT_LOAD_STATE_NONE, /* ostree_sysroot_new() was called */
+      OSTREE_SYSROOT_LOAD_STATE_INIT, /* We've loaded basic sysroot state and have an fd */
+      OSTREE_SYSROOT_LOAD_STATE_LOADED, /* We've loaded all of the deployments */
+} OstreeSysrootLoadState;
+
 /**
  * OstreeSysroot:
  * Internal struct
@@ -51,7 +57,8 @@ struct OstreeSysroot {
   int sysroot_fd;
   GLnxLockFile lock;
 
-  gboolean loaded;
+  OstreeSysrootLoadState loadstate;
+  gboolean mount_namespace_in_use; /* TRUE if caller has told us they used CLONE_NEWNS */
   gboolean root_is_ostree_booted; /* TRUE if sysroot is / and we are booted via ostree */
   /* The device/inode for /, used to detect booted deployment */
   dev_t root_device;
@@ -78,6 +85,10 @@ struct OstreeSysroot {
 #define _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED "/run/ostree/staged-deployment-locked"
 #define _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_DIR "/run/ostree/deployment-state/"
 #define _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_DEVELOPMENT "unlocked-development"
+
+gboolean
+_ostree_sysroot_ensure_writable (OstreeSysroot      *self,
+                                 GError            **error);
 
 void
 _ostree_sysroot_emit_journal_msg (OstreeSysroot  *self,

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -42,10 +42,20 @@ _OSTREE_PUBLIC
 OstreeSysroot* ostree_sysroot_new_default (void);
 
 _OSTREE_PUBLIC
+void ostree_sysroot_set_mount_namespace_in_use (OstreeSysroot  *self);
+
+_OSTREE_PUBLIC
 GFile *ostree_sysroot_get_path (OstreeSysroot *self);
 
 _OSTREE_PUBLIC
+gboolean ostree_sysroot_is_booted (OstreeSysroot *self);
+
+_OSTREE_PUBLIC
 int ostree_sysroot_get_fd (OstreeSysroot *self);
+
+_OSTREE_PUBLIC
+gboolean ostree_sysroot_initialize (OstreeSysroot  *self,
+                                    GError        **error);
 
 _OSTREE_PUBLIC
 gboolean ostree_sysroot_load (OstreeSysroot  *self,
@@ -90,6 +100,10 @@ GFile * ostree_sysroot_get_deployment_origin_path (GFile   *deployment_path);
 
 _OSTREE_PUBLIC
 gboolean ostree_sysroot_lock (OstreeSysroot  *self, GError **error);
+
+_OSTREE_PUBLIC
+gboolean ostree_sysroot_lock_with_mount_namespace (OstreeSysroot  *self, GError **error);
+
 _OSTREE_PUBLIC
 gboolean ostree_sysroot_try_lock (OstreeSysroot         *self,
                                   gboolean              *out_acquired,

--- a/src/ostree/ot-admin-builtin-finalize-staged.c
+++ b/src/ostree/ot-admin-builtin-finalize-staged.c
@@ -34,6 +34,10 @@
 #include "ostree-cmdprivate.h"
 #include "ostree.h"
 
+static GOptionEntry options[] = {
+  { NULL }
+};
+
 /* Called by ostree-finalize-staged.service, and in turn
  * invokes a cmdprivate function inside the shared library.
  */
@@ -46,11 +50,13 @@ ot_admin_builtin_finalize_staged (int argc, char **argv, OstreeCommandInvocation
   if (fstatat (AT_FDCWD, "/run/ostree-booted", &stbuf, 0) < 0)
     return TRUE;
 
-  g_autoptr(GFile) sysroot_file = g_file_new_for_path ("/");
-  g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_file);
-
-  if (!ostree_sysroot_load (sysroot, cancellable, error))
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
+  g_autoptr(OstreeSysroot) sysroot = NULL;
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                          invocation, &sysroot, cancellable, error))
     return FALSE;
+
   if (!ostree_cmd__private__()->ostree_finalize_staged (sysroot, cancellable, error))
     return FALSE;
 


### PR DESCRIPTION
Add a magic file and an API for consumers to tell us it's OK
for us to remount read-write (since it'll just affect our
mount namespace).