### PR TITLE
bin/refs: Disallow creating broken aliases

### DIFF
--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -221,6 +221,9 @@ static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellab
         {
           if (remote)
             return glnx_throw (error, "Cannot create alias to remote ref: %s", remote);
+          if (!g_hash_table_contains (refs, refspec_prefix))
+            return glnx_throw (error, "Cannot create alias to non-existent ref: %s",
+                               refspec_prefix);
           if (!ostree_repo_set_alias_ref_immediate (repo, remote, ref, refspec_prefix,
                                                     cancellable, error))
             goto out;

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 setup_fake_remote_repo1 "archive"
 
-echo '1..6'
+echo '1..7'
 
 cd ${test_tmpdir}
 mkdir repo
@@ -207,3 +207,9 @@ if ${CMD_PREFIX} ostree --repo=repo refs -A exampleos/x86_64/27/server --create=
 fi
 assert_file_has_content_literal err.txt 'Cannot create alias to remote ref'
 echo "ok ref no alias remote"
+
+if ${CMD_PREFIX} ostree --repo=repo refs -A --create foobar nonexistent 2>err.txt; then
+    fatal "Created alias to nonexistent ref?"
+fi
+assert_file_has_content_literal err.txt 'Cannot create alias to non-existent ref'
+echo "ok ref no broken alias"


### PR DESCRIPTION
This is the alias version of #1749. I.e. we want to make sure that one
can't even create an alias which would end up dangling.

See also: https://pagure.io/releng/issue/7891