### PR TITLE
bin/pull-local: Add --commit-metadata-only

### DIFF
--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -32,6 +32,7 @@
 #include "otutil.h"
 
 static char *opt_remote;
+static gboolean opt_commit_only;
 static gboolean opt_disable_fsync;
 static gboolean opt_untrusted;
 static gboolean opt_bareuseronly_files;
@@ -46,6 +47,7 @@ static int opt_depth = 0;
  */
 
 static GOptionEntry options[] = {
+  { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
   { "remote", 0, 0, G_OPTION_ARG_STRING, &opt_remote, "Add REMOTE to refspec", "REMOTE" },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
   { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Verify checksums of local sources (always enabled for HTTP pulls)", NULL },
@@ -110,6 +112,8 @@ ostree_builtin_pull_local (int argc, char **argv, OstreeCommandInvocation *invoc
     pullflags |= OSTREE_REPO_PULL_FLAGS_UNTRUSTED;
   if (opt_bareuseronly_files)
     pullflags |= OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES;
+  if (opt_commit_only)
+    pullflags |= OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
 
   if (opt_disable_fsync)
     ostree_repo_set_disable_fsync (repo, TRUE);

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((85 + ${extra_basic_tests:-0}))"
+echo "1..$((86 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -762,7 +762,19 @@ echo "ok subdir noent"
 
 if ! skip_one_without_user_xattrs; then
     cd ${test_tmpdir}
-    mkdir repo3
+    mkdir repo4
+    ostree_repo_init repo4 --mode=bare-user
+    ${CMD_PREFIX} ostree --repo=repo4 pull-local --commit-metadata-only repo test2
+    csum1=$($OSTREE rev-parse test2)
+    csum2=$(${CMD_PREFIX} ostree --repo=repo4 rev-parse test2)
+    assert_streq "${csum1}" "${csum2}"
+    test -f repo4/state/$csum1.commitpartial
+    echo "ok pull-local --commit-metadata-only"
+    rm -rf repo4
+fi
+
+if ! skip_one_without_user_xattrs; then
+    cd ${test_tmpdir}
     ostree_repo_init repo3 --mode=bare-user
     ${CMD_PREFIX} ostree --repo=repo3 pull-local --remote=aremote repo test2
     ${CMD_PREFIX} ostree --repo=repo3 rev-parse aremote/test2


### PR DESCRIPTION
It might be "local", but e.g. we may be crossing filesystems. So there
are valid use cases for only wanting to pull the commit metadata with
`pull-local`.