### PR TITLE
lib/commit: Add devino_cache_hits to txn stats

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -3338,6 +3338,9 @@ write_content_to_mtree_internal (OstreeRepo                  *self,
               if (!glnx_shutil_rm_rf_at (dfd_iter->fd, name, cancellable, error))
                 return FALSE;
             }
+          g_mutex_lock (&self->txn_lock);
+          self->txn.stats.devino_cache_hits++;
+          g_mutex_unlock (&self->txn_lock);
           return TRUE; /* Early return */
         }
     }
@@ -3469,6 +3472,10 @@ write_content_to_mtree_internal (OstreeRepo                  *self,
       if (!ostree_mutable_tree_replace_file (mtree, name, loose_checksum,
                                              error))
         return FALSE;
+
+      g_mutex_lock (&self->txn_lock);
+      self->txn.stats.devino_cache_hits++;
+      g_mutex_unlock (&self->txn_lock);
     }
   /* Next fast path - we can "adopt" the file */
   else if (can_adopt)

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -291,8 +291,9 @@ struct _OstreeRepoTransactionStats {
   guint content_objects_total;
   guint content_objects_written;
   guint64 content_bytes_written;
+  guint devino_cache_hits;
 
-  guint64 padding1;
+  guint   padding1;
   guint64 padding2;
   guint64 padding3;
   guint64 padding4;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -835,6 +835,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
       g_print ("Metadata Written: %u\n", stats.metadata_objects_written);
       g_print ("Content Total: %u\n", stats.content_objects_total);
       g_print ("Content Written: %u\n", stats.content_objects_written);
+      g_print ("Content Cache Hits: %u\n", stats.devino_cache_hits);
       g_print ("Content Bytes Written: %" G_GUINT64_FORMAT "\n", stats.content_bytes_written);
     }
   else

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -117,9 +117,10 @@ assert_file_has_content ls.txt "^-006.. ${newuid} ${newgid} .*/baz/cow"
 
 # But --devino-canonical should override that
 $OSTREE commit ${COMMIT_ARGS} --owner-uid ${newuid} --owner-gid ${newgid} \
-        -I -b test2-devino-test --tree=dir=test2-checkout
+        -I -b test2-devino-test --table-output --tree=dir=test2-checkout > out.txt
 $OSTREE ls test2-devino-test /baz/cow > ls.txt
 assert_file_has_content ls.txt "^-006.. ${myuid} ${mygid} .*/baz/cow"
+assert_file_has_content out.txt "Content Cache Hits: [1-9][0-9]*"
 
 $OSTREE refs --delete test2-{linkcheckout,devino}-test
 echo "ok commit with -I"


### PR DESCRIPTION
I found this useful while hacking on rpm-ostree but I think it might be
useful enough to upstream. This stat is really helpful for validating
that a pipeline is hitting the devino cache sweet spot.