### PR TITLE
lib/repo: Search a list of paths in gpgkeypath for gpg keys

### DIFF
--- a/man/ostree.xml
+++ b/man/ostree.xml
@@ -432,6 +432,7 @@ Boston, MA 02111-1307, USA.
 
     <refsect1>
         <title>Examples</title>
+
         <para>
             For specific examples, please see the man page regarding the specific ostree command.  For example:
         </para>
@@ -445,28 +446,32 @@ Boston, MA 02111-1307, USA.
 
         <para>
           OSTree supports signing commits with GPG.  Operations on the system
-	  repository by default use keyring files in
+          repository by default use keyring files in
           <filename>/usr/share/ostree/trusted.gpg.d</filename>.  Any
           public key in a keyring file in that directory will be
           trusted by the client.  No private keys should be present
           in this directory.
         </para>
         <para>
-	  In addition to the system repository, OSTree supports two
-	  other paths.  First, there is a
-	  <literal>gpgkeypath</literal> option for remotes, which must
-	  point to the filename of an ASCII-armored key.
-	</para>
-	<para>Second, there is support for a per-remote
-	    <filename><replaceable>remotename</replaceable>.trustedkeys.gpg</filename>
-	    file stored in the toplevel of the repository (alongside
-	    <filename>objects/</filename> and such). This is
-	    particularly useful when downloading content that may not
-	    be fully trusted (e.g. you want to inspect it but not
-	    deploy it as an OS), or use it for containers.  This file
-	    is written via <command>ostree remote add
-	    --gpg-import</command>.
-	</para>
+          In addition to the system repository, OSTree supports two
+          other paths.  First, there is a
+          <literal>gpgkeypath</literal> option for remotes, which must point
+          to the filename of an ASCII-armored GPG key, or a directory containing
+          ASCII-armored GPG keys to import.  Multiple file and directory paths
+          to import from can be specified, as a comma-separated list of paths.  This option
+          may be specified by using <command>--set</command> in <command>ostree remote add</command>.
+        </para>
+        <para>
+          Second, there is support for a per-remote
+          <filename><replaceable>remotename</replaceable>.trustedkeys.gpg</filename>
+          file stored in the toplevel of the repository (alongside
+          <filename>objects/</filename> and such).  This is
+          particularly useful when downloading content that may not
+          be fully trusted (e.g. you want to inspect it but not
+          deploy it as an OS), or use it for containers.  This file
+          is written via <command>ostree remote add
+          --gpg-import</command>.
+        </para>
     </refsect1>
 
     <refsect1>

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -334,7 +334,7 @@ _ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
 }
 
 /* Add files that exist one level below the directory at @path as ascii
- * key files. If @path exists and cannot be opened as a directory,
+ * key files. If @path cannot be opened as a directory,
  * an error is returned.
  */
 gboolean

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -304,7 +304,7 @@ _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
   g_ptr_array_add (self->key_ascii_files, g_strdup (path));
 }
 
-void
+gboolean
 _ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
                                        const char          *path,
                                        GCancellable        *cancellable,
@@ -323,12 +323,14 @@ _ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
 
               _ostree_gpg_verifier_add_key_ascii_file (self, path);
             }
-        }
-      else
-        {
-          g_propagate_error (error, temp_error);
+          else
+            {
+              g_propagate_error (error, temp_error);
+              return FALSE;
+            }
         }
     }
+  return TRUE;
 }
 
 /* Add files that exist one level below the directory at @path as ascii
@@ -342,40 +344,36 @@ _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
                                          GCancellable        *cancellable,
                                          GError             **error)
 {
-  gboolean dir_exist = FALSE;
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
 
-  if (!ot_dfd_iter_init_allow_noent (dfd, path,
-                                    &dfd_iter, &dir_exist, error))
+  if (!glnx_dirfd_iterator_init_at (dfd, path, FALSE,
+                                    &dfd_iter, error))
     return FALSE;
 
-  if (dir_exist)
-    {
-      g_autofree char *sep = NULL;
+    g_autofree char *sep = NULL;
 
-      g_debug ("Adding GPG keyfile dir %s to verifier", path);
+    g_debug ("Adding GPG keyfile dir %s to verifier", path);
 
-      if (!g_str_has_suffix (path, "/"))
-        sep = g_strdup ("/");
+    if (!g_str_has_suffix (path, "/"))
+      sep = g_strdup ("/");
 
-      while (TRUE)
-        {
-          struct dirent *dent;
+    while (TRUE)
+      {
+        struct dirent *dent;
 
-          if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent,
-                                                          cancellable, error))
-            return FALSE;
-          if (dent == NULL)
-            break;
+        if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent,
+                                                        cancellable, error))
+          return FALSE;
+        if (dent == NULL)
+          break;
 
-          if (dent->d_type != DT_REG)
-            continue;
+        if (dent->d_type != DT_REG)
+          continue;
 
-          g_autofree char *iter_path = g_strjoin (sep, path, dent->d_name, NULL);
+        g_autofree char *iter_path = g_strjoin (sep, path, dent->d_name, NULL);
 
-          _ostree_gpg_verifier_add_key_ascii_file (self, iter_path);
-        }
-    }
+        _ostree_gpg_verifier_add_key_ascii_file (self, iter_path);
+      }
 
   return TRUE;
 }

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -361,7 +361,6 @@ _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
       while (TRUE)
         {
           struct dirent *dent;
-          g_autofree char *iter_path = NULL;
 
           if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent,
                                                           cancellable, error))
@@ -372,7 +371,7 @@ _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
           if (dent->d_type != DT_REG)
             continue;
 
-          iter_path = g_strjoin (sep, path, dent->d_name, NULL);
+          g_autofree char *iter_path = g_strjoin (sep, path, dent->d_name, NULL);
 
           _ostree_gpg_verifier_add_key_ascii_file (self, iter_path);
         }

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -304,63 +304,50 @@ _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
   g_ptr_array_add (self->key_ascii_files, g_strdup (path));
 }
 
-/* Check if the file at @path is a directory, and add ascii key files that
- * exist one level below the directory. If @path does not lead to a directory,
- * the file is added.
+/* Add the given @path as an ascii key file. If @path is a directory,
+ * add paths to files that exist one level below @path as ascii key files.
  */
 void
-_ostree_gpg_verifier_add_key_ascii_files_check_dir (OstreeGpgVerifier *self,
-                                                    const char        *path,
-                                                    GCancellable      *cancellable,
-                                                    GError           **error)
+_ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier *self,
+                                       const char        *path,
+                                       GCancellable      *cancellable,
+                                       GError           **error)
 {
-  GFile *file;
-  GFileType file_type;
-
-  file = g_file_new_for_path (path);
-  file_type = g_file_query_file_type (file, G_FILE_QUERY_INFO_NONE, cancellable);
+  g_autoptr(GFile) file = g_file_new_for_path (path);
+  GFileType file_type = g_file_query_file_type (file, G_FILE_QUERY_INFO_NONE, cancellable);
 
   if (file_type == G_FILE_TYPE_DIRECTORY)
     {
-      GFileEnumerator *direnum;
+      g_autoptr(GFileEnumerator) direnum = g_file_enumerate_children (file,
+                                                                      OSTREE_GIO_FAST_QUERYINFO,
+                                                                      G_FILE_QUERY_INFO_NONE,
+                                                                      cancellable,
+                                                                      error);
+      g_autoptr(GFileInfo) child_info = NULL;
       g_autofree char *sep = NULL;
+      GError *temp_error = NULL;
 
       if (!g_str_has_suffix (path, "/"))
         sep = g_strdup ("/");
 
-      direnum = g_file_enumerate_children (file, OSTREE_GIO_FAST_QUERYINFO,
-                                          G_FILE_QUERY_INFO_NONE, cancellable, error);
       if (direnum)
         {
-          while (TRUE)
+          while ((child_info = g_file_enumerator_next_file (direnum, NULL, &temp_error)) != NULL)
             {
-              GFileInfo *child_info;
-              GFile *child;
-              const char *name;
-              guint32 type;
-
-              if (!g_file_enumerator_iterate (direnum, &child_info, &child,
-                                              NULL, error))
-                break;
-              if (child_info == NULL)
-                break;
-
-              name = g_file_info_get_attribute_byte_string (child_info, "standard::name");
-              type = g_file_info_get_attribute_uint32 (child_info, "standard::type");
-
-              if (type == G_FILE_TYPE_REGULAR)
+              if (g_file_info_get_file_type (child_info) == G_FILE_TYPE_REGULAR)
                 {
-                  g_autofree char *child_path = NULL;
-
-                  child_path = g_strjoin (sep, path, name, NULL);
+                  const char *name = g_file_info_get_attribute_byte_string (child_info, "standard::name");
+                  g_autofree char *child_path = g_strjoin (sep, path, name, NULL);
 
                   _ostree_gpg_verifier_add_key_ascii_file (self, child_path);
                 }
+              g_clear_object (&child_info);
+            }
+          if (temp_error)
+            {
+              g_propagate_error (error, temp_error);
             }
         }
-
-      g_object_unref (direnum);
-      g_object_unref (file);
     }
   else
     {

--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -365,6 +365,8 @@ _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
       if (dent->d_type != DT_REG)
         continue;
 
+      /* TODO: Potentially open the files here and have the GPG verifier iterate
+      over the fds. See https://github.com/ostreedev/ostree/pull/1773#discussion_r235421900. */
       g_autofree char *iter_path = g_build_filename (path, dent->d_name, NULL);
 
       _ostree_gpg_verifier_add_key_ascii_file (self, iter_path);

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -75,7 +75,7 @@ void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
 void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
-void
+gboolean
 _ostree_gpg_verifier_add_keyfile_path(OstreeGpgVerifier   *self,
                                       const char          *path,
                                       GCancellable        *cancellable,

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -82,7 +82,6 @@ _ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
                                        GError             **error);
 
 gboolean
-
 _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
                                          int                  dfd,
                                          const char          *path,

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -82,6 +82,7 @@ _ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
                                        GError             **error);
 
 gboolean
+
 _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
                                          int                  dfd,
                                          const char          *path,

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -76,9 +76,9 @@ void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
 void
-_ostree_gpg_verifier_add_key_ascii_files_check_dir (OstreeGpgVerifier *self,
-                                                    const char        *path,
-                                                    GCancellable      *cancellable,
-                                                    GError           **error);
+_ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier *self,
+                                       const char        *path,
+                                       GCancellable      *cancellable,
+                                       GError           **error);
 
 G_END_DECLS

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -75,10 +75,11 @@ void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
 void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
-void
-_ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier *self,
-                                       const char        *path,
-                                       GCancellable      *cancellable,
-                                       GError           **error);
+gboolean
+_ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
+                                         int                  dfd,
+                                         const char          *path,
+                                         GCancellable        *cancellable,
+                                         GError             **error);
 
 G_END_DECLS

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -76,10 +76,10 @@ void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
 gboolean
-_ostree_gpg_verifier_add_keyfile_path(OstreeGpgVerifier   *self,
-                                      const char          *path,
-                                      GCancellable        *cancellable,
-                                      GError             **error);
+_ostree_gpg_verifier_add_keyfile_path (OstreeGpgVerifier   *self,
+                                       const char          *path,
+                                       GCancellable        *cancellable,
+                                       GError             **error);
 
 gboolean
 _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -75,4 +75,10 @@ void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
 void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
+void
+_ostree_gpg_verifier_add_key_ascii_files_check_dir (OstreeGpgVerifier *self,
+                                                    const char        *path,
+                                                    GCancellable      *cancellable,
+                                                    GError           **error);
+
 G_END_DECLS

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -75,6 +75,12 @@ void _ostree_gpg_verifier_add_keyring_file (OstreeGpgVerifier *self,
 void _ostree_gpg_verifier_add_key_ascii_file (OstreeGpgVerifier *self,
                                               const char        *path);
 
+void
+_ostree_gpg_verifier_add_keyfile_path(OstreeGpgVerifier   *self,
+                                      const char          *path,
+                                      GCancellable        *cancellable,
+                                      GError             **error);
+
 gboolean
 _ostree_gpg_verifier_add_keyfile_dir_at (OstreeGpgVerifier   *self,
                                          int                  dfd,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5109,8 +5109,12 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
             {
-              _ostree_gpg_verifier_add_keyfile_path(verifier, *iter,
-                                                   cancellable, error);
+              if (!_ostree_gpg_verifier_add_keyfile_path(verifier, *iter,
+                                                         cancellable, error))
+                {
+                  g_strfreev (gpgkeypath_list);
+                  return NULL;
+                }
             }
         }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5109,7 +5109,7 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
             {
-              _ostree_gpg_verifier_add_key_ascii_files_check_dir (verifier, *iter, cancellable, error);
+              _ostree_gpg_verifier_add_keyfile_path (verifier, *iter, cancellable, error);
             }
         }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5109,17 +5109,8 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
             {
-              g_autoptr(GFile) file = g_file_new_for_path (*iter);
-
-              if (g_file_query_file_type (file, G_FILE_QUERY_INFO_NONE, cancellable) == G_FILE_TYPE_DIRECTORY)
-                {
-                  if (!_ostree_gpg_verifier_add_keyfile_dir_at(verifier, AT_FDCWD, *iter, cancellable, error))
-                    continue;
-                }
-              else
-                {
-                  _ostree_gpg_verifier_add_key_ascii_file (verifier, *iter);
-                }
+              _ostree_gpg_verifier_add_keyfile_path(verifier, *iter,
+                                                   cancellable, error);
             }
         }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5106,10 +5106,12 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         return NULL;
 
       if (gpgkeypath_list)
-        for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
-          if (!_ostree_gpg_verifier_add_keyfile_path (verifier, *iter,
-                                                      cancellable, error))
-            return NULL;
+        {
+          for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
+            if (!_ostree_gpg_verifier_add_keyfile_path (verifier, *iter,
+                                                        cancellable, error))
+              return NULL;
+        }
     }
 
   if (add_global_keyring_dir)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5099,17 +5099,11 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
           add_global_keyring_dir = FALSE;
         }
 
-      g_autofree char *gpgkeypath = NULL;
       g_auto(GStrv) gpgkeypath_list = NULL;
 
       if (!ot_keyfile_get_string_as_list (remote->options, remote->group, "gpgkeypath",
-                                          ";,", &gpgkeypath, &gpgkeypath_list, error))
+                                          ";,", &gpgkeypath_list, error))
         return NULL;
-
-      if (gpgkeypath)
-        if (!_ostree_gpg_verifier_add_keyfile_path (verifier, gpgkeypath,
-                                                    cancellable, error))
-          return NULL;
 
       if (gpgkeypath_list)
         for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5081,7 +5081,7 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
     }
   else if (remote_name != NULL)
     {
-      char **gpgkeypath_list = NULL;
+      g_auto(GStrv) gpgkeypath_list = NULL;
 
       /* Add the remote's keyring file if it exists. */
 
@@ -5109,16 +5109,13 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
             {
-              if (!_ostree_gpg_verifier_add_keyfile_path(verifier, *iter,
-                                                         cancellable, error))
+              if (!_ostree_gpg_verifier_add_keyfile_path (verifier, *iter,
+                                                          cancellable, error))
                 {
-                  g_strfreev (gpgkeypath_list);
                   return NULL;
                 }
             }
         }
-
-      g_strfreev (gpgkeypath_list);
     }
 
   if (add_global_keyring_dir)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5081,7 +5081,6 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
     }
   else if (remote_name != NULL)
     {
-      g_autofree char *gpgkeypath = NULL;
       char **gpgkeypath_list = NULL;
 
       /* Add the remote's keyring file if it exists. */
@@ -5102,22 +5101,10 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
           add_global_keyring_dir = FALSE;
         }
 
-      if (!ot_keyfile_get_value_with_default (remote->options, remote->group, "gpgkeypath", NULL,
-                                              &gpgkeypath, error))
+      if (!ot_keyfile_get_string_list_with_default (remote->options, remote->group, "gpgkeypath",
+                                                    ',', NULL, &gpgkeypath_list, error))
         return NULL;
 
-      if (gpgkeypath)
-        {
-          if (strchr (gpgkeypath, ','))
-            {
-              gpgkeypath_list = g_strsplit (gpgkeypath, ",", -1);
-            }
-          else
-            {
-              _ostree_gpg_verifier_add_key_ascii_files_check_dir (verifier, gpgkeypath, cancellable, error);
-            }
-        }
-      
       if (gpgkeypath_list)
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5108,9 +5108,9 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
 
       if (gpgkeypath)
         {
-          if (strchr (gpgkeypath, ';'))
+          if (strchr (gpgkeypath, ','))
             {
-              gpgkeypath_list = g_strsplit (gpgkeypath, ";", -1);
+              gpgkeypath_list = g_strsplit (gpgkeypath, ",", -1);
             }
           else
             {

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5109,7 +5109,17 @@ _ostree_repo_gpg_verify_data_internal (OstreeRepo    *self,
         {
           for (char **iter = gpgkeypath_list; *iter != NULL; ++iter)
             {
-              _ostree_gpg_verifier_add_keyfile_path (verifier, *iter, cancellable, error);
+              g_autoptr(GFile) file = g_file_new_for_path (*iter);
+
+              if (g_file_query_file_type (file, G_FILE_QUERY_INFO_NONE, cancellable) == G_FILE_TYPE_DIRECTORY)
+                {
+                  if (!_ostree_gpg_verifier_add_keyfile_dir_at(verifier, AT_FDCWD, *iter, cancellable, error))
+                    continue;
+                }
+              else
+                {
+                  _ostree_gpg_verifier_add_key_ascii_file (verifier, *iter);
+                }
             }
         }
 

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -111,7 +111,6 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
                                          GError       **error)
 {
   GError *temp_error = NULL;
-  g_autofree char **ret_value = NULL;
 
   g_return_val_if_fail (keyfile != NULL, FALSE);
   g_return_val_if_fail (section != NULL, FALSE);
@@ -119,8 +118,8 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
 
   g_key_file_set_list_separator (keyfile, separator);
 
-  ret_value = g_key_file_get_string_list (keyfile, section,
-                                          key, NULL, &temp_error);
+  g_autofree char **ret_value = g_key_file_get_string_list (keyfile, section,
+                                                            key, NULL, &temp_error);
 
   if (temp_error)
     {

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -101,21 +101,19 @@ ot_keyfile_get_value_with_default (GKeyFile      *keyfile,
   return ret;
 }
 
-/* Read the value of key as a string, and check if the value
- * contains at least one of the separator characters. If the
- * value string contains none of the separators, return the
- * string in out_value and leave out_value_list unchanged.
- * If the value string contains one of the separators and none
- * of the others, read the value string as a list and return the
- * list in out_value_list, leaving out_value unchanged.
- * Return TRUE on success, FALSE on error. */
+/* Read the value of key as a string. If the value string contains
+ * one of the separators and none of the others, read the
+ * string as a NULL-terminated array out_value. If the value string contains
+ * none of the separators, read the string as a single entry into a
+ * NULL-terminated array out_value. If the value string contains multiple of
+ * the separators, an error is given.
+ * Returns TRUE on success, FALSE on error. */
 gboolean
 ot_keyfile_get_string_as_list (GKeyFile      *keyfile,
                                const char    *section,
                                const char    *key,
                                const char    *separators,
-                               char         **out_value,
-                               char        ***out_value_list,
+                               char        ***out_value,
                                GError       **error)
 {
   guint sep_count = 0;
@@ -146,21 +144,22 @@ ot_keyfile_get_string_as_list (GKeyFile      *keyfile,
 
   if (sep_count == 0)
     {
-      ot_transfer_out_value (out_value, &value_str);
+      value_list = g_new (gchar *, 2);
+      value_list[0] = g_steal_pointer(&value_str);
+      value_list[1] = NULL;
     }
   else if (sep_count == 1)
     {
       if (!ot_keyfile_get_string_list_with_default (keyfile, section, key,
                                                     sep, NULL, &value_list, error))
         return FALSE;
-
-      ot_transfer_out_value (out_value_list, &value_list);
     }
   else
     {
       return glnx_throw (error, "key value list contains more than one separator");
     }
 
+  ot_transfer_out_value (out_value, &value_list);
   return TRUE;
 }
 

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -140,23 +140,23 @@ ot_keyfile_get_string_as_list (GKeyFile      *keyfile,
               sep = separators[i];
             }
         }
-    }
 
-  if (sep_count == 0)
-    {
-      value_list = g_new (gchar *, 2);
-      value_list[0] = g_steal_pointer(&value_str);
-      value_list[1] = NULL;
-    }
-  else if (sep_count == 1)
-    {
-      if (!ot_keyfile_get_string_list_with_default (keyfile, section, key,
-                                                    sep, NULL, &value_list, error))
-        return FALSE;
-    }
-  else
-    {
-      return glnx_throw (error, "key value list contains more than one separator");
+      if (sep_count == 0)
+        {
+          value_list = g_new (gchar *, 2);
+          value_list[0] = g_steal_pointer (&value_str);
+          value_list[1] = NULL;
+        }
+      else if (sep_count == 1)
+        {
+          if (!ot_keyfile_get_string_list_with_default (keyfile, section, key,
+                                                        sep, NULL, &value_list, error))
+            return FALSE;
+        }
+      else
+        {
+          return glnx_throw (error, "key value list contains more than one separator");
+        }
     }
 
   ot_transfer_out_value (out_value, &value_list);

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -102,6 +102,47 @@ ot_keyfile_get_value_with_default (GKeyFile      *keyfile,
 }
 
 gboolean
+ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
+                                         const char    *section,
+                                         const char    *key,
+                                         char           separator,
+                                         char         **default_value,
+                                         char        ***out_value,
+                                         GError       **error)
+{
+  gboolean ret = FALSE;
+  GError *temp_error = NULL;
+  g_autofree char **ret_value = NULL;
+
+  g_return_val_if_fail (keyfile != NULL, ret);
+  g_return_val_if_fail (section != NULL, ret);
+  g_return_val_if_fail (key != NULL, ret);
+
+  g_key_file_set_list_separator (keyfile, separator);
+
+  ret_value = g_key_file_get_string_list (keyfile, section, key, NULL, &temp_error);
+
+  if (temp_error)
+    {
+      if (g_error_matches (temp_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+        {
+          g_clear_error (&temp_error);
+          ret_value = default_value;
+        }
+      else
+        {
+          g_propagate_error (error, temp_error);
+          goto out;
+        }
+    }
+
+  ret = TRUE;
+  ot_transfer_out_value (out_value, &ret_value);
+ out:
+  return ret;
+}
+
+gboolean
 ot_keyfile_copy_group (GKeyFile   *source_keyfile,
                        GKeyFile   *target_keyfile,
                        const char *group_name)

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -110,7 +110,7 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
                                          char        ***out_value,
                                          GError       **error)
 {
-  GError *temp_error = NULL;
+  g_autoptr(GError) temp_error = NULL;
 
   g_return_val_if_fail (keyfile != NULL, FALSE);
   g_return_val_if_fail (section != NULL, FALSE);
@@ -131,7 +131,7 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
         }
       else
         {
-          g_propagate_error (error, temp_error);
+          g_propagate_error (error, g_steal_pointer (&temp_error));
           return FALSE;
         }
     }

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -110,21 +110,22 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
                                          char        ***out_value,
                                          GError       **error)
 {
-  gboolean ret = FALSE;
   GError *temp_error = NULL;
   g_autofree char **ret_value = NULL;
 
-  g_return_val_if_fail (keyfile != NULL, ret);
-  g_return_val_if_fail (section != NULL, ret);
-  g_return_val_if_fail (key != NULL, ret);
+  g_return_val_if_fail (keyfile != NULL, FALSE);
+  g_return_val_if_fail (section != NULL, FALSE);
+  g_return_val_if_fail (key != NULL, FALSE);
 
   g_key_file_set_list_separator (keyfile, separator);
 
-  ret_value = g_key_file_get_string_list (keyfile, section, key, NULL, &temp_error);
+  ret_value = g_key_file_get_string_list (keyfile, section,
+                                          key, NULL, &temp_error);
 
   if (temp_error)
     {
-      if (g_error_matches (temp_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+      if (g_error_matches (temp_error, G_KEY_FILE_ERROR,
+                           G_KEY_FILE_ERROR_KEY_NOT_FOUND))
         {
           g_clear_error (&temp_error);
           ret_value = default_value;
@@ -132,14 +133,12 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
       else
         {
           g_propagate_error (error, temp_error);
-          goto out;
+          return FALSE;
         }
     }
 
-  ret = TRUE;
   ot_transfer_out_value (out_value, &ret_value);
- out:
-  return ret;
+  return TRUE;
 }
 
 gboolean

--- a/src/libotutil/ot-keyfile-utils.h
+++ b/src/libotutil/ot-keyfile-utils.h
@@ -49,7 +49,6 @@ ot_keyfile_get_string_as_list (GKeyFile      *keyfile,
                                const char    *section,
                                const char    *key,
                                const char    *separators,
-                               char         **out_value,
                                char        ***out_value_list,
                                GError       **error);
 

--- a/src/libotutil/ot-keyfile-utils.h
+++ b/src/libotutil/ot-keyfile-utils.h
@@ -45,6 +45,15 @@ ot_keyfile_get_value_with_default (GKeyFile      *keyfile,
                                    GError       **error);
 
 gboolean
+ot_keyfile_get_string_as_list (GKeyFile      *keyfile,
+                               const char    *section,
+                               const char    *key,
+                               const char    *separators,
+                               char         **out_value,
+                               char        ***out_value_list,
+                               GError       **error);
+
+gboolean
 ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
                                          const char    *section,
                                          const char    *key,

--- a/src/libotutil/ot-keyfile-utils.h
+++ b/src/libotutil/ot-keyfile-utils.h
@@ -45,6 +45,15 @@ ot_keyfile_get_value_with_default (GKeyFile      *keyfile,
                                    GError       **error);
 
 gboolean
+ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
+                                         const char    *section,
+                                         const char    *key,
+                                         char           separator,
+                                         char         **default_value,
+                                         char        ***out_value,
+                                         GError       **error);
+
+gboolean
 ot_keyfile_copy_group (GKeyFile   *source_keyfile,
                        GKeyFile   *target_keyfile,
                        const char *group_name);

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -154,6 +154,64 @@ ${OSTREE} prune --refs-only
 ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key3.asc R4 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R4:main >/dev/null
 
+# Test gpgkeypath success with multiple keys to try
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc;${test_tmpdir}/gpghome/key2.asc;${test_tmpdir}/gpghome/key3.asc" R7 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R7:main >/dev/null
+
+# Test gpgkeypath failure with multiple keys but none in keyring (invalid)
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc;${test_tmpdir}/gpghome/key2.asc" R8 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R8:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with different key"
+fi
+assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
+
+# Test gpgkeypath success with directory containing a valid key
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/ R9 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R9:main >/dev/null
+
+# Test gpgkeypath failure with nonexistent directory
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ R10 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R10:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath failure with a directory containing a valid key and a nonexistent key
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/;${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R11:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath success with a directory containing a valid key and an invalid key
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/;${test_tmpdir}/gpghome/key1.asc" R14 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R14:main >/dev/null
+
+# Test gpgkeypath failure with a nonexistent directory and a valid key
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/;${test_tmpdir}/gpghome/key3.asc" R12 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R12:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath failure with a nonexistent directory and a nonexistent key
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/;${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R13 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R13:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath success for trailing slash
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R15:main >/dev/null
+
+# Test gpgkeypath failure for empty string given with prefixed semicolon
+${OSTREE} remote add --set=gpgkeypath=";${test_tmpdir}/gpghome/key3.asc" R16 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R16:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
 rm repo/refs/remotes/* -rf
 ${OSTREE} prune --refs-only
 

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -155,11 +155,11 @@ ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key3.asc R4 $(cat h
 ${OSTREE} pull R4:main >/dev/null
 
 # Test gpgkeypath success with multiple keys to try
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc;${test_tmpdir}/gpghome/key2.asc;${test_tmpdir}/gpghome/key3.asc" R7 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc,${test_tmpdir}/gpghome/key3.asc" R7 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R7:main >/dev/null
 
 # Test gpgkeypath failure with multiple keys but none in keyring (invalid)
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc;${test_tmpdir}/gpghome/key2.asc" R8 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc" R8 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R8:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with different key"
 fi
@@ -177,36 +177,36 @@ fi
 assert_file_has_content err.txt "GPG: openat.*No such file or directory"
 
 # Test gpgkeypath failure with a directory containing a valid key and a nonexistent key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/;${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R11:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
 assert_file_has_content err.txt "GPG: openat.*No such file or directory"
 
 # Test gpgkeypath success with a directory containing a valid key and an invalid key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/;${test_tmpdir}/gpghome/key1.asc" R14 $(cat httpd-address)/ostree/gnomerepo
-${OSTREE} pull R14:main >/dev/null
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/key1.asc" R12 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R12:main >/dev/null
 
 # Test gpgkeypath failure with a nonexistent directory and a valid key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/;${test_tmpdir}/gpghome/key3.asc" R12 $(cat httpd-address)/ostree/gnomerepo
-if ${OSTREE} pull R12:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
-fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
-
-# Test gpgkeypath failure with a nonexistent directory and a nonexistent key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/;${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R13 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/key3.asc" R13 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R13:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi
 assert_file_has_content err.txt "GPG: openat.*No such file or directory"
 
-# Test gpgkeypath success for trailing slash
+# Test gpgkeypath failure with a nonexistent directory and a nonexistent key
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R14 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R14:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath success for no trailing slash in directory path
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R15:main >/dev/null
 
-# Test gpgkeypath failure for empty string given with prefixed semicolon
-${OSTREE} remote add --set=gpgkeypath=";${test_tmpdir}/gpghome/key3.asc" R16 $(cat httpd-address)/ostree/gnomerepo
+# Test gpgkeypath failure for empty string given with prefixed separator
+${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/key3.asc" R16 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R16:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -169,31 +169,37 @@ assert_file_has_content err.txt "GPG signatures found, but none are in trusted k
 ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/ R9 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R9:main >/dev/null
 
-# Test gpgkeypath failure with nonexistent directory
-${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ R10 $(cat httpd-address)/ostree/gnomerepo
-if ${OSTREE} pull R10:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
-fi
-assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
+# # Test gpgkeypath failure with nonexistent directory
+# ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ R10 $(cat httpd-address)/ostree/gnomerepo
+# if ${OSTREE} pull R10:main 2>err.txt; then
+#     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+# fi
+# assert_file_has_content err.txt "GPG.*No such file or directory"
 
-# Test gpgkeypath success with a directory containing a valid key, and a nonexistent key
+# Test gpgkeypath failure with a directory containing a valid key, and a nonexistent key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
-${OSTREE} pull R11:main 2>err.txt
+if ${OSTREE} pull R11:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
+fi
+assert_file_has_content err.txt "INVALIDKEYPATH.*No such file or directory"
 
 # Test gpgkeypath success with a directory containing a valid key, and a key not in keyring
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/key1.asc" R12 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R12:main >/dev/null
 
-# Test gpgkeypath success with a nonexistent directory, and a valid key
+# Test gpgkeypath failure with a nonexistent directory, and a valid key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/key3.asc" R13 $(cat httpd-address)/ostree/gnomerepo
-${OSTREE} pull R13:main >/dev/null
+if ${OSTREE} pull R13:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath failure with a nonexistent directory and a nonexistent key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R14 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R14:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
+assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath success for no trailing slash in directory path
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
@@ -204,7 +210,7 @@ ${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/INVALIDKEYPATH.as
 if ${OSTREE} pull R16:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
+assert_file_has_content err.txt "().*No such file or directory"
 
 # Test gpgkeypath success with suffixed separator
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key3.asc," R17 $(cat httpd-address)/ostree/gnomerepo
@@ -217,7 +223,7 @@ ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYPATH.asc 
 if ${OSTREE} pull R5:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
+assert_file_has_content err.txt "INVALIDKEYPATH.*No such file or directory"
 
 rm repo/refs/remotes/* -rf
 ${OSTREE} prune --refs-only

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -155,11 +155,11 @@ ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key3.asc R4 $(cat h
 ${OSTREE} pull R4:main >/dev/null
 
 # Test gpgkeypath success with multiple keys to try
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc,${test_tmpdir}/gpghome/key3.asc" R7 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc,${test_tmpdir}/gpghome/key3.asc R7 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R7:main >/dev/null
 
 # Test gpgkeypath failure with multiple keys but none in keyring
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc" R8 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc R8 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R8:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with different key"
 fi
@@ -177,44 +177,55 @@ fi
 assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath failure with a directory containing a valid key, and a nonexistent key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc R11 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R11:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
 assert_file_has_content err.txt "INVALIDKEYPATH.*No such file or directory"
 
 # Test gpgkeypath success with a directory containing a valid key, and a key not in keyring
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/key1.asc" R12 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/key1.asc R12 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R12:main >/dev/null
 
 # Test gpgkeypath failure with a nonexistent directory, and a valid key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/key3.asc" R13 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/key3.asc R13 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R13:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi
 assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath failure with a nonexistent directory and a nonexistent key
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R14 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc R14 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R14:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
 assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath success for no trailing slash in directory path
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome R15 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R15:main >/dev/null
 
 # Test gpgkeypath failure with prefixed separator giving an empty path, and a nonexistent key
-${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R16 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc R16 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R16:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
 assert_file_has_content err.txt "().*No such file or directory"
 
 # Test gpgkeypath success with suffixed separator
-${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key3.asc," R17 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/key3.asc, R17 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R17:main >/dev/null
+
+# Test gpgkeypath success with multiple keys specified, with semicolons
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc;${test_tmpdir}/gpghome/key2.asc;${test_tmpdir}/gpghome/key3.asc" R18 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R18:main >/dev/null
+
+# Test gpgkeypath failure multiple keys specified, with mix of commas and semicolons
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc;${test_tmpdir}/gpghome/key3.asc" R19 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R19:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with invalid gpgkeypath value"
+fi
+assert_file_has_content err.txt ".*key value list contains more than one separator"
 
 rm repo/refs/remotes/* -rf
 ${OSTREE} prune --refs-only

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -169,12 +169,12 @@ assert_file_has_content err.txt "GPG signatures found, but none are in trusted k
 ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/ R9 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R9:main >/dev/null
 
-# # Test gpgkeypath failure with nonexistent directory
-# ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ R10 $(cat httpd-address)/ostree/gnomerepo
-# if ${OSTREE} pull R10:main 2>err.txt; then
-#     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
-# fi
-# assert_file_has_content err.txt "GPG.*No such file or directory"
+# Test gpgkeypath failure with nonexistent directory
+${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ R10 $(cat httpd-address)/ostree/gnomerepo
+if ${OSTREE} pull R10:main 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+fi
+assert_file_has_content err.txt "INVALIDKEYDIRPATH.*No such file or directory"
 
 # Test gpgkeypath failure with a directory containing a valid key, and a nonexistent key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -205,12 +205,16 @@ assert_file_has_content err.txt "GPG: openat.*No such file or directory"
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R15:main >/dev/null
 
-# Test gpgkeypath failure for empty string given with prefixed separator
+# Test gpgkeypath failure with prefixed separator
 ${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/key3.asc" R16 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R16:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi
 assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+
+# Test gpgkeypath success with suffixed separator
+${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key3.asc," R17 $(cat httpd-address)/ostree/gnomerepo
+${OSTREE} pull R17:main >/dev/null
 
 rm repo/refs/remotes/* -rf
 ${OSTREE} prune --refs-only

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -210,7 +210,7 @@ ${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/key3.asc" R16 $(c
 if ${OSTREE} pull R16:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+assert_file_has_content err.txt "GPG: opendir.*No such file or directory"
 
 # Test gpgkeypath success with suffixed separator
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key3.asc," R17 $(cat httpd-address)/ostree/gnomerepo

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -158,7 +158,7 @@ ${OSTREE} pull R4:main >/dev/null
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc,${test_tmpdir}/gpghome/key3.asc" R7 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R7:main >/dev/null
 
-# Test gpgkeypath failure with multiple keys but none in keyring (invalid)
+# Test gpgkeypath failure with multiple keys but none in keyring
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key1.asc,${test_tmpdir}/gpghome/key2.asc" R8 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R8:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with different key"
@@ -174,43 +174,37 @@ ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/ 
 if ${OSTREE} pull R10:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
 fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
 
-# Test gpgkeypath failure with a directory containing a valid key and a nonexistent key
+# Test gpgkeypath success with a directory containing a valid key, and a nonexistent key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R11 $(cat httpd-address)/ostree/gnomerepo
-if ${OSTREE} pull R11:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
-fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+${OSTREE} pull R11:main 2>err.txt
 
-# Test gpgkeypath success with a directory containing a valid key and an invalid key
+# Test gpgkeypath success with a directory containing a valid key, and a key not in keyring
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/,${test_tmpdir}/gpghome/key1.asc" R12 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R12:main >/dev/null
 
-# Test gpgkeypath failure with a nonexistent directory and a valid key
+# Test gpgkeypath success with a nonexistent directory, and a valid key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/key3.asc" R13 $(cat httpd-address)/ostree/gnomerepo
-if ${OSTREE} pull R13:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
-fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+${OSTREE} pull R13:main >/dev/null
 
 # Test gpgkeypath failure with a nonexistent directory and a nonexistent key
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/INVALIDKEYDIRPATH/,${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R14 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R14:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "GPG: openat.*No such file or directory"
+assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
 
 # Test gpgkeypath success for no trailing slash in directory path
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome" R15 $(cat httpd-address)/ostree/gnomerepo
 ${OSTREE} pull R15:main >/dev/null
 
-# Test gpgkeypath failure with prefixed separator
-${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/key3.asc" R16 $(cat httpd-address)/ostree/gnomerepo
+# Test gpgkeypath failure with prefixed separator giving an empty path, and a nonexistent key
+${OSTREE} remote add --set=gpgkeypath=",${test_tmpdir}/gpghome/INVALIDKEYPATH.asc" R16 $(cat httpd-address)/ostree/gnomerepo
 if ${OSTREE} pull R16:main 2>err.txt; then
-    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key directory"
+    assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "GPG: opendir.*No such file or directory"
+assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
 
 # Test gpgkeypath success with suffixed separator
 ${OSTREE} remote add --set=gpgkeypath="${test_tmpdir}/gpghome/key3.asc," R17 $(cat httpd-address)/ostree/gnomerepo
@@ -223,7 +217,7 @@ ${OSTREE} remote add --set=gpgkeypath=${test_tmpdir}/gpghome/INVALIDKEYPATH.asc 
 if ${OSTREE} pull R5:main 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at pulling with nonexistent key"
 fi
-assert_file_has_content err.txt "INVALIDKEYPATH.*No such file or directory"
+assert_file_has_content err.txt "GPG signatures found, but none are in trusted keyring"
 
 rm repo/refs/remotes/* -rf
 ${OSTREE} prune --refs-only


### PR DESCRIPTION
This allows specifying gpgpath as a list of
paths that can point to a file or a directory. If a directory path
is given, paths to all regular files in the directory are added
to the remote as gpg ascii keys. If the path is not a directory,
the file is directly added (whether regular file, empty - errors
will be reported later when verifying gpg keys e.g. when pulling).

Adding the gpgkeypath property looks like:

ostree --repo=repo remote add --set=gpgpath="/path/key1.asc,/path/keys.d" R1 https://example.com/some/remote/ostree/repo

Closes #773

**Still left to do**

- [x] Update documentation of gpgkeypath

**Other considerations**

- Checks before adding the keys in `_ostree_gpg_verifier_add_key_ascii_file` and if/how checks will be reported. Right now, entries in the list that are not directories are added automatically (whether regular, or don't exist, ...) (same as before). If the entry is a directory, all regular files in that directory are added, without traversing directories
- Regexp matching of list entries