### PR TITLE
Assume same ownership and immutable files in case of untrusted local-pulls

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((86 + ${extra_basic_tests:-0}))"
+echo "1..$((88 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -364,6 +364,39 @@ if ! skip_one_without_user_xattrs; then
     echo "ok pull-local --bareuseronly-files"
 fi
 
+rm repo2 -rf
+ostree_repo_init repo2 --mode="$mode"
+$CMD_PREFIX ostree --repo=repo2 pull-local --untrusted repo test2
+target_file_object=$(ostree_file_path_to_relative_object_path repo test2 baz/saucer)
+target_file_checksum=$(ostree_file_path_to_checksum repo test2 baz/saucer)
+assert_files_hardlinked repo{,2}/${target_file_object}
+echo "ok pull-local hardlinking, untrusted"
+
+if grep -q 'mode=bare' repo/config; then
+    # Now copy/corrupt an object in a 3rd repo, pull into 2nd (leaving the first pristine)
+    rm repo{2,3} -rf
+    ostree_repo_init repo2 --mode="$mode"
+    ostree_repo_init repo3 --mode="$mode"
+    # Pull into 3rd repo, corrupt an object
+    $CMD_PREFIX ostree --repo=repo3 pull-local repo test2
+    cp -a --reflink=auto repo3/${target_file_object}{,.tmp}
+    mv repo3/${target_file_object}{.tmp,}
+    echo blah >> repo3/${target_file_object}
+    if $CMD_PREFIX ostree --repo=repo2 pull-local --untrusted repo3 2>err.txt; then
+        assert_not_reached "pulled --untrusted from corrupted repo"
+    fi
+    assert_file_has_content err.txt 'Corrupted.*'${target_file_checksum}
+    rm -f err.txt
+    # But this one should succeed
+    $CMD_PREFIX ostree --repo=repo2 pull-local repo3
+    if $CMD_PREFIX ostree --repo=repo2 fsck 2>err.txt; then
+        fatal "repo should have pulled corrupted object"
+    fi
+    assert_file_has_content err.txt 'Corrupted.*'${target_file_checksum}
+fi
+echo "ok pull-local --untrusted corruption"
+rm repo{2,3} -rf
+
 # This is mostly a copy of the suid test in test-basic-user-only.sh,
 # but for the `pull --bareuseronly-files` case.
 cd ${test_tmpdir}
@@ -385,7 +418,7 @@ echo "ok pull-local (bareuseronly files)"
 
 if ! skip_one_without_user_xattrs; then
     cd ${test_tmpdir}
-    ${CMD_PREFIX} ostree --repo=repo2 checkout ${CHECKOUT_U_ARG} test2 test2-checkout-from-local-clone
+    ${CMD_PREFIX} ostree --repo=repo checkout ${CHECKOUT_U_ARG} test2 test2-checkout-from-local-clone
     cd test2-checkout-from-local-clone
     assert_file_has_content yet/another/tree/green 'leaf'
     echo "ok local clone checkout"

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -23,7 +23,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-setup_test_repository "bare-user-only"
+mode="bare-user-only"
+setup_test_repository "$mode"
 extra_basic_tests=5
 . $(dirname $0)/basic-test.sh
 

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -25,7 +25,8 @@ set -euo pipefail
 
 skip_without_user_xattrs
 
-setup_test_repository "bare-user"
+mode="bare-user"
+setup_test_repository "$mode"
 
 extra_basic_tests=6
 . $(dirname $0)/basic-test.sh

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -25,5 +25,6 @@ set -euo pipefail
 
 skip_without_no_selinux_or_relabel
 
-setup_test_repository "bare"
+mode="bare"
+setup_test_repository "$mode"
 . $(dirname $0)/basic-test.sh

--- a/tests/test-pull-untrusted.sh
+++ b/tests/test-pull-untrusted.sh
@@ -25,51 +25,9 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..4'
+echo '1..1'
 
 setup_test_repository "bare"
-
-cd ${test_tmpdir}
-mkdir repo2
-ostree_repo_init repo2 --mode="bare"
-
-${CMD_PREFIX} ostree --repo=repo2 --untrusted pull-local repo
-
-find repo2 -type f -links +1 | while read line; do
-    assert_not_reached "pull-local created hardlinks"
-done
-echo "ok pull-local --untrusted didn't hardlink"
-
-# Corrupt repo
-for i in ${test_tmpdir}/repo/objects/*/*.file; do
-
-    # make sure it's not a symlink
-    if [ -L $i ]; then
-        continue
-    fi
-
-    echo "corrupting $i"
-    echo "broke" >> $i
-    break;
-done
-
-rm -rf repo2
-mkdir repo2
-ostree_repo_init repo2 --mode="bare"
-if ${CMD_PREFIX} ostree --repo=repo2 pull-local repo; then
-    echo "ok trusted pull with corruption succeeded"
-else
-    assert_not_reached "corrupted trusted pull unexpectedly succeeded!"
-fi
-
-rm -rf repo2
-ostree_repo_init repo2 --mode="bare"
-if ${CMD_PREFIX} ostree --repo=repo2 pull-local --untrusted repo; then
-    assert_not_reached "corrupted untrusted pull unexpectedly failed!"
-else
-    echo "ok untrusted pull with corruption failed"
-fi
-
 
 cd ${test_tmpdir}
 tar xf ${test_srcdir}/ostree-path-traverse.tar.gz


### PR DESCRIPTION
In the pull code path, if the caller can guarantee that the files
in the local repo are immutable and checksum-verified, then use the
_OSTREE_REPO_IMPORT_FLAGS_TRUSTED flag to try hardlink or reflink
while importing.

This mainly helps flatpak for enabling a hardlink-able local pull
in the --system case during deploy. If the child repo is owned by root
and is not world-writable, one can pass this to flag solve the double
space requirement problem (i.e. copying each object during import) by
using a hardlink-able(or reflink) pull.

https://github.com/ostreedev/ostree/issues/1723