### PR TITLE
Fix leak in ostree_content_stream_parse()

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -626,9 +626,9 @@ ostree_content_stream_parse (gboolean                compressed,
                                 cancellable, error))
     return FALSE;
   g_autoptr(GVariant) file_header =
-    g_variant_new_from_data (compressed ? _OSTREE_ZLIB_FILE_HEADER_GVARIANT_FORMAT : _OSTREE_FILE_HEADER_GVARIANT_FORMAT,
-                             buf, archive_header_size, trusted,
-                             g_free, buf);
+    g_variant_ref_sink(g_variant_new_from_data (compressed ? _OSTREE_ZLIB_FILE_HEADER_GVARIANT_FORMAT : _OSTREE_FILE_HEADER_GVARIANT_FORMAT,
+                                                buf, archive_header_size, trusted,
+                                                g_free, buf));
   buf = NULL;
   g_autoptr(GFileInfo) ret_file_info = NULL;
   g_autoptr(GVariant) ret_xattrs = NULL;


### PR DESCRIPTION
We need to ref_sink new GVariants for autoptr to work