### PR TITLE
lib/kargs: allow empty-list arguments

### DIFF
--- a/src/libostree/ostree-kernel-args.c
+++ b/src/libostree/ostree-kernel-args.c
@@ -33,23 +33,14 @@ static char *
 split_keyeq (char *arg)
 {
   char *eq;
-      
+
   eq = strchr (arg, '=');
-  if (eq)
-    {
-      /* Note key/val are in one malloc block,
-       * so we don't free val...
-       */
-      *eq = '\0';
-      return eq+1;
-    }
-  else
-    {
-      /* ...and this allows us to insert a constant
-       * string.
-       */
-      return "";
-    }
+  if (eq == NULL)
+    return NULL;
+
+  // Note: key/val are in a single allocation block, so we don't free val.
+  *eq = '\0';
+  return eq+1;
 }
 
 static gboolean
@@ -264,8 +255,10 @@ _ostree_kernel_args_to_strv (OstreeKernelArgs *kargs)
       for (j = 0; j < values->len; j++)
         {
           const char *value = values->pdata[j];
-
-          g_ptr_array_add (strv, g_strconcat (key, "=", value, NULL));
+          if (value == NULL)
+            g_ptr_array_add (strv, g_strconcat (key, NULL));
+          else
+            g_ptr_array_add (strv, g_strconcat (key, "=", value, NULL));
         }
     }
   g_ptr_array_add (strv, NULL);
@@ -297,14 +290,12 @@ _ostree_kernel_args_to_string (OstreeKernelArgs *kargs)
           else
             g_string_append_c (buf, ' ');
 
-          if (value && *value)
+          g_string_append (buf, key);
+          if (value != NULL)
             {
-              g_string_append (buf, key);
               g_string_append_c (buf, '=');
               g_string_append (buf, value);
             }
-          else
-            g_string_append (buf, key);
         }
     }
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -33,21 +33,21 @@ ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testo
 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
 
 ${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAR
-${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAZ FOO=BIF TESTARG=TESTVALUE
+${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAZ FOO=BIF TESTARG=TESTVALUE KEYWORD EMPTYLIST=
 assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs (basic)"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge FOO=BAR
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF .*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs --merge"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --replace=FOO=XXX
 assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=XXX'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs --replace"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --append=FOO=BAR --append=APPENDARG=VALAPPEND --append=APPENDARG=2NDAPPEND testos:testos/buildmaster/x86_64-runtime


### PR DESCRIPTION
This adds support for empty-list arguments (e.g. `acpi_osi=`), which
are semantically different from simple-keyword arguments.

Ref: https://github.com/projectatomic/rpm-ostree/issues/1706