### PR TITLE
grub2: add support for devicetree

### DIFF
--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -32,6 +32,7 @@ read_config()
     initrd=""
     options=""
     linux=""
+    devicetree=""
 
     while read -r line
     do
@@ -46,6 +47,9 @@ read_config()
                 ;;
             "linux")
                 linux=${value}
+                ;;
+            "devicetree")
+                devicetree=${value}
                 ;;
             "options")
                 options=${value}
@@ -72,6 +76,9 @@ populate_menu()
         menu="${menu}\t linux ${boot_prefix}${linux} ${options}\n"
         if [ -n "${initrd}" ] ; then
             menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+        fi
+        if [ -n "${devicetree}" ] ; then
+            menu="${menu}\t devicetree ${boot_prefix}${devicetree}\n"
         fi
         menu="${menu}}\n\n"
     done

--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -251,10 +251,6 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
       if (devicetree)
         {
           g_string_append (output, "devicetree");
-          if (is_efi)
-            g_string_append (output, GRUB2_EFI_SUFFIX);
-          else
-            g_string_append (output, GRUB2_SUFFIX);
           g_string_append_c (output, ' ');
           g_string_append (output, devicetree);
           g_string_append_c (output, '\n');

--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -191,6 +191,7 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
       const char *options;
       const char *kernel;
       const char *initrd;
+      const char *devicetree;
       char *quoted_title = NULL;
       char *uuid = NULL;
       char *quoted_uuid = NULL;
@@ -243,6 +244,19 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
             g_string_append (output, GRUB2_SUFFIX);
           g_string_append_c (output, ' ');
           g_string_append (output, initrd);
+          g_string_append_c (output, '\n');
+        }
+
+      devicetree = ostree_bootconfig_parser_get (config, "devicetree");
+      if (devicetree)
+        {
+          g_string_append (output, "devicetree");
+          if (is_efi)
+            g_string_append (output, GRUB2_EFI_SUFFIX);
+          else
+            g_string_append (output, GRUB2_SUFFIX);
+          g_string_append_c (output, ' ');
+          g_string_append (output, devicetree);
           g_string_append_c (output, '\n');
         }
 


### PR DESCRIPTION
Similar as available for u-boot (ce2995e1dc1557c4d97ef5af807eacf3ef4a22d8)
and syslinux (c5112c25e4519835c4cd53f4350c1b2f2a477746), enable parsing
and writing devicetree filename into grub.cfg.

This is required by arm64-based devices running edk2 instead of u-boot
as the main bootloader (e.g. 96boards HiKey and HiKey960).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>