### PR TITLE
pull: If built with --disable-http2, allow enabling via http2=1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,7 @@ AS_HELP_STRING([--disable-http2],
   [Disable use of http2 (default: no)]),,
   [enable_http2=yes])
 AS_IF([test x$enable_http2 != xno ], [
-  AC_DEFINE([BUILDOPT_HTTP2], 1, [Define if we enable http2])
+  AC_DEFINE([BUILDOPT_HTTP2], 1, [Define if we enable http2 by default])
 ], [
   OSTREE_FEATURES="$OSTREE_FEATURES no-http2"
 ])

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -777,7 +777,6 @@ initiate_next_curl_request (FetcherRequest *req,
    * there are numerous HTTP/2 fixes since the original version in
    * libcurl 7.43.0.
    */
-#ifdef BUILDOPT_HTTP2
   if (!(self->config_flags & OSTREE_FETCHER_FLAGS_DISABLE_HTTP2))
     {
 #if CURL_AT_LEAST_VERSION(7, 51, 0)
@@ -789,7 +788,7 @@ initiate_next_curl_request (FetcherRequest *req,
       curl_easy_setopt (req->easy, CURLOPT_PIPEWAIT, 1L);
 #endif
     }
-#endif
+
   curl_easy_setopt (req->easy, CURLOPT_WRITEFUNCTION, write_cb);
   if (g_getenv ("OSTREE_DEBUG_HTTP"))
     curl_easy_setopt (req->easy, CURLOPT_VERBOSE, 1L);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2948,9 +2948,14 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
   if (gzip)
     fetcher_flags |= OSTREE_FETCHER_FLAGS_TRANSFER_GZIP;
 
-  { gboolean http2 = TRUE;
+  { gboolean http2_default = TRUE;
+#ifndef BUILDOPT_HTTP2
+    http2_default = FALSE;
+#endif
+    gboolean http2;
+
     if (!ostree_repo_get_remote_boolean_option (self, remote_name,
-                                                "http2", TRUE,
+                                                "http2", http2_default,
                                                 &http2, error))
       goto out;
     if (!http2)


### PR DESCRIPTION
We have a `http2=[0|1]` remote config option; let's have the
`--disable-http2` build option define the default for that.  This way
it's easy to still enable http2 for testing even if
we have it disabled by default.