### PR TITLE
Kill GPG daemons

### DIFF
--- a/src/libostree/ostree-gpg-verifier.c
+++ b/src/libostree/ostree-gpg-verifier.c
@@ -87,6 +87,7 @@ verify_result_finalized_cb (gpointer data,
    *     finalize() method, but I didn't want this keyring hack
    *     bleeding into multiple classes. */
 
+  ot_gpgme_kill_agent (tmp_dir);
   (void) glnx_shutil_rm_rf_at (AT_FDCWD, tmp_dir, NULL, NULL);
 }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2300,11 +2300,15 @@ out:
   if (remote != NULL)
     ostree_remote_unref (remote);
 
-  if (source_tmp_dir != NULL)
+  if (source_tmp_dir != NULL) {
+    ot_gpgme_kill_agent (source_tmp_dir);
     (void) glnx_shutil_rm_rf_at (AT_FDCWD, source_tmp_dir, NULL, NULL);
+  }
 
-  if (target_tmp_dir != NULL)
+  if (target_tmp_dir != NULL) {
+    ot_gpgme_kill_agent (target_tmp_dir);
     (void) glnx_shutil_rm_rf_at (AT_FDCWD, target_tmp_dir, NULL, NULL);
+  }
 
   g_prefix_error (error, "GPG: ");
 

--- a/src/libotutil/ot-gpg-utils.c
+++ b/src/libotutil/ot-gpg-utils.c
@@ -437,3 +437,29 @@ ot_gpgme_new_ctx (const char *homedir,
 
   return g_steal_pointer (&context);
 }
+
+void
+ot_gpgme_kill_agent (const char *homedir)
+{
+  g_return_if_fail (homedir != NULL);
+
+  /* Run gpg-connect-agent killagent /bye */
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GSubprocess) proc = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_SILENCE,
+                                                 &local_error,
+                                                 "gpg-connect-agent",
+                                                 "--homedir",
+                                                 homedir,
+                                                 "killagent",
+                                                 "/bye",
+                                                 NULL);
+  if (proc == NULL) {
+    g_debug ("Spawning gpg-connect-agent failed: %s", local_error->message);
+    return;
+  }
+  if (!g_subprocess_wait_check (proc, NULL, &local_error)) {
+    g_debug ("Killing GPG agent with gpg-connect-agent failed: %s",
+             local_error->message);
+    return;
+  }
+}

--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -46,4 +46,6 @@ gpgme_data_t ot_gpgme_data_output (GOutputStream *output_stream);
 gpgme_ctx_t ot_gpgme_new_ctx (const char *homedir,
                               GError    **error);
 
+void ot_gpgme_kill_agent (const char *homedir);
+
 G_END_DECLS

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -34,13 +34,24 @@ else
 fi
 . ${test_srcdir}/libtest-core.sh
 
+# Array of expressions to execute when exiting. Each expression should
+# be a single string (quoting if necessary) that will be eval'd. To add
+# a command to run on exit, append to the libtest_exit_cmds array like
+# libtest_exit_cmds+=(expr).
+libtest_exit_cmds=()
+run_exit_cmds() {
+  for expr in "${libtest_exit_cmds[@]}"; do
+    eval "${expr}" || true
+  done
+}
+trap run_exit_cmds EXIT
+
 save_core() {
   if [ -e core ]; then
     cp core "$test_srcdir/core"
   fi
 }
-
-trap save_core EXIT;
+libtest_exit_cmds+=(save_core)
 
 test_tmpdir=$(pwd)
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -614,6 +614,7 @@ has_gpgme () {
 libtest_cleanup_gpg () {
     gpg-connect-agent --homedir ${test_tmpdir}/gpghome killagent /bye || true
 }
+libtest_exit_cmds+=(libtest_cleanup_gpg)
 
 is_bare_user_only_repo () {
   grep -q 'mode=bare-user-only' $1/config

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -140,4 +140,3 @@ assert_not_file_has_content show.txt 'Found.*signature'
 echo "ok pull sig deleted"
 
 rm -rf repo gnomerepo-files
-libtest_cleanup_gpg

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -80,6 +80,4 @@ if ${OSTREE} show test2 | grep -o 'Found [[:digit:]] signature'; then
   assert_not_reached
 fi
 
-libtest_cleanup_gpg
-
 echo "ok"

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -120,5 +120,3 @@ echo "ok pull mirror with invalid summary sig and no verification"
 # assert_file_has_content deltas.txt "${origmain}-${newmain}"
 
 # echo "ok pull mirror with signed summary covering static deltas"
-
-libtest_cleanup_gpg

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -274,5 +274,3 @@ cmp repo/tmp/cache/summaries/origin ${test_tmpdir}/ostree-srv/gnomerepo/summary.
 cmp repo/tmp/cache/summaries/origin.sig ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig.2 >&2
 
 echo "ok pull with signed summary broken cache"
-
-libtest_cleanup_gpg

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -280,5 +280,3 @@ ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u --gpg
 ${OSTREE} pull --require-static-deltas R1:main
 
 echo "ok gpg trusted signed commit for delta upgrades"
-
-libtest_cleanup_gpg

--- a/tests/test-repo-finder-mount-integration.sh
+++ b/tests/test-repo-finder-mount-integration.sh
@@ -55,7 +55,7 @@ _mount_cleanup () {
 
 case "${TEST_SKIP_CLEANUP:-}" in
     no|"")
-        trap _mount_cleanup EXIT
+        libtest_exit_cmds+=(_mount_cleanup)
         ;;
     err)
         trap _mount_cleanup ERR

--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -41,7 +41,7 @@ rofiles-fuse checkout-test2 mnt
 cleanup_fuse() {
     fusermount -u ${test_tmpdir}/mnt || true
 }
-trap cleanup_fuse EXIT
+libtest_exit_cmds+=(cleanup_fuse)
 assert_file_has_content mnt/firstfile first
 echo "ok mount"
 

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -62,5 +62,3 @@ assert_file_has_content_literal raw-summary.txt "('main', ("
 assert_file_has_content_literal raw-summary.txt "('other', ("
 assert_file_has_content_literal raw-summary.txt "{'ostree.summary.last-modified': <uint64"
 echo "ok view summary raw"
-
-libtest_cleanup_gpg


### PR DESCRIPTION
GnuPG 2 has a fun implementation where it spawns a `gpg-agent` daemon that never exits for any operation. Coupled with libostree's usage of temporary directories for keyring construction, this can leave a lot of `gpg-agent`s running. When we know that the components are associated with a temporary directory that's being deleted, we can call `gpgconf --kill all` to get rid of them.

Now when I run the test suite there are no `gpg-agent`s left behind!

Closes: #727