### PR TITLE
lib/commit: Fix bare → bare imports

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -4287,7 +4287,7 @@ import_one_object_direct (OstreeRepo    *dest_repo,
               if (bytes == NULL)
                 return FALSE;
 
-              if (TEMP_FAILURE_RETRY (fsetxattr (src_fd, "user.ostreemeta",
+              if (TEMP_FAILURE_RETRY (fsetxattr (tmp_dest.fd, "user.ostreemeta",
                                                  (char*)g_bytes_get_data (bytes, NULL),
                                                  g_bytes_get_size (bytes), 0)) != 0)
                 return glnx_throw_errno_prefix (error, "fsetxattr");

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -4279,8 +4279,18 @@ import_one_object_direct (OstreeRepo    *dest_repo,
                                            cancellable, error))
                 return FALSE;
             }
+          else if (dest_repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)
+            {
+              /* Nothing; this is the "bareuser-only conversion case",
+               * we don't need to set any xattrs in the dest repo.
+               */
+            }
           else
             {
+              /* And this case must be bare-user → bare-user */
+              g_assert (src_repo->mode == OSTREE_REPO_MODE_BARE_USER);
+              g_assert (src_repo->mode == dest_repo->mode);
+
               /* bare-user; we just want ostree.usermeta */
               g_autoptr(GBytes) bytes =
                 glnx_fgetxattr_bytes (src_fd, "user.ostreemeta", error);

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -4269,7 +4269,7 @@ import_one_object_direct (OstreeRepo    *dest_repo,
         G_IN_SET (src_repo->mode, OSTREE_REPO_MODE_BARE, OSTREE_REPO_MODE_BARE_USER);
       if (src_is_bare_or_bare_user && !OSTREE_OBJECT_TYPE_IS_META(objtype))
         {
-          if (src_repo == OSTREE_REPO_MODE_BARE)
+          if (src_repo->mode == OSTREE_REPO_MODE_BARE)
             {
               g_autoptr(GVariant) xattrs = NULL;
               if (!glnx_fd_get_all_xattrs (src_fd, &xattrs,


### PR DESCRIPTION
Regression from https://github.com/ostreedev/ostree/pull/1771

This broke rpmostreepayload in Anaconda where we import a bare repo:
https://openqa.fedoraproject.org/tests/345339#step/_do_install_and_reboot/4

Reported-by: Adam Williamson <adamwill@fedoraproject.org>