### PR TITLE
tests: Remove unused includes in libostreetest.c

### DIFF
--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -22,8 +22,6 @@
 #include "config.h"
 #include <stdlib.h>
 #include <string.h>
-#include <linux/magic.h>
-#include <sys/vfs.h>
 
 #include "libglnx.h"
 #include "libostreetest.h"


### PR DESCRIPTION
Since commit a06bd82cd we no longer use OVERLAYFS_SUPER_MAGIC or
statfs() so remove the includes for linux/magic.h and sys/vfs.h