### PR TITLE
lib/repo-pull: Don't omit results that seem out-of-date

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5665,10 +5665,11 @@ find_remotes_cb (GObject      *obj,
 
           if (n_latest_refs == 0)
             {
-              g_debug ("%s: Omitting remote ‘%s’ from results as none of its refs are new enough.",
+              /* Here we used to remove the result from the final set, but
+               * let's leave it in since the result providing the latest might
+               * have bad signatures or another failure */
+              g_debug ("%s: Remote ‘%s’ does not have the latest rev of ony ref; leaving in results as a fallback.",
                        G_STRFUNC, result->remote->name);
-              ostree_repo_finder_result_free (g_steal_pointer (&g_ptr_array_index (results, i)));
-              continue;
             }
         }
 


### PR DESCRIPTION
Currently in find_remotes_cb() which is the callback that does the
processing for ostree_repo_find_remotes_async(), if any result doesn't
provide the latest version of any ref it gets dropped from the final set
of results that are returned. This presents a problem if you want to be
robust against a source (configured remote, LAN, or USB) providing
malicious updates, as we do in Flatpak which doesn't trust each remote
to the same degree. Another reason you might want to pull from results
that seem to provide outdated refs is if the pull from the result
providing the latest commit failed for external reasons (say, the USB
drive was removed).

So this commit leaves results in the set returned by
find_remotes_async() even if all their refs are mapped to NULL in the
ref_to_checksum map (meaning they're outdated compared to another
result).

Say I want to pull (com.example.Collection, example-ref) and I have
configured both good-remote and malicious-remote with that collection
ID. Say good-remote advertises commit v1 and remote malicious-remote
advertises commit v2 which seems newer but is signed with the malicious
GPG keyring. With this patch, I can have both remotes in the results
array and when the malicious-remote pull fails for lack of good GPG
signatures (see the "ref-keyring-map" option) a successful pull will
happen from good-remote for the older, legitimate commit.