### PR TITLE
lib/repo-refs: Fix resolving collection-refs

### DIFF
--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -514,7 +514,7 @@ ostree_repo_resolve_rev_ext (OstreeRepo                    *self,
  * the given @ref cannot be found, a %G_IO_ERROR_NOT_FOUND error will be
  * returned.
  *
- * If you want to check only local refs not remote or mirrored ones, use the
+ * If you want to check only local refs, not remote or mirrored ones, use the
  * flag %OSTREE_REPO_RESOLVE_REV_EXT_LOCAL_ONLY. This is analogous to using
  * ostree_repo_resolve_rev_ext() but for collection-refs.
  *

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -462,9 +462,11 @@ gboolean      ostree_repo_resolve_rev (OstreeRepo  *self,
 /**
  * OstreeRepoResolveRevExtFlags:
  * @OSTREE_REPO_RESOLVE_REV_EXT_NONE: No flags.
+ * @OSTREE_REPO_RESOLVE_REV_EXT_LOCAL_ONLY: Exclude remote and mirrored refs. Since: 2019.2
  */
 typedef enum {
   OSTREE_REPO_RESOLVE_REV_EXT_NONE = 0,
+  OSTREE_REPO_RESOLVE_REV_EXT_LOCAL_ONLY = (1 << 0),
 } OstreeRepoResolveRevExtFlags;
 
 _OSTREE_PUBLIC

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -496,11 +496,13 @@ gboolean      ostree_repo_list_refs (OstreeRepo       *self,
  * @OSTREE_REPO_LIST_REFS_EXT_NONE: No flags.
  * @OSTREE_REPO_LIST_REFS_EXT_ALIASES: Only list aliases.  Since: 2017.10
  * @OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES: Exclude remote refs.  Since: 2017.11
+ * @OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_MIRRORS: Exclude mirrored refs.  Since: 2019.2
  */
 typedef enum {
   OSTREE_REPO_LIST_REFS_EXT_NONE = 0,
   OSTREE_REPO_LIST_REFS_EXT_ALIASES = (1 << 0),
   OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_REMOTES = (1 << 1),
+  OSTREE_REPO_LIST_REFS_EXT_EXCLUDE_MIRRORS = (1 << 2),
 } OstreeRepoListRefsExtFlags;
 
 _OSTREE_PUBLIC


### PR DESCRIPTION
My last commit "lib/repo-refs: Resolve collection-refs in-memory and in
parent repos" changed ostree_repo_resolve_collection_ref() to check the
in-memory set of refs *after* failing to find the ref on disk but that's
not what we want. We want to use the in-memory set of refs first,
because those are the most up to date commits, and then fall back to the
on-disk repo and finally fall back to checking any parent repo. This
commit makes such a change to the order of operations, which is
consistent with how ostree_repo_resolve_rev() works.

Aside from this change being logical, it also fixes some unit test
failures on an unmerged branch of flatpak:
https://github.com/flatpak/flatpak/pull/2705