### PR TITLE
lib/deploy: Don't include version twice in bootmenu title

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1739,7 +1739,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
    *     (specifically, it looks for the substring "(ostree"), so further
    *     changes to the title format may require updating that backend. */
   g_autoptr(GString) title_key = g_string_new (val);
-  if (deployment_version && *deployment_version)
+  if (deployment_version && *deployment_version && !strstr (val, deployment_version))
     {
       g_string_append_c (title_key, ' ');
       g_string_append (title_key, deployment_version);

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((25 + ${extra_admin_tests:-0}))"
+echo "1..$((26 + ${extra_admin_tests:-0}))"
 
 function validate_bootloader() {
     cd ${test_tmpdir};
@@ -279,6 +279,16 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf 'consol
 validate_bootloader
 
 echo "ok upgrade with multiple kernel args"
+
+os_repository_new_commit
+${CMD_PREFIX} ostree admin upgrade --os=testos
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 ${version} (ostree:testos)$"
+os_repository_new_commit 0 0 testos/buildmaster/x86_64-runtime 42
+${CMD_PREFIX} ostree admin upgrade --os=testos
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 (ostree:testos)$"
+
+echo "ok no duplicate version strings in title"
+
 
 # Test upgrade with and without --override-commit
 # See https://github.com/GNOME/ostree/pull/147

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -465,6 +465,7 @@ os_repository_new_commit ()
     boot_checksum_iteration=${1:-0}
     content_iteration=${2:-0}
     branch=${3:-testos/buildmaster/x86_64-runtime}
+    export version=${4:-$(date "+%Y%m%d.${content_iteration}")}
     echo "BOOT ITERATION: $boot_checksum_iteration"
     cd ${test_tmpdir}/osdata
     kver=3.6.0
@@ -498,8 +499,6 @@ os_repository_new_commit ()
     echo "a new default dir and file" > usr/etc/new-default-dir/moo
 
     echo "content iteration ${content_iteration}" > usr/bin/content-iteration
-
-    export version=$(date "+%Y%m%d.${content_iteration}")
 
     ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" -b $branch -s "Build"
     cd ${test_tmpdir}


### PR DESCRIPTION
In Silverblue right now, the boot menu title looks like this:

    Fedora 29.20190301.0 (Workstation Edition) 29.20190301.0 (ostree)

This is because RPM-OSTree's `mutate-os-release` feature is enabled,
which injects the OSTree version string directly into `VERSION` and
`PRETTY_NAME`. So appending the version string again is a bit redundant.
Let's just do a simple substring check here before adding the version to
the title.