### PR TITLE
[WIP] lib/deploy: Check space before copying into /boot

### DIFF
--- a/src/libostree/ostree-deployment-private.h
+++ b/src/libostree/ostree-deployment-private.h
@@ -31,7 +31,8 @@ G_BEGIN_DECLS
  * @osname:
  * @csum: OSTree checksum of tree
  * @deployserial: How many times this particular csum appears in deployment list
- * @bootcsum: Checksum of kernel+initramfs
+ * @bootcsum: Checksum of kernel+initramfs+devicetree
+ * @bootsize: Size in bytes of kernel+initramfs+devicetree
  * @bootserial: An integer assigned to this tree per its ${bootcsum}
  * @bootconfig: Bootloader configuration
  * @origin: How to construct an upgraded version of this tree
@@ -47,6 +48,7 @@ struct _OstreeDeployment
   char *csum;
   int deployserial;
   char *bootcsum;
+  int bootsize;
   int bootserial;
   OstreeBootconfigParser *bootconfig;
   GKeyFile *origin;
@@ -55,5 +57,6 @@ struct _OstreeDeployment
 };
 
 void _ostree_deployment_set_bootcsum (OstreeDeployment *self, const char *bootcsum);
+void _ostree_deployment_set_bootsize (OstreeDeployment *self, int bootsize);
 
 G_END_DECLS

--- a/src/libostree/ostree-deployment.c
+++ b/src/libostree/ostree-deployment.c
@@ -39,6 +39,12 @@ ostree_deployment_get_bootcsum (OstreeDeployment *self)
   return self->bootcsum;
 }
 
+int
+ostree_deployment_get_bootsize (OstreeDeployment *self)
+{
+  return self->bootsize;
+}
+
 /*
  * ostree_deployment_get_osname:
  * @self: Deployemnt
@@ -156,6 +162,13 @@ _ostree_deployment_set_bootcsum (OstreeDeployment *self,
 {
   g_free (self->bootcsum);
   self->bootcsum = g_strdup (bootcsum);
+}
+
+void
+_ostree_deployment_set_bootsize (OstreeDeployment *self,
+                                 int bootsize)
+{
+  self->bootsize = bootsize;
 }
 
 /**

--- a/src/libostree/ostree-deployment.h
+++ b/src/libostree/ostree-deployment.h
@@ -67,6 +67,8 @@ const char *ostree_deployment_get_csum (OstreeDeployment *self);
 _OSTREE_PUBLIC
 const char *ostree_deployment_get_bootcsum (OstreeDeployment *self);
 _OSTREE_PUBLIC
+int ostree_deployment_get_bootsize (OstreeDeployment *self);
+_OSTREE_PUBLIC
 int ostree_deployment_get_bootserial (OstreeDeployment *self);
 _OSTREE_PUBLIC
 OstreeBootconfigParser *ostree_deployment_get_bootconfig (OstreeDeployment *self);


### PR DESCRIPTION
Pushing this up as a draft, WIP for #1648 .

To finish:
- Write unit tests.
- Use `_ostree_deployment_set_bootsize` somewhere before `install_deploy_kernel` so that the assertion https://github.com/ostreedev/ostree/compare/master...rfairley:rfairley-filesystem-space-checks-pr?expand=1#diff-f0c889fb056dc4a713f8a87702fdd27eR1687 can succeed.
- Clear out the debug printfs and comments that aren't needed.

Can be tested by (do this in a virtual machine which is OK to break):

```
# Take up space in /boot so that the partition becomes nearly full around 99%
dd if=/dev/zero of=/boot/some_empty_file bs=file_size count=<number of bytes to fill>
# Try pinning the current deployment, then upgrading or deploying a new tree that has a different /boot
ostree admin pin 0
# E.g. from Fedora 29:
ostree remote add --set=gpgkeypath=/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-primary fedora-atomic-28 https://kojipkgs.fedoraproject.org/atomic/repo/
rpm-ostree rebase fedora-atomic-28:fedora/28/x86_64/atomic-host
```

