### PR TITLE
grub2: Generate config from pending deployment

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -332,6 +332,7 @@ grub2_child_setup (gpointer user_data)
 static gboolean
 _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
                                        int                    bootversion,
+                                       GPtrArray             *new_deployments,
                                        GCancellable          *cancellable,
                                        GError               **error)
 {
@@ -357,15 +358,11 @@ _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
   if (use_system_grub2_mkconfig && ostree_sysroot_get_booted_deployment (self->sysroot) == NULL
       && g_file_has_parent (self->sysroot->path, NULL))
     {
-      g_autoptr(GPtrArray) deployments = NULL;
       OstreeDeployment *tool_deployment;
       g_autoptr(GFile) tool_deployment_root = NULL;
 
-      deployments = ostree_sysroot_get_deployments (self->sysroot);
-
-      g_assert_cmpint (deployments->len, >, 0);
-
-      tool_deployment = deployments->pdata[0];
+      g_assert_cmpint (new_deployments->len, >, 0);
+      tool_deployment = new_deployments->pdata[0];
 
       /* Sadly we have to execute code to generate the bootloader configuration.
        * If we're in a booted deployment, we just don't chroot.
@@ -379,6 +376,8 @@ _ostree_bootloader_grub2_write_config (OstreeBootloader      *bootloader,
       tool_deployment_root = ostree_sysroot_get_deployment_directory (self->sysroot, tool_deployment);
       grub2_mkconfig_chroot = g_file_get_path (tool_deployment_root);
     }
+
+  g_debug ("Using grub2-mkconfig chroot: %s\n", grub2_mkconfig_chroot);
 
   g_autoptr(GFile) new_config_path = NULL;
   g_autoptr(GFile) config_path_efi_dir = NULL;

--- a/src/libostree/ostree-bootloader-syslinux.c
+++ b/src/libostree/ostree-bootloader-syslinux.c
@@ -108,10 +108,11 @@ append_config_from_loader_entries (OstreeBootloaderSyslinux  *self,
 }
 
 static gboolean
-_ostree_bootloader_syslinux_write_config (OstreeBootloader          *bootloader,
-                                          int                    bootversion,
-                                          GCancellable          *cancellable,
-                                          GError               **error)
+_ostree_bootloader_syslinux_write_config (OstreeBootloader  *bootloader,
+                                          int                bootversion,
+                                          GPtrArray         *new_deployments,
+                                          GCancellable      *cancellable,
+                                          GError           **error)
 {
   OstreeBootloaderSyslinux *self = OSTREE_BOOTLOADER_SYSLINUX (bootloader);
 

--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -158,10 +158,11 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
 }
 
 static gboolean
-_ostree_bootloader_uboot_write_config (OstreeBootloader          *bootloader,
-                                  int                    bootversion,
-                                  GCancellable          *cancellable,
-                                  GError               **error)
+_ostree_bootloader_uboot_write_config (OstreeBootloader *bootloader,
+                                       int               bootversion,
+                                       GPtrArray        *new_deployments,
+                                       GCancellable     *cancellable,
+                                       GError          **error)
 {
   OstreeBootloaderUboot *self = OSTREE_BOOTLOADER_UBOOT (bootloader);
 

--- a/src/libostree/ostree-bootloader.c
+++ b/src/libostree/ostree-bootloader.c
@@ -54,13 +54,15 @@ _ostree_bootloader_get_name (OstreeBootloader  *self)
 gboolean
 _ostree_bootloader_write_config (OstreeBootloader  *self,
                             int            bootversion,
+                            GPtrArray     *new_deployments,
                             GCancellable  *cancellable,
                             GError       **error)
 {
   g_return_val_if_fail (OSTREE_IS_BOOTLOADER (self), FALSE);
 
-  return OSTREE_BOOTLOADER_GET_IFACE (self)->write_config (self, bootversion, 
-                                                       cancellable, error);
+  return OSTREE_BOOTLOADER_GET_IFACE (self)->write_config (self, bootversion,
+                                                           new_deployments,
+                                                           cancellable, error);
 }
 
 gboolean

--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -44,6 +44,7 @@ struct _OstreeBootloaderInterface
   const char *         (* get_name)               (OstreeBootloader  *self);
   gboolean             (* write_config)           (OstreeBootloader  *self,
                                                    int            bootversion,
+                                                   GPtrArray     *new_deployments,
                                                    GCancellable  *cancellable,
                                                    GError       **error);
   gboolean             (* is_atomic)              (OstreeBootloader  *self);
@@ -61,6 +62,7 @@ const char *_ostree_bootloader_get_name (OstreeBootloader  *self);
 
 gboolean _ostree_bootloader_write_config (OstreeBootloader  *self,
                                           int            bootversion,
+                                          GPtrArray     *new_deployments,
                                           GCancellable  *cancellable,
                                           GError       **error);
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2122,7 +2122,8 @@ write_deployments_bootswap (OstreeSysroot     *self,
   if (bootloader)
     {
       if (!_ostree_bootloader_write_config (bootloader, new_bootversion,
-                                            cancellable, error))
+                                            new_deployments, cancellable,
+                                            error))
         return glnx_prefix_error (error, "Bootloader write config");
     }
 

--- a/tests/test-admin-deploy-none.sh
+++ b/tests/test-admin-deploy-none.sh
@@ -35,8 +35,8 @@ cd ${test_tmpdir}
 rm httpd osdata testos-repo sysroot -rf
 setup_os_repository "archive" "sysroot.bootloader none"
 ${CMD_PREFIX} ostree pull-local --repo=sysroot/ostree/repo --remote testos testos-repo testos/buildmaster/x86_64-runtime
-# Test grub2 does not get detected with bootloader configuration "none"
-# (see https://github.com/ostreedev/ostree/issues/1774)
+# Test that configuring sysroot.bootloader="none" is a workaround for previous
+# grub2 bootloader issue (see https://github.com/ostreedev/ostree/issues/1774)
 mkdir -p sysroot/boot/grub2 && touch sysroot/boot/grub2/grub.cfg
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os testos testos/buildmaster/x86_64-runtime > out.txt
 assert_file_has_content out.txt "Bootloader updated.*"

--- a/tests/test-admin-deploy-none.sh
+++ b/tests/test-admin-deploy-none.sh
@@ -37,7 +37,8 @@ setup_os_repository "archive" "sysroot.bootloader none"
 ${CMD_PREFIX} ostree pull-local --repo=sysroot/ostree/repo --remote testos testos-repo testos/buildmaster/x86_64-runtime
 # Test that configuring sysroot.bootloader="none" is a workaround for previous
 # grub2 bootloader issue (see https://github.com/ostreedev/ostree/issues/1774)
-mkdir -p sysroot/boot/grub2 && touch sysroot/boot/grub2/grub.cfg
+mkdir -p sysroot/boot/grub2
+touch sysroot/boot/grub2/grub.cfg
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os testos testos/buildmaster/x86_64-runtime > out.txt
 assert_file_has_content out.txt "Bootloader updated.*"
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'


### PR DESCRIPTION
Attempt at a fix for #1774. Previously pushed these changes (see https://github.com/ostreedev/ostree/issues/1774#issuecomment-473088193) - posting a PR so we can discuss here.

Involves an interface change to add the `new_deployments` argument to each bootloader `*_write_config` function. It'd be preferable to avoid passing down the extra argument - but this seems to be what's needed to expose the pending deployment to the bootloader functions.

Need to verify that the tests work (recently updated my dev environment and tests that previously passed are failing locally).