### PR TITLE
travis: Update to Debian Stretch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 
 env:
   - ci_distro=ubuntu ci_suite=trusty ci_test=no  # TODO: use libcurl on this
-  - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie
-  - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie ci_configopts="--with-curl"
+  - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch
+  - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl"
   - ci_docker=debian:stretch-slim ci_distro=debian ci_suite=stretch ci_test=no  # TODO gpgme flake https://github.com/ostreedev/ostree/pull/664#issuecomment-276033383
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
 

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -48,7 +48,7 @@ NULL=
 # Typical values for ci_distro=ubuntu: xenial, trusty
 # Typical values for ci_distro=debian: sid, jessie
 # Typical values for ci_distro=fedora might be 25, rawhide
-: "${ci_suite:=jessie}"
+: "${ci_suite:=stretch}"
 
 # ci_configopts: Additional arguments for configure
 : "${ci_configopts:=}"

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -76,7 +76,9 @@ assert_not_file_has_content repo/config "lock-timeout-secs="
 if ${CMD_PREFIX} ostree config --repo=repo get core.lock-timeout-secs 2>err.txt; then
     assert_not_reached "ostree config get should not work after unsetting a key"
 fi
-assert_file_has_content err.txt "error: Key file does not have key “lock-timeout-secs” in group “core”"
+# Check for any character where quotation marks would be as they appear differently in the Fedora and Debian
+# test suites (“” and '' respectively). See: https://github.com/ostreedev/ostree/pull/1839
+assert_file_has_content err.txt "error: Key file does not have key .lock-timeout-secs. in group .core."
 
 # Check that it's idempotent
 ${CMD_PREFIX} ostree config --repo=repo unset core.lock-timeout-secs


### PR DESCRIPTION
Update to Stretch to use updated version of glib2.0. Fixes CI
failure when parsing error output in tests/test-config.sh. See:

https://github.com/ostreedev/ostree/pull/1838#issuecomment-482186680
https://api.travis-ci.org/v3/job/518830164/log.txt

---

Leaving as WIP, to check if CI tests pass first.