### PR TITLE
boot: Activate ostree-finalize-staged even earlier

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -24,8 +24,8 @@ ConditionPathExists=/run/ostree-booted
 DefaultDependencies=no
 
 RequiresMountsFor=/sysroot
-After=basic.target
-Before=multi-user.target final.target
+After=local-fs.target
+Before=basic.target final.target
 Conflicts=final.target
 
 [Service]


### PR DESCRIPTION
Really, all `ostree admin finalize-staged` needs is access to `/sysroot`
and `/boot`. So let's activate it right after `local-fs.target` so that
it gets deactivated later in the shutdown process. This should allow us
to conflict with less services still running and possibly writing things
to `/etc`.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1672283