### PR TITLE
lib/deploy: Support locking deployment finalization

### DIFF
--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -163,18 +163,16 @@ _ostree_fetcher_journal_failure (const char *remote_name,
                                  const char *url,
                                  const char *msg)
 {
-#ifdef HAVE_LIBSYSTEMD
   /* Sanity - we don't want to log this when doing local/file pulls */
   if (!remote_name)
     return;
-  sd_journal_send ("MESSAGE=libostree HTTP error from remote %s for <%s>: %s",
+  ot_journal_send ("MESSAGE=libostree HTTP error from remote %s for <%s>: %s",
                    remote_name, url, msg,
                    "MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_HTTP_FAILURE_ID),
                    "OSTREE_REMOTE=%s", remote_name,
                    "OSTREE_URL=%s", url,
                    "PRIORITY=%i", LOG_ERR,
                    NULL);
-#endif
 }
 
 /* Check whether a particular operation should be retried. This is entirely

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4655,7 +4655,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       g_autofree char *formatted_xferred = g_format_size (bytes_transferred);
       g_string_append_printf (msg, "\ntransfer: secs: %u size: %s", n_seconds, formatted_xferred);
 
-      sd_journal_send ("MESSAGE=%s", msg->str,
+      ot_journal_send ("MESSAGE=%s", msg->str,
                        "MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_MESSAGE_FETCH_COMPLETE_ID),
                        "OSTREE_REMOTE=%s", pull_data->remote_name,
                        "OSTREE_GPG=%s", gpg_verify_state,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2880,7 +2880,10 @@ _ostree_sysroot_finalize_staged (OstreeSysroot *self,
    * service when a staged deployment is created.
    */
   if (!self->staged_deployment)
-    return TRUE;
+    {
+      ot_journal_print (LOG_INFO, "No deployment staged for finalization");
+      return TRUE;
+    }
 
   /* Notice we send this *after* the trivial `return TRUE` above; this msg implies we've
    * committed to finalizing the deployment. */

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2885,6 +2885,17 @@ _ostree_sysroot_finalize_staged (OstreeSysroot *self,
       return TRUE;
     }
 
+  /* Check if finalization is locked. */
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED,
+                                 NULL, 0, error))
+    return FALSE;
+  if (errno == 0)
+    {
+      ot_journal_print (LOG_INFO, "Not finalizing; found "
+                                  _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED);
+      return TRUE;
+    }
+
   /* Notice we send this *after* the trivial `return TRUE` above; this msg implies we've
    * committed to finalizing the deployment. */
     ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -447,14 +447,12 @@ merge_configuration_from (OstreeSysroot    *sysroot,
   { g_autofree char *msg =
       g_strdup_printf ("Copying /etc changes: %u modified, %u removed, %u added",
                        modified->len, removed->len, added->len);
-#ifdef HAVE_LIBSYSTEMD
-    sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_CONFIGMERGE_ID),
+    ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_CONFIGMERGE_ID),
                      "MESSAGE=%s", msg,
                      "ETC_N_MODIFIED=%u", modified->len,
                      "ETC_N_REMOVED=%u", removed->len,
                      "ETC_N_ADDED=%u", added->len,
                      NULL);
-#endif
     _ostree_sysroot_emit_journal_msg (sysroot, msg);
   }
 
@@ -701,11 +699,9 @@ selinux_relabel_var_if_needed (OstreeSysroot                 *sysroot,
     {
       { g_autofree char *msg =
           g_strdup_printf ("Relabeling /var (no stamp file '%s' found)", selabeled);
-#ifdef HAVE_LIBSYSTEMD
-        sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_VARRELABEL_ID),
+        ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_VARRELABEL_ID),
                          "MESSAGE=%s", msg,
                          NULL);
-#endif
         _ostree_sysroot_emit_journal_msg (sysroot, msg);
       }
 
@@ -2386,8 +2382,7 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
                        (bootloader_is_atomic ? "Transaction complete" : "Bootloader updated"),
                        requires_new_bootversion ? "yes" : "no",
                        new_deployments->len - self->deployments->len);
-#ifdef HAVE_LIBSYSTEMD
-    sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_DEPLOYMENT_COMPLETE_ID),
+    ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_DEPLOYMENT_COMPLETE_ID),
                      "MESSAGE=%s", msg,
                      "OSTREE_BOOTLOADER=%s", bootloader ? _ostree_bootloader_get_name (bootloader) : "none",
                      "OSTREE_BOOTLOADER_CONFIG=%s", bootloader_config,
@@ -2398,7 +2393,6 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
                      "OSTREE_SYNCFS_BOOT_MSEC=%" G_GUINT64_FORMAT, syncstats.boot_syncfs_msec,
                      "OSTREE_SYNCFS_EXTRA_MSEC=%" G_GUINT64_FORMAT, syncstats.extra_syncfs_msec,
                      NULL);
-#endif
     _ostree_sysroot_emit_journal_msg (self, msg);
   }
 
@@ -2890,8 +2884,7 @@ _ostree_sysroot_finalize_staged (OstreeSysroot *self,
 
   /* Notice we send this *after* the trivial `return TRUE` above; this msg implies we've
    * committed to finalizing the deployment. */
-#ifdef HAVE_LIBSYSTEMD
-    sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
+    ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
                      SD_ID128_FORMAT_VAL(OSTREE_DEPLOYMENT_FINALIZING_ID),
                      "MESSAGE=Finalizing staged deployment",
                      "OSTREE_OSNAME=%s",
@@ -2901,7 +2894,6 @@ _ostree_sysroot_finalize_staged (OstreeSysroot *self,
                      "OSTREE_DEPLOYSERIAL=%u",
                      ostree_deployment_get_deployserial (self->staged_deployment),
                      NULL);
-#endif
 
   g_assert (self->staged_deployment_data);
 

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -76,6 +76,7 @@ struct OstreeSysroot {
 #define OSTREE_SYSROOT_LOCKFILE "ostree/lock"
 /* We keep some transient state in /run */
 #define _OSTREE_SYSROOT_RUNSTATE_STAGED "/run/ostree/staged-deployment"
+#define _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED "/run/ostree/staged-deployment-locked"
 #define _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_DIR "/run/ostree/deployment-state/"
 #define _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_DEVELOPMENT "unlocked-development"
 

--- a/src/libotutil/otutil.h
+++ b/src/libotutil/otutil.h
@@ -44,6 +44,14 @@
     }                                                      \
   } G_STMT_END;
 
+#ifdef HAVE_LIBSYSTEMD
+#define ot_journal_send(...) sd_journal_send(__VA_ARGS__)
+#define ot_journal_print(...) sd_journal_print(__VA_ARGS__)
+#else
+#define ot_journal_send(...) {}
+#define ot_journal_print(...) {}
+#endif
+
 #include <ot-keyfile-utils.h>
 #include <ot-gio-utils.h>
 #include <ot-fs-utils.h>


### PR DESCRIPTION
Teach `ostree-finalize-staged.service` to check for a file in `/run` to
determine if it should do the finalization. This will be used in
RPM-OSTree, where we want to be able to separate out "preparing updates"
from "making update the default" for more fine-grained control. See:
projectatomic/rpm-ostree#1748