### PR TITLE
ostree-prepare-root: Log journal message after finding deployment

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -59,7 +59,7 @@ ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) -Isrc/switchroot
 
 if BUILDOPT_SYSTEMD
 ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD=1
-ostree_prepare_root_LDADD = $(LIBSYSTEMD_LIBS)
+ostree_prepare_root_LDADD = $(AM_LDFLAGS) $(LIBSYSTEMD_LIBS)
 endif
 
 # This is the "new mode" of using a generator for /var; see

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -57,6 +57,11 @@ ostree_remount_SOURCES = \
     $(NULL)
 ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) -Isrc/switchroot
 
+if BUILDOPT_SYSTEMD
+ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD=1
+ostree_prepare_root_LDADD = $(LIBSYSTEMD_LIBS)
+endif
+
 # This is the "new mode" of using a generator for /var; see
 # https://github.com/ostreedev/ostree/issues/855
 if BUILDOPT_SYSTEMD_AND_LIBMOUNT

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -47,6 +47,11 @@
 #include <errno.h>
 #include <ctype.h>
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-journal.h>
+#define OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG SD_ID128_MAKE(71,70,33,6a,73,ba,46,01,ba,d3,1a,f8,88,aa,0d,f7)
+#endif
+
 #include "ostree-mount-util.h"
 
 /* Initialized early in main */
@@ -71,9 +76,18 @@ resolve_deploy_path (const char * root_mountpoint)
   deploy_path = realpath (destpath, NULL);
   if (deploy_path == NULL)
     err (EXIT_FAILURE, "realpath(%s) failed", destpath);
+  if (stat (deploy_path, &stbuf) < 0)
+    err (EXIT_FAILURE, "stat(%s) failed", deploy_path);
   /* Quiet logs if there's no journal */
-  if (!running_as_pid1)
-    printf ("Resolved OSTree target to: %s\n", deploy_path);
+#ifdef HAVE_LIBSYSTEMD
+  const char *resolved_path = deploy_path + strlen (root_mountpoint);
+  sd_journal_send ("MESSAGE=Resolved OSTree target to: %s", deploy_path,
+                   "MESSAGE_ID=" SD_ID128_FORMAT_STR,
+                   SD_ID128_FORMAT_VAL(OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG),
+                   "DEPLOYMENT_PATH=%s", resolved_path,
+                   "DEPLOYMENT_INODE=%u", stbuf.st_ino,
+                   NULL);
+#endif
   return deploy_path;
 }
 

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -85,6 +85,7 @@ resolve_deploy_path (const char * root_mountpoint)
                    "MESSAGE_ID=" SD_ID128_FORMAT_STR,
                    SD_ID128_FORMAT_VAL(OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG),
                    "DEPLOYMENT_PATH=%s", resolved_path,
+                   "DEPLOYMENT_DEVICE=%u", stbuf.st_dev,
                    "DEPLOYMENT_INODE=%u", stbuf.st_ino,
                    NULL);
 #endif


### PR DESCRIPTION
Log a structured journal message when resolving the deployment path.
This will be used by the `rpm-ostree history` command to find past
deployments the system has booted into.