### PR TITLE
Retry requests on HTTP 503 and 504

### DIFF
--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -231,6 +231,8 @@ _ostree_fetcher_http_status_code_to_io_error (guint status_code)
     case 410:  /* SOUP_STATUS_GONE */
       return G_IO_ERROR_NOT_FOUND;
     case 408:  /* SOUP_STATUS_REQUEST_TIMEOUT */
+    case 503:  /* SOUP_STATUS_SERVICE_UNAVAILABLE */
+    case 504:  /* SOUP_STATUS_GATEWAY_TIMEOUT */
       return G_IO_ERROR_TIMED_OUT;
     default:
       return G_IO_ERROR_FAILED;

--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -47,12 +47,15 @@ static int opt_random_500s_percentage;
 static int opt_random_500s_max = 100;
 static int opt_random_408s_percentage;
 static int opt_random_408s_max = 100;
+static int opt_random_503s_percentage;
+static int opt_random_503s_max = 100;
 static gint opt_port = 0;
 static gchar **opt_expected_cookies;
 static gchar **opt_expected_headers;
 
 static guint emitted_random_500s_count = 0;
 static guint emitted_random_408s_count = 0;
+static guint emitted_random_503s_count = 0;
 
 typedef struct {
   int root_dfd;
@@ -73,6 +76,8 @@ static GOptionEntry options[] = {
   { "force-range-requests", 0, 0, G_OPTION_ARG_NONE, &opt_force_ranges, "Force range requests by only serving half of files", NULL },
   { "random-500s", 0, 0, G_OPTION_ARG_INT, &opt_random_500s_percentage, "Generate random HTTP 500 errors approximately for PERCENTAGE requests", "PERCENTAGE" },
   { "random-500s-max", 0, 0, G_OPTION_ARG_INT, &opt_random_500s_max, "Limit HTTP 500 errors to MAX (default 100)", "MAX" },
+  { "random-503s", 0, 0, G_OPTION_ARG_INT, &opt_random_503s_percentage, "Generate random HTTP 503 errors approximately for PERCENTAGE requests", "PERCENTAGE" },
+  { "random-503s-max", 0, 0, G_OPTION_ARG_INT, &opt_random_503s_max, "Limit HTTP 503 errors to MAX (default 100)", "MAX" },
   { "random-408s", 0, 0, G_OPTION_ARG_INT, &opt_random_408s_percentage, "Generate random HTTP 408 errors approximately for PERCENTAGE requests", "PERCENTAGE" },
   { "random-408s-max", 0, 0, G_OPTION_ARG_INT, &opt_random_408s_max, "Limit HTTP 408 errors to MAX (default 100)", "MAX" },
   { "log-file", 0, 0, G_OPTION_ARG_FILENAME, &opt_log, "Put logs here (use - for stdout)", "PATH" },
@@ -302,6 +307,14 @@ do_get (OtTrivialHttpd    *self,
     {
       emitted_random_408s_count++;
       soup_message_set_status (msg, SOUP_STATUS_REQUEST_TIMEOUT);
+      goto out;
+    }
+  else if (opt_random_503s_percentage > 0 &&
+      emitted_random_503s_count < opt_random_503s_max &&
+      g_random_int_range (0, 100) < opt_random_503s_percentage)
+    {
+      emitted_random_503s_count++;
+      soup_message_set_status (msg, SOUP_STATUS_SERVICE_UNAVAILABLE);
       goto out;
     }
 


### PR DESCRIPTION
PR #1594 added logic to retry downloads when they fail due to network errors, or due to HTTP 408 Request Timeout.

In practice, pulling from Flathub frequently fails with 503 Service Unavailable. This is a transient error, so it makes sense to retry when it's encountered.

There is no good code in GIOErrorEnum for this so this patch takes the lazy route of mapping it to G_IO_ERROR_TIMED_OUT, which is already treated as a transient error in _ostree_fetcher_should_retry_request().

While we're here, also map 504 Gateway Timeout to G_IO_ERROR_TIMED_OUT (which does seem correct, if lossy).

----

Aside from a general interest in automatically retrying in the face of transient errors, another reason I am interested in mapping these errors to something other than G_IO_ERROR_FAILED is that we would like to make gnome-software show a more useful error message when pulling an app fails. Right now, users see (an example transcribed from a screenshot):

> Unable to install Blender
> While pulling app/org.blender.Blender/x86_64/stable from remote flathub: Server returned status 503: Service Unavailable

I believe that "Server returned status ..." is untranslated -- it comes from

https://github.com/ostreedev/ostree/blob/3ca1035e989ae2efec3103bd70128ff34aa515aa/src/libostree/ostree-fetcher-soup.c#L1098

Of course, it's not libostree's fault that GNOME Software shows this error message (filtered through libflatpak) verbatim, but while this status code is mapped to G_IO_ERROR_FAILED it's impossible to distinguish from any other errors. I wonder whether it would actually be better to introduce an error domain for HTTP errors (I know libsoup has one but ostree also has a libcurl backend) and propagate the HTTP status code out.