### PR TITLE
docs: fix switchroot source link

### DIFF
--- a/docs/manual/adapting-existing.md
+++ b/docs/manual/adapting-existing.md
@@ -83,8 +83,9 @@ After these steps, systemd switches root.
 
 If you are not using dracut or systemd, using OSTree should still be
 possible, but you will have to write the integration code. See the
-existing sources in [src/switchroot](/src/switchroot) as a reference,
-as well as [src/switchroot/switchroot.sh](/src/switchroot/switchroot.sh).
+existing sources in
+[src/switchroot](https://github.com/ostreedev/ostree/tree/master/src/switchroot)
+as a reference.
 
 Patches to support other initramfs technologies and init systems, if
 sufficiently clean, will likely be accepted upstream.


### PR DESCRIPTION
This change updates the switchroot source relative url to an absolute url so
that it works from the readthedocs service. This change also removes
redundant switchroot.sh reference.