### PR TITLE
docs: fix missing as typo

### DIFF
--- a/docs/manual/adapting-existing.md
+++ b/docs/manual/adapting-existing.md
@@ -91,7 +91,7 @@ Patches to support other initramfs technologies and init systems, if
 sufficiently clean, will likely be accepted upstream.
 
 A further specific note regarding `sysvinit`: OSTree used to support
-recording device files such the `/dev/initctl` FIFO, but no longer
+recording device files such as the `/dev/initctl` FIFO, but no longer
 does.  It's recommended to just patch your initramfs to create this at
 boot.
 


### PR DESCRIPTION
This change fixes a typo in the adapting-existing doc.