### PR TITLE
Various fixes to GI metadata

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -485,6 +485,8 @@ _ostree_raw_file_to_archive_stream (GInputStream       *input,
  *
  * Convert from a "bare" file representation into an
  * OSTREE_OBJECT_TYPE_FILE stream suitable for ostree pull.
+ *
+ * Since: 2016.6
  */
 gboolean
 ostree_raw_file_to_archive_z2_stream (GInputStream       *input,
@@ -581,7 +583,7 @@ ostree_raw_file_to_content_stream (GInputStream       *input,
  * @input_length: Length of stream
  * @trusted: If %TRUE, assume the content has been validated
  * @out_input: (out): The raw file content stream
- * @out_file_info: (out): Normal metadata 
+ * @out_file_info: (out): Normal metadata
  * @out_xattrs: (out): Extended attributes
  * @cancellable: Cancellable
  * @error: Error
@@ -680,7 +682,7 @@ ostree_content_stream_parse (gboolean                compressed,
  * @path: Subpath
  * @trusted: If %TRUE, assume the content has been validated
  * @out_input: (out): The raw file content stream
- * @out_file_info: (out): Normal metadata 
+ * @out_file_info: (out): Normal metadata
  * @out_xattrs: (out): Extended attributes
  * @cancellable: Cancellable
  * @error: Error
@@ -730,7 +732,7 @@ ostree_content_file_parse_at (gboolean                compressed,
  * @content_path: Path to file containing content
  * @trusted: If %TRUE, assume the content has been validated
  * @out_input: (out): The raw file content stream
- * @out_file_info: (out): Normal metadata 
+ * @out_file_info: (out): Normal metadata
  * @out_xattrs: (out): Extended attributes
  * @cancellable: Cancellable
  * @error: Error
@@ -1068,7 +1070,7 @@ checksum_file_async_data_free (gpointer datap)
   g_free (data->csum);
   g_free (data);
 }
-  
+
 /**
  * ostree_checksum_file_async:
  * @f: File path
@@ -1098,7 +1100,7 @@ ostree_checksum_file_async (GFile                 *f,
 
   res = g_simple_async_result_new (G_OBJECT (f), callback, user_data, ostree_checksum_file_async);
   g_simple_async_result_set_op_res_gpointer (res, data, (GDestroyNotify)checksum_file_async_data_free);
-  
+
   g_simple_async_result_run_in_thread (res, checksum_file_async_thread, io_priority, cancellable);
   g_object_unref (res);
 }
@@ -1323,7 +1325,7 @@ ostree_hash_object_name (gconstpointer a)
   const char *checksum;
   OstreeObjectType objtype;
   gint objtype_int;
-  
+
   ostree_object_name_deserialize (variant, &checksum, &objtype);
   objtype_int = (gint) objtype;
   return g_str_hash (checksum) + g_int_hash (&objtype_int);
@@ -1472,6 +1474,8 @@ ostree_checksum_to_bytes_v (const char *checksum)
  * @checksum: An ASCII checksum
  *
  * Returns: (transfer full) (array fixed-size=32): Binary version of @checksum.
+ *
+ * Since: 2016.8
  */
 guchar *
 ostree_checksum_b64_to_bytes (const char *checksum)
@@ -1571,6 +1575,8 @@ ostree_checksum_from_bytes_v (GVariant *csum_v)
  *
  * The "modified" term refers to the fact that instead of '/', the '_'
  * character is used.
+ *
+ * Since: 2016.8
  */
 char *
 ostree_checksum_b64_from_bytes (const guchar *csum)
@@ -1849,7 +1855,7 @@ _ostree_get_relative_static_delta_path (const char *from,
       g_string_append_c (ret, '/');
       g_string_append (ret, target);
     }
-  
+
   return g_string_free (ret, FALSE);
 }
 
@@ -2174,7 +2180,7 @@ _ostree_verify_metadata_object (OstreeObjectType objtype,
  * ostree_validate_structureof_commit:
  * @commit: A commit object, %OSTREE_OBJECT_TYPE_COMMIT
  * @error: Error
- * 
+ *
  * Use this to validate the basic structure of @commit, independent of
  * any other objects it references.
  *
@@ -2214,7 +2220,7 @@ ostree_validate_structureof_commit (GVariant      *commit,
  * ostree_validate_structureof_dirtree:
  * @dirtree: A dirtree object, %OSTREE_OBJECT_TYPE_DIR_TREE
  * @error: Error
- * 
+ *
  * Use this to validate the basic structure of @dirtree, independent of
  * any other objects it references.
  *
@@ -2326,7 +2332,7 @@ ostree_validate_structureof_file_mode (guint32            mode,
  * ostree_validate_structureof_dirmeta:
  * @dirmeta: A dirmeta object, %OSTREE_OBJECT_TYPE_DIR_META
  * @error: Error
- * 
+ *
  * Use this to validate the basic structure of @dirmeta.
  *
  * Returns: %TRUE if @dirmeta is structurally valid
@@ -2340,7 +2346,7 @@ ostree_validate_structureof_dirmeta (GVariant      *dirmeta,
   if (!validate_variant (dirmeta, OSTREE_DIRMETA_GVARIANT_FORMAT, error))
     return FALSE;
 
-  g_variant_get_child (dirmeta, 2, "u", &mode); 
+  g_variant_get_child (dirmeta, 2, "u", &mode);
   mode = GUINT32_FROM_BE (mode);
 
   if (!S_ISDIR (mode))
@@ -2395,6 +2401,8 @@ ostree_commit_get_timestamp (GVariant  *commit_variant)
  * root "dirmeta" checksum (both in binary form, not hexadecimal).
  *
  * Returns: (nullable): A SHA-256 hex string, or %NULL if @commit_variant is not well-formed
+ *
+ * Since: 2018.2
  */
 gchar *
 ostree_commit_get_content_checksum (GVariant *commit_variant)
@@ -2513,6 +2521,8 @@ _ostree_get_default_sysroot_path (void)
  * @required_release: Release version required
  *
  * Returns: %TRUE if current libostree has at least the requested version, %FALSE otherwise
+ *
+ * Since: 2017.4
  */
 gboolean
 ostree_check_version (guint required_year, guint required_release)

--- a/src/libostree/ostree-deployment.c
+++ b/src/libostree/ostree-deployment.c
@@ -302,6 +302,11 @@ ostree_deployment_get_origin_relpath (OstreeDeployment *self)
                           ostree_deployment_get_deployserial (self));
 }
 
+/**
+ * ostree_deployment_unlocked_state_to_string:
+ *
+ * Since: 2016.4
+ */
 const char *
 ostree_deployment_unlocked_state_to_string (OstreeDeploymentUnlockedState state)
 {
@@ -317,6 +322,11 @@ ostree_deployment_unlocked_state_to_string (OstreeDeploymentUnlockedState state)
   g_assert_not_reached ();
 }
 
+/**
+ * ostree_deployment_get_unlocked:
+ *
+ * Since: 2016.4
+ */
 OstreeDeploymentUnlockedState
 ostree_deployment_get_unlocked (OstreeDeployment *self)
 {

--- a/src/libostree/ostree-diff.c
+++ b/src/libostree/ostree-diff.c
@@ -239,6 +239,8 @@ ostree_diff_dirs (OstreeDiffFlags flags,
  *
  * Compute the difference between directory @a and @b as 3 separate
  * sets of #OstreeDiffItem in @modified, @removed, and @added.
+ *
+ * Since: 2017.4
  */
 gboolean
 ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
@@ -305,7 +307,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
     {
       OstreeRepoFile *a_repof = (OstreeRepoFile*) a;
       OstreeRepoFile *b_repof = (OstreeRepoFile*) b;
-      
+
       if (strcmp (ostree_repo_file_tree_get_contents_checksum (a_repof),
                   ostree_repo_file_tree_get_contents_checksum (b_repof)) == 0)
         {
@@ -317,7 +319,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
   g_clear_object (&child_a_info);
   g_clear_object (&child_b_info);
 
-  dir_enum = g_file_enumerate_children (a, OSTREE_GIO_FAST_QUERYINFO, 
+  dir_enum = g_file_enumerate_children (a, OSTREE_GIO_FAST_QUERYINFO,
                                         G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
                                         cancellable, error);
   if (!dir_enum)
@@ -368,7 +370,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
             {
               OstreeDiffItem *diff_item = diff_item_new (child_a, child_a_info,
                                                    child_b, child_b_info, NULL, NULL);
-              
+
               g_ptr_array_add (modified, diff_item);
             }
           else
@@ -378,7 +380,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
               if (!diff_files (flags, child_a, child_a_info, child_b, child_b_info, &diff_item,
                                cancellable, error))
                 goto out;
-              
+
               if (diff_item)
                 g_ptr_array_add (modified, diff_item); /* Transfer ownership */
 
@@ -391,7 +393,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
                 }
             }
         }
-      
+
       g_clear_object (&child_a_info);
     }
   if (temp_error != NULL)
@@ -401,7 +403,7 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
     }
 
   g_clear_object (&dir_enum);
-  dir_enum = g_file_enumerate_children (b, OSTREE_GIO_FAST_QUERYINFO, 
+  dir_enum = g_file_enumerate_children (b, OSTREE_GIO_FAST_QUERYINFO,
                                         G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
                                         cancellable, error);
   if (!dir_enum)

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -695,6 +695,8 @@ ostree_gpg_verify_result_describe_variant (GVariant *variant,
  *
  * Returns: %TRUE if @result was not %NULL and had at least one
  * signature from trusted keyring, otherwise %FALSE
+ *
+ * Since: 2016.6
  */
 gboolean
 ostree_gpg_verify_result_require_valid_signature (OstreeGpgVerifyResult *result,

--- a/src/libostree/ostree-gpg-verify-result.h
+++ b/src/libostree/ostree-gpg-verify-result.h
@@ -161,6 +161,11 @@ typedef enum {
   OSTREE_GPG_ERROR_MISSING_KEY,
 } OstreeGpgError;
 
+/**
+ * ostree_gpg_error_quark:
+ *
+ * Since: 2017.10
+ */
 _OSTREE_PUBLIC
 GQuark ostree_gpg_error_quark (void);
 #define OSTREE_GPG_ERROR (ostree_gpg_error_quark ())

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -401,6 +401,14 @@ ostree_mutable_tree_ensure_dir (OstreeMutableTree *self,
   return TRUE;
 }
 
+/**
+ * ostree_mutable_tree_lookup:
+ * @self: Tree
+ * @name: name
+ * @out_file_checksum: (out) (transfer full): checksum
+ * @out_subdir: (out) (transfer full): subdirectory
+ * @error: a #GError
+ */
 gboolean
 ostree_mutable_tree_lookup (OstreeMutableTree   *self,
                             const char          *name,

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -331,6 +331,8 @@ ostree_mutable_tree_replace_file (OstreeMutableTree *self,
  * @error: a #GError
  *
  * Remove the file or subdirectory named @name from the mutable tree @self.
+ *
+ * Since: 2018.9
  */
 gboolean
 ostree_mutable_tree_remove (OstreeMutableTree *self,
@@ -494,6 +496,8 @@ const char empty_tree_csum[] = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb3373876
  * This function enables optimisations when composing trees.  The provided
  * checksums are not loaded or checked when this function is called.  Instead
  * the contents will be loaded only when needed.
+ *
+ * Since: 2018.7
  */
 gboolean
 ostree_mutable_tree_fill_empty_from_dirtree (OstreeMutableTree *self,
@@ -585,7 +589,7 @@ ostree_mutable_tree_walk (OstreeMutableTree     *self,
 /**
  * ostree_mutable_tree_get_subdirs:
  * @self:
- * 
+ *
  * Returns: (transfer none) (element-type utf8 OstreeMutableTree): All children directories
  */
 GHashTable *
@@ -598,7 +602,7 @@ ostree_mutable_tree_get_subdirs (OstreeMutableTree *self)
 /**
  * ostree_mutable_tree_get_files:
  * @self:
- * 
+ *
  * Returns: (transfer none) (element-type utf8 utf8): All children files (the value is a checksum)
  */
 GHashTable *
@@ -654,6 +658,8 @@ ostree_mutable_tree_new (void)
  * and checksums.  The data will be loaded from the repo lazily as needed.
  *
  * Returns: (transfer full): A new tree
+ *
+ * Since: 2018.7
  */
 OstreeMutableTree *
 ostree_mutable_tree_new_from_checksum (OstreeRepo *repo,

--- a/src/libostree/ostree-ref.c
+++ b/src/libostree/ostree-ref.c
@@ -47,7 +47,7 @@ G_DEFINE_BOXED_TYPE (OstreeCollectionRef, ostree_collection_ref,
  * refspec; no remote name is included), which can be used for non-P2P
  * operations.
  *
- * Returns: (transfer full): a new #OstreeCollectionRef
+ * Returns: (transfer full) (nullable): a new #OstreeCollectionRef
  * Since: 2018.6
  */
 OstreeCollectionRef *
@@ -69,7 +69,7 @@ ostree_collection_ref_new (const gchar *collection_id,
 
 /**
  * ostree_collection_ref_dup:
- * @ref: an #OstreeCollectionRef
+ * @ref: (not nullable): an #OstreeCollectionRef
  *
  * Create a copy of the given @ref.
  *
@@ -104,7 +104,7 @@ ostree_collection_ref_free (OstreeCollectionRef *ref)
 
 /**
  * ostree_collection_ref_hash:
- * @ref: an #OstreeCollectionRef
+ * @ref: (not nullable): an #OstreeCollectionRef
  *
  * Hash the given @ref. This function is suitable for use with #GHashTable.
  * @ref must be non-%NULL.
@@ -125,8 +125,8 @@ ostree_collection_ref_hash (gconstpointer ref)
 
 /**
  * ostree_collection_ref_equal:
- * @ref1: an #OstreeCollectionRef
- * @ref2: another #OstreeCollectionRef
+ * @ref1: (not nullable): an #OstreeCollectionRef
+ * @ref2 : (not nullable): another #OstreeCollectionRef
  *
  * Compare @ref1 and @ref2 and return %TRUE if they have the same collection ID and
  * ref name, and %FALSE otherwise. Both @ref1 and @ref2 must be non-%NULL.

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -771,7 +771,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
        */
       g_mutex_lock (&repo->cache_lock);
       {
-        gpointer key = GUINT_TO_POINTER ((g_ascii_xdigit_value (checksum[0]) << 4) + 
+        gpointer key = GUINT_TO_POINTER ((g_ascii_xdigit_value (checksum[0]) << 4) +
                                          g_ascii_xdigit_value (checksum[1]));
         if (repo->updated_uncompressed_dirs == NULL)
           repo->updated_uncompressed_dirs = g_hash_table_new (NULL, NULL);
@@ -1321,6 +1321,8 @@ ostree_repo_checkout_tree_at (OstreeRepo                        *self,
  * Note in addition that unlike ostree_repo_checkout_tree(), the
  * default is not to use the repository-internal uncompressed objects
  * cache.
+ *
+ * Since: 2016.8
  */
 gboolean
 ostree_repo_checkout_at (OstreeRepo                        *self,
@@ -1391,6 +1393,8 @@ ostree_repo_checkout_at (OstreeRepo                        *self,
  *
  * Note that cache does *not* have its refcount incremented - the lifetime of
  * @cache must be equal to or greater than that of @opts.
+ *
+ * Since: 2017.13
  */
 void
 ostree_repo_checkout_at_options_set_devino (OstreeRepoCheckoutAtOptions *opts,
@@ -1418,7 +1422,7 @@ devino_equal (gconstpointer   a,
 
 /**
  * ostree_repo_devino_cache_new:
- * 
+ *
  * OSTree has support for pairing ostree_repo_checkout_tree_at() using
  * hardlinks in combination with a later
  * ostree_repo_write_directory_to_mtree() using a (normally modified)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2065,6 +2065,8 @@ ostree_repo_set_ref_immediate (OstreeRepo *self,
  * @error: GError
  *
  * Like ostree_repo_set_ref_immediate(), but creates an alias.
+ *
+ * Since: 2017.10
  */
 gboolean
 ostree_repo_set_alias_ref_immediate (OstreeRepo *self,

--- a/src/libostree/ostree-repo-file.c
+++ b/src/libostree/ostree-repo-file.c
@@ -292,6 +292,13 @@ ostree_repo_file_ensure_resolved (OstreeRepoFile  *self,
   return TRUE;
 }
 
+/**
+ * ostree_repo_file_get_xattrs:
+ * @self: #OstreeRepoFile
+ * @out_xattrs: (out) (optional): the extended attributes
+ * @cancellable: Cancellable
+ * @error: Error
+ */
 gboolean
 ostree_repo_file_get_xattrs (OstreeRepoFile  *self,
                              GVariant       **out_xattrs,
@@ -724,6 +731,13 @@ query_child_info_dir (OstreeRepo               *repo,
   return TRUE;
 }
 
+/**
+ * ostree_repo_file_tree_find_child:
+ * @self: #OstreeRepoFile
+ * @name: name of the child
+ * @is_dir: (out caller-allocates):
+ * @out_container: (out):
+ */
 int
 ostree_repo_file_tree_find_child  (OstreeRepoFile  *self,
                                     const char      *name,
@@ -769,6 +783,16 @@ ostree_repo_file_tree_find_child  (OstreeRepoFile  *self,
   return i;
 }
 
+/**
+ * ostree_repo_file_tree_query_child:
+ * @self: #OstreeRepoFile
+ * @n:
+ * @attributes:
+ * @flags:
+ * @out_info: (out):
+ * @cancellable: Cancellable
+ * @error: Error
+ */
 gboolean
 ostree_repo_file_tree_query_child (OstreeRepoFile  *self,
                                     int              n,

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -473,6 +473,8 @@ ostree_repo_prune (OstreeRepo        *self,
  * statistics on objects that would be deleted, without actually deleting them.
  *
  * Locking: exclusive
+ *
+ * Since: 2017.1
  */
 gboolean
 ostree_repo_prune_from_reachable (OstreeRepo        *self,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1063,7 +1063,7 @@ content_fetch_on_write_complete (GObject        *object,
 static void
 content_fetch_on_complete (GObject        *object,
                            GAsyncResult   *result,
-                           gpointer        user_data) 
+                           gpointer        user_data)
 {
   OstreeFetcher *fetcher = (OstreeFetcher *)object;
   FetchObjectData *fetch_data = user_data;
@@ -1167,7 +1167,7 @@ on_metadata_written (GObject           *object,
   g_autofree guchar *csum = NULL;
   g_autofree char *stringified_object = NULL;
 
-  if (!ostree_repo_write_metadata_finish ((OstreeRepo*)object, result, 
+  if (!ostree_repo_write_metadata_finish ((OstreeRepo*)object, result,
                                           &csum, error))
     goto out;
 
@@ -6103,6 +6103,8 @@ ostree_repo_pull_from_remotes_finish (OstreeRepo    *self,
  *   means return errors without retrying
  *
  * Returns: %TRUE on success, %FALSE on failure
+ *
+ * Since: 2016.6
  */
 gboolean
 ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -482,6 +482,8 @@ ostree_repo_resolve_rev (OstreeRepo     *self,
  *
  * The flag %OSTREE_REPO_RESOLVE_REV_EXT_LOCAL_ONLY is implied so
  * using it has no effect.
+ *
+ * Since: 2016.7
  */
 gboolean
 ostree_repo_resolve_rev_ext (OstreeRepo                    *self,
@@ -856,6 +858,8 @@ ostree_repo_list_refs (OstreeRepo       *self,
  * @out_all_refs will be returned as a mapping from refspecs (including the
  * remote name) to checksums. Differently from ostree_repo_list_refs(), the
  * @refspec_prefix will not be removed from the refspecs in the hash table.
+ *
+ * Since: 2016.4
  */
 gboolean
 ostree_repo_list_refs_ext (OstreeRepo                 *self,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2048,9 +2048,9 @@ ostree_repo_remote_get_gpg_verify_summary (OstreeRepo  *self,
  * ostree_repo_remote_gpg_import:
  * @self: Self
  * @name: name of a remote
- * @source_stream: (allow-none): a #GInputStream, or %NULL
- * @key_ids: (array zero-terminated=1) (element-type utf8) (allow-none): a %NULL-terminated array of GPG key IDs, or %NULL
- * @out_imported: (allow-none): return location for the number of imported
+ * @source_stream: (nullable): a #GInputStream, or %NULL
+ * @key_ids: (array zero-terminated=1) (element-type utf8) (nullable): a %NULL-terminated array of GPG key IDs, or %NULL
+ * @out_imported: (out) (optional): return location for the number of imported
  *                              keys, or %NULL
  * @cancellable: a #GCancellable
  * @error: a #GError
@@ -2385,6 +2385,12 @@ ostree_repo_mode_to_string (OstreeRepoMode   mode,
   return TRUE;
 }
 
+/**
+ * ostree_repo_mode_from_string:
+ * @mode: a repo mode as a string
+ * @out_mode: (out): the corresponding #OstreeRepoMode
+ * @error: a #GError if the string is not a valid mode
+ */
 gboolean
 ostree_repo_mode_from_string (const char      *mode,
                               OstreeRepoMode  *out_mode,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -786,6 +786,8 @@ _ostree_repo_remote_name_is_file (const char *remote_name)
  * option name.  If an error is returned, @out_value will be set to %NULL.
  *
  * Returns: %TRUE on success, otherwise %FALSE with @error set
+ *
+ * Since: 2016.5
  */
 gboolean
 ostree_repo_get_remote_option (OstreeRepo  *self,
@@ -864,6 +866,8 @@ ostree_repo_get_remote_option (OstreeRepo  *self,
  * to %NULL.
  *
  * Returns: %TRUE on success, otherwise %FALSE with @error set
+ *
+ * Since: 2016.5
  */
 gboolean
 ostree_repo_get_remote_list_option (OstreeRepo   *self,
@@ -939,6 +943,8 @@ ostree_repo_get_remote_list_option (OstreeRepo   *self,
  * error is returned, @out_value will be set to %FALSE.
  *
  * Returns: %TRUE on success, otherwise %FALSE with @error set
+ *
+ * Since: 2016.5
  */
 gboolean
 ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
@@ -1255,6 +1261,8 @@ repo_open_at_take_fd (int *dfd,
  * already extant repository.  If you want to create one, use ostree_repo_create_at().
  *
  * Returns: (transfer full): An accessor object for an OSTree repository located at @dfd + @path
+ *
+ * Since: 2017.10
  */
 OstreeRepo*
 ostree_repo_open_at (int           dfd,
@@ -2570,6 +2578,8 @@ ostree_repo_create (OstreeRepo     *self,
  *   - collection-id: s: Set as collection ID in repo/config (Since 2017.9)
  *
  * Returns: (transfer full): A new OSTree repository reference
+ *
+ * Since: 2017.10
  */
 OstreeRepo *
 ostree_repo_create_at (int             dfd,
@@ -3149,6 +3159,8 @@ reload_sysroot_config (OstreeRepo          *self,
  *
  * By default, an #OstreeRepo will cache the remote configuration and its
  * own repo/config data.  This API can be used to reload it.
+ *
+ * Since: 2017.2
  */
 gboolean
 ostree_repo_reload_config (OstreeRepo          *self,
@@ -3313,6 +3325,8 @@ ostree_repo_set_disable_fsync (OstreeRepo    *self,
  * per-remote summary caches. Setting this manually is useful when
  * doing operations on a system repo as a user because you don't have
  * write permissions in the repo, where the cache is normally stored.
+ *
+ * Since: 2016.5
  */
 gboolean
 ostree_repo_set_cache_dir (OstreeRepo    *self,
@@ -3394,6 +3408,7 @@ ostree_repo_get_path (OstreeRepo  *self)
  * repository (to see whether a ref was written).
  *
  * Returns: File descriptor for repository root - owned by @self
+ * Since: 2016.4
  */
 int
 ostree_repo_get_dfd (OstreeRepo  *self)
@@ -4334,6 +4349,8 @@ ostree_repo_import_object_from (OstreeRepo           *self,
  * this will simply be a fast Unix hard link operation.
  *
  * Otherwise, a copy will be performed.
+ *
+ * Since: 2016.5
  */
 gboolean
 ostree_repo_import_object_from_with_trust (OstreeRepo           *self,
@@ -5431,6 +5448,8 @@ ostree_repo_verify_commit_ext (OstreeRepo    *self,
  * configured for @remote.
  *
  * Returns: (transfer full): an #OstreeGpgVerifyResult, or %NULL on error
+ *
+ * Since: 2016.14
  */
 OstreeGpgVerifyResult *
 ostree_repo_verify_commit_for_remote (OstreeRepo    *self,
@@ -5466,6 +5485,8 @@ ostree_repo_verify_commit_for_remote (OstreeRepo    *self,
  * the verifications using GPG keys in the keyrings of all remotes.
  *
  * Returns: (transfer full): an #OstreeGpgVerifyResult, or %NULL on error
+ *
+ * Since: 2016.6
  */
 OstreeGpgVerifyResult *
 ostree_repo_gpg_verify_data (OstreeRepo    *self,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3466,7 +3466,7 @@ ostree_repo_get_mode (OstreeRepo  *self)
 }
 
 /**
- * ostree_repo_get_min_free_space:
+ * ostree_repo_get_min_free_space_bytes:
  * @self: Repo
  * @out_reserved_bytes: (out): Location to store the result
  * @error: Return location for a #GError
@@ -3576,7 +3576,7 @@ list_loose_objects_at (OstreeRepo             *self,
           if (objtype != OSTREE_OBJECT_TYPE_COMMIT)
               continue;
 
-          /* commit checksum does not match "starting with", do not add to array */     
+          /* commit checksum does not match "starting with", do not add to array */
           if (!g_str_has_prefix (buf, commit_starting_with))
             continue;
         }
@@ -4446,7 +4446,7 @@ ostree_repo_load_variant (OstreeRepo       *self,
  */
 gboolean
 ostree_repo_load_commit (OstreeRepo            *self,
-                         const char            *checksum, 
+                         const char            *checksum,
                          GVariant             **out_variant,
                          OstreeRepoCommitState *out_state,
                          GError               **error)
@@ -6098,10 +6098,10 @@ ostree_repo_get_default_repo_finders (OstreeRepo *self)
 /**
  * ostree_repo_get_bootloader:
  * @self: an #OstreeRepo
- * 
+ *
  * Get the bootloader configured. See the documentation for the
  * "sysroot.bootloader" config key.
- * 
+ *
  * Returns: bootloader configuration for the sysroot
  * Since: 2019.2
  */

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -351,7 +351,7 @@ initable_init (GInitable     *initable,
 
           if (g_str_has_prefix (line, selinuxtype_prefix))
             {
-              policytype = g_strstrip (g_strdup (line + strlen (selinuxtype_prefix))); 
+              policytype = g_strstrip (g_strdup (line + strlen (selinuxtype_prefix)));
               policy_root = g_file_get_child (etc_selinux_dir, policytype);
             }
           else if (g_str_has_prefix (line, selinux_prefix))
@@ -430,6 +430,8 @@ ostree_sepolicy_new (GFile         *path,
  * @error: Error
  *
  * Returns: (transfer full): An accessor object for SELinux policy in root located at @rootfs_dfd
+ *
+ * Since: 2017.4
  */
 OstreeSePolicy*
 ostree_sepolicy_new_at (int         rootfs_dfd,
@@ -472,6 +474,8 @@ ostree_sepolicy_get_name (OstreeSePolicy *self)
  * @self:
  *
  * Returns: (transfer none): Checksum of current policy
+ *
+ * Since: 2016.5
  */
 const char *
 ostree_sepolicy_get_csum (OstreeSePolicy *self)

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2170,6 +2170,8 @@ write_deployments_finish (OstreeSysroot *self,
  * ostree_sysroot_cleanup() at some point after the transaction, or specify
  * `do_postclean` in @opts.  Skipping the post-transaction cleanup is useful
  * if for example you want to control pruning of the repository.
+ *
+ * Since: 2017.4
  */
 gboolean
 ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
@@ -2756,6 +2758,8 @@ _ostree_sysroot_deserialize_deployment_from_variant (GVariant *v,
  *
  * Like ostree_sysroot_deploy_tree(), but "finalization" only occurs at OS
  * shutdown time.
+ *
+ * Since: 2018.5
  */
 gboolean
 ostree_sysroot_stage_tree (OstreeSysroot     *self,

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -855,6 +855,11 @@ _ostree_sysroot_reload_staged (OstreeSysroot *self,
   return TRUE;
 }
 
+/**
+ * ostree_sysroot_load_if_changed:
+ *
+ * Since: 2016.4
+ */
 gboolean
 ostree_sysroot_load_if_changed (OstreeSysroot  *self,
                                 gboolean       *out_changed,
@@ -1033,6 +1038,8 @@ ostree_sysroot_get_booted_deployment (OstreeSysroot       *self)
  * @self: Sysroot
  *
  * Returns: (transfer none): The currently staged deployment, or %NULL if none
+ *
+ * Since: 2018.5
  */
 OstreeDeployment *
 ostree_sysroot_get_staged_deployment (OstreeSysroot       *self)
@@ -1144,6 +1151,8 @@ ostree_sysroot_get_repo (OstreeSysroot         *self,
  * has been invoked successfully.
  *
  * Returns: (transfer none): The OSTree repository in sysroot @self.
+ *
+ * Since: 2017.7
  */
 OstreeRepo *
 ostree_sysroot_repo (OstreeSysroot *self)
@@ -1475,6 +1484,8 @@ ostree_sysroot_lock_finish (OstreeSysroot         *self,
  * Initialize the directory structure for an "osname", which is a
  * group of operating system deployments, with a shared `/var`.  One
  * is required for generating a deployment.
+ *
+ * Since: 2016.4
  */
 gboolean
 ostree_sysroot_init_osname (OstreeSysroot       *self,
@@ -1729,6 +1740,8 @@ static gboolean mkdir_unmasked (int                   dfd,
  *
  * The `OSTREE_DEPLOYMENT_UNLOCKED_HOTFIX` state is persistent
  * across reboots.
+ *
+ * Since: 2016.4
  */
 gboolean
 ostree_sysroot_deployment_unlock (OstreeSysroot     *self,

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -857,6 +857,10 @@ _ostree_sysroot_reload_staged (OstreeSysroot *self,
 
 /**
  * ostree_sysroot_load_if_changed:
+ * @self: #OstreeSysroot
+ * @out_changed: (out caller-allocates):
+ * @cancellable: Cancellable
+ * @error: Error
  *
  * Since: 2016.4
  */


### PR DESCRIPTION
This PR fixes some issue with the GObject-Introspection metadata I ran into when updating the Rust bindings yesterday.

* `ostree_repo_get_min_free_space_bytes` had the wrong name in its doc comment which meant the GI generator didn't find it.
* Several functions were also missing "Since" tags so I added a bunch based on libostree-released.sym. (That wasn't a huge problem, but I noticed and it was bothering me.)
* There were a few functions with inconsistent "nullable" annotations.
* Some functions were missing the "out" annotation on their out parameters. These are always quite easy to spot because the generated code doesn't compile.

(It seems I also ended up nuking some trailing whitespace. Oh well.)