### PR TITLE
ci: Split out installdeps.sh from build.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,21 +6,7 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libpaprci/libbuild.sh
 
-pkg_upgrade
-pkg_install_buildroot
-pkg_builddep ostree
-pkg_install sudo which attr fuse strace \
-    libubsan libasan libtsan PyYAML redhat-rpm-config \
-    elfutils
-if test -n "${CI_PKGS:-}"; then
-    pkg_install ${CI_PKGS}
-fi
-pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang \
-                  python3-PyYAML
-if test "${OS_ID}" = "centos"; then
-    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    pkg_install python34{,-PyYAML}
-fi
+${dn}/installdeps.sh
 
 # Default libcurl on by default in fedora unless libsoup is enabled
 if test "${OS_ID}" = 'fedora'; then

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+# Install build dependencies.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libpaprci/libbuild.sh
+
+pkg_upgrade
+pkg_install_buildroot
+pkg_builddep ostree
+pkg_install sudo which attr fuse strace \
+    libubsan libasan libtsan PyYAML redhat-rpm-config \
+    elfutils
+if test -n "${CI_PKGS:-}"; then
+    pkg_install ${CI_PKGS}
+fi
+pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang \
+                  python3-PyYAML
+if test "${OS_ID}" = "centos"; then
+    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    pkg_install python34{,-PyYAML}
+fi


### PR DESCRIPTION
This script is useful to run individually when setting up a
development environment for OSTree.