### PR TITLE
lib/util: Fix segfault when validating filename

### DIFF
--- a/src/libotutil/ot-unix-utils.c
+++ b/src/libotutil/ot-unix-utils.c
@@ -43,6 +43,8 @@ gboolean
 ot_util_filename_validate (const char *name,
                            GError    **error)
 {
+  if (name == NULL)
+    return glnx_throw (error, "Invalid NULL filename");
   if (strcmp (name, ".") == 0)
     return glnx_throw (error, "Invalid self-referential filename '.'");
   if (strcmp (name, "..") == 0)


### PR DESCRIPTION
This change fixes the segfault issue when calling ostree_repo_checkout_tree with
empty GFileInfo. A simple condition check for NULL value is added at
src/libotutil/ot-unix-utils.c:46. Closes: ostreedev#1864.