### PR TITLE
bin/refs: Allow overwriting existing ref

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -952,6 +952,7 @@ _ostree_refs() {
         --collections -c
         --delete
         --list
+        --force
     "
 
     local options_with_args="

--- a/man/ostree-refs.xml
+++ b/man/ostree-refs.xml
@@ -126,6 +126,16 @@ Boston, MA 02111-1307, USA.
                   PREFIX are deleted.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--force</option></term>
+
+                <listitem><para>
+                  When creating <literal>NEWREF</literal> with
+                  <option>--create</option>, allow an existing ref to be
+                  updated instead of erroring.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -90,6 +90,11 @@ if ${CMD_PREFIX} ostree --repo=repo refs foo/ctest --create=ctest; then
     assert_not_reached "refs --create unexpectedly succeeded in overwriting an existing prefix!"
 fi
 
+# Force overwriting ctest and check the revision got updated
+foo_ctest_rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse foo/ctest)
+${CMD_PREFIX} ostree --repo=repo refs foo/ctest --create=ctest --force
+assert_ref repo ctest ${foo_ctest_rev}
+
 # https://github.com/ostreedev/ostree/issues/1285
 # One tool was creating .latest_rsync files in each dir, let's ignore stuff like
 # that.


### PR DESCRIPTION
Currently if you want to update a non-alias ref, you need to first check
if it exists and use either `ostree refs --create` or `ostree reset` as
appropriate. That's unnecessarily complicated and is much less
convenient than the old `write-refs` builtin that simply called
`ostree_repo_set_ref_immediate()` without any checks.

Add a `--force` option to be used with `--create` that does not raise an
error when the destination ref already exists.