### PR TITLE
ci: Use Fedora 29 artifacts

### DIFF
--- a/.papr-ex.yaml
+++ b/.papr-ex.yaml
@@ -4,15 +4,15 @@ branches:
     - auto
     - try
 
-context: FAH28-insttests
+context: FAH29-insttests
 required: false
 
 container:
-  image: registry.fedoraproject.org/fedora:28
+  image: registry.fedoraproject.org/fedora:29
   kvm: true
 
 tests:
-  - ci/fah28-insttests.sh
+  - ci/fah29-insttests.sh
 
 artifacts:
   - tests/installed/artifacts/
@@ -27,8 +27,8 @@ branches:
     - try
 required: true
 container:
-  image: registry.fedoraproject.org/fedora:28
-context: f28-primary
+  image: registry.fedoraproject.org/fedora:29
+context: f29-primary
 env:
   # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
   CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
@@ -51,10 +51,10 @@ artifacts:
 ---
 # And now the contexts below here are variant container builds
 
-context: f28-rust
+context: f29-rust
 inherit: true
 container:
-    image: registry.fedoraproject.org/fedora:28
+    image: registry.fedoraproject.org/fedora:29
 env:
   CONFIGOPTS: '--enable-rust'
   CI_PKGS: cargo
@@ -65,10 +65,10 @@ tests:
 
 ---
 
-context: f28-gnutls
+context: f29-gnutls
 inherit: true
 container:
-    image: registry.fedoraproject.org/fedora:28
+    image: registry.fedoraproject.org/fedora:29
 env:
   CONFIGOPTS: '--with-crypto=gnutls'
   CI_PKGS: pkgconfig(gnutls)
@@ -81,7 +81,7 @@ tests:
 
 inherit: true
 
-context: f28-minimal
+context: f29-minimal
 env:
   CONFIGOPTS: '--without-curl --without-soup --disable-gtk-doc --disable-man
    --disable-rust --without-libarchive --without-selinux --without-smack
@@ -96,7 +96,7 @@ tests:
 inherit: true
 required: true
 
-context: f28-libsoup
+context: f29-libsoup
 
 env:
   CONFIGOPTS: "--without-curl --without-openssl --with-soup"
@@ -109,7 +109,7 @@ tests:
 inherit: true
 required: true
 
-context: f28-introspection-tests
+context: f29-introspection-tests
 
 env:
     # ASAN conflicts with introspection testing;

--- a/.papr.yml
+++ b/.papr.yml
@@ -6,8 +6,8 @@ branches:
     - try
 required: true
 container:
-  image: registry.fedoraproject.org/fedora:28
-context: f28-primary
+  image: registry.fedoraproject.org/fedora:29
+context: f29-primary
 env:
   # We only use -Werror=maybe-uninitialized here with a "fixed" toolchain
   CFLAGS: '-fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2'
@@ -31,10 +31,10 @@ artifacts:
 ---
 # And now the contexts below here are variant container builds
 
-context: f28-rust
+context: f29-rust
 inherit: true
 container:
-    image: registry.fedoraproject.org/fedora:28
+    image: registry.fedoraproject.org/fedora:29
 env:
   CONFIGOPTS: '--enable-rust'
   CI_PKGS: cargo
@@ -45,10 +45,10 @@ tests:
 
 ---
 
-context: f28-gnutls
+context: f29-gnutls
 inherit: true
 container:
-    image: registry.fedoraproject.org/fedora:28
+    image: registry.fedoraproject.org/fedora:29
 env:
   CONFIGOPTS: '--with-crypto=gnutls'
   CI_PKGS: pkgconfig(gnutls)
@@ -61,7 +61,7 @@ tests:
 
 inherit: true
 
-context: f28-minimal
+context: f29-minimal
 env:
   CONFIGOPTS: '--without-curl --without-soup --disable-gtk-doc --disable-man
    --disable-rust --without-libarchive --without-selinux --without-smack
@@ -76,7 +76,7 @@ tests:
 inherit: true
 required: true
 
-context: f28-libsoup
+context: f29-libsoup
 
 env:
   CONFIGOPTS: "--without-curl --without-openssl --with-soup"
@@ -89,7 +89,7 @@ tests:
 inherit: true
 required: true
 
-context: f28-introspection-tests
+context: f29-introspection-tests
 
 env:
     # ASAN conflicts with introspection testing;
@@ -108,19 +108,19 @@ branches:
     - auto
     - try
 
-context: f28-flatpak
+context: f29-flatpak
 required: true
 
 # This test case wants an "unprivileged container with bubblewrap",
 # which we don't have right now; so just provision a VM and do a
 # docker --privileged run.
 host:
-  distro: fedora/28/atomic
+  distro: fedora/29/atomic
   specs:
     ram: 4096  # build-bundle is a static delta, which needs RAM right now
 
 tests:
-  - docker run --rm --privileged -v $(pwd):/srv/code registry.fedoraproject.org/fedora:28 /bin/sh -c "cd /srv/code && ./ci/flatpak.sh"
+  - docker run --rm --privileged -v $(pwd):/srv/code registry.fedoraproject.org/fedora:29 /bin/sh -c "cd /srv/code && ./ci/flatpak.sh"
 
 artifacts:
   - test-suite.log
@@ -136,16 +136,16 @@ branches:
     - auto
     - try
 
-context: f28-rpmostree
+context: f29-rpmostree
 # XXX: some issues currently failing that need investigating.
 required: false
 
 cluster:
   hosts:
     - name: vmcheck
-      distro: fedora/28/atomic
+      distro: fedora/29/atomic
   container:
-    image: registry.fedoraproject.org/fedora:28
+    image: registry.fedoraproject.org/fedora:29
 
 env:
   HOSTS: vmcheck

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -251,6 +251,10 @@ libostree_1_la_CFLAGS += $(OT_DEP_SELINUX_CFLAGS)
 libostree_1_la_LIBADD += $(OT_DEP_SELINUX_LIBS)
 endif
 
+# XXX: work around clang being passed -fstack-clash-protection which it doesn't understand
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1672012
+INTROSPECTION_SCANNER_ENV = CC=gcc
+
 if BUILDOPT_INTROSPECTION
 OSTree-1.0.gir: libostree-1.la Makefile
 OSTree_1_0_gir_EXPORT_PACKAGES = ostree-1

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -25,8 +25,7 @@ if test -x /usr/bin/clang; then
     if grep -q -e 'static inline.*_GLIB_AUTOPTR_LIST_FUNC_NAME' /usr/include/glib-2.0/glib/gmacros.h; then
         echo 'Skipping clang check, see https://bugzilla.gnome.org/show_bug.cgi?id=796346'
     else
-    # Except for clang-4.0: error: argument unused during compilation: '-specs=/usr/lib/rpm/redhat/redhat-hardened-cc1' [-Werror,-Wunused-command-line-argument]
-    export CFLAGS="-Wall -Werror -Wno-error=unused-command-line-argument ${CFLAGS:-}"
+    export CFLAGS="-Wall -Werror ${CFLAGS:-}"
     git clean -dfx && git submodule foreach git clean -dfx
     export CC=clang
     build

--- a/ci/fah28-insttests.sh
+++ b/ci/fah28-insttests.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/bash
-set -xeuo pipefail
-
-./tests/installed/provision.sh
-# TODO: enhance papr to have caching, a bit like https://docs.travis-ci.com/user/caching/
-cd tests/installed
-# This should be https://getfedora.org/atomic_qcow2_latest but that's broken
-curl -Lo fedora-atomic-host.qcow2 https://kojipkgs.fedoraproject.org/compose/twoweek/Fedora-Atomic-28-20180626.0/compose/AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180626.0.x86_64.qcow2
-exec env "TEST_SUBJECTS=$(pwd)/fedora-atomic-host.qcow2" ./run.sh

--- a/ci/fah29-insttests.sh
+++ b/ci/fah29-insttests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+set -xeuo pipefail
+
+./tests/installed/provision.sh
+# TODO: enhance papr to have caching, a bit like https://docs.travis-ci.com/user/caching/
+cd tests/installed
+curl -Lo fedora-atomic-host.qcow2 https://getfedora.org/atomic_qcow2_latest
+exec env "TEST_SUBJECTS=$(pwd)/fedora-atomic-host.qcow2" ./run.sh

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 # Keep this pinned to avoid arbitrary change for now; it's also
 # good to test building older code against newer ostree as it helps
 # us notice any API breaks.
-FLATPAK_TAG=0.99.2
+FLATPAK_TAG=1.4.1
 
 dn=$(dirname $0)
 . ${dn}/libpaprci/libbuild.sh


### PR DESCRIPTION
Use Fedora 29 artifacts instead of Fedora 28, since 28 is now
end-of-life.

Also rename `ci/fah28-insttests.sh` -> `ci/fah29-insttests.sh`
and use the https://getfedora.org/atomic_qcow2_latest redirect
URL for the latest Fedora Atomic Host 29 image.

---

Fedora Atomic Host 29 is used for now as it is still being released - and it is quick to switch the CI to this image. CI will soon switch to test against Fedora CoreOS however once Fedora Atomic Host 29 is EOL.