### PR TITLE
lib/util: Drop unneeded ot-tool-util.h includes

### DIFF
--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -25,7 +25,6 @@
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
 #include "ostree.h"
-#include "ot-tool-util.h"
 #include "otutil.h"
 
 #include <unistd.h>

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -30,7 +30,6 @@
 #include "ot-builtins.h"
 #include "ostree.h"
 #include "otutil.h"
-#include "ot-tool-util.h"
 
 static gboolean opt_user_mode;
 static gboolean opt_allow_noent;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -28,7 +28,6 @@
 #include "ot-editor.h"
 #include "ostree.h"
 #include "otutil.h"
-#include "ot-tool-util.h"
 #include "parse-datetime.h"
 #include "ostree-repo-private.h"
 #include "ostree-libarchive-private.h"

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -22,7 +22,6 @@
 #include "config.h"
 
 #include "otutil.h"
-#include "ot-tool-util.h"
 
 #include "ot-main.h"
 #include "ot-remote-builtins.h"


### PR DESCRIPTION
With `ot-tool-util.h` made visible in `otutil.h` (in
be2572bf68090a5e277338d2613d3c7d53b0c9e8), drop previous includes
of `ot-tool-util.h` elsewhere.