### PR TITLE
fsck: Throw and error and return non-zero for non-verified commits

### DIFF
--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -444,7 +444,7 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
     }
   else if (n_partial > 0)
     {
-      g_print ("%u partial commits not verified\n", n_partial);
+      return glnx_throw (error, "%u partial commits not verified", n_partial);
     }
 
   if (found_corruption)


### PR DESCRIPTION
After the corruption has been fixed with "ostree fsck -a --delete", a
second run of the "ostree fsck" command will print X partial commits
not verified and exit with a zero.

The zero exit code makes it hard to detect if a repair operation needs
to be run, it is easier to check an exit code than try to parse the
text that is emitted from the ostree fsck.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>