### PR TITLE
tests/sizes.js: Fix byte array unpacking

### DIFF
--- a/tests/test-sizes.js
+++ b/tests/test-sizes.js
@@ -64,10 +64,10 @@ assertEquals(nSizes, 2);
 let expectedUncompressedSizes = [12, 18];
 let foundExpectedUncompressedSizes = 0;
 for (let i = 0; i < nSizes; i++) {
-    let sizeEntry = sizes.get_child_value(i).deep_unpack();
-    assertEquals(sizeEntry.length, 34);
-    let compressedSize = sizeEntry[32];
-    let uncompressedSize = sizeEntry[33];
+    let sizeEntry = sizes.get_child_value(i);
+    assertEquals(sizeEntry.n_children(), 34);
+    let compressedSize = sizeEntry.get_child_value(32).get_byte();
+    let uncompressedSize = sizeEntry.get_child_value(33).get_byte();
     print("compressed = " + compressedSize);
     print("uncompressed = " + uncompressedSize);
     for (let j = 0; j < expectedUncompressedSizes.length; j++) {

--- a/tests/test-sizes.js
+++ b/tests/test-sizes.js
@@ -53,7 +53,7 @@ let [,dirTree] = repo.write_mtree(mtree, null);
 let [,commit] = repo.write_commit(null, 'Some subject', 'Some body', null, dirTree, null);
 print("commit => " + commit);
 
-repo.commit_transaction(null, null);
+repo.commit_transaction(null);
 
 // Test the sizes metadata
 let [,commitVariant] = repo.load_variant(OSTree.ObjectType.COMMIT, commit);


### PR DESCRIPTION
Recent GJS changed how byte arrays are unpacked with some assumptions
that they are likely strings. Manually use get_child_value() and
get_byte() to ensure the correct value is parsed when checking the
`ostree.sizes` metadata.

The upstream test is currently passing fine with GJS 1.56.2, but at
Endless we (unfortunately) have a downstream change that adds the object
type as an additional byte in the array. This is parsed incorrectly by
`deep_unpack()`. We can carry this patch downstream, but this change
makes the test more robust regardless.

One more commit is included that I noticed when inspecting the test log.