### PR TITLE
RFC - Implementation of partialcommit reason

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -129,6 +129,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-create-usb.sh \
 	tests/test-find-remotes.sh \
 	tests/test-fsck-collections.sh \
+	tests/test-fsck-delete.sh \
 	tests/test-init-collections.sh \
 	tests/test-prune-collections.sh \
 	tests/test-refs-collections.sh \

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -333,6 +333,7 @@ ostree_repo_set_cache_dir
 ostree_repo_sign_delta
 ostree_repo_has_object
 ostree_repo_mark_commit_partial
+ostree_repo_mark_commit_partial_reason
 ostree_repo_write_metadata
 ostree_repo_write_metadata_async
 ostree_repo_write_metadata_finish

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -39,6 +39,7 @@ global:
   ostree_kernel_args_from_string;
   ostree_kernel_args_to_strv;
   ostree_kernel_args_to_string;
+  ostree_repo_mark_commit_partial_reason;
 } LIBOSTREE_2018.9;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -269,6 +269,26 @@ gboolean      ostree_repo_write_config (OstreeRepo *self,
                                         GError    **error);
 
 /**
+ * OstreeRepoCommitState:
+ * @OSTREE_REPO_COMMIT_STATE_NORMAL: Commit is complete. This is the default.
+ *    (Since: 2017.14.)
+ * @OSTREE_REPO_COMMIT_STATE_PARTIAL: One or more objects are missing from the
+ *    local copy of the commit, but metadata is present. (Since: 2015.7.)
+ * @OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL: One or more objects are missing from the
+ *    local copy of the commit, due to an fsck --delete. (Since: 2019.3.)
+ *
+ * Flags representing the state of a commit in the local repository, as returned
+ * by ostree_repo_load_commit().
+ *
+ * Since: 2015.7
+ */
+typedef enum {
+  OSTREE_REPO_COMMIT_STATE_NORMAL = 0,
+  OSTREE_REPO_COMMIT_STATE_PARTIAL = (1 << 0),
+  OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL = (1 << 1),
+} OstreeRepoCommitState;
+
+/**
  * OstreeRepoTransactionStats:
  * @metadata_objects_total: The total number of metadata objects
  * in the repository after this transaction has completed.
@@ -334,6 +354,13 @@ gboolean      ostree_repo_mark_commit_partial (OstreeRepo     *self,
                                                const char     *checksum,
                                                gboolean        is_partial,
                                                GError        **error);
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_mark_commit_partial_reason (OstreeRepo     *self,
+                                                      const char     *checksum,
+                                                      gboolean        is_partial,
+                                                      OstreeRepoCommitState in_state,
+                                                      GError        **error);
 
 _OSTREE_PUBLIC
 void          ostree_repo_transaction_set_refspec (OstreeRepo *self,
@@ -545,23 +572,6 @@ gboolean      ostree_repo_load_variant_if_exists (OstreeRepo  *self,
                                                   const char    *sha256, 
                                                   GVariant     **out_variant,
                                                   GError       **error);
-
-/**
- * OstreeRepoCommitState:
- * @OSTREE_REPO_COMMIT_STATE_NORMAL: Commit is complete. This is the default.
- *    (Since: 2017.14.)
- * @OSTREE_REPO_COMMIT_STATE_PARTIAL: One or more objects are missing from the
- *    local copy of the commit, but metadata is present. (Since: 2015.7.)
- *
- * Flags representing the state of a commit in the local repository, as returned
- * by ostree_repo_load_commit().
- *
- * Since: 2015.7
- */
-typedef enum {
-  OSTREE_REPO_COMMIT_STATE_NORMAL = 0,
-  OSTREE_REPO_COMMIT_STATE_PARTIAL = (1 << 0),
-} OstreeRepoCommitState;
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_commit (OstreeRepo            *self,

--- a/tests/test-fsck-delete.sh
+++ b/tests/test-fsck-delete.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Copyright © 2019 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo '1..6'
+
+cd ${test_tmpdir}
+
+rm -rf ./f1
+mkdir -p ./f1
+${CMD_PREFIX} ostree --repo=./f1 init --mode=archive-z2
+mkdir -p ./trial
+echo test > ./trial/test
+${CMD_PREFIX} ostree --repo=./f1 commit --tree=dir=./trial --skip-if-unchanged --branch=exp1 --subject="test Commit"
+
+rm -rf ./f2
+mkdir -p ./f2
+${CMD_PREFIX} ostree --repo=./f2 init
+${CMD_PREFIX} ostree --repo=./f2 pull-local  ./f1
+echo "ok 1 fsck-pre-commit"
+
+echo whoops > `find ./f2 |grep objects |grep \\.file `
+
+# First check for corruption
+if ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^error: In commits"
+
+echo "ok 2 fsck-fail-check"
+
+# Fix the corruption
+if ${CMD_PREFIX} ostree fsck --delete --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^In commits"
+
+echo "ok 3 fsck-delete-check"
+
+# Check that fsck still exits with non-zero after corruption fix
+if ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^error: 1"
+
+echo "ok 4 fsck-post-delete-check"
+
+${CMD_PREFIX} ostree --repo=./f2 pull-local ./f1 > /dev/null
+echo "ok 5 fsck-repair"
+
+if ! ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck failed when it should have passed"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_empty fsck-error
+echo "ok 6 fsck-good"

--- a/tests/test-fsck-delete.sh
+++ b/tests/test-fsck-delete.sh
@@ -30,17 +30,20 @@ cd ${test_tmpdir}
 rm -rf ./f1
 mkdir -p ./f1
 ${CMD_PREFIX} ostree --repo=./f1 init --mode=archive-z2
+rm -rf ./trial
 mkdir -p ./trial
 echo test > ./trial/test
 ${CMD_PREFIX} ostree --repo=./f1 commit --tree=dir=./trial --skip-if-unchanged --branch=exp1 --subject="test Commit"
 
 rm -rf ./f2
 mkdir -p ./f2
-${CMD_PREFIX} ostree --repo=./f2 init
+${CMD_PREFIX} ostree --repo=./f2 init --mode=archive-z2
 ${CMD_PREFIX} ostree --repo=./f2 pull-local  ./f1
 echo "ok 1 fsck-pre-commit"
 
-echo whoops > `find ./f2 |grep objects |grep \\.file `
+file=`find ./f2 |grep objects |grep \\.file |tail -1 `
+rm $file
+echo whoops > $file
 
 # First check for corruption
 if ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then


### PR DESCRIPTION
This is an implementation as well as a test case for the partialcommit reason in order to allow the fsck operation to continue to exit with non-zero status after an "ostree fsck --delete" operation has been run.