### PR TITLE
Add OSTREE_BUILT_FEATURES to ostree-verison.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -584,6 +584,9 @@ OSTREE_FEATURES="$OSTREE_FEATURES $release_build_type"
 # P2P API is public in OSTree >= 2018.6
 OSTREE_FEATURES="$OSTREE_FEATURES p2p"
 
+# Strip leading whitespace
+OSTREE_FEATURES=$(echo ${OSTREE_FEATURES})
+
 AC_CONFIG_FILES([
 Makefile
 apidoc/Makefile

--- a/src/libostree/ostree-version.h.in
+++ b/src/libostree/ostree-version.h.in
@@ -91,3 +91,13 @@
 #define OSTREE_CHECK_VERSION(year,release)   \
         (OSTREE_YEAR_VERSION > (year) || \
          (OSTREE_YEAR_VERSION == (year) && OSTREE_RELEASE_VERSION >= (release)))
+
+/**
+ * OSTREE_BUILT_FEATURES:
+ *
+ * Whitespace separated set of features this libostree was configured with at build time.
+ * Consult the source code in configure.ac (or the CLI `ostree --version`) for examples.
+ *
+ * Since: 2019.3
+ */
+#define OSTREE_BUILT_FEATURES "@OSTREE_FEATURES@"


### PR DESCRIPTION
This way projects can dispatch at run-time based on ostree's
build time options, e.g. detect the availability of GPG.