### PR TITLE
config/set: Don't fail when setting negative value

### DIFF
--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -74,6 +74,8 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
   int correct_argc;
 
   context = g_option_context_new ("(get KEY|set KEY VALUE|unset KEY)");
+  /* Needed so we don't fail when passing negative integers as VALUE */
+  g_option_context_set_ignore_unknown_options (context, TRUE);
 
   if (!ostree_option_context_parse (context, options, &argc, &argv, invocation, &repo, cancellable, error))
     return FALSE;

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -71,7 +71,7 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
   g_autofree char *section = NULL;
   g_autofree char *key = NULL;
   g_autoptr(GKeyFile) config = NULL;
-  int correct_argc;
+  int i, correct_argc;
 
   context = g_option_context_new ("(get KEY|set KEY VALUE|unset KEY)");
   /* Needed so we don't fail when passing negative integers as VALUE */
@@ -79,6 +79,17 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
 
   if (!ostree_option_context_parse (context, options, &argc, &argv, invocation, &repo, cancellable, error))
     return FALSE;
+
+  for (i = 0; i < argc; i++)
+    {
+      /* There should be no more options at this point */
+      if (g_str_has_prefix (argv[i], "--"))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unknown option %s", argv[i]);
+          return FALSE;
+        }
+    }
 
   if (argc < 2)
     {


### PR DESCRIPTION
Some config options have special meaning when the value is negative. For
example, `core.lock-timeout-secs` when set to -1 means timeout disabled.
Currently, `g_option_context_parse` fails when parsing negative values:
```
ostree config set core.lock-timeout-secs -1
error: Unknown option -1
```
We need to tell it to ignore unknown options instead of erroring out and
let the `ostree_builtin_config` code handle the value properly.

Fixes #1893

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>