### PR TITLE
bin: Better handle --

### DIFF
--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -152,11 +152,6 @@ ostree_run (int    argc,
             }
         }
 
-      else if (g_str_equal (argv[in], "--"))
-        {
-          break;
-        }
-
       argv[out] = argv[in];
     }
 
@@ -347,6 +342,22 @@ ostree_option_context_parse (GOptionContext *context,
 
   if (!g_option_context_parse (context, argc, argv, error))
     return FALSE;
+
+  /* Filter out the first -- we see; g_option_context_parse() leaves it in */
+  int in, out;
+  gboolean removed_double_dashes = FALSE;
+  for (in = 1, out = 1; in < *argc; in++, out++)
+    {
+      if (g_str_equal ((*argv)[in], "--") && !removed_double_dashes)
+        {
+          removed_double_dashes = TRUE;
+          out--;
+          continue;
+        }
+
+      (*argv)[out] = (*argv)[in];
+    }
+  *argc = out;
 
   if (opt_version)
     {

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -66,9 +66,11 @@ fi
 assert_file_has_content err.txt "error: Too many arguments given"
 echo "ok config set"
 
-# Check that "ostree config unset" works
+# Check that using `--` works and that "ostree config unset" works
 ${CMD_PREFIX} ostree config --repo=repo set core.lock-timeout-secs 60
 assert_file_has_content repo/config "lock-timeout-secs=60"
+${CMD_PREFIX} ostree config --repo=repo -- set core.lock-timeout-secs -1
+assert_file_has_content repo/config "lock-timeout-secs=-1"
 ${CMD_PREFIX} ostree config --repo=repo unset core.lock-timeout-secs
 assert_not_file_has_content repo/config "lock-timeout-secs="
 


### PR DESCRIPTION
We would stop passing through `--` and args after it to the underlying
command in `ostree_run`. This made it impossible to use `--` to tell the
parser that following args starting with `-` really are positional.

AFAICT, that logic for `--` here came from a time when we parse options
manually in a big loop, in which case breaking out made sense (see
97558276e4f855442337be01abc8f90cf0dd1810).

There's an extra step here, which is that glib by default leaves the
`--` in the list of args, so we need to take care to remove it from the
list after parsing.

Closes: #1898