### PR TITLE
lib/deploy: handle FIFREEZE ENOSYS failure

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1374,7 +1374,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
            * the filesystem is already frozen (EBUSY).
            * OK, let's just do a syncfs.
            */
-          if (G_IN_SET (errno, EOPNOTSUPP, EPERM, EBUSY))
+          if (G_IN_SET (errno, EOPNOTSUPP, ENOSYS, EPERM, EBUSY))
             {
               /* Warn if the filesystem was already frozen */
               if (errno == EBUSY)


### PR DESCRIPTION
When running under qemu, unimplemented ioctls such as FIFREEZE
return ENOSYS, and this causes the deployment to fail.

Catch this and handle it like EOPNOTSUPP.

I'm not sure if qemu's behaviour is fully correct here (or if it should
return EOPNOTSUPP) but it's trivial to handle regardless.