### PR TITLE
ci: Add prow/ subdirectory with Dockerfile

### DIFF
--- a/ci/libpaprci/libbuild.sh
+++ b/ci/libpaprci/libbuild.sh
@@ -35,7 +35,13 @@ pkg_install_if_os() {
 
 pkg_install_buildroot() {
     case "${OS_ID}" in
-        fedora) pkg_install dnf-plugins-core @buildsys-build;;
+        fedora)
+            # https://github.com/projectatomic/rpm-ostree/pull/1889/commits/9ff611758bea22b0ad4892cc16182dd1f7f47e89
+            # https://fedoraproject.org/wiki/Common_F30_bugs#Conflicts_between_fedora-release_packages_when_installing_package_groups
+            if rpm -q fedora-release-container; then
+                yum -y swap fedora-release{-container,}
+            fi
+            pkg_install dnf-plugins-core @buildsys-build;;
         centos) pkg_install yum-utils
                 # Base buildroot, copied from the mock config sadly
                 pkg_install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ \

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.fedoraproject.org/fedora:30
+WORKDIR /src
+COPY . .
+RUN ./ci/build.sh


### PR DESCRIPTION
I'd like to add OpenShift's prow to this repository.  Let's start
by adding a Dockerfile - it doesn't really do anything besides build.

However...I've lately been thinking about e.g. shipping the ostree tests
as an image, and then e.g. we could test FCOS by running that container
(which would orchestrate the *host's* ostree).

Anyways, not doing that right now but this is a start.

Also this cherry picks the fix from rpm-ostree CI for the sad
Fedora release package brokenness.