### PR TITLE
lib/kernel-args: Store kernel args as key/value entries

### DIFF
--- a/src/libostree/ostree-kernel-args.h
+++ b/src/libostree/ostree-kernel-args.h
@@ -27,10 +27,39 @@
 G_BEGIN_DECLS
 
 typedef struct _OstreeKernelArgs OstreeKernelArgs;
+typedef struct _OstreeKernelArgsEntry OstreeKernelArgsEntry;
 
 GHashTable *_ostree_kernel_arg_get_kargs_table (OstreeKernelArgs *kargs);
 
 GPtrArray *_ostree_kernel_arg_get_key_array (OstreeKernelArgs *kargs);
+
+char *
+_ostree_kernel_args_entry_get_key (const OstreeKernelArgsEntry *e);
+
+char *
+_ostree_kernel_args_entry_get_value (const OstreeKernelArgsEntry *e);
+
+void
+_ostree_kernel_args_entry_set_key (OstreeKernelArgsEntry *e,
+                                   char  *key);
+
+void
+_ostree_kernel_args_entry_set_value (OstreeKernelArgsEntry *e,
+                                     char  *value);
+
+char *
+_ostree_kernel_args_get_key_index (const OstreeKernelArgs *kargs,
+                                   int i);
+
+char *
+_ostree_kernel_args_get_value_index (const OstreeKernelArgs *kargs,
+                                     int i);
+
+OstreeKernelArgsEntry *
+_ostree_kernel_args_entry_new (void);
+
+void
+_ostree_kernel_args_entry_value_free (OstreeKernelArgsEntry *e);
 
 _OSTREE_PUBLIC
 void ostree_kernel_args_free (OstreeKernelArgs *kargs);

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -66,4 +66,8 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'option
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 
+# Check correct ordering of different-valued args of the same key.
+${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=FOO=TESTORDERED --karg-append=APPENDARG=3RDAPPEND testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND .*FOO=TESTORDERED .*APPENDARG=3RDAPPEND'
+
 echo "ok deploy --karg-append"


### PR DESCRIPTION
Define an `OstreeKernelArgsEntry` structure, which holds
both the key and the value. The kargs order array stores
entries for each key/value pair, instead of just the keys.
The hash table is used to locate entries, by storing
entries in a pointer array for each key. This preserves
ordering information about each key/value pair when
appending/replacing/deleting kargs, and maintains the
same public interface.

Fixes: #1859

---

Proposing this as an approach for #1859 . `tests/test-kargs.c` worked locally. Letting `tests/test-admin-deploy-karg.sh` run in CI as a seemingly unrelated error occurred in my local container `error: Cleaning deployments: ioctl(EXT2_IOC_GETFLAGS): Bad file descriptor`. Not yet manually verified when installed with `rpm-ostree` - leaving WIP for now.