### PR TITLE
Implementation of partialcommit reason

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -126,6 +126,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-create-usb.sh \
 	tests/test-find-remotes.sh \
 	tests/test-fsck-collections.sh \
+	tests/test-fsck-delete.sh \
 	tests/test-init-collections.sh \
 	tests/test-prune-collections.sh \
 	tests/test-refs-collections.sh \

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -333,6 +333,7 @@ ostree_repo_set_cache_dir
 ostree_repo_sign_delta
 ostree_repo_has_object
 ostree_repo_mark_commit_partial
+ostree_repo_mark_commit_partial_reason
 ostree_repo_write_metadata
 ostree_repo_write_metadata_async
 ostree_repo_write_metadata_finish

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,7 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2019.4 {
+  ostree_repo_mark_commit_partial_reason;
 } LIBOSTREE_2019.3;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1874,15 +1874,67 @@ ensure_txn_refs (OstreeRepo *self)
 }
 
 /**
+ * ostree_repo_mark_commit_partial_reason:
+ * @self: Repo
+ * @checksum: Commit SHA-256
+ * @is_partial: Whether or not this commit is partial
+ * @in_state: Reason bitmask for partial commit
+ * @error: Error
+ *
+ * Allows the setting of a reason code for a partial commit. Presently
+ * it only supports setting reason bitmask to
+ * OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL, or
+ * OSTREE_REPO_COMMIT_STATE_NORMAL.  This will allow successive ostree
+ * fsck operations to exit properly with an error code if the
+ * repository has been truncated as a result of fsck trying to repair
+ * it.
+ *
+ * Since: 2019.4
+ */
+gboolean
+ostree_repo_mark_commit_partial_reason (OstreeRepo     *self,
+                                        const char     *checksum,
+                                        gboolean        is_partial,
+                                        OstreeRepoCommitState in_state,
+                                        GError        **error)
+{
+  g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (checksum);
+  if (is_partial)
+    {
+      glnx_autofd int fd = openat (self->repo_dir_fd, commitpartial_path,
+                                   O_EXCL | O_CREAT | O_WRONLY | O_CLOEXEC | O_NOCTTY, 0644);
+      if (fd == -1)
+        {
+          if (errno != EEXIST)
+            return glnx_throw_errno_prefix (error, "open(%s)", commitpartial_path);
+        }
+      else
+        {
+          if (in_state & OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL)
+            if (glnx_loop_write (fd, "f", 1) < 0)
+              return glnx_throw_errno_prefix (error, "write(%s)", commitpartial_path);
+        }
+    }
+  else
+    {
+      if (!ot_ensure_unlinked_at (self->repo_dir_fd, commitpartial_path, 0))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+/**
  * ostree_repo_mark_commit_partial:
  * @self: Repo
  * @checksum: Commit SHA-256
  * @is_partial: Whether or not this commit is partial
  * @error: Error
  *
- * Commits in "partial" state do not have all their child objects written. This
- * occurs in various situations, such as during a pull, but also if a "subpath"
- * pull is used, as well as "commit only" pulls.
+ * Commits in the "partial" state do not have all their child objects
+ * written.  This occurs in various situations, such as during a pull,
+ * but also if a "subpath" pull is used, as well as "commit only"
+ * pulls.
  *
  * This function is used by ostree_repo_pull_with_options(); you
  * should use this if you are implementing a different type of transport.
@@ -1895,24 +1947,9 @@ ostree_repo_mark_commit_partial (OstreeRepo     *self,
                                  gboolean        is_partial,
                                  GError        **error)
 {
-  g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (checksum);
-  if (is_partial)
-    {
-      glnx_autofd int fd = openat (self->repo_dir_fd, commitpartial_path,
-                                   O_EXCL | O_CREAT | O_WRONLY | O_CLOEXEC | O_NOCTTY, 0644);
-      if (fd == -1)
-        {
-          if (errno != EEXIST)
-            return glnx_throw_errno_prefix (error, "open(%s)", commitpartial_path);
-        }
-    }
-  else
-    {
-      if (!ot_ensure_unlinked_at (self->repo_dir_fd, commitpartial_path, 0))
-        return FALSE;
-    }
-
-  return TRUE;
+  return ostree_repo_mark_commit_partial_reason (self, checksum, is_partial,
+                                                 OSTREE_REPO_COMMIT_STATE_NORMAL,
+                                                 error);
 }
 
 /**

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -249,6 +249,26 @@ gboolean      ostree_repo_write_config (OstreeRepo *self,
                                         GError    **error);
 
 /**
+ * OstreeRepoCommitState:
+ * @OSTREE_REPO_COMMIT_STATE_NORMAL: Commit is complete. This is the default.
+ *    (Since: 2017.14.)
+ * @OSTREE_REPO_COMMIT_STATE_PARTIAL: One or more objects are missing from the
+ *    local copy of the commit, but metadata is present. (Since: 2015.7.)
+ * @OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL: One or more objects are missing from the
+ *    local copy of the commit, due to an fsck --delete. (Since: 2019.3.)
+ *
+ * Flags representing the state of a commit in the local repository, as returned
+ * by ostree_repo_load_commit().
+ *
+ * Since: 2015.7
+ */
+typedef enum {
+  OSTREE_REPO_COMMIT_STATE_NORMAL = 0,
+  OSTREE_REPO_COMMIT_STATE_PARTIAL = (1 << 0),
+  OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL = (1 << 1),
+} OstreeRepoCommitState;
+
+/**
  * OstreeRepoTransactionStats:
  * @metadata_objects_total: The total number of metadata objects
  * in the repository after this transaction has completed.
@@ -314,6 +334,13 @@ gboolean      ostree_repo_mark_commit_partial (OstreeRepo     *self,
                                                const char     *checksum,
                                                gboolean        is_partial,
                                                GError        **error);
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_mark_commit_partial_reason (OstreeRepo     *self,
+                                                      const char     *checksum,
+                                                      gboolean        is_partial,
+                                                      OstreeRepoCommitState in_state,
+                                                      GError        **error);
 
 _OSTREE_PUBLIC
 void          ostree_repo_transaction_set_refspec (OstreeRepo *self,
@@ -525,23 +552,6 @@ gboolean      ostree_repo_load_variant_if_exists (OstreeRepo  *self,
                                                   const char    *sha256, 
                                                   GVariant     **out_variant,
                                                   GError       **error);
-
-/**
- * OstreeRepoCommitState:
- * @OSTREE_REPO_COMMIT_STATE_NORMAL: Commit is complete. This is the default.
- *    (Since: 2017.14.)
- * @OSTREE_REPO_COMMIT_STATE_PARTIAL: One or more objects are missing from the
- *    local copy of the commit, but metadata is present. (Since: 2015.7.)
- *
- * Flags representing the state of a commit in the local repository, as returned
- * by ostree_repo_load_commit().
- *
- * Since: 2015.7
- */
-typedef enum {
-  OSTREE_REPO_COMMIT_STATE_NORMAL = 0,
-  OSTREE_REPO_COMMIT_STATE_PARTIAL = (1 << 0),
-} OstreeRepoCommitState;
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_commit (OstreeRepo            *self,

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -127,7 +127,7 @@ fsck_one_object (OstreeRepo            *repo,
                   if ((state & OSTREE_REPO_COMMIT_STATE_PARTIAL) == 0)
                     {
                       g_printerr ("Marking commit as partial: %s\n", parent_commit);
-                      if (!ostree_repo_mark_commit_partial (repo, parent_commit, TRUE, error))
+                      if (!ostree_repo_mark_commit_partial_reason (repo, parent_commit, TRUE, OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL, error))
                         return FALSE;
                     }
                 }
@@ -302,6 +302,7 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
     opt_verify_bindings = TRUE;
 
   guint n_partial = 0;
+  guint n_fsck_partial = 0;
   g_hash_table_iter_init (&hash_iter, objects);
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
     {
@@ -410,7 +411,11 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
             }
 
           if (commitstate & OSTREE_REPO_COMMIT_STATE_PARTIAL)
-            n_partial++;
+            {
+              n_partial++;
+              if (commitstate & OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL)
+                n_fsck_partial++;
+            }
           else
             g_hash_table_add (commits, g_variant_ref (serialized_key));
         }
@@ -449,6 +454,9 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
 
   if (found_corruption)
     return glnx_throw (error, "Repository corruption encountered");
+
+  if (n_fsck_partial > 0)
+    return glnx_throw (error, "%u fsck deleted partial commits not verified", n_partial);
 
   return TRUE;
 }

--- a/tests/test-fsck-delete.sh
+++ b/tests/test-fsck-delete.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright © 2019 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo '1..6'
+
+cd ${test_tmpdir}
+
+rm -rf ./f1
+mkdir -p ./f1
+${CMD_PREFIX} ostree --repo=./f1 init --mode=archive-z2
+rm -rf ./trial
+mkdir -p ./trial
+echo test > ./trial/test
+${CMD_PREFIX} ostree --repo=./f1 commit --tree=dir=./trial --skip-if-unchanged --branch=exp1 --subject="test Commit"
+
+rm -rf ./f2
+mkdir -p ./f2
+${CMD_PREFIX} ostree --repo=./f2 init --mode=archive-z2
+${CMD_PREFIX} ostree --repo=./f2 pull-local  ./f1
+echo "ok 1 fsck-pre-commit"
+
+file=`find ./f2 |grep objects |grep \\.file |tail -1 `
+rm $file
+echo whoops > $file
+
+# First check for corruption
+if ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^error: In commits"
+
+echo "ok 2 fsck-fail-check"
+
+# Fix the corruption
+if ${CMD_PREFIX} ostree fsck --delete --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^In commits"
+
+echo "ok 3 fsck-delete-check"
+
+# Check that fsck still exits with non-zero after corruption fix
+if ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck did not fail"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_has_content fsck-error "^error: 1"
+
+echo "ok 4 fsck-post-delete-check"
+
+${CMD_PREFIX} ostree --repo=./f2 pull-local ./f1 > /dev/null
+echo "ok 5 fsck-repair"
+
+if ! ${CMD_PREFIX} ostree fsck --repo=./f2 > fsck 2> fsck-error; then
+  assert_not_reached "fsck failed when it should have passed"
+fi
+assert_file_has_content fsck "^Validating refs\.\.\.$"
+assert_file_empty fsck-error
+echo "ok 6 fsck-good"


### PR DESCRIPTION
This a cleaned up version of the rfc fsck patch. It contains the implementation of the partial commit reason as well as a test case for the partialcommit reason.  The intent is to allow the fsck operation to continue to exit with non-zero status after an "ostree fsck --delete" operation has been run, which has removed objects.