### PR TITLE
lib/bootconfig-parser: Always include deployment index in BLS title

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1746,10 +1746,9 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
       g_string_append_c (title_key, ':');
       g_string_append (title_key, osname);
     }
-  if (!(deployment_version && *deployment_version))
-    {
-      g_string_append_printf (title_key, ":%d", ostree_deployment_get_index (deployment));
-    }
+
+  g_string_append_printf (title_key, ":%d", ostree_deployment_get_index (deployment));
+
   g_string_append_c (title_key, ')');
   ostree_bootconfig_parser_set (bootconfig, "title", title_key->str);
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -290,10 +290,10 @@ echo "ok upgrade with multiple kernel args"
 
 os_repository_new_commit
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 ${version} (ostree:testos)$"
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 ${version} (ostree:testos:0)$"
 os_repository_new_commit 0 0 testos/buildmaster/x86_64-runtime 42
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 (ostree:testos)$"
+assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 (ostree:testos:0)$"
 
 echo "ok no duplicate version strings in title"
 


### PR DESCRIPTION
If there are different deployments for the same commit version, the BLS
snippets will have the same title fields (but different version fields):

$ grep title *
ostree-1-testos.conf:title TestOS 42 20190902.0 (ostree)
ostree-2-testos.conf:title TestOS 42 20190902.0 (ostree)
ostree-3-testos.conf:title TestOS 42 20190902.0 (ostree)

But bootloaders could expect the title field to be unique for BLS files.
For example, the zipl bootloader used in the s390x architecture uses the
field to name the boot sections that are created from the BLS snippets.

So two BLS snippets having the same title would lead to zipl failing to
create the IPL boot sections because they would have duplicated names:

$ zipl
Using config file '/etc/zipl.conf'
Using BLS config file '/boot/loader/entries/ostree-3-testos.conf'
Using BLS config file '/boot/loader/entries/ostree-2-testos.conf'
Using BLS config file '/boot/loader/entries/ostree-1-testos.conf'
Error: Config file '/etc/zipl.conf': Line 0: section name 'TestOS 42 20190902.0 (ostree)' already specified

Avoid this by always including the deployment index along with the commit
version in the title field, so this will be unique even if there are BLS
files for deployments that use the same commit version:

$ grep title *
ostree-1-testos.conf:title TestOS 42 20190902.0 (ostree:2)
ostree-2-testos.conf:title TestOS 42 20190902.0 (ostree:1)
ostree-3-testos.conf:title TestOS 42 20190902.0 (ostree:0)

$ zipl
Using config file '/etc/zipl.conf'
Using BLS config file '/boot/loader/entries/ostree-3-testos.conf'
Using BLS config file '/boot/loader/entries/ostree-2-testos.conf'
Using BLS config file '/boot/loader/entries/ostree-1-testos.conf'
Building bootmap in '/boot'
Building menu 'zipl-automatic-menu'
Adding #1: IPL section 'TestOS 42 20190902.0 (ostree:0)' (default)
Adding #2: IPL section 'TestOS 42 20190902.0 (ostree:1)'
Adding #3: IPL section 'TestOS 42 20190902.0 (ostree:2)'
Preparing boot device: dasda (0120).
Done.