### PR TITLE
Gate ostree-trivial-httpd on BUILDOPT_TRIVIAL_HTTPD

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -143,12 +143,13 @@ ostree_SOURCES += src/ostree/ot-builtin-pull.c
 endif
 
 if USE_LIBSOUP
-# Eventually once we stop things from using this, we should support disabling this
+if BUILDOPT_TRIVIAL_HTTPD
 ostree_SOURCES += src/ostree/ot-builtin-trivial-httpd.c
 pkglibexec_PROGRAMS += ostree-trivial-httpd
 ostree_trivial_httpd_SOURCES = src/ostree/ostree-trivial-httpd.c
 ostree_trivial_httpd_CFLAGS = $(ostree_bin_shared_cflags) $(OT_INTERNAL_SOUP_CFLAGS)
 ostree_trivial_httpd_LDADD = $(ostree_bin_shared_ldadd) $(OT_INTERNAL_SOUP_LIBS)
+endif
 
 if !USE_CURL
 # This is necessary for the cookie jar bits

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS += \
 	--enable-gtk-doc \
 	--enable-man \
 	--disable-maintainer-mode \
+	--enable-trivial-httpd-cmdline \
 	$(NULL)
 
 GITIGNOREFILES = aclocal.m4 build-aux/ buildutil/*.m4 config.h.in gtk-doc.make

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -22,6 +22,11 @@ case "${CONFIGOPTS:-}" in
         fi
         ;;
 esac
+# unless libsoup is disabled, enable trivial-httpd for the tests
+case "${CONFIGOPTS:-}" in
+    *--without-soup*) ;;
+    *) CONFIGOPTS="${CONFIGOPTS:-} --enable-trivial-httpd-cmdline" ;;
+esac
 
 # always fail on warnings; https://github.com/ostreedev/ostree/pull/971
 # NB: this disables the default set of flags from configure.ac

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -85,6 +85,7 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
 
 ../configure \
     --enable-always-build-tests \
+    --enable-trivial-httpd-cmdline \
     ${ci_configopts}
     "$@"
 

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,9 @@ AC_ARG_ENABLE(trivial-httpd-cmdline,
   [Continue to support "ostree trivial-httpd" [default=no]])],,
   enable_trivial_httpd_cmdline=no)
 AM_CONDITIONAL(BUILDOPT_TRIVIAL_HTTPD, test x$enable_trivial_httpd_cmdline = xyes)
+AS_IF([test x$with_soup = xno && test x$enable_trivial_httpd_cmdline = xyes], [
+  AC_MSG_ERROR([trivial-httpd enabled, but libsoup is not; libsoup is needed for trivial-httpd])
+])
 AM_COND_IF(BUILDOPT_TRIVIAL_HTTPD,
   [AC_DEFINE([BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE], 1, [Define if we are enabling ostree trivial-httpd entrypoint])]
 )


### PR DESCRIPTION
When building without --enable-trivial-httpd-cmdline, don't build or install
the ostree-trivial-httpd binary.
