### PR TITLE
ci/prow: add helper dockerfiles

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,4 +1,0 @@
-FROM registry.fedoraproject.org/fedora:30
-WORKDIR /src
-COPY . .
-RUN ./ci/build.sh

--- a/ci/prow/Dockerfile.buildroot
+++ b/ci/prow/Dockerfile.buildroot
@@ -1,0 +1,5 @@
+FROM quay.io/coreos-assembler/coreos-buildroot:latest
+WORKDIR /src
+COPY . .
+RUN ./ci/libpaprci/libbuild.sh
+RUN ./ci/installdeps.sh

--- a/ci/prow/Dockerfile.minimal
+++ b/ci/prow/Dockerfile.minimal
@@ -1,0 +1,3 @@
+FROM buildroot
+ENV CONFIGOPTS '--without-curl --without-soup --disable-gtk-doc --disable-man --disable-rust --without-libarchive --without-selinux --without-smack --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse --disable-experimental-api'
+RUN ./ci/build.sh

--- a/ci/prow/Dockerfile.sanity
+++ b/ci/prow/Dockerfile.sanity
@@ -1,0 +1,3 @@
+FROM buildroot
+RUN ./ci/build.sh && \
+    make install


### PR DESCRIPTION
Add helper dockerfiles for Prow builds. The base for all tests is `Dockerfile.buildroot` which only contains builddeps. Other dockerfiles build  ostree with various config options