### PR TITLE
lib/gpg-verify: Fix out arg annotation

### DIFF
--- a/src/libostree/ostree-gpg-verify-result-dummy.c
+++ b/src/libostree/ostree-gpg-verify-result-dummy.c
@@ -202,7 +202,7 @@ ostree_gpg_verify_result_get_all (OstreeGpgVerifyResult *result,
  * ostree_gpg_verify_result_describe:
  * @result: an #OstreeGpgVerifyResult
  * @signature_index: which signature to describe
- * @output_buffer: a #GString to hold the description
+ * @output_buffer: (out): a #GString to hold the description
  * @line_prefix: (allow-none): optional line prefix string
  * @flags: flags to adjust the description format
  *

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -509,7 +509,7 @@ ostree_gpg_verify_result_get_all (OstreeGpgVerifyResult *result,
  * ostree_gpg_verify_result_describe:
  * @result: an #OstreeGpgVerifyResult
  * @signature_index: which signature to describe
- * @output_buffer: a #GString to hold the description
+ * @output_buffer: (out): a #GString to hold the description
  * @line_prefix: (allow-none): optional line prefix string
  * @flags: flags to adjust the description format
  *


### PR DESCRIPTION
Was trying to use the GI bindings to verify a commit signature, and hit
this.