### PR TITLE
boot/finalize-staged: Run after systemd-journal-flush.service

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -26,6 +26,9 @@ DefaultDependencies=no
 RequiresMountsFor=/sysroot
 After=local-fs.target
 Before=basic.target final.target
+# We want to make sure the transaction logs are persisted to disk:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1751272
+After=systemd-journal-flush.service
 Conflicts=final.target
 
 [Service]


### PR DESCRIPTION
In Fedora 31, `systemd-journal-flush.service` uses a new
`--smart-relinquish-var` switch which fixes the
`umount: /var: target is busy` bug by telling journald to stop logging
to `/var` and back to `/run` again during shutdown.

This interacted with `ostree-finalize-staged.service` in a tricky way:
since we weren't strongly ordered against it, when we happened to
finalize after `/var` is relinquished, we never persisted the output
from that service to disk. This then threw off `rpm-ostree status` when
trying to find the completion message to know that finalization went
well.

Just fix this by adding an explicit `After=` on that unit. That way we
shut down *before* `systemd-journal-flush.service` (the `/var`
relinquish bit happens in its `ExecStop=`).

For more info, see:
https://github.com/systemd/systemd/commit/3ff7a50d66e3f851d3d9f132b740a7fb2055aa1d
https://github.com/systemd/systemd/commit/1e187d2dd52cbb4f0bb30e4d96acf7f72a145b91
https://bugzilla.redhat.com/show_bug.cgi?id=1751272