### PR TITLE
Release 2019.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ m4_define([year_version], [2019])
 m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl update libostree-released.sym from libostree-devel.sym, and update the check
 dnl in test-symbols.sh, and also set is_release_build=yes below.  Then make
 dnl another post-release commit to bump the version, and set is_release_build=no.
 m4_define([year_version], [2019])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,6 +18,8 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
+LIBOSTREE_2019.5 {
+} LIBOSTREE_2019.4;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,9 +18,6 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2019.4 {
-  ostree_repo_mark_commit_partial_reason;
-} LIBOSTREE_2019.3;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -571,6 +571,10 @@ global:
   ostree_kernel_args_to_string;
 } LIBOSTREE_2018.9;
 
+LIBOSTREE_2019.4 {
+  ostree_repo_mark_commit_partial_reason;
+} LIBOSTREE_2019.3;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-f2f4a0367673e84bc168c7085fec346101a0b6be1962fcca196d8a14fc6eb5c3  ${released_syms}
+21e8ee92ef53c62c682ef8ae818bb6191b3cf6256d298493f75cc734fb3a3a02  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
Tiny release. Just want to get out the important bugfixes instead of
backporting patches (notably the gpg-agent stuff and
`ostree-finalize-staged.service` ordering).
