### PR TITLE
grub2: Exit gracefully if the configuration has BLS enabled

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -26,6 +26,13 @@ if ! test -d /ostree/repo; then
     exit 0
 fi
 
+# Gracefully exit if the grub2 configuration has BLS enabled,
+# since there is no need to create menu entries in that case.
+. /etc/default/grub
+if test ${GRUB_ENABLE_BLSCFG} = "true"; then
+    exit 0
+fi
+
 # Make sure we're in the right environment
 if ! test -n "${GRUB_DEVICE}"; then
     echo "This script must be run as a child of grub2-mkconfig" 1>&2


### PR DESCRIPTION
Since Fedora 30 grub2 has support to populate its menu entries from the
BootLoaderSpec fragments in /boot/loader/entries, so there's no need to
generate menu entries anymore using the /etc/grub.d/15_ostree script.

But since ostree doesn't update the bootloader, it may be that the grub2
installed is an old one that doesn't have BLS support.

For new installs, GRUB_ENABLE_BLSCFG=true is set in /etc/default/grub to
tell the /etc/grub.d/10_linux script if a blscfg command has to be added
to the generated grub2 config file.

So check if BLS is enabled in /etc/default/grub and only add the entries
if that's not the case. Otherwise the menu entries will be duplicated.