### PR TITLE
libostree: Add an assert to pacify clang-analyzer

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -717,6 +717,8 @@ checkout_one_file_at (OstreeRepo                        *repo,
             }
           current_repo = current_repo->parent_repo;
         }
+      /* Pacify clang-analyzer which sees us testing effectively if (repo == NULL) */
+      g_assert (repo);
 
       need_copy = (hardlink_res == HARDLINK_RESULT_NOT_SUPPORTED);
     }


### PR DESCRIPTION
Got this error when trying to rebase libostree in RHEL:

```
Error: CLANG_WARNING: [#def1]
libostree-2019.2/src/libostree/ostree-repo-checkout.c:375:21: warning: Access to field 'disable_xattrs' results in a dereference of a null pointer (loaded from variable 'repo')
```

I think what's happening is it sees us effectively testing
`if (repo == NULL)` via the `while (current_repo)`.  Let's
tell it we're sure it's non-null right after the loop.