### PR TITLE
OWNERS: New file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+# Keep these lists in alphabetical order (just to avoid ordering implying anything)
+# Changes to this list can be done via regular pull requests.  A generally good
+# approach can be to just start reviewing pull requests - if you do that enough
+# and understand the libostree code base, feel free to submit a PR to add
+# yourself to one of these lists.
+# Use the responsibility to merge carefully.
+approvers:
+  - cgwalters
+  - jlebon
+  - pwithnall
+  # Does not currently have affiliation public
+  # - wmanley
+reviewers:
+  - lucab
+  - mwleeds
+  - rfairley


### PR DESCRIPTION
I tried to balance reflecting the reality of who works on libostree
today with keeping some of the existing committers - particularly
committers from multiple organizations.

Part of switching libostree over to OpenShift Prow.