### PR TITLE
ci: Trim PAPR config to drop required flag

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -1,10 +1,6 @@
 # This suite skips the RPMs and does the build+unit tests in a container
 inherit: false
-branches:
-    - master
-    - auto
-    - try
-required: true
+
 container:
   image: registry.fedoraproject.org/fedora:29
 context: f29-primary
@@ -74,7 +70,6 @@ tests:
 ---
 
 inherit: true
-required: true
 
 context: f29-libsoup
 
@@ -87,7 +82,6 @@ tests:
 ---
 
 inherit: true
-required: true
 
 context: f29-introspection-tests
 
@@ -103,13 +97,8 @@ tests:
 
 # Reset inheritance for non-variant builds
 inherit: false
-branches:
-    - master
-    - auto
-    - try
 
 context: f29-flatpak
-required: true
 
 # This test case wants an "unprivileged container with bubblewrap",
 # which we don't have right now; so just provision a VM and do a
@@ -131,14 +120,7 @@ artifacts:
 # we share more code. https://github.com/projectatomic/rpm-ostree/issues/662
 inherit: false
 
-branches:
-    - master
-    - auto
-    - try
-
 context: f29-rpmostree
-# XXX: some issues currently failing that need investigating.
-required: false
 
 cluster:
   hosts:


### PR DESCRIPTION
Same as https://github.com/coreos/rpm-ostree/pull/1923
Quoting that rationale:

> Since we're not using Homu anymore (and Tide instead looks at
> all statuses by default), let's just drop it. This brings down the
> number of statuses on PRs by one more (and so one less context to
> override when needed).