### PR TITLE
build-sys: Rename internal conditionals for trivial-httpd

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -34,7 +34,7 @@ ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 \
 ostree-pull.1 ostree-refs.1 ostree-remote.1 ostree-reset.1 \
 ostree-rev-parse.1 ostree-show.1 ostree-summary.1 \
 ostree-static-delta.1
-if BUILDOPT_TRIVIAL_HTTPD
+if USE_LIBSOUP
 man1_files += ostree-trivial-httpd.1
 else
 # We still want to distribute the source, even if we are not building it

--- a/configure.ac
+++ b/configure.ac
@@ -194,8 +194,7 @@ AC_ARG_ENABLE(trivial-httpd-cmdline,
   [AS_HELP_STRING([--enable-trivial-httpd-cmdline],
   [Continue to support "ostree trivial-httpd" [default=no]])],,
   enable_trivial_httpd_cmdline=no)
-AM_CONDITIONAL(BUILDOPT_TRIVIAL_HTTPD, test x$enable_trivial_httpd_cmdline = xyes)
-AM_COND_IF(BUILDOPT_TRIVIAL_HTTPD,
+AS_IF([test x$enable_trivial_httpd_cmdline = xyes],
   [AC_DEFINE([BUILDOPT_ENABLE_TRIVIAL_HTTPD_CMDLINE], 1, [Define if we are enabling ostree trivial-httpd entrypoint])]
 )
 


### PR DESCRIPTION
This way it's clearer the option is only about the CLI entrypoint
also living in `ostree trivial-httpd`.

Co-authored-by: Jonathan Lebon <jonathan@jlebon.com>