### PR TITLE
async-progress: Plug memory leak while destroying GSource

### DIFF
--- a/src/libostree/ostree-async-progress.c
+++ b/src/libostree/ostree-async-progress.c
@@ -465,7 +465,7 @@ ostree_async_progress_finish (OstreeAsyncProgress *self)
       if (self->idle_source)
         {
           g_source_destroy (self->idle_source);
-          self->idle_source = NULL;
+          g_clear_pointer (&self->idle_source, g_source_unref);
           emit_changed = TRUE;
         }
     }


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/glib/commit/71973c722