### PR TITLE
Revert grub2 exit, add new grub2: Honor /boot/.grub2-bls-enabled 

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -26,13 +26,6 @@ if ! test -d /ostree/repo; then
     exit 0
 fi
 
-# Gracefully exit if the grub2 configuration has BLS enabled,
-# since there is no need to create menu entries in that case.
-. /etc/default/grub
-if test ${GRUB_ENABLE_BLSCFG} = "true"; then
-    exit 0
-fi
-
 # Make sure we're in the right environment
 if ! test -n "${GRUB_DEVICE}"; then
     echo "This script must be run as a child of grub2-mkconfig" 1>&2


### PR DESCRIPTION
In this case this is reverted in Fedora; I don't like carrying downstream patches.  Let's revert it here, and I added a different approach.