### PR TITLE
tests/export: Guard with check for libarchive

### DIFF
--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -21,6 +21,11 @@
 
 set -euo pipefail
 
+if ! ostree --version | grep -q -e '- libarchive'; then
+    echo "1..0 #SKIP no libarchive support compiled in"
+    exit 0
+fi
+
 . $(dirname $0)/libtest.sh
 
 setup_test_repository "archive"


### PR DESCRIPTION
If we are built without libarchive support, this test fails:

  error: This version of ostree is not compiled with libarchive support
  ...
  ERROR: tests/test-export.sh - too few tests run (expected 5, got 0)
  ERROR: tests/test-export.sh - exited with status 1

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>