### PR TITLE
Initial fs-verity support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,10 @@ LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
 # What's in RHEL7.2.
 FUSE_DEPENDENCY="fuse >= 2.9.2"
 
+AC_CHECK_HEADERS([linux/fsverity.h])
+AS_IF([test x$ac_cv_header_linux_fsverity_h = xyes ],
+  [OSTREE_FEATURES="$OSTREE_FEATURES ex-fsverity"])
+
 # check for gtk-doc
 m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
@@ -618,6 +622,7 @@ echo "
     HTTP backend:                                 $fetcher_backend
     \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
+    fs-verity:                                    $ac_cv_header_linux_fsverity_h
     cryptographic checksums:                      $with_crypto
     systemd:                                      $with_libsystemd
     libmount:                                     $with_libmount

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <sys/statvfs.h>
+#include "config.h"
 #include "otutil.h"
 #include "ostree-ref.h"
 #include "ostree-repo.h"
@@ -97,6 +98,12 @@ typedef struct {
   fsblkcnt_t max_blocks;
 } OstreeRepoTxn;
 
+typedef enum {
+  _OSTREE_FEATURE_NO,
+  _OSTREE_FEATURE_MAYBE,
+  _OSTREE_FEATURE_YES,
+} _OstreeFeatureSupport;
+
 /**
  * OstreeRepo:
  *
@@ -127,6 +134,8 @@ struct OstreeRepo {
   GMutex txn_lock;
   OstreeRepoTxn txn;
   gboolean txn_locked;
+  _OstreeFeatureSupport fs_verity_wanted;
+  _OstreeFeatureSupport fs_verity_supported;
 
   GMutex cache_lock;
   guint dirmeta_cache_refcount;
@@ -470,5 +479,16 @@ OstreeRepoAutoLock * _ostree_repo_auto_lock_push (OstreeRepo          *self,
                                                   GError             **error);
 void          _ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *lock);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoLock, _ostree_repo_auto_lock_cleanup)
+
+gboolean
+_ostree_tmpf_fsverity_core (GLnxTmpfile *tmpf,
+                            _OstreeFeatureSupport fsverity_requested,
+                            gboolean    *supported,
+                            GError     **error);
+
+gboolean
+_ostree_tmpf_fsverity (OstreeRepo *self,
+                       GLnxTmpfile *tmpf,
+                       GError    **error);
 
 G_END_DECLS


### PR DESCRIPTION
Using [fs-verity](https://www.kernel.org/doc/html/latest/filesystems/fsverity.html) is natural for OSTree because it's file-based,
as opposed to block based (like [dm-verity](https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/verity.html)).  This only covers
files - not symlinks or directories.  And we clearly need to
have integrity for the deployment directories at least.

More background on fs-verity:

- https://lwn.net/Articles/763729/
- https://lwn.net/Articles/752614/
    
So making this truly secure would need a lot more work.  Nevertheless,
I think it's time to start experimenting with it.  Among other things,
it does *finally* add an API that makes files immutable, which will
help against some accidental damage.