### PR TITLE
lib/deploy: Also install HMAC file into /boot

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -395,6 +395,8 @@ setup_os_repository () {
     mkdir -p usr/bin ${bootdir} usr/lib/modules/${kver} usr/share usr/etc
     kernel_path=${bootdir}/vmlinuz
     initramfs_path=${bootdir}/initramfs.img
+    # the HMAC file is only in /usr/lib/modules
+    hmac_path=usr/lib/modules/${kver}/.vmlinuz.hmac
     # /usr/lib/modules just uses "vmlinuz", since the version is in the module
     # directory name.
     if [[ $bootdir != usr/lib/modules/* ]]; then
@@ -403,6 +405,7 @@ setup_os_repository () {
     fi
     echo "a kernel" > ${kernel_path}
     echo "an initramfs" > ${initramfs_path}
+    echo "an hmac file" > ${hmac_path}
     bootcsum=$(cat ${kernel_path} ${initramfs_path} | sha256sum | cut -f 1 -d ' ')
     export bootcsum
     # Add the checksum for legacy dirs (/boot, /usr/lib/ostree-boot), but not

--- a/tests/test-admin-deploy-none.sh
+++ b/tests/test-admin-deploy-none.sh
@@ -43,6 +43,7 @@ ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os testos
 assert_file_has_content out.txt "Bootloader updated.*"
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
+assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/.vmlinuz-3.6.0.hmac  'an hmac file'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
 echo "ok generate bls config on first deployment"
 


### PR DESCRIPTION
To allow for FIPS mode, we need to also install the HMAC file from
`/usr/lib/modules` to `/boot` alongside the kernel image where the
`fips` dracut module will find it. For details, see:

https://github.com/coreos/fedora-coreos-tracker/issues/302

Note I didn't include the file in the boot checksum since it's itself a
checksum of the kernel, so we don't really gain much here other than
potentially causing an unnecessary bootcsum bump.