### PR TITLE
tests/core: Fallback to en_US.UTF-8 locale

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -35,15 +35,11 @@ assert_not_reached () {
 }
 
 # Some tests look for specific English strings. Use a UTF-8 version
-# of the C (POSIX) locale if we have one, or fall back to POSIX
+# of the C (POSIX) locale if we have one, or fall back to en_US.UTF-8
 # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
-if locale -a | grep '^C.UTF-8$' >/dev/null; then
-    export LC_ALL=C.UTF-8
-elif locale -a | grep '^C.utf8$' >/dev/null; then
-    export LC_ALL=C.utf8
-else
-    export LC_ALL=C
-fi
+export LC_ALL=$(locale -a | grep -Ee '\.(UTF-8|utf8)' | grep -iEe '^(C|en_US)' | head -1 || true)
+if [ -z "${LC_ALL}" ]; then fatal "Can't find suitable UTF-8 locale"; fi
+
 # A GNU extension, used whenever LC_ALL is not C
 unset LANGUAGE
 


### PR DESCRIPTION
A number of tests expect explicit left/right single quotes in their
messages, which will never happen in the C locale. Change the fallback
to en_US.UTF-8 as the most likely next option to be present, or fail if
we can't find one of these locales.

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>