### PR TITLE
Use rename of directories instead of symbolic links in boot partition.

### DIFF
--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -80,7 +80,8 @@ echo "ok --print-current-dir"
 
 # Test layout of bootloader config and refs
 assert_not_has_dir sysroot/boot/loader.0
-assert_has_dir sysroot/boot/loader.1
+assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.1'
 assert_has_dir sysroot/ostree/boot.1.1
 assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
@@ -103,8 +104,9 @@ ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-run
 new_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 assert_not_streq "${orig_mtime}" "${new_mtime}"
 # Need a new bootversion, sine we now have two deployments
-assert_has_dir sysroot/boot/loader.0
+assert_not_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.0'
 assert_has_dir sysroot/ostree/boot.0.1
 assert_not_has_dir sysroot/ostree/boot.0.0
 assert_not_has_dir sysroot/ostree/boot.1.0
@@ -121,8 +123,9 @@ echo "ok second deploy"
 
 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
 # Keep the same bootversion
-assert_has_dir sysroot/boot/loader.0
+assert_not_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.0'
 # But swap subbootversion
 assert_has_dir sysroot/ostree/boot.0.0
 assert_not_has_dir sysroot/ostree/boot.0.1
@@ -136,7 +139,8 @@ ${CMD_PREFIX} ostree admin os-init otheros
 
 ${CMD_PREFIX} ostree admin deploy --os=otheros testos/buildmain/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
-assert_has_dir sysroot/boot/loader.1
+assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.1'
 assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
 assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
@@ -148,8 +152,9 @@ validate_bootloader
 echo "ok independent deploy"
 
 ${CMD_PREFIX} ostree admin deploy --retain --os=testos testos:testos/buildmain/x86_64-runtime
-assert_has_dir sysroot/boot/loader.0
+assert_not_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.0'
 assert_has_file sysroot/boot/loader/entries/ostree-4-testos.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.2/etc/os-release 'NAME=TestOS'
 assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
@@ -166,7 +171,8 @@ rm sysroot/ostree/deploy/testos/deploy/${rev}.3/etc/aconfigfile
 ln -s /ENOENT sysroot/ostree/deploy/testos/deploy/${rev}.3/etc/a-new-broken-symlink
 ${CMD_PREFIX} ostree admin deploy --retain --os=testos testos:testos/buildmain/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
-assert_has_dir sysroot/boot/loader.1
+assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.1'
 link=sysroot/ostree/deploy/testos/deploy/${rev}.4/etc/a-new-broken-symlink
 if ! test -L ${link}; then
     ls -al ${link}
@@ -190,8 +196,9 @@ assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
 assert_not_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
 assert_not_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
 ${CMD_PREFIX} ostree admin deploy --not-as-default --os=otheros testos:testos/buildmain/x86_64-runtime
-assert_has_dir sysroot/boot/loader.0
+assert_not_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.0'
 assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
 assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf
 ${CMD_PREFIX} ostree admin status
@@ -201,7 +208,8 @@ echo "ok deploy --not-as-default"
 
 ${CMD_PREFIX} ostree admin deploy --retain-rollback --os=otheros testos:testos/buildmain/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
-assert_has_dir sysroot/boot/loader.1
+assert_not_has_dir sysroot/boot/loader.1
+assert_file_has_content sysroot/boot/loader/version 'loader.1'
 assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
 assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
 assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf


### PR DESCRIPTION
This implements  @AdrianVovk idea from https://github.com/ostreedev/ostree/issues/1719#issuecomment-449895351 to solve issue #1719.

This uses `renameat2` to do atomic swap of the loader directory in the
boot partition. It fallsback to non-atomic rename. This stays atomic
on filesystems supporting links but also provide a non-atomic behavior
when filesystem does not provide any atomic alternative.

This is working with SystemD boot on EFI using boot loader
specifications.

There is still the issue of losing `/loader/loader.conf` with SystemD
boot. Maybe we should think about copying other files from previous loader directories.