### PR TITLE
libostree: Add ostree_async_progress_copy_state()

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -3,6 +3,7 @@
 OstreeAsyncProgress
 ostree_async_progress_new
 ostree_async_progress_new_and_connect
+ostree_async_progress_copy_state
 ostree_async_progress_get_status
 ostree_async_progress_get
 ostree_async_progress_get_variant

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -19,6 +19,7 @@
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2019.6 {
+  ostree_async_progress_copy_state;
 } LIBOSTREE_2019.4;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -18,7 +18,7 @@
 ***/
 
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
-LIBOSTREE_2019.5 {
+LIBOSTREE_2019.6 {
 } LIBOSTREE_2019.4;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-async-progress.h
+++ b/src/libostree/ostree-async-progress.h
@@ -92,4 +92,8 @@ void ostree_async_progress_set_variant (OstreeAsyncProgress *self,
 _OSTREE_PUBLIC
 void ostree_async_progress_finish (OstreeAsyncProgress *self);
 
+_OSTREE_PUBLIC
+void ostree_async_progress_copy_state (OstreeAsyncProgress *self,
+                                       OstreeAsyncProgress *dest);
+
 G_END_DECLS


### PR DESCRIPTION
This allows copying the state from one OstreeAsyncProgress object to
another, atomically, without invoking the callback. This is needed in
libflatpak, in order to chain OstreeAsyncProgress objects so that you
can still receive progress updates when iterating a different
GMainContext than the one that the OstreeAsyncProgress object was
created under.