### PR TITLE
Makefile: declare ostree_boot_SCRIPTS and append values

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -60,7 +60,7 @@ grub2configdir = $(sysconfdir)/grub.d
 INSTALL_DATA_HOOKS += install-grub2-config-hook
 else
 # We're using our internal generator
-ostree_boot_SCRIPTS = src/boot/grub2/ostree-grub-generator
+ostree_boot_SCRIPTS += src/boot/grub2/ostree-grub-generator
 endif
 
 EXTRA_DIST += src/boot/dracut/module-setup.sh \

--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -47,6 +47,7 @@ typelibdir = $(libdir)/girepository-1.0
 typelib_DATA =
 gsettings_SCHEMAS =
 ostree_bootdir = $(prefix)/lib/ostree
+ostree_boot_SCRIPTS =
 ostree_boot_PROGRAMS =
 
 # This initializes some more variables

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -42,7 +42,7 @@ if BUILDOPT_USE_STATIC_COMPILER
 # to get autotools to install this as an executable but without generating rules
 # to make it itself which we have specified manually.  See
 # https://lists.gnu.org/archive/html/help-gnu-utils/2007-01/msg00007.html
-ostree_boot_SCRIPTS = ostree-prepare-root
+ostree_boot_SCRIPTS += ostree-prepare-root
 
 ostree-prepare-root : $(ostree_prepare_root_SOURCES)
 	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES) -DOSTREE_PREPARE_ROOT_STATIC=1


### PR DESCRIPTION
ostree_boot_SCRIPTS was being set on both Makefile-boot.am and
Makefile-switchroot.am, causing the first one to be replaced by the
other at the final Makefile, so declare as empty and append on both
places instead.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>