### PR TITLE
lib/keyfile: Treat "group not found" the same as "key not found"

### DIFF
--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -27,6 +27,13 @@
 
 #include <string.h>
 
+static gboolean
+is_notfound (GError *error)
+{
+  return g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)
+          || g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND);
+}
+
 gboolean
 ot_keyfile_get_boolean_with_default (GKeyFile      *keyfile,
                                      const char    *section,
@@ -43,7 +50,7 @@ ot_keyfile_get_boolean_with_default (GKeyFile      *keyfile,
   gboolean ret_bool = g_key_file_get_boolean (keyfile, section, value, &temp_error);
   if (temp_error)
     {
-      if (g_error_matches (temp_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+      if (is_notfound (temp_error))
         {
           g_clear_error (&temp_error);
           ret_bool = default_value;
@@ -75,7 +82,7 @@ ot_keyfile_get_value_with_default (GKeyFile      *keyfile,
   g_autofree char *ret_value = g_key_file_get_value (keyfile, section, value, &temp_error);
   if (temp_error)
     {
-      if (g_error_matches (temp_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+      if (is_notfound (temp_error))
         {
           g_clear_error (&temp_error);
           g_assert (ret_value == NULL);
@@ -206,8 +213,7 @@ ot_keyfile_get_string_list_with_default (GKeyFile      *keyfile,
 
   if (temp_error)
     {
-      if (g_error_matches (temp_error, G_KEY_FILE_ERROR,
-                           G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+      if (is_notfound (temp_error))
         {
           g_clear_error (&temp_error);
           ret_value = g_strdupv (default_value);

--- a/tests/test-keyfile-utils.c
+++ b/tests/test-keyfile-utils.c
@@ -60,12 +60,12 @@ test_get_boolean_with_default (void)
   g_assert_true (out);
 
   g_clear_error (&error);
-  g_assert_false (ot_keyfile_get_boolean_with_default (g_keyfile,
-                                                       "a_fake_section",
-                                                       "a_boolean_true",
-                                                       FALSE,
-                                                       &out,
-                                                       &error));
+  g_assert (ot_keyfile_get_boolean_with_default (g_keyfile,
+                                                 "a_fake_section",
+                                                 "a_boolean_true",
+                                                 FALSE,
+                                                 &out,
+                                                 &error));
 }
 
 static void
@@ -122,13 +122,13 @@ test_get_value_with_default (void)
   g_assert_cmpstr (out, ==, "correct");
   g_clear_pointer (&out, g_free);
 
-  g_assert_false (ot_keyfile_get_value_with_default (g_keyfile,
-                                                     "a_fake_section",
-                                                     "a_value_true",
-                                                     "no value",
-                                                     &out,
-                                                     &error));
-  g_clear_error (&error);
+  g_assert (ot_keyfile_get_value_with_default (g_keyfile,
+                                               "a_fake_section",
+                                               "a_value_true",
+                                               "no value",
+                                               &out,
+                                               &error));
+  g_assert_cmpstr (out, ==, "no value");
   g_clear_pointer (&out, g_free);
 }
 


### PR DESCRIPTION
Prep for fsverity, where I want to create a new group
`[fsverity]` in the keyfile that has default values.  We should
treat the absence of a group the same as absence of a key
in these "with defaults" APIs.