### PR TITLE
build: create tests directory for split builds

### DIFF
--- a/buildutil/glib-tap.mk
+++ b/buildutil/glib-tap.mk
@@ -116,6 +116,7 @@ installed_testcases = $(test_programs) $(installed_test_programs) \
 installed_test_meta_DATA = $(installed_testcases:=.test)
 
 %.test: %$(EXEEXT) Makefile
+	@$(MKDIR_P) $(dir $@)
 	$(AM_V_GEN) (echo '[Test]' > $@.tmp; \
 	echo 'Type=session' >> $@.tmp; \
 	echo 'Exec=env G_TEST_SRCDIR=$(installed_testdir) G_TEST_BUILDDIR=$(installed_testdir) $(installed_testdir)/$(notdir $<)' >> $@.tmp; \


### PR DESCRIPTION
When `--disable-dependency-tracking` is in effect with separate build
directory, the tests directory isn't created as a result of the
dependency generation, which leads to a build race for the tests
directory being created and failures:
```
  Making all in .
  make[2]: Entering directory 'TOPDIR/build/tmp/work/riscv64-yoe-linux-musl/ostree/2019.5-r0/build'
  (echo '[Test]' > tests/test-local-pull-depth.sh.test.tmp; \
  echo 'Type=session' >> tests/test-local-pull-depth.sh.test.tmp; \
  echo 'Exec=env G_TEST_SRCDIR=/usr/libexec/installed-tests/libostree G_TEST_BUILDDIR=/usr/libexec/installed-tests/libostree /usr/libexec/installed-tests/libostree/test-local-pull-depth.sh' >> tests/test-local-pull-depth.sh.test.tmp; \
  mv tests/test-local-pull-depth.sh.test.tmp tests/test-local-pull-depth.sh.test)
  /bin/sh: tests/test-local-pull-depth.sh.test.tmp: No such file or directory
  /bin/sh: line 1: tests/test-local-pull-depth.sh.test.tmp: No such file or directory
  /bin/sh: line 2: tests/test-local-pull-depth.sh.test.tmp: No such file or directory
  mv: cannot stat 'tests/test-local-pull-depth.sh.test.tmp': No such file or directory
  make[2]: *** [Makefile:9282: tests/test-local-pull-depth.sh.test] Error 1
```
Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>