### PR TITLE
Don't copy summary for collection-ref mirror subset pulls

### DIFF
--- a/man/ostree-find-remotes.xml
+++ b/man/ostree-find-remotes.xml
@@ -116,6 +116,16 @@ Boston, MA 02111-1307, USA.
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--mirror</option></term>
+
+                <listitem><para>
+                  Do a mirror pull (see the documentation for
+                  <command>ostree pull --mirror</command>). This option can
+                  only be used in combination with <option>--pull</option>.
+                </para></listitem>
+            </varlistentry>
+
         </variablelist>
     </refsect1>
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4567,7 +4567,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         }
     }
 
-  if (pull_data->is_mirror && pull_data->summary_data && !refs_to_fetch && !configured_branches)
+  if (pull_data->is_mirror && pull_data->summary_data &&
+      !refs_to_fetch && !opt_collection_refs_set && !configured_branches)
     {
       GLnxFileReplaceFlags replaceflag =
         pull_data->repo->disable_fsync ? GLNX_FILE_REPLACE_NODATASYNC : 0;


### PR DESCRIPTION
Spotted this bug from reading the code; I haven't seen it in the wild.