### PR TITLE
Avoid race condition when building outside of source tree

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -123,6 +123,7 @@ ostree_SOURCES += src/ostree/ot-remote-builtin-add-cookie.c \
 endif
 
 src/ostree/parse-datetime.c: src/ostree/parse-datetime.y Makefile
+	mkdir -p src/ostree/
 	$(AM_V_GEN) $(YACC) $< -o $@
 
 EXTRA_DIST += src/ostree/parse-datetime.y


### PR DESCRIPTION
When building outside of source tree it can happen that src/ostree/
does not exist (yet) when bison is called. This leads to an build
error like so:
  bison: src/ostree/parse-datetime.c: cannot open: No such file or directory

Make sure that src/ostree/ exists when parse-datetime.c is built.