### PR TITLE
lib/repo: Create repo directories as 0775

### DIFF
--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -30,6 +30,12 @@ G_BEGIN_DECLS
 /* It's what gzip does, 9 is too slow */
 #define OSTREE_ARCHIVE_DEFAULT_COMPRESSION_LEVEL (6)
 
+/* Note the permissive group bits. We want to be liberal here and let individual machines
+ * narrow permissions as needed via umask. This is important in setups where group ownership
+ * can matter for repo management (like OpenShift). */
+#define DEFAULT_DIRECTORY_MODE 0775
+#define DEFAULT_REGFILE_MODE 0660
+
 /* This file contains private implementation data format definitions
  * read by multiple implementation .c files.
  */

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -92,8 +92,8 @@ checkout_object_for_uncompressed_cache (OstreeRepo      *self,
 
   if (self->uncompressed_objects_dir_fd == -1)
     {
-      if (!glnx_shutil_mkdir_p_at (self->repo_dir_fd, "uncompressed-objects-cache", 0755,
-                                   cancellable, error))
+      if (!glnx_shutil_mkdir_p_at (self->repo_dir_fd, "uncompressed-objects-cache",
+                                   DEFAULT_DIRECTORY_MODE, cancellable, error))
         return FALSE;
       if (!glnx_opendirat (self->repo_dir_fd, "uncompressed-objects-cache", TRUE,
                            &self->uncompressed_objects_dir_fd,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2925,7 +2925,7 @@ _ostree_repo_cache_summary (OstreeRepo        *self,
   if (self->cache_dir_fd == -1)
     return TRUE;
 
-  if (!glnx_shutil_mkdir_p_at (self->cache_dir_fd, _OSTREE_SUMMARY_CACHE_DIR, 0775, cancellable, error))
+  if (!glnx_shutil_mkdir_p_at (self->cache_dir_fd, _OSTREE_SUMMARY_CACHE_DIR, DEFAULT_DIRECTORY_MODE, cancellable, error))
     return FALSE;
 
   const char *summary_cache_file = glnx_strjoina (_OSTREE_SUMMARY_CACHE_DIR, "/", remote);

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -1181,7 +1181,7 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
           char *parent = strdupa (ref->ref_name);
           parent[lastslash - ref->ref_name] = '\0';
 
-          if (!glnx_shutil_mkdir_p_at (dfd, parent, 0755, cancellable, error))
+          if (!glnx_shutil_mkdir_p_at (dfd, parent, DEFAULT_DIRECTORY_MODE, cancellable, error))
             return FALSE;
         }
 

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1427,7 +1427,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
       g_autofree char *dnbuf = g_strdup (descriptor_relpath);
       const char *dn = dirname (dnbuf);
 
-      if (!glnx_shutil_mkdir_p_at (self->repo_dir_fd, dn, 0755, cancellable, error))
+      if (!glnx_shutil_mkdir_p_at (self->repo_dir_fd, dn, DEFAULT_DIRECTORY_MODE, cancellable, error))
         goto out;
       if (!glnx_opendirat (self->repo_dir_fd, dn, TRUE, &descriptor_dfd, error))
         goto out;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -357,7 +357,7 @@ push_repo_lock (OstreeRepo          *self,
       g_debug ("Opening repo lock file");
       lock->fd = TEMP_FAILURE_RETRY (openat (self->repo_dir_fd, ".lock",
                                              O_CREAT | O_RDWR | O_CLOEXEC,
-                                             0600));
+                                             DEFAULT_REGFILE_MODE));
       if (lock->fd < 0)
         {
           free_repo_lock (lock);
@@ -2489,7 +2489,7 @@ repo_create_at_internal (int             dfd,
       }
   }
 
-  if (mkdirat (dfd, path, 0755) != 0)
+  if (mkdirat (dfd, path, DEFAULT_DIRECTORY_MODE) != 0)
     {
       if (G_UNLIKELY (errno != EEXIST))
         return glnx_throw_errno_prefix (error, "mkdirat");
@@ -2527,7 +2527,7 @@ repo_create_at_internal (int             dfd,
   for (guint i = 0; i < G_N_ELEMENTS (state_dirs); i++)
     {
       const char *elt = state_dirs[i];
-      if (mkdirat (repo_dfd, elt, 0755) == -1)
+      if (mkdirat (repo_dfd, elt, DEFAULT_DIRECTORY_MODE) == -1)
         {
           if (G_UNLIKELY (errno != EEXIST))
             return glnx_throw_errno_prefix (error, "mkdirat");
@@ -3295,7 +3295,7 @@ ostree_repo_open (OstreeRepo    *self,
        *
        * https://github.com/ostreedev/ostree/issues/1018
        */
-      if (mkdirat (self->repo_dir_fd, "tmp", 0755) == -1)
+      if (mkdirat (self->repo_dir_fd, "tmp", DEFAULT_DIRECTORY_MODE) == -1)
         {
           if (G_UNLIKELY (errno != EEXIST))
             return glnx_throw_errno_prefix (error, "mkdir(tmp)");
@@ -3307,7 +3307,7 @@ ostree_repo_open (OstreeRepo    *self,
 
   if (self->writable)
     {
-      if (!glnx_shutil_mkdir_p_at (self->tmp_dir_fd, _OSTREE_CACHE_DIR, 0775, cancellable, error))
+      if (!glnx_shutil_mkdir_p_at (self->tmp_dir_fd, _OSTREE_CACHE_DIR, DEFAULT_DIRECTORY_MODE, cancellable, error))
         return FALSE;
 
       if (!glnx_opendirat (self->tmp_dir_fd, _OSTREE_CACHE_DIR, TRUE, &self->cache_dir_fd, error))
@@ -6099,7 +6099,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
     {
       g_auto(GLnxTmpDir) new_tmpdir = { 0, };
       /* No existing tmpdir found, create a new */
-      if (!glnx_mkdtempat (tmpdir_dfd, tmpdir_name_template, 0755,
+      if (!glnx_mkdtempat (tmpdir_dfd, tmpdir_name_template, DEFAULT_DIRECTORY_MODE,
                            &new_tmpdir, error))
         return FALSE;
 


### PR DESCRIPTION
For repo structure directories like `objects`, `refs`, etc... we should
be more permissive and let the system's `umask` narrow down the
permission bits as wanted.

This came up in a context where we want to be able to have read/write
access on an OSTree repo on NFS from two separate OpenShift apps by
using supplemental groups[1] so we don't require SCCs for running as the
same UID (supplemental groups are part of the default restricted SCC).

[1] https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/persistent_storage_nfs.html#nfs-supplemental-groups