### PR TITLE
Skip /var test if running with systemd and libmount

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -533,6 +533,7 @@ dnl If we have both, we use the "new /var" model with ostree-system-generator
 AM_CONDITIONAL(BUILDOPT_SYSTEMD_AND_LIBMOUNT,[test x$with_systemd = xyes && test x$with_libmount = xyes])
 AM_COND_IF(BUILDOPT_SYSTEMD_AND_LIBMOUNT,
   AC_DEFINE([BUILDOPT_LIBSYSTEMD_AND_LIBMOUNT], 1, [Define if systemd and libmount]))
+if test x$with_systemd != xno; then OSTREE_FEATURES="$OSTREE_FEATURES systemd"; fi
 
 AC_ARG_WITH(builtin-grub2-mkconfig,
             AS_HELP_STRING([--with-builtin-grub2-mkconfig],

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -559,6 +559,18 @@ skip_without_user_xattrs () {
     fi
 }
 
+_have_systemd_and_libmount=''
+have_systemd_and_libmount() {
+    if test "${_have_systemd_and_libmount}" = ''; then
+        if [ $(ostree --version | grep -c -e '- systemd' -e '- libmount') -eq 2 ]; then
+            _have_systemd_and_libmount=yes
+        else
+            _have_systemd_and_libmount=no
+        fi
+    fi
+    test ${_have_systemd_and_libmount} = yes
+}
+
 # Skip unless SELinux is disabled, or we can relabel.
 # Default Docker has security.selinux xattrs, but returns
 # EOPNOTSUPP when trying to set them, even to the existing value.

--- a/tests/test-switchroot.sh
+++ b/tests/test-switchroot.sh
@@ -56,7 +56,7 @@ find_in_env() {
 		"$1" "$tmpdir"
 		enter_fs "$tmpdir"
 		ostree-prepare-root /sysroot
-		find /
+		find / \( -path /proc -o -path /sysroot/proc \) -prune -o -print
 		touch /usr/usr_writable 2>/null \
 			&& echo "/usr is writable" \
 			|| echo "/usr is not writable"

--- a/tests/test-switchroot.sh
+++ b/tests/test-switchroot.sh
@@ -82,7 +82,9 @@ test_that_prepare_root_sets_sysroot_up_correctly_with_initrd() {
 	grep -qx "/this_is_bootfs" files
 	grep -qx "/sysroot/this_is_ostree_root" files
 	grep -qx "/sysroot/sysroot/this_is_real_root" files
-	grep -qx "/sysroot/var/this_is_ostree_var" files
+	if ! have_systemd_and_libmount; then
+		grep -qx "/sysroot/var/this_is_ostree_var" files
+	fi
 	grep -qx "/sysroot/usr/this_is_ostree_usr" files
 
 	grep -qx "/sysroot/usr is not writable" files
@@ -101,7 +103,9 @@ test_that_prepare_root_sets_root_up_correctly_with_no_initrd() {
 	grep -qx "/this_is_ostree_root" files
 	grep -qx "/sysroot/this_is_bootfs" files
 	grep -qx "/sysroot/this_is_real_root" files
-	grep -qx "/var/this_is_ostree_var" files
+	if ! have_systemd_and_libmount; then
+		grep -qx "/var/this_is_ostree_var" files
+	fi
 	grep -qx "/usr/this_is_ostree_usr" files
 
 	grep -qx "/usr is not writable" files


### PR DESCRIPTION
If running with systemd and libmount then /var mounting is deferred for systemd. Skip the relevant tests in this case as it will always fail.

Fixes: #1983 