### PR TITLE
tests/core: Really pick C.UTF-8 locale

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -41,7 +41,7 @@ assert_not_reached () {
 # If we can't find the locale command assume we have support for C.UTF-8
 # (e.g. musl based systems)
 if type -p locale >/dev/null; then
-    export LC_ALL=$(locale -a | grep -Ee '\.(UTF-8|utf8)' | grep -iEe '^(C|en_US)' | head -1 || true)
+    export LC_ALL=$(locale -a | grep -iEe '^(C|en_US)\.(UTF-8|utf8)$' | head -n1 || true)
     if [ -z "${LC_ALL}" ]; then fatal "Can't find suitable UTF-8 locale"; fi
 else
     export LC_ALL=C.UTF-8


### PR DESCRIPTION
The case-ignoring regex `^(C|en_US)` will match any locale that starts
with `c`. On my system this is `ca_AD.utf8`, which breaks the test
suite. Instead, use a single regex that includes the joining `.` rather
than 2 separate regexes. This also changes `head` to use the `-n`
option, which has been preferred for at least 10 years in the coreutils
version and is supported by busybox as well.