### PR TITLE
build: fix systemd feature advertisement

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -214,7 +214,7 @@ libostree_1_la_CFLAGS += $(OT_DEP_AVAHI_CFLAGS)
 libostree_1_la_LIBADD += $(OT_DEP_AVAHI_LIBS)
 endif
 
-if BUILDOPT_LIBSYSTEMD
+if BUILDOPT_SYSTEMD
 libostree_1_la_CFLAGS += $(LIBSYSTEMD_CFLAGS)
 libostree_1_la_LIBADD += $(LIBSYSTEMD_LIBS)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -509,10 +509,8 @@ AS_IF([ test x$with_libsystemd != xno ], [
         with_libsystemd=no
     ])
 ], [ with_libsystemd=no ])
-AM_CONDITIONAL(BUILDOPT_LIBSYSTEMD, test $with_libsystemd != no)
 
-AS_IF([test "x$have_libsystemd" = "xyes"], [
-  with_systemd=yes
+AS_IF([test "x$with_libsystemd" = "xyes"], [
   AC_ARG_WITH([systemdsystemunitdir],
               AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
               [],
@@ -528,12 +526,12 @@ AS_IF([test "x$have_libsystemd" = "xyes"], [
     AC_SUBST([systemdsystemgeneratordir], [$with_systemdsystemgeneratordir])
   ])
 ])
-AM_CONDITIONAL(BUILDOPT_SYSTEMD, test x$with_systemd = xyes)
+AM_CONDITIONAL(BUILDOPT_SYSTEMD, test x$with_libsystemd = xyes)
 dnl If we have both, we use the "new /var" model with ostree-system-generator
-AM_CONDITIONAL(BUILDOPT_SYSTEMD_AND_LIBMOUNT,[test x$with_systemd = xyes && test x$with_libmount = xyes])
+AM_CONDITIONAL(BUILDOPT_SYSTEMD_AND_LIBMOUNT,[test x$with_libsystemd = xyes && test x$with_libmount = xyes])
 AM_COND_IF(BUILDOPT_SYSTEMD_AND_LIBMOUNT,
   AC_DEFINE([BUILDOPT_LIBSYSTEMD_AND_LIBMOUNT], 1, [Define if systemd and libmount]))
-if test x$with_systemd != xno; then OSTREE_FEATURES="$OSTREE_FEATURES systemd"; fi
+if test x$with_libsystemd = xyes; then OSTREE_FEATURES="$OSTREE_FEATURES systemd"; fi
 
 AC_ARG_WITH(builtin-grub2-mkconfig,
             AS_HELP_STRING([--with-builtin-grub2-mkconfig],
@@ -621,7 +619,7 @@ echo "
     \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
     SELinux:                                      $with_selinux
     cryptographic checksums:                      $with_crypto
-    systemd:                                      $have_libsystemd
+    systemd:                                      $with_libsystemd
     libmount:                                     $with_libmount
     libarchive (parse tar files directly):        $with_libarchive
     static deltas:                                yes (always enabled now)


### PR DESCRIPTION
17db0f15a798 ("configure: add option for libsystemd") exposed
--without-libsystemd to allow systemd to be disabled even if the systemd
pkgconfig script was present, introducing a new variable
with_libsystemd; there are now three, almost identical variables:

- with_libsystemd [yes, no, maybe] - controlled by --without-libsystemd,
  resolved into yes/no by the initial checks
- have_libsystemd [yes, no, <undefined>] - only set if with_libsystemd
  is yes/maybe, otherwise undefined
- with_systemd [yes, <undefined>] - yes if have_systemd is yes,
  otherwise undefined

with_systemd is the earliest variable and was previously set by a set of
checks for dracut and mkinitcpio. These checks were changed for a
systemd check in 9e2763106be0 ("lib: Use sd_journal directly
(optionally)"). This commit also introduced BUILDOPT_LIBSYSTEMD, which
will always match BUILDOPT_SYSTEMD.

Fix the confusion by removing with_systemd which will always be yes when
with_libsystemd=yes, or undefined if with_libsystemd=no. We can ignore
the with_libsystemd=maybe case because it will always be resolved into
yes/no before with_systemd is set.

And replace all uses of BUILDOPT_SYSTEMD with BUILDOPT_LIBSYSTEMD, since
they again always match.

This fixes both the advertised features and the summary output when
systemd is disabled by using with_libsystemd which is always defined.

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
Fixes: 5c62a7e4d0a5 ("build: Expose systemd in OSTREE_FEATURES")
Fixes: 17db0f15a798 ("configure: add option for libsystemd")
Supersedes: #1992