### PR TITLE
docs: Fix 'package layering' rpm-ostree link

### DIFF
--- a/docs/manual/adapting-existing.md
+++ b/docs/manual/adapting-existing.md
@@ -166,7 +166,7 @@ Then to actually deploy this tree for the next boot:
 `ostree admin deploy $osname/$releasename/$description`
 
 This is essentially what [rpm-ostree](https://github.com/projectatomic/rpm-ostree/)
-does to support its [package layering model](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#package-layering).
+does to support its [package layering model](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#hybrid-imagepackaging-via-package-layering).
 
 ###### Licensing for this document:
 `SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later)`


### PR DESCRIPTION
The referenced fragment name has changed in the published rpm-ostree docs.
Fix it.

Also, it seems ostree's readthedocs content is out of date, b35f337dc7c
is from May 2019 but the published content doesn't contain that fix