### PR TITLE
deploy: Avoid trying to change immutable state unnecessarily

### DIFF
--- a/src/libostree/ostree-linuxfsutil.c
+++ b/src/libostree/ostree-linuxfsutil.c
@@ -68,6 +68,10 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
     }
   else
     {
+      gboolean prev_immutable_state = (flags & EXT2_IMMUTABLE_FL) > 0;
+      if (prev_immutable_state == new_immutable_state)
+        return TRUE;  /* Nothing to do */
+
       if (new_immutable_state)
         flags |= EXT2_IMMUTABLE_FL;
       else


### PR DESCRIPTION
For some reason I haven't fully debugged (probably a recent
kernel change), in the case where the immutable bit isn't set,
trying to call `EXT2_IOC_SETFLAGS` without it set returns `EINVAL`.

Let's avoid calling the `ioctl()` if we don't have anything to do.

This fixes a slew of `make check` failures here in my toolbox
environment.

(kernel is `5.5.0-0.rc6.git0.1.fc32.x86_64` with `xfs`)