### PR TITLE
lib: Fix Since versions for 2020.1

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2445,7 +2445,7 @@ G_DEFINE_BOXED_TYPE (OstreeCommitSizesEntry, ostree_commit_sizes_entry,
  * commit's "ostree.sizes" metadata.
  *
  * Returns: (transfer full) (nullable): a new #OstreeCommitSizesEntry
- * Since: 2019.7
+ * Since: 2020.1
  */
 OstreeCommitSizesEntry *
 ostree_commit_sizes_entry_new (const gchar      *checksum,
@@ -2471,7 +2471,7 @@ ostree_commit_sizes_entry_new (const gchar      *checksum,
  * Create a copy of the given @entry.
  *
  * Returns: (transfer full) (nullable): a new copy of @entry
- * Since: 2019.7
+ * Since: 2020.1
  */
 OstreeCommitSizesEntry *
 ostree_commit_sizes_entry_copy (const OstreeCommitSizesEntry *entry)
@@ -2490,7 +2490,7 @@ ostree_commit_sizes_entry_copy (const OstreeCommitSizesEntry *entry)
  *
  * Free given @entry.
  *
- * Since: 2019.7
+ * Since: 2020.1
  */
 void
 ostree_commit_sizes_entry_free (OstreeCommitSizesEntry *entry)
@@ -2572,7 +2572,7 @@ read_sizes_entry (GVariant                *entry,
  * the "ostree.sizes" metadata, a %G_IO_ERROR_NOT_FOUND error will be
  * returned.
  *
- * Since: 2019.7
+ * Since: 2020.1
  */
 gboolean
 ostree_commit_get_object_sizes (GVariant   *commit_variant,

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -531,7 +531,7 @@ gchar *  ostree_commit_get_content_checksum  (GVariant  *commit_variant);
  * Structure representing an entry in the "ostree.sizes" commit metadata. Each
  * entry corresponds to an object in the associated commit.
  *
- * Since: 2019.5
+ * Since: 2020.1
  */
 typedef struct {
   gchar *checksum;

--- a/src/libostree/ostree-gpg-verify-result.h
+++ b/src/libostree/ostree-gpg-verify-result.h
@@ -159,11 +159,11 @@ gboolean ostree_gpg_verify_result_require_valid_signature (OstreeGpgVerifyResult
  * @OSTREE_GPG_ERROR_NO_SIGNATURE: A signature was expected, but not found.
  * @OSTREE_GPG_ERROR_INVALID_SIGNATURE: A signature was malformed.
  * @OSTREE_GPG_ERROR_MISSING_KEY: A signature was found, but was created with a key not in the configured keyrings.
- * @OSTREE_GPG_ERROR_EXPIRED_SIGNATURE: A signature was expired. Since: 2019.7.
+ * @OSTREE_GPG_ERROR_EXPIRED_SIGNATURE: A signature was expired. Since: 2020.1.
  * @OSTREE_GPG_ERROR_EXPIRED_KEY: A signature was found, but the key used to
- *   sign it has expired. Since: 2019.7.
+ *   sign it has expired. Since: 2020.1.
  * @OSTREE_GPG_ERROR_REVOKED_KEY: A signature was found, but the key used to
- *   sign it has been revoked. Since: 2019.7.
+ *   sign it has been revoked. Since: 2020.1.
  *
  * Errors returned by signature creation and verification operations in OSTree.
  * These may be returned by any API which creates or verifies signatures.

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -242,7 +242,7 @@ ostree_sysroot_new_default (void)
  * If you invoke this function, it must be before ostree_sysroot_load(); it may
  * be invoked before or after ostree_sysroot_initialize().
  *
- * Since: 2019.7
+ * Since: 2020.1
  */
 void
 ostree_sysroot_set_mount_namespace_in_use (OstreeSysroot  *self)
@@ -341,7 +341,7 @@ ostree_sysroot_get_fd (OstreeSysroot *self)
  * Can only be invoked after `ostree_sysroot_initialize()`.
  * 
  * Returns: %TRUE iff the sysroot points to a booted deployment
- * Since: 2019.7
+ * Since: 2020.1
  */
 gboolean
 ostree_sysroot_is_booted (OstreeSysroot *self)
@@ -890,7 +890,7 @@ ensure_repo (OstreeSysroot  *self,
  * It is not necessary to call this function if ostree_sysroot_load() is
  * invoked.
  *
- * Since: 2019.7
+ * Since: 2020.1
  */
 gboolean
 ostree_sysroot_initialize (OstreeSysroot  *self,


### PR DESCRIPTION
These had been added assuming 2019.7 would be the next version, but now
it's 2020 and there's been a release. In the case of
`OstreeCommitSizesEntry`, I'd forgotten to move it forward from 2019.5
to 2019.7 in the time between when I started working on the feature and
it landed.