### PR TITLE
Release 2020.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,10 @@ dnl Seed the release notes with `git-shortlog-with-prs <previous-release>..`. Th
 dnl `git-evtag` to create the tag and push it. Finally, create a GitHub release and attach
 dnl the tarball from `make dist`.
 m4_define([year_version], [2020])
-m4_define([release_version], [2])
+m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.63])
 dnl To do a release: follow the instructions to update libostree-released.sym from
 dnl libostree-devel.sym, update the checksum in test-symbols.sh, set is_release_build=yes
 dnl below. Then make another post-release commit to bump the version and set
-dnl is_release_build=no
+dnl is_release_build=yes
 dnl Seed the release notes with `git-shortlog-with-prs <previous-release>..`. Then use
 dnl `git-evtag` to create the tag and push it. Finally, create a GitHub release and attach
 dnl the tarball from `make dist`.
@@ -10,7 +10,7 @@ m4_define([year_version], [2020])
 m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -593,6 +593,8 @@ global:
   ostree_sysroot_set_mount_namespace_in_use;
 } LIBOSTREE_2019.6;
 
+/* No new symbols in 2020.2 */
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-8c4daff9ed94369cf5c113af9758ee4315ac8593aade7073e875b7c5f066b26b  ${released_syms}
+dd16acf1370f9b4ecd77d4eb7c4b45548b249f33f629d3147ddc9d264bd32e41  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
"Brown paper bag" release that actually sets the
`is_release_build=yes` flag and also fixes the
`Since:` on a few new functions.