### PR TITLE
ci: migrate to new coreos-ci project

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,47 +1,40 @@
-// See https://github.com/jlebon/coreos-ci
-// This was originally copied from the rpm-ostree one
-@Library('github.com/coreos/coreos-ci-lib@master') _
-
-COSA_IMAGE = 'quay.io/coreos-assembler/coreos-assembler:latest'
-COSA_BUILDROOT_IMAGE = 'registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest'
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
 stage("Build") {
 parallel normal: {
-  coreos.pod(image: COSA_BUILDROOT_IMAGE, runAsUser: 0) {
+  cosaPod(buildroot: true, runAsUser: 0) {
       checkout scm
       stage("Core build") {
-      sh """
-        set -xeuo pipefail
-        # fetch tags so `git describe` gives a nice NEVRA when building the RPM
-        git fetch origin --tags
-        git submodule update --init
+        shwrap("""
+          # fetch tags so `git describe` gives a nice NEVRA when building the RPM
+          git fetch origin --tags
+          git submodule update --init
 
-        env SKIP_INSTALLDEPS=1 ./ci/build.sh
-      """
+          env SKIP_INSTALLDEPS=1 ./ci/build.sh
+        """)
       }
       stage("Unit tests") {
-      try {
-        sh """
-        make check
-        make syntax-check
-        """
-      } finally {
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'test-suite.log'
+        try {
+          shwrap("""
+            make check
+            make syntax-check
+          """)
+        } finally {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'test-suite.log'
+        }
       }
-      }
-      sh """
+      shwrap("""
         make install DESTDIR=\$(pwd)/insttree/
         tar -c -C insttree/ -zvf insttree.tar.gz .
-      """
+      """)
       stash includes: 'insttree.tar.gz', name: 'build'
   }
 },
 // A minimal build, helps test our build options
 minimal: {
-  coreos.pod(image: COSA_BUILDROOT_IMAGE, runAsUser: 0) {
+  cosaPod(buildroot: true, runAsUser: 0) {
       checkout scm
-      sh """
-        set -xeuo pipefail
+      shwrap("""
         git submodule update --init
 
         env NOCONFIGURE=1 ./autogen.sh
@@ -50,19 +43,18 @@ minimal: {
           --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
           --disable-experimental-api
         make
-      """
+      """)
   }
 },
 codestyle: {
-  coreos.pod(image: COSA_IMAGE) {
+  cosaPod {
       checkout scm
-      sh """
-        set -xeuo pipefail
+      shwrap("""
         # Jenkins by default only fetches the branch it's testing. Explicitly fetch master
         # for ci-commitmessage-submodules.sh
         git fetch origin +refs/heads/master:refs/remotes/origin/master
         ci/ci-commitmessage-submodules.sh
-      """
+      """)
   }
 }
 }
@@ -70,12 +62,11 @@ codestyle: {
 // Build FCOS and do a kola basic run
 stage("More builds and test") {
 parallel fcos: {
-  coreos.pod(image: COSA_IMAGE, runAsUser: 0, kvm: true, memory: "2048Mi", cpu: "2") {
+  cosaPod(runAsUser: 0, memory: "2048Mi", cpu: "2") {
     stage("Build FCOS") {
       checkout scm
       unstash 'build'
-      sh """
-        set -xeuo pipefail
+      shwrap("""
         mkdir insttree
         tar -C insttree -xzvf insttree.tar.gz
         rsync -rlv insttree/ /
@@ -84,23 +75,19 @@ parallel fcos: {
         mv insttree/* overrides/rootfs/
         rmdir insttree
         coreos-assembler build
-      """
+      """)
     }
     stage("FCOS basic") {
       timeout(time: 30, unit: 'MINUTES') {
-        sh """
-          set -xeuo pipefail
-          cosa kola run --basic-qemu-scenarios
-        """
+        shwrap("cosa kola run --basic-qemu-scenarios")
       }
     }
   }
 },
 buildopts: {
-  coreos.pod(image: COSA_BUILDROOT_IMAGE, runAsUser: 0) {
+  cosaPod(buildroot: true, runAsUser: 0) {
       checkout scm
-      sh """
-        set -xeuo pipefail
+      shwrap("""
         git submodule update --init
 
         git worktree add build-rust && cd build-rust
@@ -112,7 +99,7 @@ buildopts: {
         env CONFIGOPTS="--without-curl --without-openssl --with-soup" SKIP_INSTALLDEPS=1 ./ci/build.sh
         make check
         cd .. && rm -rf build-libsoup
-      """
+      """)
   }
 }
 }


### PR DESCRIPTION
Use the new custom steps. I think we could simplify things further by
using `fcosBuild` but let's start with this for now.