### PR TITLE
ci: use `fcosKola` for running kola tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -77,20 +77,7 @@ parallel fcos: {
         coreos-assembler build
       """)
     }
-    stage("FCOS basic") {
-      timeout(time: 30, unit: 'MINUTES') {
-        shwrap("cosa kola run --basic-qemu-scenarios")
-      }
-    }
-    stage("FCOS upgrades") {
-      timeout(time: 30, unit: 'MINUTES') {
-        shwrap("""
-          cosa kola --upgrades --no-test-exit-error
-          tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
-          """)
-        archiveArtifacts "kola-run-upgrade.tar.xz"
-      }
-    }
+    fcosKola("${env.WORKSPACE}")
   }
 },
 buildopts: {


### PR DESCRIPTION
We were using `--no-test-exit-error` for upgrade tests but weren't
actually checking for test failures after.

Instead of running kola directly, just use the `fcosKola` custom step
which automatically takes care of e.g. running tests in parallel and
archiving results.