### PR TITLE
lib/pull: Don't leave commits pulled by depth as partial

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4719,6 +4719,13 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           if (!ostree_repo_mark_commit_partial (pull_data->repo, commit, FALSE, error))
             goto out;
         }
+
+      /* and finally any parent commits we might also have pulled because of depth>0 */
+      GLNX_HASH_TABLE_FOREACH (pull_data->commit_to_depth, const char*, commit)
+        {
+          if (!ostree_repo_mark_commit_partial (pull_data->repo, commit, FALSE, error))
+            goto out;
+        }
     }
 
   ret = TRUE;

--- a/tests/test-local-pull-depth.sh
+++ b/tests/test-local-pull-depth.sh
@@ -34,21 +34,31 @@ ostree_repo_init repo2 --mode="archive"
 ${CMD_PREFIX} ostree --repo=repo2 pull-local repo
 find repo2/objects -name '*.commit' | wc -l > commitcount
 assert_file_has_content commitcount "^1$"
+find repo2/state -name '*.commitpartial' | wc -l > commitpartialcount
+assert_file_has_content commitpartialcount "^0$"
 
 ${CMD_PREFIX} ostree --repo=repo2 pull-local --depth=0 repo
 find repo2/objects -name '*.commit' | wc -l > commitcount
 assert_file_has_content commitcount "^1$"
+find repo2/state -name '*.commitpartial' | wc -l > commitpartialcount
+assert_file_has_content commitpartialcount "^0$"
+
+${CMD_PREFIX} ostree --repo=repo2 pull-local --depth=1 --commit-metadata-only repo
+find repo2/objects -name '*.commit' | wc -l > commitcount
+assert_file_has_content commitcount "^2$"
+find repo2/state -name '*.commitpartial' | wc -l > commitpartialcount
+assert_file_has_content commitpartialcount "^1$"
 
 ${CMD_PREFIX} ostree --repo=repo2 pull-local --depth=1 repo
 find repo2/objects -name '*.commit' | wc -l > commitcount
 assert_file_has_content commitcount "^2$"
-
-${CMD_PREFIX} ostree --repo=repo2 pull-local --depth=1 repo
-find repo2/objects -name '*.commit' | wc -l > commitcount
-assert_file_has_content commitcount "^2$"
+find repo2/state -name '*.commitpartial' | wc -l > commitpartialcount
+assert_file_has_content commitpartialcount "^0$"
 
 ${CMD_PREFIX} ostree --repo=repo2 pull-local --depth=-1 repo
 find repo2/objects -name '*.commit' | wc -l > commitcount
 assert_file_has_content commitcount "^2$"
+find repo2/state -name '*.commitpartial' | wc -l > commitpartialcount
+assert_file_has_content commitpartialcount "^0$"
 
 echo "ok local pull depth"


### PR DESCRIPTION
When pulling full parent commits via e.g. `--depth N`, we weren't
unmarking them as partial in the out path.

Closes: #2035