### PR TITLE
lib/fetcher-util: retry download on G_IO_ERROR_PARTIAL_INPUT

### DIFF
--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -202,6 +202,7 @@ _ostree_fetcher_should_retry_request (const GError *error,
   if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
 #if !GLIB_CHECK_VERSION(2, 44, 0)
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE) ||
 #else


### PR DESCRIPTION
Add G_IO_ERROR_PARTIAL_INPUT to the list of error codes caused by
transient networking errors which lead us to retry the request. When
attempting to install the spotify flatpak you often get the error
message "Connection terminated unexpectedly" and the download of the deb
file fails. In this case, libsoup is setting G_IO_ERROR_PARTIAL_INPUT
and sometimes a subsequent download attempt is successful, so we should
treat it as transient.

Ideally we would behave as wget does in this case and retry the download
picking up where we left off in the file rather than starting over, but
that would require changes to libsoup I think.

Sadly this patch does not fix the flatpak installation of spotify in the
face of such errors, because flatpak doesn't use libostree to download
extra data, but presumably it's possible we could encounter such an
error pulling from an ostree repo, so the patch is still correct.