### PR TITLE
tests/pull-repeated: Bump up retries to match max fails

### DIFF
--- a/tests/test-pull-repeated.sh
+++ b/tests/test-pull-repeated.sh
@@ -92,8 +92,8 @@ pushd ${test_tmpdir}
 ostree_repo_init repo --mode=archive
 ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
 
-# Using 8 network retries gives error rate of <0.5%, when --random-408s=50
-${CMD_PREFIX} ostree --repo=repo pull --mirror origin --network-retries=8 main
+# We limit 408s above to 100, so 100 retries should be enough always.
+${CMD_PREFIX} ostree --repo=repo pull --mirror origin --network-retries=100 main
 echo "Success with big number of network retries"
 
 ${CMD_PREFIX} ostree --repo=repo fsck


### PR DESCRIPTION
This test keeps occasionally failing in CI - as expected, because
we retry 8 times for an object but it's completely possible for
us to hit the <0.5% chance of 50% failure 8 times in a row.

Since the max errors from the server is 100, set retries to the
same thing.