### PR TITLE
grub2: Don't add menu entries if GRUB supports parsing BLS snippets

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -26,6 +26,16 @@ if ! test -d /ostree/repo; then
     exit 0
 fi
 
+# Gracefully exit if the grub2 configuration has BLS enabled,
+# and the installed version has support for the blscfg module.
+# Since there is no need to create menu entries for that case.
+# See: https://src.fedoraproject.org/rpms/grub2/c/7c2bab5e98d
+. /etc/default/grub
+if test -f /boot/grub2/.grub2-blscfg-supported && \
+   test "${GRUB_ENABLE_BLSCFG}" = "true"; then
+   exit 0
+fi
+
 # Make sure we're in the right environment
 if ! test -n "${GRUB_DEVICE}"; then
     echo "This script must be run as a child of grub2-mkconfig" 1>&2


### PR DESCRIPTION
This is another attempt to avoid having duplicated menu entries caused by
GRUB having support to parse BLS snippets and the 15_ostree script adding
menu entries as well.

The previous attempt was in commit 985a1410029 ("grub2: Exit gracefully if
the configuration has BLS enabled") but that lead to users not having menu
entries at all, due having an old GRUB version that was not able to parse
the BLS snippets.

This happened because the GRUB bootloader is never updated in the ESP as
a part of the OSTree upgrade transaction.

The logic is similar to the previous commit, the 15_ostree script exits if
able to determine that the bootloader can parse the BLS snippets directly.

But this time it will not only check that a BLS configuration was enabled,
but also that a /boot/grub2/.grub2-blscfg-supported file exists. This file
has to be created by a component outside of OSTree that also takes care of
updating GRUB to a version that has proper BLS support.