### PR TITLE
lib: Add error prefixing for sysroot load and repo open

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3257,6 +3257,8 @@ ostree_repo_open (OstreeRepo    *self,
                   GCancellable  *cancellable,
                   GError       **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("opening repo", error);
+
   struct stat stbuf;
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -3291,10 +3293,7 @@ ostree_repo_open (OstreeRepo    *self,
       g_assert (self->repodir);
       if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (self->repodir), TRUE,
                            &self->repo_dir_fd, error))
-        {
-          g_prefix_error (error, "%s: ", gs_file_get_path_cached (self->repodir));
-          return FALSE;
-        }
+        return FALSE;
     }
 
   if (!glnx_fstat (self->repo_dir_fd, &stbuf, error))

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1003,6 +1003,7 @@ ostree_sysroot_load_if_changed (OstreeSysroot  *self,
                                 GCancellable   *cancellable,
                                 GError        **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("loading sysroot", error);
   if (!ostree_sysroot_initialize (self, error))
     return FALSE;
 


### PR DESCRIPTION
Noticed this while writing tests for a core `ostree_sysroot_load()`
entrypoint.  And decided to do the same for `ostree_repo_open()`,
and while there also noted we had a duplicate error prefixing
for the open (more recently `glnx_opendirat()` automatically
prefixes with the path).