### PR TITLE
lib: fix typo in function docs

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -1358,7 +1358,7 @@ ostree_repo_finder_avahi_init (OstreeRepoFinderAvahi *self)
 }
 
 /**
- * ostree_repo-finder_avahi_new:
+ * ostree_repo_finder_avahi_new:
  * @context: (transfer none) (nullable): a #GMainContext for processing Avahi
  *    events in, or %NULL to use the current thread-default
  *


### PR DESCRIPTION
Kind of a mild typo, but it caused the Rust bindings generator to produce broken code because the "Since" tag didn't work.