### PR TITLE
lib: Squash two gtk-doc warnings

### DIFF
--- a/src/libostree/ostree-repo-deprecated.h
+++ b/src/libostree/ostree-repo-deprecated.h
@@ -24,8 +24,10 @@
 #include "ostree-core.h"
 #include "ostree-types.h"
 
+#ifndef __GI_SCANNER__
 #ifndef G_GNUC_DEPRECATED_FOR
 # define G_GNUC_DEPRECATED_FOR(x)
+#endif
 #endif
 
 G_BEGIN_DECLS

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -694,7 +694,7 @@ void ostree_repo_commit_modifier_set_sepolicy (OstreeRepoCommitModifier         
 _OSTREE_PUBLIC
 gboolean ostree_repo_commit_modifier_set_sepolicy_from_commit (OstreeRepoCommitModifier              *modifier,
                                                                OstreeRepo                            *repo,
-                                                               const char                            *commit,
+                                                               const char                            *rev,
                                                                GCancellable                          *cancellable,
                                                                GError                               **error);
 


### PR DESCRIPTION
Just noticed these while doing a build.