### PR TITLE
pull: Update key loading function to match error style

### DIFF
--- a/tests/test-signed-pull.sh
+++ b/tests/test-signed-pull.sh
@@ -93,6 +93,7 @@ echo "ok pull failure with incorrect keys file option"
 
 # Test with correct dummy key
 ${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-key "${DUMMYSIGN}"
+${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-file
 test_signed_pull "dummy" ""
 
 if ! has_libsodium; then


### PR DESCRIPTION
This code wasn't written with idiomatic GError usage; it's not standard
to construct an error up front and continually append to its
message.  The exit from a function is usually `return TRUE`,
with error conditions before that.

Updating it to match style reveals what I think is a bug;
we were silently ignoring failure to parse key files.