### PR TITLE
lib/repo-pull: fix GPG check while pulling remote

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3856,7 +3856,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
 #ifdef OSTREE_DISABLE_GPGME
   /* Explicitly fail here if gpg verification is requested and we have no GPG support */
-  if (opt_gpg_verify_set || opt_gpg_verify_summary_set)
+  if (pull_data->gpg_verify || pull_data->gpg_verify_summary)
   {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
               "'%s': GPG feature is disabled in a build time",


### PR DESCRIPTION
If GPG support is disabled in a build time we should to check if any of
options "gpg_verify" or "gpg_verify_summary" is set to TRUE instead
of checking if they are passed via options while pulling from remote.

Fixed the failure with assertion of `ostree find-remotes --pull --mirror`
calling (`tests/test-pull-collections.sh`) if libostree has been compiled
without GPG support.