### PR TITLE
pull: Cleanup signature verification functions

### DIFF
--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -242,7 +242,7 @@ gboolean ostree_sign_ed25519_data_verify (OstreeSign *self,
         }
     }
 
-  return glnx_throw (error, "Not able to verify: no valid signatures found");
+  return glnx_throw (error, "no valid ed25519 signatures found");
 #endif /* HAVE_LIBSODIUM */
 
   return FALSE;

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -121,27 +121,29 @@ if has_libsodium; then
 
     mkdir repo8
     ostree_repo_init repo8 --mode="archive"
-    ${CMD_PREFIX} ostree --repo=repo8 remote add --set=verification-key="${ED25519PUBLIC}" origin repo
+    ${CMD_PREFIX} ostree --repo=repo8 remote add --set=verification-ed25519-key="${ED25519PUBLIC}" origin repo
     cat repo8/config
 
-    if ${CMD_PREFIX} ostree --repo=repo8 pull-local --remote=origin --sign-verify repo test2 2>&1; then
+    if ${CMD_PREFIX} ostree --repo=repo8 pull-local --remote=origin --sign-verify repo test2 2>err.txt; then
         assert_not_reached "Ed25519 signature verification unexpectedly succeeded"
     fi
+    assert_file_has_content err.txt 'ed25519: commit have no signatures of my type'
     echo "ok --sign-verify with no signature"
 
     ${OSTREE} sign test2 ${ED25519SECRET}
 
     mkdir repo9
     ostree_repo_init repo9 --mode="archive"
-    ${CMD_PREFIX} ostree --repo=repo9 remote add --set=verification-key="$(gen_ed25519_random_public)" origin repo
-    if ${CMD_PREFIX} ostree --repo=repo9 pull-local --remote=origin --sign-verify repo test2 2>&1; then
+    ${CMD_PREFIX} ostree --repo=repo9 remote add --set=verification-ed25519-key="$(gen_ed25519_random_public)" origin repo
+    if ${CMD_PREFIX} ostree --repo=repo9 pull-local --remote=origin --sign-verify repo test2 2>err.txt; then
         assert_not_reached "Ed25519 signature verification unexpectedly succeeded"
     fi
+    assert_file_has_content err.txt 'no valid ed25519 signatures found'
     echo "ok --sign-verify with wrong signature"
 
     mkdir repo10
     ostree_repo_init repo10 --mode="archive"
-    ${CMD_PREFIX} ostree --repo=repo10 remote add --set=verification-key="${ED25519PUBLIC}" origin repo
+    ${CMD_PREFIX} ostree --repo=repo10 remote add --set=verification-ed25519-key="${ED25519PUBLIC}" origin repo
     ${CMD_PREFIX} ostree --repo=repo10 pull-local --remote=origin --sign-verify repo test2
     echo "ok --sign-verify"
 else

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -115,7 +115,7 @@ do
     ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
     cd ${test_tmpdir}
-    repo_reinit --set=verification-key=${PUBLIC_KEY}
+    repo_reinit --set=verification-${engine}-key=${PUBLIC_KEY}
     ${OSTREE} --repo=repo pull origin main
     assert_has_file repo/tmp/cache/summaries/origin
     assert_has_file repo/tmp/cache/summaries/origin.sig
@@ -136,7 +136,7 @@ do
     echo "ok ${engine} prune summary cache"
 
     cd ${test_tmpdir}
-    repo_reinit --set=verification-key=${PUBLIC_KEY}
+    repo_reinit --set=verification-${engine}-key=${PUBLIC_KEY}
     mkdir cachedir
     ${OSTREE} --repo=repo pull --cache-dir=cachedir origin main
     assert_not_has_file repo/tmp/cache/summaries/origin
@@ -152,13 +152,13 @@ do
     echo "ok ${engine} pull with signed summary and cachedir"
 
     cd ${test_tmpdir}
-    repo_reinit --set=verification-key=${PUBLIC_KEY}
+    repo_reinit --set=verification-${engine}-key=${PUBLIC_KEY}
     mv ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{,.good}
     echo invalid > ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig
     if ${OSTREE} --repo=repo pull origin main 2>err.txt; then
         assert_not_reached "Successful pull with invalid ${engine} signature"
     fi
-    assert_file_has_content err.txt "signed with unknown key"
+    assert_file_has_content err.txt "No signatures found"
     mv ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.good,}
     echo "ok ${engine} pull with invalid ${engine} summary signature fails"
 
@@ -167,7 +167,7 @@ do
     ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
     cd ${test_tmpdir}
-    repo_reinit --set=verification-key=${PUBLIC_KEY}
+    repo_reinit --set=verification-${engine}-key=${PUBLIC_KEY}
     ${OSTREE} --repo=repo pull origin main
     echo "ok ${engine} pull delta with signed summary"
 
@@ -212,7 +212,7 @@ cd ${test_tmpdir}
 # Reset to the old valid summary and pull to cache it
 cp ${test_tmpdir}/ostree-srv/gnomerepo/summary{.1,}
 cp ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.1,}
-repo_reinit --set=verification-key=${PUBLIC_KEY}
+repo_reinit --set=verification-ed25519-key=${PUBLIC_KEY}
 ${OSTREE} --repo=repo pull origin main
 assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig
@@ -226,7 +226,7 @@ cp ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.2,}
 if ${OSTREE} --repo=repo pull origin main 2>err.txt; then
     assert_not_reached "Successful pull with old summary"
 fi
-assert_file_has_content err.txt "signed with unknown key"
+assert_file_has_content err.txt "no valid ed25519 signatures found"
 assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig
 cmp repo/tmp/cache/summaries/origin ${test_tmpdir}/ostree-srv/gnomerepo/summary.1 >&2
@@ -246,7 +246,7 @@ echo "ok ${engine} pull with signed summary remote old summary"
 # Reset to the old valid summary and pull to cache it
 cp ${test_tmpdir}/ostree-srv/gnomerepo/summary{.1,}
 cp ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.1,}
-repo_reinit --set=verification-key=${PUBLIC_KEY}
+repo_reinit --set=verification-ed25519-key=${PUBLIC_KEY}
 ${OSTREE} --repo=repo pull origin main
 assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig

--- a/tests/test-signed-pull.sh
+++ b/tests/test-signed-pull.sh
@@ -80,22 +80,22 @@ if ${CMD_PREFIX} ostree --repo=repo pull origin main; then
 fi
 echo "ok pull failure without keys preloaded"
 
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-key "somewrongkey"
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-dummy-key "somewrongkey"
 if ${CMD_PREFIX} ostree --repo=repo pull origin main; then
     assert_not_reached "pull with unknown key unexpectedly succeeded"
 fi
 echo "ok pull failure with incorrect key option"
 
-${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-key
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-file "/non/existing/file"
+${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-dummy-key
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-dummy-file "/non/existing/file"
 if ${CMD_PREFIX} ostree --repo=repo pull origin main; then
     assert_not_reached "pull with unknown keys file unexpectedly succeeded"
 fi
 echo "ok pull failure with incorrect keys file option"
 
 # Test with correct dummy key
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-key "${DUMMYSIGN}"
-${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-file
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-dummy-key "${DUMMYSIGN}"
+${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-dummy-file
 test_signed_pull "dummy" ""
 
 if ! has_libsodium; then
@@ -117,7 +117,7 @@ SECRET=${ED25519SECRET}
 COMMIT_ARGS="--sign=${SECRET} --sign-type=ed25519"
 
 repo_init --set=sign-verify=true
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-key "${PUBLIC}"
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-ed25519-key "${PUBLIC}"
 test_signed_pull "ed25519" "key"
 
 # Prepare files with public ed25519 signatures
@@ -130,13 +130,13 @@ for((i=0;i<100;i++)); do
 done > ${PUBKEYS}
 
 # Test case with the file containing incorrect signatures and with the correct key set
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-file "${PUBKEYS}"
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-ed25519-file "${PUBKEYS}"
 test_signed_pull "ed25519" "key+file"
 
 # Add correct key into the list
 echo ${PUBLIC} >> ${PUBKEYS}
 
 repo_init --set=sign-verify=true
-${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-file "${PUBKEYS}"
+${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-ed25519-file "${PUBKEYS}"
 test_signed_pull "ed25519" "file"
 


### PR DESCRIPTION
Rework this to use standard error handling - we fail fast if
we can't load the public keys for example.  Preserve
the semantics of accepting the first valid signature.  The
first signature error is captured, the others are currently
compressed into a `(and %d more)` prefix.

And now that I look at this more closely there's a lot of
duplication between the two code paths in pull.c for verifying;
will dedup this next.