### PR TITLE
ci: Adapt to use new fcosKola semantics

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -77,7 +77,7 @@ parallel fcos: {
         coreos-assembler build
       """)
     }
-    fcosKola("${env.WORKSPACE}")
+    fcosKola(cosaDir: "${env.WORKSPACE}")
   }
 },
 buildopts: {


### PR DESCRIPTION
This was changed recently and broke us since we do explicitly call
`fcosKola` instead of implicitly via `fcosBuild`. Adapt to the new
semantics.