### PR TITLE
travis: Add some libsodium coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ dist: trusty
 sudo: required
 
 env:
-  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch
-  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl"
+  # debian has libsodium-dev, ubuntu doesn't in core at least
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-libsodium" ci_pkgs="libsodium-dev"
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl --with-libsodium --without-gpgme" ci_pkgs="libsodium-dev"
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
   - ci_docker=ubuntu:bionic ci_distro=ubuntu ci_suite=bionic
 

--- a/ci/travis-Dockerfile.in
+++ b/ci/travis-Dockerfile.in
@@ -2,7 +2,7 @@ FROM @ci_docker@
 ENV container docker
 
 ADD ci/travis-install.sh /travis-install.sh
-RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /travis-install.sh
+RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_pkgs="@ci_pkgs@" ci_in_docker=yes /travis-install.sh
 
 ADD . /home/user/ostree
 RUN chown -R user:user /home/user/ostree

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -91,7 +91,7 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
 ${make}
 [ "$ci_test" = no ] || ${make} check || maybe_fail_tests
 cat test-suite.log || :
-[ "$ci_test" = no ] || ${make} distcheck || maybe_fail_tests
+[ "$ci_test" = no ] || ${make} distcheck DISTCHECK_CONFIGURE_FLAGS="${ci_configopts}" || maybe_fail_tests
 cat test-suite.log || :
 
 ${make} install DESTDIR=$(pwd)/DESTDIR

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -85,7 +85,7 @@ make="make -j${ci_parallel} V=1 VERBOSE=1"
 
 ../configure \
     --enable-always-build-tests \
-    ${ci_configopts}
+    ${ci_configopts} \
     "$@"
 
 ${make}

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -53,6 +53,9 @@ NULL=
 # ci_configopts: Additional arguments for configure
 : "${ci_configopts:=}"
 
+# ci_pkgs: Additional packages to be installed
+: "${ci_pkgs:=}"
+
 if [ $(id -u) = 0 ]; then
     sudo=
 else

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -64,6 +64,7 @@ if [ -n "$ci_docker" ]; then
         -e "s/@ci_distro@/${ci_distro}/" \
         -e "s/@ci_docker@/${ci_docker}/" \
         -e "s/@ci_suite@/${ci_suite}/" \
+        -e "s/@ci_pkgs@/${ci_pkgs}/" \
         < ci/travis-Dockerfile.in > Dockerfile
     exec docker build -t ci-image .
 fi
@@ -111,6 +112,7 @@ case "$ci_distro" in
             procps \
             zlib1g-dev \
             python3-yaml \
+            ${ci_pkgs:-} \
             ${NULL}
 
         if [ "$ci_in_docker" = yes ]; then


### PR DESCRIPTION
As far as I can tell we're not gating on this right now.  From
a quick glance, it looks like Debian stable has `libsodium-dev`
but only Ubuntu eoan does which we're not testing right now.