### PR TITLE
ci: Build minimal without libsodium too

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -41,7 +41,7 @@ minimal: {
         ./configure --without-curl --without-soup --disable-gtk-doc --disable-man \
           --disable-rust --without-libarchive --without-selinux --without-smack \
           --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
-          --disable-experimental-api
+          --disable-experimental-api --without-libsodium
         make
       """)
   }


### PR DESCRIPTION
The goal is to test "no options" build - and eventually tests.
(We're not actually including libsodium in the cosa buildroot right
 now, but we may in the future)