### PR TITLE
Use `sign-ed25519` for the feature name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ AS_IF([test x$with_libsodium != xno], [
     AS_IF([ test x$have_libsodium = xno ], [
        AC_MSG_ERROR([Need LIBSODIUM version $LIBSODIUM_DEPENDENCY or later])
     ])
-    OSTREE_FEATURES="$OSTREE_FEATURES libsodium"
+    OSTREE_FEATURES="$OSTREE_FEATURES sign-ed25519"
 ], with_libsodium=no )
 AM_CONDITIONAL(USE_LIBSODIUM, test "x$have_libsodium" = xyes)
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -679,10 +679,10 @@ libtest_cleanup_gpg () {
 }
 libtest_exit_cmds+=(libtest_cleanup_gpg)
 
-has_libsodium () {
+has_sign_ed25519 () {
     local ret
     ${CMD_PREFIX} ostree --version > version.txt
-    grep -q -e '- libsodium' version.txt
+    grep -q -e '- sign-ed25519' version.txt
     ret=$?
     rm -f version.txt
     return ${ret}

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -116,7 +116,7 @@ for src_object in `find repo/objects -name '*.filez'`; do
 done
 echo "ok pull-local z2 to z2 default hardlink"
 
-if has_libsodium; then
+if has_sign_ed25519; then
     gen_ed25519_keys
 
     mkdir repo8

--- a/tests/test-signed-commit.sh
+++ b/tests/test-signed-commit.sh
@@ -63,7 +63,7 @@ assert_file_has_content_literal err.txt ' No valid signatures found'
 echo "ok dummy sig requires env"
 
 # tests below require libsodium support
-if ! has_libsodium; then
+if ! has_sign_ed25519; then
     echo "ok Detached ed25519 signature # SKIP due libsodium unavailability"
     echo "ok ed25519 signature verified # SKIP due libsodium unavailability"
     echo "ok multiple signing # SKIP due libsodium unavailability"

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -51,7 +51,7 @@ do
             PUBLIC_KEY="dummysign"
             ;;
         ed25519)
-            if ! has_libsodium; then
+            if ! has_sign_ed25519; then
                 echo "ok ${engine} pull mirror summary # SKIP due libsodium unavailability"
                 echo "ok ${engine} pull with signed summary # SKIP due libsodium unavailability"
                 echo "ok ${engine} prune summary cache # SKIP due libsodium unavailability"
@@ -173,7 +173,7 @@ do
 
 done
 
-if ! has_libsodium; then
+if ! has_sign_ed25519; then
     echo "ok ${engine} pull with signed summary remote old summary # SKIP due libsodium unavailability"
     echo "ok ${engine} pull with signed summary broken cache # SKIP due libsodium unavailability"
     exit 0

--- a/tests/test-signed-pull.sh
+++ b/tests/test-signed-pull.sh
@@ -98,7 +98,7 @@ ${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-dummy
 ${CMD_PREFIX} ostree --repo=repo config unset 'remote "origin"'.verification-dummy-file
 test_signed_pull "dummy" ""
 
-if ! has_libsodium; then
+if ! has_sign_ed25519; then
     echo "ok ed25519-key pull signed commit # SKIP due libsodium unavailability"
     echo "ok ed25519-key re-pull signature for stored commit # SKIP due libsodium unavailability"
     echo "ok ed25519-key+file pull signed commit # SKIP due libsodium unavailability"


### PR DESCRIPTION
`libsodium` is an implementation detail.  In particular, I'd like
to consider using OpenSSL for ed25519 (if libsodium isn't configured
and openssl is).

So switch the name of the exposed feature and adjust the tests.