### PR TITLE
sign: rename option for enabling ed25519

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 
 env:
   # debian has libsodium-dev, ubuntu doesn't in core at least
-  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-libsodium" ci_pkgs="libsodium-dev"
-  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl --with-libsodium --without-gpgme" ci_pkgs="libsodium-dev"
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-ed25519-libsodium" ci_pkgs="libsodium-dev"
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl --with-ed25519-libsodium --without-gpgme" ci_pkgs="libsodium-dev"
   - ci_docker=ubuntu:xenial ci_distro=ubuntu ci_suite=xenial
   - ci_docker=ubuntu:bionic ci_distro=ubuntu ci_suite=bionic
 

--- a/configure.ac
+++ b/configure.ac
@@ -244,17 +244,17 @@ AM_CONDITIONAL(USE_GPGME, test "x$have_gpgme" = xyes)
 
 
 LIBSODIUM_DEPENDENCY="1.0.14"
-AC_ARG_WITH(libsodium,
-	    AS_HELP_STRING([--with-libsodium], [Use libsodium @<:@default=no@:>@]),
-	    [], [with_libsodium=no])
-AS_IF([test x$with_libsodium != xno], [
+AC_ARG_WITH(ed25519_libsodium,
+	    AS_HELP_STRING([--with-ed25519-libsodium], [Use libsodium for ed25519 @<:@default=no@:>@]),
+	    [], [with_ed25519_libsodium=no])
+AS_IF([test x$with_ed25519_libsodium != xno], [
     AC_DEFINE([HAVE_LIBSODIUM], 1, [Define if using libsodium])
     PKG_CHECK_MODULES(OT_DEP_LIBSODIUM, libsodium >= $LIBSODIUM_DEPENDENCY, have_libsodium=yes,  have_libsodium=no)
     AS_IF([ test x$have_libsodium = xno ], [
        AC_MSG_ERROR([Need LIBSODIUM version $LIBSODIUM_DEPENDENCY or later])
     ])
     OSTREE_FEATURES="$OSTREE_FEATURES sign-ed25519"
-], with_libsodium=no )
+], with_ed25519_libsodium=no )
 AM_CONDITIONAL(USE_LIBSODIUM, test "x$have_libsodium" = xyes)
 
 LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
@@ -641,7 +641,7 @@ echo "
     cryptographic checksums:                      $with_crypto
     systemd:                                      $with_libsystemd
     libmount:                                     $with_libmount
-    libsodium (ed25519 signatures):               $with_libsodium
+    libsodium (ed25519 signatures):               $with_ed25519_libsodium
     libarchive (parse tar files directly):        $with_libarchive
     static deltas:                                yes (always enabled now)
     O_TMPFILE:                                    $enable_otmpfile


### PR DESCRIPTION
As follow up of #2072

Use option `--with-ed25519-libsodium` instead of
`--with-libsodium` to enable ed25519 signature engine.

This allows to use later different implementations of ed25519
signing/verification. For instance, based on openssl.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>