### PR TITLE
lib/commit: Check that dirent is a directory before cleaning 

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1943,6 +1943,9 @@ cleanup_txn_dir (OstreeRepo   *self,
                  GCancellable *cancellable,
                  GError      **error)
 {
+  const char *errprefix = glnx_strjoina ("Cleaning up txn dir ", path);
+  GLNX_AUTO_PREFIX_ERROR (errprefix, error);
+
   g_auto(GLnxLockFile) lockfile = { 0, };
   gboolean did_lock;
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2011,7 +2011,7 @@ cleanup_tmpdir (OstreeRepo        *self,
         continue;
 
       /* Handle transaction tmpdirs */
-      if (_ostree_repo_is_locked_tmpdir (dent->d_name))
+      if (_ostree_repo_has_staging_prefix (dent->d_name))
         {
           if (!cleanup_txn_dir (self, dfd_iter.fd, dent->d_name, cancellable, error))
             return FALSE;

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2011,7 +2011,7 @@ cleanup_tmpdir (OstreeRepo        *self,
         continue;
 
       /* Handle transaction tmpdirs */
-      if (_ostree_repo_has_staging_prefix (dent->d_name))
+      if (_ostree_repo_has_staging_prefix (dent->d_name) && S_ISDIR (stbuf.st_mode))
         {
           if (!cleanup_txn_dir (self, dfd_iter.fd, dent->d_name, cancellable, error))
             return FALSE;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -247,7 +247,7 @@ _ostree_repo_allocate_tmpdir (int           tmpdir_dfd,
                               GError      **error);
 
 gboolean
-_ostree_repo_is_locked_tmpdir (const char *filename);
+_ostree_repo_has_staging_prefix (const char *filename);
 
 gboolean
 _ostree_repo_try_lock_tmpdir (int            tmpdir_dfd,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5959,7 +5959,7 @@ _ostree_repo_maybe_regenerate_summary (OstreeRepo    *self,
 }
 
 gboolean
-_ostree_repo_is_locked_tmpdir (const char *filename)
+_ostree_repo_has_staging_prefix (const char *filename)
 {
   return g_str_has_prefix (filename, OSTREE_REPO_TMPDIR_STAGING);
 }
@@ -6019,7 +6019,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
                               GCancellable *cancellable,
                               GError **error)
 {
-  g_return_val_if_fail (_ostree_repo_is_locked_tmpdir (tmpdir_prefix), FALSE);
+  g_return_val_if_fail (_ostree_repo_has_staging_prefix (tmpdir_prefix), FALSE);
 
   /* Look for existing tmpdir (with same prefix) to reuse */
   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };


### PR DESCRIPTION
I've only noticed this by inspection. But I think it's possible for
`cleanup_txn_dir` to get called with the `staging-...-lock` file since
it matches the prefix.

Make the checking here stronger by verifying that it's a directory. If
it's not a directory (lockfile), then follow the default pruning expiry
logic so that we still cleanup stray lockfiles eventually.