### PR TITLE
deploy: Add --no-merge

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -74,6 +74,7 @@ parallel fcos: {
         mkdir -p overrides/rootfs
         mv insttree/* overrides/rootfs/
         rmdir insttree
+        coreos-assembler fetch
         coreos-assembler build
       """)
     }

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -102,6 +102,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-deploy-etcmerge-cornercases.sh \
 	tests/test-admin-deploy-uboot.sh \
 	tests/test-admin-deploy-grub2.sh \
+	tests/test-admin-deploy-nomerge.sh \
 	tests/test-admin-deploy-none.sh \
 	tests/test-admin-deploy-bootid-gc.sh \
 	tests/test-admin-instutil-set-kargs.sh \

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -37,6 +37,7 @@ static gboolean opt_retain_pending;
 static gboolean opt_retain_rollback;
 static gboolean opt_not_as_default;
 static gboolean opt_no_prune;
+static gboolean opt_no_merge;
 static char **opt_kernel_argv;
 static char **opt_kernel_argv_append;
 static gboolean opt_kernel_proc_cmdline;
@@ -48,6 +49,7 @@ static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
   { "origin-file", 0, 0, G_OPTION_ARG_FILENAME, &opt_origin_path, "Specify origin file", "FILENAME" },
   { "no-prune", 0, 0, G_OPTION_ARG_NONE, &opt_no_prune, "Don't prune the repo when done", NULL},
+  { "no-merge", 0, 0, G_OPTION_ARG_NONE, &opt_no_merge, "Do not apply configuration (/etc and kernel arguments) from booted deployment", NULL},
   { "retain", 0, 0, G_OPTION_ARG_NONE, &opt_retain, "Do not delete previous deployments", NULL },
   { "stage", 0, 0, G_OPTION_ARG_NONE, &opt_stage, "Complete deployment at OS shutdown", NULL },
   { "retain-pending", 0, 0, G_OPTION_ARG_NONE, &opt_retain_pending, "Do not delete pending deployments", NULL },
@@ -113,7 +115,7 @@ ot_admin_builtin_deploy (int argc, char **argv, OstreeCommandInvocation *invocat
     return FALSE;
 
   g_autoptr(OstreeDeployment) merge_deployment =
-    ostree_sysroot_get_merge_deployment (sysroot, opt_osname);
+    opt_no_merge ? NULL : ostree_sysroot_get_merge_deployment (sysroot, opt_osname);
 
   /* Here we perform cleanup of any leftover data from previous
    * partial failures.  This avoids having to call

--- a/tests/test-admin-deploy-nomerge.sh
+++ b/tests/test-admin-deploy-nomerge.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive" "syslinux"
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+
+echo "1..1"
+${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=LABEL=foo --karg=testkarg=1 testos:testos/buildmaster/x86_64-runtime
+origdeployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
+testconfig=etc/modified-config-file-that-will-be-removed
+touch "${origdeployment}"/"${testconfig}"
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options.*root=LABEL=foo.*testkarg"
+${CMD_PREFIX} ostree admin deploy --os=testos --no-merge --karg=root=LABEL=bar testos:testos/buildmaster/x86_64-runtime
+deployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
+assert_not_streq "${origdeployment}" "${deployment}"
+assert_not_has_file "${deployment}/${testconfig}"
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options root=LABEL=bar"
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options .*testkarg"
+echo "ok no merge deployment"


### PR DESCRIPTION
All of the underlying libostree APIs have supported passing `NULL`
for a merge deployment for...a long time.  But we never plumbed
it up into the CLI.

Add a `--no-merge` option to aid people who want to do a "factory reset":
https://github.com/ostreedev/ostree/issues/1793