### PR TITLE
finalize-staged: Add ProtectHome=yes and ReadOnlyPaths=/etc

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -39,3 +39,11 @@ ExecStop=/usr/bin/ostree admin finalize-staged
 # here is that people don't get an upgrade.  We need to handle
 # cases with slow rotational media, etc.
 TimeoutStopSec=5m
+# OSTree should never touch /var at all...except, we need to remove
+# the /var/.updated flag, so we can't just `InaccessiblePaths=/var` right now.
+# For now, let's at least use ProtectHome just so we have some sandboxing
+# of that.
+ProtectHome=yes
+# And we shouldn't affect the current deployment's /etc.
+ReadOnlyPaths=/etc
+# We write to /sysroot and /boot of course.


### PR DESCRIPTION
Same motivation as
https://github.com/coreos/rpm-ostree/pull/2060

I tried `InaccessiblePaths=/var` first and was very sad to find
out we have one tiny exception that breaks it.  Otherwise it'd
be so elegant.  Maybe in the future we split out that one thing
to a separate `ostree-finalized-stage-var.service` that's just
`ExecStart=/bin/rm -vf /var/.updated` and is otherwise
`ProtectSystem=strict` etc.