### PR TITLE
signapi: expose metadata format and key

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -719,6 +719,8 @@ ostree_sign_get_name
 ostree_sign_add_pk
 ostree_sign_clear_keys
 ostree_sign_load_pk
+ostree_sign_metadata_format
+ostree_sign_metadata_key
 ostree_sign_set_pk
 ostree_sign_set_sk
 ostree_sign_summary

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -32,6 +32,8 @@ global:
   ostree_sign_get_name;
   ostree_sign_clear_keys;
   ostree_sign_load_pk;
+  ostree_sign_metadata_format;
+  ostree_sign_metadata_key;
   ostree_sign_set_pk;
   ostree_sign_add_pk;
   ostree_sign_set_sk;


### PR DESCRIPTION
Explicitly expose functions for querying the metadata format
and key name used by OstreeSign object:
 - ostree_sign_metadata_format
 - ostree_sign_metadata_key

This allows to use the same metadata format and key name
by 3-rd party applications using signapi.

I thought there is no need to use them externally but we have at least one case then it helps to avoid duplication of name and format in code.