### PR TITLE
signing: Add #define OSTREE_SIGN_NAME_ED25519

### DIFF
--- a/src/libostree/ostree-sign.c
+++ b/src/libostree/ostree-sign.c
@@ -62,7 +62,7 @@ typedef struct
 _sign_type sign_types[] =
 {
 #if defined(HAVE_LIBSODIUM)
-    {"ed25519", 0},
+    {OSTREE_SIGN_NAME_ED25519, 0},
 #endif
     {"dummy", 0}
 };

--- a/src/libostree/ostree-sign.h
+++ b/src/libostree/ostree-sign.h
@@ -49,6 +49,12 @@ static inline gboolean OSTREE_IS_SIGN (gpointer ptr) { return G_TYPE_CHECK_INSTA
 static inline OstreeSignInterface *OSTREE_SIGN_GET_IFACE (gpointer ptr) { return G_TYPE_INSTANCE_GET_INTERFACE (ptr, ostree_sign_get_type (), OstreeSignInterface); }
 G_GNUC_END_IGNORE_DEPRECATIONS
 
+/**
+ * OSTREE_SIGN_NAME_ED25519:
+ * The name of the default ed25519 signing type.
+ */
+#define OSTREE_SIGN_NAME_ED25519 "ed25519"
+
 /* Have to use glib-2.44 for this
 _OSTREE_PUBLIC
 G_DECLARE_INTERFACE (OstreeSign, ostree_sign, OSTREE, SIGN, GObject)

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -868,8 +868,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
       if (opt_key_ids)
         {
           /* Initialize crypto system */
-          if (!opt_sign_name)
-            opt_sign_name = "ed25519";
+          opt_sign_name = opt_sign_name ?: OSTREE_SIGN_NAME_ED25519;
 
           sign = ostree_sign_get_by_name (opt_sign_name, error);
           if (sign == NULL)

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -105,8 +105,7 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
     goto out;
 
   /* Initialize crypto system */
-  if (!opt_sign_name)
-    opt_sign_name = "ed25519";
+  opt_sign_name = opt_sign_name ?: OSTREE_SIGN_NAME_ED25519;
 
   sign = ostree_sign_get_by_name (opt_sign_name, error);
   if (sign == NULL)

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -103,8 +103,7 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
   /* Initialize crypto system */
   if (opt_key_ids)
     {
-      if (!opt_sign_name)
-        opt_sign_name = "ed25519";
+      opt_sign_name = opt_sign_name ?: OSTREE_SIGN_NAME_ED25519;
 
       sign = ostree_sign_get_by_name (opt_sign_name, error);
       if (sign == NULL)


### PR DESCRIPTION
Using `#define` or constants instead of strings helps avoid
typos and encourages documentation.