### PR TITLE
ostree-prepare-root: Requires=sysroot.mount

### DIFF
--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -23,6 +23,7 @@ ConditionKernelCommandLine=ostree
 ConditionPathExists=/etc/initrd-release
 OnFailure=emergency.target
 After=sysroot.mount
+Requires=sysroot.mount
 Before=initrd-root-fs.target
 
 [Service]


### PR DESCRIPTION
With just `After=` we'll still try to run in the scenario
where `sysroot.mount` fails because the rootfs didn't appear.
And this will end up spewing an error which can confuse people
into thinking something is wrong at the ostree level.

This has come up numerous times w/{Fedora,RHEL} CoreOS, most
recently while looking at
https://bugzilla.redhat.com/show_bug.cgi?id=1803130