### PR TITLE
signing: Change API to create instances directly

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -709,7 +709,7 @@ ostree_kernel_args_to_string
 <SECTION>
 <FILE>ostree-sign</FILE>
 OstreeSign
-ostree_sign_list_names
+ostree_sign_get_all
 ostree_sign_commit
 ostree_sign_commit_verify
 ostree_sign_data

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -23,7 +23,7 @@ global:
   ostree_repo_commit_modifier_set_sepolicy_from_commit;
   someostree_symbol_deleteme;
   ostree_sign_get_type;
-  ostree_sign_list_names;
+  ostree_sign_get_all;
   ostree_sign_commit;
   ostree_sign_commit_verify;
   ostree_sign_data;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1544,14 +1544,11 @@ scan_commit_object (OtPullData                 *pull_data,
       gboolean found_any_signature = FALSE;
       gboolean found_valid_signature = FALSE;
 
-      /* list all signature types in detached metadata and check if signed by any? */
-      g_auto (GStrv) names = ostree_sign_list_names();
-      for (char **iter=names; iter && *iter; iter++)
+      /* FIXME - dedup this with _sign_verify_for_remote() */
+      g_autoptr(GPtrArray) signers = ostree_sign_get_all ();
+      for (guint i = 0; i < signers->len; i++)
         {
-          g_autoptr (OstreeSign) sign = NULL;
-
-          if ((sign = ostree_sign_get_by_name (*iter, NULL)) == NULL)
-            continue;
+          OstreeSign *sign = signers->pdata[i];
 
           /* Try to load public key(s) according remote's configuration */
           if (!_signapi_load_public_keys (sign, pull_data->repo, pull_data->remote_name, error))

--- a/src/libostree/ostree-sign.h
+++ b/src/libostree/ostree-sign.h
@@ -153,7 +153,7 @@ gboolean ostree_sign_load_pk (OstreeSign *self,
 
 
 _OSTREE_PUBLIC
-GStrv ostree_sign_list_names(void);
+GPtrArray * ostree_sign_get_all(void);
 
 _OSTREE_PUBLIC
 OstreeSign * ostree_sign_get_by_name (const gchar *name, GError **error);


### PR DESCRIPTION
This cleans up the verification code; it was weird how
we'd get the list of known names and then try to create
an instance from it (and throw an error if that failed, which
couldn't happen).