### PR TITLE
pull: Further cleanup signapi verification

### DIFF
--- a/src/libostree/ostree-repo-pull-private.h
+++ b/src/libostree/ostree-repo-pull-private.h
@@ -123,6 +123,8 @@ typedef struct {
   gboolean          is_commit_only;
   OstreeRepoImportFlags importflags;
 
+  GPtrArray        *signapi_verifiers;
+
   GPtrArray        *dirs;
 
   gboolean      have_previous_bytes;
@@ -137,18 +139,16 @@ typedef struct {
   GSource *idle_src;
 } OtPullData;
 
-gboolean
-_sign_verify_for_remote (OstreeRepo *repo,
-                          const gchar *remote_name,
-                          GBytes *signed_data,
-                          GVariant *metadata,
-                          GError **error);
+GPtrArray *
+_signapi_verifiers_for_remote (OstreeRepo *repo,
+                               const char *remote_name,
+                               GError    **error);
 
 gboolean
-_signapi_load_public_keys (OstreeSign *sign,
-                           OstreeRepo *repo,
-                           const gchar *remote_name,
-                           GError **error);
+_sign_verify_for_remote (GPtrArray *signers,
+                         GBytes *signed_data,
+                         GVariant *metadata,
+                         GError **error);
 
 gboolean
 _verify_unwritten_commit (OtPullData                 *pull_data,


### PR DESCRIPTION
Previously in the pull code, every time we went to verify
a commit we would re-initialize an `OstreeSign` instance
of each time, re-parse the remote configuration
and re-load its public keys etc.

In most cases this doesn't matter really because we're
pulling one commit, but if e.g. pulling a commit with
history would get a bit silly.

This changes things so that the pull code initializes the
verifiers once, and reuses them thereafter.

This is continuing towards changing the code to support
explicitly configured verifiers, xref
https://github.com/ostreedev/ostree/issues/2080