### PR TITLE
finalize: Add RequiresMountsFor=/boot too

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -23,7 +23,7 @@ Documentation=man:ostree(1)
 ConditionPathExists=/run/ostree-booted
 DefaultDependencies=no
 
-RequiresMountsFor=/sysroot
+RequiresMountsFor=/sysroot /boot
 After=local-fs.target
 Before=basic.target final.target
 # We want to make sure the transaction logs are persisted to disk:


### PR DESCRIPTION
In https://bugzilla.redhat.com/show_bug.cgi?id=1827712
some OpenShift CI is seeing `/boot` being unmounted before
`ostree-finalize-staged.service` runs or completes.

We finally tracked this down to a bug elsewhere, but
I think we should add this because it clearly shows
our requirements.