### PR TITLE
ci: Install kola tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -76,6 +76,9 @@ parallel fcos: {
         rmdir insttree
         coreos-assembler fetch
         coreos-assembler build
+        # Install the tests, then be sure they're not run again
+        make -C tests/kola install
+        rm tests/kola -rf
       """)
     }
     fcosKola(cosaDir: "${env.WORKSPACE}")

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -456,3 +456,10 @@ else
 endif
 INSTALL_DATA_HOOKS += install-installed-tests-extra
 endif
+
+# Just forward these
+build-kola-tests:
+	$(MAKE) -C tests/kola
+
+install-kola-tests:
+	$(MAKE) -C tests/kola install

--- a/tests/kola/Makefile
+++ b/tests/kola/Makefile
@@ -1,0 +1,13 @@
+DESTDIR ?=
+
+TESTDIRS := $(shell find -mindepth 1 -maxdepth 1 -type d)
+LIBSCRIPTS := $(shell ls *.sh)
+
+KOLA_TESTDIR = $(DESTDIR)/usr/lib/coreos-assembler/tests/kola/ostree/
+
+all:
+	for x in $(LIBSCRIPTS); do bash -n "$${x}"; done
+
+install:
+	install -D -m 0644 -t $(KOLA_TESTDIR) $(LIBSCRIPTS)
+	for x in $(TESTDIRS); do rsync -rlv ./$${x} $(KOLA_TESTDIR)/; done


### PR DESCRIPTION
This builds on
https://github.com/coreos/coreos-assembler/pull/1441
to install our tests rather than running them from the source
directory.  This model will more cleanly allow us to ship
our tests along with a test container or elsewhere, separate
from the source directory.

Also prep for https://github.com/ostreedev/ostree/pull/2048