### PR TITLE
pull: Only have API to disable signapi for local pulls

### DIFF
--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -39,8 +39,6 @@ static gboolean opt_bareuseronly_files;
 static gboolean opt_require_static_deltas;
 static gboolean opt_gpg_verify;
 static gboolean opt_gpg_verify_summary;
-static gboolean opt_sign_verify;
-static gboolean opt_sign_verify_summary;
 static int opt_depth = 0;
 
 /* ATTENTION:
@@ -57,8 +55,6 @@ static GOptionEntry options[] = {
   { "require-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_require_static_deltas, "Require static deltas", NULL },
   { "gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify, "GPG verify commits (must specify --remote)", NULL },
   { "gpg-verify-summary", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify_summary, "GPG verify summary (must specify --remote)", NULL },
-  { "sign-verify", 0, 0, G_OPTION_ARG_NONE, &opt_sign_verify, "Verify commits signature (must specify --remote)", NULL },
-  { "sign-verify-summary", 0, 0, G_OPTION_ARG_NONE, &opt_sign_verify, "Verify summary signature (must specify --remote)", NULL },
   { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
   { NULL }
 };
@@ -185,13 +181,13 @@ ostree_builtin_pull_local (int argc, char **argv, OstreeCommandInvocation *invoc
                              g_variant_new_variant (g_variant_new_boolean (TRUE)));
     g_variant_builder_add (&builder, "{s@v}", "depth",
                            g_variant_new_variant (g_variant_new_int32 (opt_depth)));
-
-    if (opt_sign_verify)
-      g_variant_builder_add (&builder, "{s@v}", "sign-verify",
-                             g_variant_new_variant (g_variant_new_boolean (TRUE)));
-    if (opt_sign_verify_summary)
-      g_variant_builder_add (&builder, "{s@v}", "sign-verify-summary",
-                             g_variant_new_variant (g_variant_new_boolean (TRUE)));
+    /* local pulls always disable signapi verification.  If you don't want this, use
+     * ostree remote add --sign-verify=<key> file://
+     */
+    g_variant_builder_add (&builder, "{s@v}", "disable-sign-verify",
+                           g_variant_new_variant (g_variant_new_boolean (TRUE)));
+    g_variant_builder_add (&builder, "{s@v}", "disable-sign-verify-summary",
+                           g_variant_new_variant (g_variant_new_boolean (TRUE)));
 
     if (console.is_tty)
       progress = ostree_async_progress_new_and_connect (ostree_repo_pull_default_console_progress_changed, &console);


### PR DESCRIPTION
There's a lot of historical baggage associated with GPG verification
and `ostree pull` versus `ostree pull-local`.  In particular nowadays,
if you use a `file://` remote things are transparently optimized
to e.g. use reflinks if available.

So for anyone who doesn't trust the "remote" repository, you should
really go through through the regular
`ostree remote add --sign-verify=X file://`
path for example.

Having a mechanism to say "turn on signapi verification" *without*
providing keys goes back into the "global state" debate I brought
up in https://github.com/ostreedev/ostree/issues/2080

It's just much cleaner architecturally if there is exactly one
path to find keys: from a remote config.

So here in contrast to the GPG code, for `pull-local` we explictily
disable signapi validation, and the `ostree_repo_pull()` API just
surfaces flags to disable it, not enable it.