### PR TITLE
pull: Add support for sign-verify=<list>

### DIFF
--- a/src/libostree/ostree-repo-pull-private.h
+++ b/src/libostree/ostree-repo-pull-private.h
@@ -67,8 +67,6 @@ typedef struct {
 
   gboolean          gpg_verify;
   gboolean          gpg_verify_summary;
-  gboolean          sign_verify;
-  gboolean          sign_verify_summary;
   gboolean          require_static_deltas;
   gboolean          disable_static_deltas;
   gboolean          has_tombstone_commits;
@@ -124,7 +122,8 @@ typedef struct {
   gboolean          is_commit_only;
   OstreeRepoImportFlags importflags;
 
-  GPtrArray        *signapi_verifiers;
+  GPtrArray        *signapi_commit_verifiers;
+  GPtrArray        *signapi_summary_verifiers;
 
   GPtrArray        *dirs;
 
@@ -140,11 +139,12 @@ typedef struct {
   GSource *idle_src;
 } OtPullData;
 
-GPtrArray *
-_signapi_verifiers_for_remote (OstreeRepo *repo,
-                               const char *remote_name,
-                               GError    **error);
-
+gboolean
+_signapi_init_for_remote (OstreeRepo *repo,
+                          const char *remote_name,
+                          GPtrArray **out_commit_verifiers,
+                          GPtrArray **out_summary_verifiers,
+                          GError    **error);
 gboolean
 _sign_verify_for_remote (GPtrArray *signers,
                          GBytes *signed_data,


### PR DESCRIPTION
The goal here is to move the code towards a model
where the *client* can explicitly specify which signature types
are acceptable.

We retain support for `sign-verify=true` for backwards compatibility.
But in that configuration, a missing public key is just "no signatures found".

With `sign-verify=ed25519` and no key configured, we can
explicitly say `No keys found for required signapi type ed25519`
which is much, much clearer.

Implementation side, rather than maintaining `gboolean sign_verify` *and*
`GPtrArray sign_verifiers`, just have the array.  If it's `NULL` that means
not to verify.

Note that currently, an explicit list is an OR of signatures, not AND.
In practice...I think most people are going to be using a single entry
anyways.