### PR TITLE
switchroot/remount: Neuter sysroot.readonly for now

### DIFF
--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -93,7 +93,10 @@ sysroot_is_configured_ro (void)
   if (!g_key_file_load_from_file (keyfile, config_path, 0, NULL))
     return false;
 
-  return g_key_file_get_boolean (keyfile, "sysroot", "readonly", NULL);
+  if (g_key_file_get_boolean (keyfile, "sysroot", "readonly", NULL))
+    puts ("Ignoring sysroot.readonly config; see https://github.com/coreos/fedora-coreos-tracker/issues/488.");
+
+  return false;
 }
 
 int


### PR DESCRIPTION
We're hitting issues with the read-only remounts racing with various
services coming up. Let's neuter it for now until we rework how it
works.

See: https://github.com/coreos/fedora-coreos-tracker/issues/488