### PR TITLE
tests/admin-test: Fix --allow-downgrade check

### DIFF
--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -302,23 +302,31 @@ echo "ok no duplicate version strings in title"
 # See https://github.com/GNOME/ostree/pull/147
 sleep 1
 os_repository_new_commit
-${CMD_PREFIX} ostree pull --repo=sysroot/ostree/repo --commit-metadata-only --depth=-1 testos:testos/buildmaster/x86_64-runtime
+# upgrade to the latest
+${CMD_PREFIX} ostree admin upgrade --os=testos
 head_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buildmaster/x86_64-runtime)
-prev_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buildmaster/x86_64-runtime^^^^)
+prev_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buildmaster/x86_64-runtime^)
 assert_not_streq ${head_rev} ${prev_rev}
-# check that we can't "upgrade" to an older commit without --allow-downgrade
+# Don't use `ostree admin status | head -n 1` directly here because `head`
+# exiting early might cause SIGPIPE to ostree, which with `set -euo pipefail`
+# will cause us to exit. See: https://github.com/ostreedev/ostree/pull/2110.
+${CMD_PREFIX} ostree admin status > status-out.txt
+head -n 1 < status-out.txt > status.txt
+assert_file_has_content status.txt ".* testos ${head_rev}.*"
+# now, check that we can't downgrade to an older commit without --allow-downgrade
 if ${CMD_PREFIX} ostree admin upgrade --os=testos --override-commit=${prev_rev} 2> err.txt; then
     cat err.txt
     fatal "downgraded without --allow-downgrade?"
 fi
 assert_file_has_content err.txt "Upgrade.*is chronologically older"
 ${CMD_PREFIX} ostree admin upgrade --os=testos --override-commit=${prev_rev} --allow-downgrade
-curr_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buildmaster/x86_64-runtime)
-
-assert_streq ${curr_rev} ${prev_rev}
+${CMD_PREFIX} ostree admin status > status-out.txt
+head -n 1 < status-out.txt > status.txt
+assert_file_has_content status.txt ".* testos ${prev_rev}.*"
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-curr_rev=$(${CMD_PREFIX} ostree rev-parse --repo=sysroot/ostree/repo testos/buildmaster/x86_64-runtime)
-assert_streq ${curr_rev} ${head_rev}
+${CMD_PREFIX} ostree admin status > status-out.txt
+head -n 1 < status-out.txt > status.txt
+assert_file_has_content status.txt ".* testos ${head_rev}.*"
 
 echo "ok upgrade with and without override-commit"
 


### PR DESCRIPTION
We were doing a check to verify that `ostree admin upgrade` wouldn't
accept a downgrade without `--allow-downgrade`. However, there's no
guarantee that the commit it's upgrading from is older than HEAD^ (what
we're upgrading to). Specifically, if the test runs fast enough, the
timestamps could be equal, since the lowest resolution is seconds.

Rework the test so that we first upgrade to HEAD, which we're sure is at
least 1 second apart from HEAD^, and *then* check that downgrade
protection is enforced.

We also can't use `rev-parse testos/buildmaster/x86_64-runtime` as a way
to know what commit the host is sitting on since the ref might've gone
ahead. Instead, just use `ostree admin status | head -n1`. (I played
with using the `ostree/I/J/K` refs, but those depend on what the
boot/subbootversion is and can easily change if we change previous
tests).