### PR TITLE
lib: Add error prefixing with specific object when loading

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -999,7 +999,10 @@ content_fetch_on_complete (GObject        *object,
       if (!ostree_content_stream_parse (TRUE, tmpf_input, stbuf.st_size, FALSE,
                                         &file_in, &file_info, &xattrs,
                                         cancellable, error))
-        goto out;
+        {
+          g_prefix_error (error, "Parsing %s: ", checksum_obj);
+          goto out;
+        }
 
       if (verifying_bareuseronly)
         {


### PR DESCRIPTION
One OpenShift user saw this from rpm-ostree:
```
client(id:cli dbus:1.583 unit:machine-config-daemon-host.service uid:0) added; new total=1
Initiated txn UpdateDeployment for client(id:cli dbus:1.583 unit:machine-config-daemon-host.service uid:0): /org/projectatomic/rpmostree1/rhcos
Txn UpdateDeployment on /org/projectatomic/rpmostree1/rhcos failed: File header size 4294967295 exceeds size 0
```

which isn't very helpful.  Let's add some error
prefixing here which would at least tell us which
object was corrupted.