### PR TITLE
bupsplit: rustfmt(*)

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
Let's use the standard rustfmt style.
Also remove unused parenthesis which rust-analyzer was complaining
about.

Also add a `.gitignore`.