### PR TITLE
core: Add OSTREE_COMMIT_META_KEY_ARCH

### DIFF
--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -212,6 +212,19 @@ typedef enum {
  * Since: 2014.9
  */
 #define OSTREE_COMMIT_META_KEY_VERSION "version"
+
+/**
+ * OSTREE_COMMIT_META_KEY_ARCHITECTURE:
+ *
+ * GVariant type `s`.  Intended to describe the CPU architecture.  This is a freeform string, and some distributions
+ * which have existing package managers might want to match that schema.  If you
+ * don't have a prior schema, it's recommended to use `uname -m` by default (i.e. the Linux kernel schema).  In the future
+ * ostree might include a builtin function to compare architectures.
+ *
+ * Since: 2020.4
+ */
+#define OSTREE_COMMIT_META_KEY_ARCHITECTURE "ostree.architecture"
+
 /**
  * OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE:
  *


### PR DESCRIPTION
Add a standard key for this.  We actually had a case in OpenShift
builds recently where a ppc64le image was pushed over an `x86_64`
one and this started failing at runtime with a not immediately
obvious error.

I'll probably end up changing rpm-ostree at least to use
the RPM architecture for this key and fail if it doesn't match
the booted value.

Possibly that should live in ostree but it would involve adding
architecture schema here, which gets into a big mess.  Let's
just standardize the key.