### PR TITLE
Improve checkout man page

### DIFF
--- a/man/ostree-checkout.xml
+++ b/man/ostree-checkout.xml
@@ -109,6 +109,14 @@ Boston, MA 02111-1307, USA.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--whiteouts</option></term>
+
+                <listitem><para>
+                    Process whiteout files (Docker style).
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--allow-noent</option></term>
 
                 <listitem><para>
@@ -129,6 +137,69 @@ Boston, MA 02111-1307, USA.
 
                 <listitem><para>
                     Process many checkouts from input file.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--fsync</option>="POLICY"</term>
+
+                <listitem><para>
+                    POLICY is a boolean which specifies whether fsync should be
+                    used or not. Default to true.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--require-hardlinks</option>,
+                <option>-H</option></term>
+
+                <listitem><para>
+                    Do not fall back to full copies if hardlinking fails.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--force-copy-zerosized</option>,
+                <option>-z</option></term>
+
+                <listitem><para>
+                    Do not hardlink zero-sized files.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--force-copy</option>, <option>-C</option></term>
+
+                <listitem><para>
+                    Never hardlink (but may reflink if available).
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--bareuseronly-dirs</option>,
+                <option>-M</option></term>
+
+                <listitem><para>
+                    Suppress mode bits outside of 0775 for directories (suid,
+                    world writable, etc.).
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--skip-list</option>="FILE"</term>
+
+                <listitem><para>
+                    Skip checking out the absolute file paths listed in FILE,
+                    one per line.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--selinux-policy</option></term>
+
+                <listitem><para>
+                    Set SELinux labels based on policy in root filesystem PATH
+                    (may be /). This implies <literal>--force-copy</literal>.
                 </para></listitem>
             </varlistentry>
         </variablelist>

--- a/man/ostree-checkout.xml
+++ b/man/ostree-checkout.xml
@@ -68,7 +68,7 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
-                <term><option>--user-mode</option>,<option> -u</option></term>
+                <term><option>--user-mode</option>, <option>-U</option></term>
 
                 <listitem><para>
                     Do not change file ownership or initialize extended attributes.

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -87,7 +87,7 @@ static GOptionEntry options[] = {
   { "force-copy-zerosized", 'z', 0, G_OPTION_ARG_NONE, &opt_force_copy_zerosized, "Do not hardlink zero-sized files", NULL },
   { "force-copy", 'C', 0, G_OPTION_ARG_NONE, &opt_force_copy, "Never hardlink (but may reflink if available)", NULL },
   { "bareuseronly-dirs", 'M', 0, G_OPTION_ARG_NONE, &opt_bareuseronly_dirs, "Suppress mode bits outside of 0775 for directories (suid, world writable, etc.)", NULL },
-  { "skip-list", 0, 0, G_OPTION_ARG_FILENAME, &opt_skiplist_file, "File containing list of files to skip", "PATH" },
+  { "skip-list", 0, 0, G_OPTION_ARG_FILENAME, &opt_skiplist_file, "File containing list of files to skip", "FILE" },
   { "selinux-policy", 0, 0, G_OPTION_ARG_FILENAME, &opt_selinux_policy, "Set SELinux labels based on policy in root filesystem PATH (may be /); implies --force-copy", "PATH" },
   { "selinux-prefix", 0, 0, G_OPTION_ARG_STRING, &opt_selinux_prefix, "When setting SELinux labels, prefix all paths by PREFIX", "PREFIX" },
   { NULL }


### PR DESCRIPTION
This merge request adds all missing options to the checkout man page. There is actually one mistake which really confused me (`-u` for `--user-mode`) which I kept in a separate commit.