### PR TITLE
sign/ed25519: Output failed signatures in error message

### DIFF
--- a/tests/test-pre-signed-pull.sh
+++ b/tests/test-pre-signed-pull.sh
@@ -48,5 +48,5 @@ ostree --repo=repo remote add badupstream --set=gpg-verify=false --sign-verify=e
 if ostree --repo=repo pull badupstream:testref 2>err.txt; then
     fatal "pulled with wrong key"
 fi
-assert_file_has_content err.txt 'error:.* no valid ed25519 signatures found'
+assert_file_has_content err.txt 'error:.* ed25519: Signature couldn.t be verified with: key'
 echo "ok pre-signed pull"

--- a/tests/test-signed-commit.sh
+++ b/tests/test-signed-commit.sh
@@ -148,9 +148,10 @@ for((i=0;i<100;i++)); do
     gen_ed25519_random_public
 done > ${PUBKEYS}
 # Check if file contain no valid signatures
-if ${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 --keys-file=${PUBKEYS} ${COMMIT}; then
-    exit 1
+if ${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 --keys-file=${PUBKEYS} ${COMMIT} 2>err.txt; then
+    fatal "validated with no signatures"
 fi
+assert_file_has_content err.txt 'error:.* ed25519: Signature couldn.t be verified; tried 100 keys'
 # Check if no valid signatures provided via args&file
 if ${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 --keys-file=${PUBKEYS} ${COMMIT} ${WRONG_PUBLIC}; then
     exit 1

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -226,7 +226,7 @@ cp ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.2,}
 if ${OSTREE} --repo=repo pull origin main 2>err.txt; then
     assert_not_reached "Successful pull with old summary"
 fi
-assert_file_has_content err.txt "no valid ed25519 signatures found"
+assert_file_has_content err.txt "ed25519: Signature couldn't be verified with: key"
 assert_has_file repo/tmp/cache/summaries/origin
 assert_has_file repo/tmp/cache/summaries/origin.sig
 cmp repo/tmp/cache/summaries/origin ${test_tmpdir}/ostree-srv/gnomerepo/summary.1 >&2


### PR DESCRIPTION
To aid debuggability, when we find a commit that isn't signed
by our expected key, output a specific error message with the
key.

(And then add code to switch to just printing the count beyond 3
 because the test suite injects 100 keys and hopefully no one
 ever actually does that)