### PR TITLE
signapi: Change API to also return a success message

### DIFF
--- a/src/libostree/ostree-repo-pull-private.h
+++ b/src/libostree/ostree-repo-pull-private.h
@@ -77,6 +77,7 @@ typedef struct {
   GHashTable       *summary_deltas_checksums;
   GHashTable       *ref_original_commits; /* Maps checksum to commit, used by timestamp checks */
   GHashTable       *verified_commits; /* Set<checksum> of commits that have been verified */
+  GHashTable       *signapi_verified_commits; /* Map<checksum,verification> of commits that have been signapi verified */
   GHashTable       *ref_keyring_map; /* Maps OstreeCollectionRef to keyring remote name */
   GPtrArray        *static_delta_superblocks;
   GHashTable       *expected_commit_sizes; /* Maps commit checksum to known size */
@@ -149,6 +150,7 @@ gboolean
 _sign_verify_for_remote (GPtrArray *signers,
                          GBytes *signed_data,
                          GVariant *metadata,
+                         char    **out_success_message,
                          GError **error);
 
 gboolean

--- a/src/libostree/ostree-sign-dummy.c
+++ b/src/libostree/ostree-sign-dummy.c
@@ -154,6 +154,7 @@ const gchar * ostree_sign_dummy_metadata_format (OstreeSign *self)
 gboolean ostree_sign_dummy_data_verify (OstreeSign *self,
                                             GBytes     *data,
                                             GVariant   *signatures,
+                                            char       **out_success_message,
                                             GError     **error)
 {
   if (!check_dummy_sign_enabled (error))
@@ -182,7 +183,11 @@ gboolean ostree_sign_dummy_data_verify (OstreeSign *self,
       g_debug("Stored signature %d: %s", (gint)i, sign->pk_ascii);
 
       if (!g_strcmp0(sign_ascii, sign->pk_ascii))
-        return TRUE;
+        {
+          if (out_success_message)
+            *out_success_message = g_strdup ("dummy: Signature verified");
+          return TRUE;
+        }
       else
         return glnx_throw (error, "signature: dummy: incorrect signature %" G_GSIZE_FORMAT, i);
     }

--- a/src/libostree/ostree-sign-dummy.h
+++ b/src/libostree/ostree-sign-dummy.h
@@ -63,6 +63,7 @@ gboolean ostree_sign_dummy_data (OstreeSign *self,
 gboolean ostree_sign_dummy_data_verify (OstreeSign *self,
                                         GBytes     *data,
                                         GVariant   *signatures,
+                                        char       **success_message,
                                         GError     **error);
 
 const gchar * ostree_sign_dummy_metadata_key (OstreeSign *self);

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -169,6 +169,7 @@ _compare_ed25519_keys(gconstpointer a, gconstpointer b) {
 gboolean ostree_sign_ed25519_data_verify (OstreeSign *self,
                                           GBytes     *data,
                                           GVariant   *signatures,
+                                          char      **out_success_message,
                                           GError     **error)
 {
   g_return_val_if_fail (OSTREE_IS_SIGN (self), FALSE);
@@ -243,8 +244,12 @@ gboolean ostree_sign_ed25519_data_verify (OstreeSign *self,
             }
           else
             {
-              g_debug ("Signature verified successfully with key '%s'",
-                       sodium_bin2hex (hex, crypto_sign_PUBLICKEYBYTES*2+1, public_key->data, crypto_sign_PUBLICKEYBYTES));
+              if (out_success_message)
+                {
+                  *out_success_message =
+                    g_strdup_printf ("ed25519: Signature verified successfully with key '%s'",
+                                     sodium_bin2hex (hex, crypto_sign_PUBLICKEYBYTES*2+1, public_key->data, crypto_sign_PUBLICKEYBYTES));
+                }
               return TRUE;
             }
         }

--- a/src/libostree/ostree-sign-ed25519.h
+++ b/src/libostree/ostree-sign-ed25519.h
@@ -61,6 +61,7 @@ gboolean ostree_sign_ed25519_data (OstreeSign *self,
 gboolean ostree_sign_ed25519_data_verify (OstreeSign *self,
                                           GBytes     *data,
                                           GVariant   *signatures,
+                                          char      **out_success_message,
                                           GError     **error);
 
 const gchar * ostree_sign_ed25519_get_name (OstreeSign *self);

--- a/src/libostree/ostree-sign.c
+++ b/src/libostree/ostree-sign.c
@@ -322,13 +322,14 @@ gboolean
 ostree_sign_data_verify (OstreeSign *self,
                          GBytes     *data,
                          GVariant   *signatures,
+                         char      **out_success_message,
                          GError     **error)
 {
   g_return_val_if_fail (OSTREE_IS_SIGN (self), FALSE);
   if (OSTREE_SIGN_GET_IFACE (self)->data_verify == NULL)
     return glnx_throw (error, "not implemented");
 
-  return OSTREE_SIGN_GET_IFACE (self)->data_verify(self, data, signatures, error);
+  return OSTREE_SIGN_GET_IFACE (self)->data_verify(self, data, signatures, out_success_message, error);
 }
 
 /*
@@ -389,6 +390,7 @@ gboolean
 ostree_sign_commit_verify (OstreeSign     *self,
                            OstreeRepo     *repo,
                            const gchar    *commit_checksum,
+                           char          **out_success_message,
                            GCancellable   *cancellable,
                            GError         **error)
 
@@ -427,6 +429,7 @@ ostree_sign_commit_verify (OstreeSign     *self,
   return ostree_sign_data_verify (self,
                                   signed_data,
                                   signatures,
+                                  out_success_message,
                                   error);
 }
 

--- a/src/libostree/ostree-sign.h
+++ b/src/libostree/ostree-sign.h
@@ -72,6 +72,7 @@ struct _OstreeSignInterface
   gboolean (* data_verify) (OstreeSign *self,
                             GBytes *data,
                             GVariant   *signatures,
+                            char      **out_success_message,
                             GError **error);
   const gchar *(* metadata_key) (OstreeSign *self);
   const gchar *(* metadata_format) (OstreeSign *self);
@@ -105,6 +106,7 @@ _OSTREE_PUBLIC
 gboolean ostree_sign_data_verify (OstreeSign *self,
                                   GBytes     *data,
                                   GVariant   *signatures,
+                                  char      **out_success_message,
                                   GError     **error);
 
 _OSTREE_PUBLIC
@@ -124,6 +126,7 @@ _OSTREE_PUBLIC
 gboolean ostree_sign_commit_verify (OstreeSign *self,
                                     OstreeRepo     *repo,
                                     const gchar    *commit_checksum,
+                                    char          **out_success_message,
                                     GCancellable   *cancellable,
                                     GError         **error);
 

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -70,6 +70,7 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
   g_autoptr (OstreeRepo) repo = NULL;
   g_autoptr (OstreeSign) sign = NULL;
   g_autofree char *resolved_commit = NULL;
+  g_autofree char *success_message = NULL;
   const char *commit;
   char **key_ids;
   int n_key_ids, ii;
@@ -130,9 +131,12 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
           if (ostree_sign_commit_verify (sign,
                                          repo,
                                          resolved_commit,
+                                         &success_message,
                                          cancellable,
                                          &local_error))
             {
+              g_assert (success_message);
+              g_print ("%s\n", success_message);
               ret = TRUE;
               goto out;
             }
@@ -180,9 +184,13 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
           if (ostree_sign_commit_verify (sign,
                                          repo,
                                          resolved_commit,
+                                         &success_message,
                                          cancellable,
                                          error))
-            ret = TRUE;
+            {
+              g_print ("%s\n", success_message);
+              ret = TRUE;
+            }
         } /* Check via file */
     }
   else

--- a/tests/test-signed-commit.sh
+++ b/tests/test-signed-commit.sh
@@ -121,8 +121,10 @@ done
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --sign-type=dummy ${COMMIT} ${DUMMYSIGN}
 ${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --sign-type=ed25519 ${COMMIT} ${SECRET}
 # and verify
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 ${COMMIT} ${PUBLIC}
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --sign-type=dummy --verify ${COMMIT} ${DUMMYSIGN}
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 ${COMMIT} ${PUBLIC} >out.txt
+assert_file_has_content out.txt "ed25519: Signature verified successfully with key"
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --sign-type=dummy --verify ${COMMIT} ${DUMMYSIGN} >out.txt
+assert_file_has_content out.txt "dummy: Signature verified"
 echo "ok multiple signing "
 
 # Prepare files with public ed25519 signatures
@@ -140,7 +142,8 @@ fi
 
 # Test with single key in list
 echo ${PUBLIC} > ${PUBKEYS}
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 --keys-file=${PUBKEYS} ${COMMIT}
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo sign --verify --sign-type=ed25519 --keys-file=${PUBKEYS} ${COMMIT} >out.txt
+assert_file_has_content out.txt 'ed25519: Signature verified successfully'
 
 # Test the file with multiple keys without a valid public key
 for((i=0;i<100;i++)); do


### PR DESCRIPTION
This is the dual of https://github.com/ostreedev/ostree/pull/2129/commits/1f3c8c5b3de978f6e069c24938967f823cce7ee8
where we output more detail when signapi fails to validate.

Extend the API to return a string for success, which we output
to stdout.

This will help the test suite *and* end users validate that the expected
thing is happening.

In order to make this cleaner, split the "verified commit" set
in the pull code into GPG and signapi verified sets, and have
the signapi verified set contain the verification string.

We're not doing anything with the verification string in the
pull code *yet* but I plan to add something like
`ostree pull --verbose` which would finally print this.