### PR TITLE
libostree-devel.sym: Remove nonexistent stub symbol

### DIFF
--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -21,7 +21,6 @@
 LIBOSTREE_2020.2 {
 global:
   ostree_repo_commit_modifier_set_sepolicy_from_commit;
-  someostree_symbol_deleteme;
   ostree_sign_get_type;
   ostree_sign_get_all;
   ostree_sign_commit;


### PR DESCRIPTION
This should have been removed when we added symbols to this list.