### PR TITLE
sysroot: Remove unimplemented ostree_sysroot_lock_with_mount_namespace

### DIFF
--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -102,9 +102,6 @@ _OSTREE_PUBLIC
 gboolean ostree_sysroot_lock (OstreeSysroot  *self, GError **error);
 
 _OSTREE_PUBLIC
-gboolean ostree_sysroot_lock_with_mount_namespace (OstreeSysroot  *self, GError **error);
-
-_OSTREE_PUBLIC
 gboolean ostree_sysroot_try_lock (OstreeSysroot         *self,
                                   gboolean              *out_acquired,
                                   GError               **error);


### PR DESCRIPTION
This came in with 5af403be0cc64df50ad21cef05f3268ead256d6d but
was never implemented.

I noticed this now because the Rust ostree bindings generate a
wrapper for it which the linker tries to use.