### PR TITLE
tests: Port to Debian autopkgtest reboot API

### DIFF
--- a/tests/kolainst/destructive/staged-deploy.sh
+++ b/tests/kolainst/destructive/staged-deploy.sh
@@ -6,9 +6,8 @@ set -xeuo pipefail
 require_writable_sysroot
 prepare_tmpdir
 
-n=$(nth_boot)
-case "${n}" in
-  1)
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
   # Initial cleanup to handle the cosa fast-build case
     ## TODO remove workaround for https://github.com/coreos/rpm-ostree/pull/2021
     mkdir -p /var/lib/rpm-ostree/history
@@ -48,9 +47,9 @@ case "${n}" in
       fatal "Pinned staged deployment"
     fi
     assert_file_has_content err.txt 'Cannot pin staged deployment'
-    kola_reboot
+    /tmp/autopkgtest-reboot "2"
     ;;
-  2) 
+  "2") 
     # Check that deploy-staged service worked
     rpm-ostree status
     # Assert that the previous boot had a journal entry for it
@@ -118,5 +117,5 @@ case "${n}" in
     ostree refs --delete staged-deploy nonstaged-deploy
     echo "ok cleanup refs"
     ;;
-  *) fatal "Unexpected boot count" ;;
+  *) fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}" ;;
 esac

--- a/tests/kolainst/destructive/var-mount.sh
+++ b/tests/kolainst/destructive/var-mount.sh
@@ -4,20 +4,19 @@ set -xeuo pipefail
 
 . ${KOLA_EXT_DATA}/libinsttest.sh
 
-n=$(nth_boot)
-case "${n}" in
-  1) 
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "") 
     require_writable_sysroot
     # Hack this off for now
     chattr -i /sysroot
     cp -a /var /sysroot/myvar
     touch /sysroot/myvar/somenewfile
     echo '/sysroot/myvar /var none bind 0 0' >> /etc/fstab
-    kola_reboot
+    /tmp/autopkgtest-reboot "2"
     ;;
-  2)
+  "2")
     systemctl status var.mount
     test -f /var/somenewfile
     ;;
-  *) fatal "Unexpected boot count $n"
+  *) fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}" ;;
 esac

--- a/tests/kolainst/libinsttest.sh
+++ b/tests/kolainst/libinsttest.sh
@@ -66,13 +66,6 @@ nth_boot() {
     journalctl --list-boots | wc -l
 }
 
-kola_reboot() {
-    kill -TERM $$
-    sleep 2m
-    echo "failed to reboot?" 1>&2
-    exit 1
-}
-
 # Determine our origin refspec - we'll use this as a test base
 rpmostree=$(which rpm-ostree 2>/dev/null)
 if test -z "${rpmostree}"; then


### PR DESCRIPTION
See https://github.com/coreos/coreos-assembler/pull/1528

I think we can drop the old cosa reboot APIs after this,
though I've already forgotten where else I might have written
tests using it.