### PR TITLE
lib/repo: Handle EACCES for POSIX locking

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1933,7 +1933,7 @@ rename_pending_loose_objects (OstreeRepo        *self,
   return TRUE;
 }
 
-/* Try to lock a transaction stage directory created by
+/* Try to lock and delete a transaction stage directory created by
  * ostree_repo_prepare_transaction().
  */
 static gboolean

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5980,7 +5980,9 @@ _ostree_repo_try_lock_tmpdir (int            tmpdir_dfd,
   if (!glnx_make_lock_file (tmpdir_dfd, lock_name, LOCK_EX | LOCK_NB,
                             file_lock_out, &local_error))
     {
-      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
+      /* we need to handle EACCES too in the case of POSIX locks; see F_SETLK in fcntl(2) */
+      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK)
+          || g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED))
         {
           did_lock = FALSE;
         }


### PR DESCRIPTION
If `glnx_make_lock_file` falls back to `flock`, on NFS this uses POSIX
locks (`F_SETLK`). As such, we need to be able to handle `EACCES` as
well as `EAGAIN` (see `fnctl(2)`).

I think this is what coreos-ostree-importer has been hitting, which runs
on RHEL7 in the Fedora infra and does locking over an NFS share where
multiple apps could concurrently pull things into the repo.