### PR TITLE
sysroot: Support customising /boot on root for syslinux and u-boot

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -96,6 +96,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-upgrade-endoflife.sh \
 	tests/test-admin-upgrade-systemd-update.sh \
 	tests/test-admin-deploy-syslinux.sh \
+	tests/test-admin-deploy-syslinux-bootonslash.sh \
 	tests/test-admin-deploy-2.sh \
 	tests/test-admin-deploy-karg.sh \
 	tests/test-admin-deploy-switch.sh \

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -372,6 +372,33 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>boot_path_on_disk</varname></term>
+        <listitem>
+          <para>
+            Tell ostree where the bootloader will be looking for the kernel.
+            This is the location of <literal>/boot</literal> relative to the
+            root of the boot partition.
+          </para>
+          <para>
+            This allows explicitly telling ostree that the boot partition is or
+            is not seperate from the root partition.  If
+            <literal>/boot</literal> is on root set this to
+            <literal>/boot</literal>.  If it's on seperate partition this
+            should be set to <literal>/</literal>.
+          </para>
+          <para>
+            This must be either an absolute path (starting with
+            <literal>/</literal>) or <literal>auto</literal>.  Defaults to
+            <literal>auto</literal>.
+          </para>
+          <para>
+            This setting currently only respected by the u-boot and syslinux
+            bootloaders.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
 
   </refsect1>

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -347,7 +347,9 @@ Boston, MA 02111-1307, USA.
         <term><varname>bootloader</varname></term>
         <listitem><para>Configure the bootloader that OSTree uses when
         deploying the sysroot.  This may take the values
-        <literal>bootloader=none</literal> or <literal>bootloader=auto</literal>.
+        <literal>bootloader=none</literal>, <literal>bootloader=auto</literal>,
+        <literal>bootloader=grub2</literal>, <literal>bootloader=syslinux</literal>,
+        <literal>bootloader=uboot</literal> or <literal>bootloader=zipl</literal>.
         Default is <literal>auto</literal>.
         </para>
         <para>
@@ -361,6 +363,11 @@ Boston, MA 02111-1307, USA.
           uboot, and syslinux bootloaders.  If one of the bootloaders is found,
           then OSTree will generate a config for the bootloader found.  For
           example, <literal>grub2-mkconfig</literal> is run for the grub2 case.
+        </para>
+        <para>
+          A specific bootloader type may also be explicitly requested by choosing
+          <literal>grub2</literal>, <literal>syslinux</literal>, <literal>uboot</literal> or
+          <literal>zipl</literal>.
         </para>
         </listitem>
       </varlistentry>

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -107,6 +107,9 @@ typedef enum {
 typedef enum {
   CFG_SYSROOT_BOOTLOADER_OPT_AUTO = 0,
   CFG_SYSROOT_BOOTLOADER_OPT_NONE,
+  CFG_SYSROOT_BOOTLOADER_OPT_GRUB2,
+  CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX,
+  CFG_SYSROOT_BOOTLOADER_OPT_UBOOT,
   CFG_SYSROOT_BOOTLOADER_OPT_ZIPL,
   /* Non-exhaustive */
 } OstreeCfgSysrootBootloaderOpt;
@@ -115,6 +118,9 @@ static const char* const CFG_SYSROOT_BOOTLOADER_OPTS_STR[] = {
   /* This must be kept in the same order as the enum */
   "auto",
   "none",
+  "grub2",
+  "syslinux",
+  "uboot",
   "zipl",
   NULL,
 };

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -103,6 +103,22 @@ typedef enum {
   _OSTREE_FEATURE_YES,
 } _OstreeFeatureSupport;
 
+/* Possible values for the sysroot.bootloader configuration variable */
+typedef enum {
+  CFG_SYSROOT_BOOTLOADER_OPT_AUTO = 0,
+  CFG_SYSROOT_BOOTLOADER_OPT_NONE,
+  CFG_SYSROOT_BOOTLOADER_OPT_ZIPL,
+  /* Non-exhaustive */
+} OstreeCfgSysrootBootloaderOpt;
+
+static const char* const CFG_SYSROOT_BOOTLOADER_OPTS_STR[] = {
+  /* This must be kept in the same order as the enum */
+  "auto",
+  "none",
+  "zipl",
+  NULL,
+};
+
 /**
  * OstreeRepo:
  *
@@ -185,7 +201,7 @@ struct OstreeRepo {
   guint64 payload_link_threshold;
   gint fs_support_reflink; /* The underlying filesystem has support for ioctl (FICLONE..) */
   gchar **repo_finders;
-  gchar *bootloader; /* Configure which bootloader to use. */
+  OstreeCfgSysrootBootloaderOpt bootloader; /* Configure which bootloader to use. */
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1048,7 +1048,6 @@ ostree_repo_finalize (GObject *object)
   g_mutex_clear (&self->txn_lock);
   g_free (self->collection_id);
   g_strfreev (self->repo_finders);
-  g_free (self->bootloader);
 
   g_clear_pointer (&self->remotes, g_hash_table_destroy);
   g_mutex_clear (&self->remotes_lock);
@@ -3182,28 +3181,28 @@ reload_sysroot_config (OstreeRepo          *self,
                        GCancellable        *cancellable,
                        GError             **error)
 {
-  { g_autofree char *bootloader = NULL;
+  g_autofree char *bootloader = NULL;
 
-    if (!ot_keyfile_get_value_with_default_group_optional (self->config, "sysroot",
-                                                           "bootloader", "auto",
-                                                           &bootloader, error))
-      return FALSE;
+  if (!ot_keyfile_get_value_with_default_group_optional (self->config, "sysroot",
+                                                         "bootloader", "auto",
+                                                         &bootloader, error))
+    return FALSE;
 
-    /* TODO: possibly later add support for specifying a generic bootloader
-     * binary "x" in /usr/lib/ostree/bootloaders/x). See:
-     * https://github.com/ostreedev/ostree/issues/1719
-     * https://github.com/ostreedev/ostree/issues/1801
-     * Also, dedup these strings with the bootloader implementations
-     */
-    if (!(g_str_equal (bootloader, "auto") || g_str_equal (bootloader, "none")
-          || g_str_equal (bootloader, "zipl")))
-      return glnx_throw (error, "Invalid bootloader configuration: '%s'", bootloader);
+  /* TODO: possibly later add support for specifying a generic bootloader
+   * binary "x" in /usr/lib/ostree/bootloaders/x). See:
+   * https://github.com/ostreedev/ostree/issues/1719
+   * https://github.com/ostreedev/ostree/issues/1801
+   */
+  for (int i = 0; CFG_SYSROOT_BOOTLOADER_OPTS_STR[i]; i++)
+    {
+      if (g_str_equal (bootloader, CFG_SYSROOT_BOOTLOADER_OPTS_STR[i]))
+        {
+          self->bootloader = (OstreeCfgSysrootBootloaderOpt) i;
+          return TRUE;
+        }
+    }
 
-    g_free (self->bootloader);
-    self->bootloader = g_steal_pointer (&bootloader);
-  }
-
-  return TRUE;
+  return glnx_throw (error, "Invalid bootloader configuration: '%s'", bootloader);
 }
 
 /**
@@ -6241,7 +6240,7 @@ ostree_repo_get_bootloader (OstreeRepo   *self)
 {
   g_return_val_if_fail (OSTREE_IS_REPO (self), NULL);
 
-  return self->bootloader;
+  return CFG_SYSROOT_BOOTLOADER_OPTS_STR[self->bootloader];
 }
 
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -6233,7 +6233,7 @@ ostree_repo_get_default_repo_finders (OstreeRepo *self)
  * Get the bootloader configured. See the documentation for the
  * "sysroot.bootloader" config key.
  *
- * Returns: bootloader configuration for the sysroot
+ * Returns: (transfer none): bootloader configuration for the sysroot
  * Since: 2019.2
  */
 const gchar *

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -49,6 +49,22 @@
 #include "ostree-linuxfsutil.h"
 #include "libglnx.h"
 
+#ifdef HAVE_LIBMOUNT
+typedef struct libmnt_table libmnt_table;
+typedef struct libmnt_fs libmnt_fs;
+typedef struct libmnt_cache libmnt_cache;
+
+#ifdef HAVE_MNT_UNREF_CACHE
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_table, mnt_unref_table);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_fs, mnt_unref_fs);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_cache, mnt_unref_cache);
+#else
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_table, mnt_free_table);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_fs, mnt_free_fs);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (libmnt_cache, mnt_free_cache);
+#endif
+#endif /* HAVE_LIBMOUNT */
+
 #ifdef HAVE_LIBSYSTEMD
 #define OSTREE_VARRELABEL_ID            SD_ID128_MAKE(da,67,9b,08,ac,d3,45,04,b7,89,d9,6f,81,8e,a7,81)
 #define OSTREE_CONFIGMERGE_ID           SD_ID128_MAKE(d3,86,3b,ae,c1,3e,44,49,ab,03,84,68,4a,8a,f3,a7)
@@ -2184,28 +2200,17 @@ is_ro_mount (const char *path)
    * Systemd has a totally different implementation in
    * src/basic/mount-util.c.
    */
-  struct libmnt_table *tb = mnt_new_table_from_file ("/proc/self/mountinfo");
-  struct libmnt_fs *fs;
-  struct libmnt_cache *cache;
-  gboolean is_mount = FALSE;
-  struct statvfs stvfsbuf;
+  g_autoptr(libmnt_table) tb = mnt_new_table_from_file ("/proc/self/mountinfo");
 
   if (!tb)
     return FALSE;
 
-  /* to canonicalize all necessary paths */
-  cache = mnt_new_cache ();
+    /* to canonicalize all necessary paths */
+  g_autoptr(libmnt_cache) cache = mnt_new_cache ();
   mnt_table_set_cache (tb, cache);
 
-  fs = mnt_table_find_target(tb, path, MNT_ITER_BACKWARD);
-  is_mount = fs && mnt_fs_get_target (fs);
-#ifdef HAVE_MNT_UNREF_CACHE
-  mnt_unref_table (tb);
-  mnt_unref_cache (cache);
-#else
-  mnt_free_table (tb);
-  mnt_free_cache (cache);
-#endif
+  g_autoptr(libmnt_fs) fs = mnt_table_find_target(tb, path, MNT_ITER_BACKWARD);
+  gboolean is_mount = fs && mnt_fs_get_target (fs);
 
   if (!is_mount)
     return FALSE;
@@ -2213,6 +2218,7 @@ is_ro_mount (const char *path)
   /* We *could* parse the options, but it seems more reliable to
    * introspect the actual mount at runtime.
    */
+  struct statvfs stvfsbuf;
   if (statvfs (path, &stvfsbuf) == 0)
     return (stvfsbuf.f_flag & ST_RDONLY) != 0;
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -44,7 +44,6 @@
 #include "ostree-repo-private.h"
 #include "ostree-sysroot-private.h"
 #include "ostree-sepolicy-private.h"
-#include "ostree-bootloader-zipl.h"
 #include "ostree-deployment-private.h"
 #include "ostree-core-private.h"
 #include "ostree-linuxfsutil.h"
@@ -2503,7 +2502,6 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
   gboolean bootloader_is_atomic = FALSE;
   SyncStats syncstats = { 0, };
   g_autoptr(OstreeBootloader) bootloader = NULL;
-  const char *bootloader_config = NULL;
   if (!requires_new_bootversion)
     {
       if (!create_new_bootlinks (self, self->bootversion,
@@ -2535,29 +2533,8 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
             return glnx_throw_errno_prefix (error, "Remounting /boot read-write");
         }
 
-      OstreeRepo *repo = ostree_sysroot_repo (self);
-
-      bootloader_config = ostree_repo_get_bootloader (repo);
-
-      g_debug ("Using bootloader configuration: %s", bootloader_config);
-
-      if (g_str_equal (bootloader_config, "auto"))
-        {
-          if (!_ostree_sysroot_query_bootloader (self, &bootloader, cancellable, error))
-            return FALSE;
-        }
-      else if (g_str_equal (bootloader_config, "none"))
-        {
-          /* No bootloader specified; do not query bootloaders to run. */
-        }
-      else if (g_str_equal (bootloader_config, "zipl"))
-        {
-          /* Because we do not mark zipl as active by default, lets creating one here,
-           * which is basically the same what _ostree_sysroot_query_bootloader() does
-           * for other bootloaders if being activated.
-           * */
-          bootloader = (OstreeBootloader*) _ostree_bootloader_zipl_new (self);
-        }
+      if (!_ostree_sysroot_query_bootloader (self, &bootloader, cancellable, error))
+        return FALSE;
 
       bootloader_is_atomic = bootloader != NULL && _ostree_bootloader_is_atomic (bootloader);
 
@@ -2588,6 +2565,7 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot     *self,
                        (bootloader_is_atomic ? "Transaction complete" : "Bootloader updated"),
                        requires_new_bootversion ? "yes" : "no",
                        new_deployments->len - self->deployments->len);
+    const gchar *bootloader_config = ostree_repo_get_bootloader (ostree_sysroot_repo (self));
     ot_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(OSTREE_DEPLOYMENT_COMPLETE_ID),
                      "MESSAGE=%s", msg,
                      "OSTREE_BOOTLOADER=%s", bootloader ? _ostree_bootloader_get_name (bootloader) : "none",

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -167,4 +167,7 @@ gboolean _ostree_sysroot_cleanup_internal (OstreeSysroot *sysroot,
                                            GCancellable  *cancellable,
                                            GError       **error);
 
+char * _ostree_sysroot_get_boot_path_on_disk (OstreeSysroot *sysroot,
+                                              GError **error);
+
 G_END_DECLS

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1313,50 +1313,53 @@ _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
                                   GError           **error)
 {
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
-  g_autofree gchar *bootloader_config = ostree_repo_get_bootloader (repo);
+  OstreeCfgSysrootBootloaderOpt bootloader_config = repo->bootloader;
 
-  g_debug ("Using bootloader configuration: %s", bootloader_config);
+  g_debug ("Using bootloader configuration: %s",
+      CFG_SYSROOT_BOOTLOADER_OPTS_STR[bootloader_config]);
 
   g_autoptr(OstreeBootloader) ret_loader = NULL;
-  if (g_str_equal (bootloader_config, "none"))
+  switch (repo->bootloader)
     {
+    case CFG_SYSROOT_BOOTLOADER_OPT_NONE:
       /* No bootloader specified; do not query bootloaders to run. */
       ret_loader = NULL;
-    }
-  else if (g_str_equal (bootloader_config, "zipl"))
-    {
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_ZIPL:
       /* We never consider zipl as active by default, so it can only be created
        * if it's explicitly requested in the config */
       ret_loader = (OstreeBootloader*) _ostree_bootloader_zipl_new (sysroot);
-    }
-  else if (g_str_equal (bootloader_config, "auto"))
-    {
-      gboolean is_active;
-      ret_loader = (OstreeBootloader*)_ostree_bootloader_syslinux_new (sysroot);
-      if (!_ostree_bootloader_query (ret_loader, &is_active,
-                                     cancellable, error))
-        return FALSE;
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_AUTO:
+      {
+        gboolean is_active;
+        ret_loader = (OstreeBootloader*)_ostree_bootloader_syslinux_new (sysroot);
+        if (!_ostree_bootloader_query (ret_loader, &is_active,
+                                      cancellable, error))
+          return FALSE;
 
-      if (!is_active)
-        {
-          g_object_unref (ret_loader);
-          ret_loader = (OstreeBootloader*)_ostree_bootloader_grub2_new (sysroot);
-          if (!_ostree_bootloader_query (ret_loader, &is_active,
-                                         cancellable, error))
-            return FALSE;
-        }
-      if (!is_active)
-        {
-          g_object_unref (ret_loader);
-          ret_loader = (OstreeBootloader*)_ostree_bootloader_uboot_new (sysroot);
-          if (!_ostree_bootloader_query (ret_loader, &is_active, cancellable, error))
-            return FALSE;
-        }
-      if (!is_active)
-        g_clear_object (&ret_loader);
+        if (!is_active)
+          {
+            g_object_unref (ret_loader);
+            ret_loader = (OstreeBootloader*)_ostree_bootloader_grub2_new (sysroot);
+            if (!_ostree_bootloader_query (ret_loader, &is_active,
+                                          cancellable, error))
+              return FALSE;
+          }
+        if (!is_active)
+          {
+            g_object_unref (ret_loader);
+            ret_loader = (OstreeBootloader*)_ostree_bootloader_uboot_new (sysroot);
+            if (!_ostree_bootloader_query (ret_loader, &is_active, cancellable, error))
+              return FALSE;
+          }
+        if (!is_active)
+          g_clear_object (&ret_loader);
+        break;
+      }
+    default:
+      g_assert_not_reached ();
     }
-  else
-    g_assert_not_reached ();
 
   ot_transfer_out_value(out_bootloader, &ret_loader);
   return TRUE;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1325,6 +1325,15 @@ _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
       /* No bootloader specified; do not query bootloaders to run. */
       ret_loader = NULL;
       break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_GRUB2:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_grub2_new (sysroot);
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_syslinux_new (sysroot);
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_UBOOT:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_uboot_new (sysroot);
+      break;
     case CFG_SYSROOT_BOOTLOADER_OPT_ZIPL:
       /* We never consider zipl as active by default, so it can only be created
        * if it's explicitly requested in the config */

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -36,6 +36,7 @@
 #include "ostree-bootloader-uboot.h"
 #include "ostree-bootloader-syslinux.h"
 #include "ostree-bootloader-grub2.h"
+#include "ostree-bootloader-zipl.h"
 
 /**
  * SECTION:ostree-sysroot
@@ -1301,6 +1302,7 @@ ostree_sysroot_repo (OstreeSysroot *self)
  * ostree_sysroot_query_bootloader:
  * @sysroot: Sysroot
  * @out_bootloader: (out) (transfer full) (allow-none): Return location for bootloader, may be %NULL
+ * @out_bootloader_config: (out) (transfer none) (allow-none): Return location for value of ostree repo config variable sysroot.bootloader, may be %NULL
  * @cancellable: Cancellable
  * @error: Error
  */
@@ -1310,30 +1312,51 @@ _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
                                   GCancellable      *cancellable,
                                   GError           **error)
 {
-  gboolean is_active;
-  g_autoptr(OstreeBootloader) ret_loader =
-    (OstreeBootloader*)_ostree_bootloader_syslinux_new (sysroot);
-  if (!_ostree_bootloader_query (ret_loader, &is_active,
-                                 cancellable, error))
-    return FALSE;
+  OstreeRepo *repo = ostree_sysroot_repo (sysroot);
+  g_autofree gchar *bootloader_config = ostree_repo_get_bootloader (repo);
 
-  if (!is_active)
+  g_debug ("Using bootloader configuration: %s", bootloader_config);
+
+  g_autoptr(OstreeBootloader) ret_loader = NULL;
+  if (g_str_equal (bootloader_config, "none"))
     {
-      g_object_unref (ret_loader);
-      ret_loader = (OstreeBootloader*)_ostree_bootloader_grub2_new (sysroot);
+      /* No bootloader specified; do not query bootloaders to run. */
+      ret_loader = NULL;
+    }
+  else if (g_str_equal (bootloader_config, "zipl"))
+    {
+      /* We never consider zipl as active by default, so it can only be created
+       * if it's explicitly requested in the config */
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_zipl_new (sysroot);
+    }
+  else if (g_str_equal (bootloader_config, "auto"))
+    {
+      gboolean is_active;
+      ret_loader = (OstreeBootloader*)_ostree_bootloader_syslinux_new (sysroot);
       if (!_ostree_bootloader_query (ret_loader, &is_active,
                                      cancellable, error))
         return FALSE;
+
+      if (!is_active)
+        {
+          g_object_unref (ret_loader);
+          ret_loader = (OstreeBootloader*)_ostree_bootloader_grub2_new (sysroot);
+          if (!_ostree_bootloader_query (ret_loader, &is_active,
+                                         cancellable, error))
+            return FALSE;
+        }
+      if (!is_active)
+        {
+          g_object_unref (ret_loader);
+          ret_loader = (OstreeBootloader*)_ostree_bootloader_uboot_new (sysroot);
+          if (!_ostree_bootloader_query (ret_loader, &is_active, cancellable, error))
+            return FALSE;
+        }
+      if (!is_active)
+        g_clear_object (&ret_loader);
     }
-  if (!is_active)
-    {
-      g_object_unref (ret_loader);
-      ret_loader = (OstreeBootloader*)_ostree_bootloader_uboot_new (sysroot);
-      if (!_ostree_bootloader_query (ret_loader, &is_active, cancellable, error))
-        return FALSE;
-    }
-  if (!is_active)
-    g_clear_object (&ret_loader);
+  else
+    g_assert_not_reached ();
 
   ot_transfer_out_value(out_bootloader, &ret_loader);
   return TRUE;

--- a/tests/bootloader-entries-crosscheck.py
+++ b/tests/bootloader-entries-crosscheck.py
@@ -45,7 +45,7 @@ def get_ostree_option(optionstring):
     for o in optionstring.split():
         if o.startswith('ostree='):
             return o[8:]
-    raise ValueError('ostree= not found')
+    raise ValueError('ostree= not found in %r' % (optionstring,))
             
 entries = []
 syslinux_entries = []
@@ -98,7 +98,7 @@ def assert_matches_key(a, b, key):
     aval = a[key]
     bval = b[key]
     if aval != bval:
-        fatal("Mismatch on {0}: {1} != {2}".format(key, aval, bval))
+        fatal("Mismatch on {0}: entry: {1} != syslinux: {2}".format(key, aval, bval))
 
 for i,(entry,syslinuxentry) in enumerate(zip(entries, syslinux_entries)):
     assert_matches_key(entry, syslinuxentry, 'linux')

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -49,6 +49,7 @@ trap run_exit_cmds EXIT
 save_core() {
   if [ -e core ]; then
     cp core "$test_srcdir/core"
+    gdb -batch -ex bt "$test_builddir/../.libs/ostree" core
   fi
 }
 libtest_exit_cmds+=(save_core)

--- a/tests/test-admin-deploy-syslinux-bootonslash.sh
+++ b/tests/test-admin-deploy-syslinux-bootonslash.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive-z2" "syslinux"
+
+echo "1..2"
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+
+# Override the default and say that /boot is not a partition
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set sysroot.boot_path_on_disk /boot
+${CMD_PREFIX} ostree admin deploy --verbose --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "KERNEL /boot/ostree/testos.*vmlinuz"
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "INITRD /boot/ostree/testos.*initramfs"
+
+echo "ok bootonslash"
+
+${CMD_PREFIX} ostree admin undeploy 0
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set sysroot.boot_path_on_disk /
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "KERNEL /ostree/testos.*vmlinuz"
+assert_file_has_content sysroot/boot/syslinux/syslinux.cfg "INITRD /ostree/testos.*initramfs"
+
+echo "ok bootpartition"


### PR DESCRIPTION
This introduces a new config value "sysroot.boot_path_on_disk":

> Tell ostree where the bootloader will be looking for the kernel.  This is
> the location of `/boot` relative to the root of the boot partition.
>
> This allows explicitly telling ostree that the boot partition is or is
> not separate from the root partition.  If `/boot` is on root set this to
> `/boot`.  If it's on seperate partition this should be set to `/`.
>
> This must be either an absolute path (starting with `/`) or `auto`.
> Defaults to `auto`.
>
> This setting currently only respected by the u-boot and syslinux
> bootloaders.

This commit is based on an original by Colin Walters (#215), but takes a
different tack.  #215 attempts to determine automatically whether `/boot`
is on root or not, but there are always situations where this isn't
possible so I'm adding a config option here so the user can make it
explicit.

Future commits can add the automatic detection in, but this means that we
don't need to be completely general with the auto-detection.

See also some background here: https://github.com/ostreedev/ostree/pull/1404#issuecomment-654169968