### PR TITLE
sysroot: Support /boot on root or as seperate filesystem for syslinux and u-boot

### DIFF
--- a/src/libostree/ostree-bootloader-syslinux.c
+++ b/src/libostree/ostree-bootloader-syslinux.c
@@ -89,15 +89,15 @@ append_config_from_loader_entries (OstreeBootloaderSyslinux  *self,
       val = ostree_bootconfig_parser_get (config, "linux");
       if (!val)
         return glnx_throw (error, "No \"linux\" key in bootloader config");
-      g_ptr_array_add (new_lines, g_strdup_printf ("\tKERNEL %s", val));
+      g_ptr_array_add (new_lines, g_strdup_printf ("\tKERNEL /boot%s", val));
 
       val = ostree_bootconfig_parser_get (config, "initrd");
       if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("\tINITRD %s", val));
+        g_ptr_array_add (new_lines, g_strdup_printf ("\tINITRD /boot%s", val));
 
       val = ostree_bootconfig_parser_get (config, "devicetree");
       if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("\tDEVICETREE %s", val));
+        g_ptr_array_add (new_lines, g_strdup_printf ("\tDEVICETREE /boot%s", val));
 
       val = ostree_bootconfig_parser_get (config, "options");
       if (val)
@@ -150,10 +150,13 @@ _ostree_bootloader_syslinux_write_config (OstreeBootloader  *bootloader,
           if (kernel_arg == NULL)
             return glnx_throw (error, "No KERNEL argument found after LABEL");
 
-          /* If this is a non-ostree kernel, just emit the lines
-           * we saw.
+          /* If this is a non-ostree kernel, just emit the lines we saw.
+           *
+           * We check for /ostree (without /boot prefix) as well to support
+           * upgrading ostree from <v2020.4.
            */
-          if (!g_str_has_prefix (kernel_arg, "/ostree/"))
+          if (!g_str_has_prefix (kernel_arg, "/ostree/") &&
+              !g_str_has_prefix (kernel_arg, "/boot/ostree/"))
             {
               for (guint i = 0; i < tmp_lines->len; i++)
                 {

--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -134,19 +134,19 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
                        "No \"linux\" key in bootloader config");
           return FALSE;
         }
-      g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image%s=%s", index_suffix, val));
+      g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image%s=/boot%s", index_suffix, val));
 
       val = ostree_bootconfig_parser_get (config, "initrd");
       if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("ramdisk_image%s=%s", index_suffix, val));
+        g_ptr_array_add (new_lines, g_strdup_printf ("ramdisk_image%s=/boot%s", index_suffix, val));
 
       val = ostree_bootconfig_parser_get (config, "devicetree");
       if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("fdt_file%s=%s", index_suffix, val));
+        g_ptr_array_add (new_lines, g_strdup_printf ("fdt_file%s=/boot%s", index_suffix, val));
 
       val = ostree_bootconfig_parser_get (config, "fdtdir");
       if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("fdtdir%s=%s", index_suffix, val));
+        g_ptr_array_add (new_lines, g_strdup_printf ("fdtdir%s=/boot%s", index_suffix, val));
 
       val = ostree_bootconfig_parser_get (config, "options");
       if (val)

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1998,6 +1998,12 @@ prepare_new_bootloader_link (OstreeSysroot  *sysroot,
   g_assert ((current_bootversion == 0 && new_bootversion == 1) ||
             (current_bootversion == 1 && new_bootversion == 0));
 
+  /* This allows us to support both /boot on a seperate filesystem to / as well
+   * as on the same filesystem. */
+  if (TEMP_FAILURE_RETRY (symlinkat (".", sysroot->sysroot_fd, "boot/boot")) < 0)
+    if (errno != EEXIST)
+      return glnx_throw_errno_prefix (error, "symlinkat");
+
   g_autofree char *new_target = g_strdup_printf ("loader.%d", new_bootversion);
 
   /* We shouldn't actually need to replace but it's easier to reuse

--- a/tests/bootloader-entries-crosscheck.py
+++ b/tests/bootloader-entries-crosscheck.py
@@ -73,21 +73,24 @@ with open(syslinuxpath) as f:
     syslinux_entry = None
     syslinux_default = None
     for line in f:
-        line = line.strip()
-        if line.startswith('DEFAULT '):
+        try:
+            k, v = line.strip().split(" ", 1)
+        except ValueError:
+            continue
+        if k == 'DEFAULT':
             if syslinux_entry is not None:
-                syslinux_default = line.split(' ', 1)[1]
-        elif line.startswith('LABEL '):
+                syslinux_default = v
+        elif k == 'LABEL':
             if syslinux_entry is not None:
                 syslinux_entries.append(syslinux_entry)
             syslinux_entry = {}
-            syslinux_entry['title'] = line.split(' ', 1)[1]
-        elif line.startswith('KERNEL '):
-            syslinux_entry['linux'] = line.split(' ', 1)[1]
-        elif line.startswith('INITRD '):
-            syslinux_entry['initrd'] = line.split(' ', 1)[1]
-        elif line.startswith('APPEND '):
-            syslinux_entry['options'] = line.split(' ', 1)[1]
+            syslinux_entry['title'] = v
+        elif k == 'KERNEL':
+            syslinux_entry['linux'] = v
+        elif k == 'INITRD':
+            syslinux_entry['initrd'] = v
+        elif k == 'APPEND':
+            syslinux_entry['options'] = v
     if syslinux_entry is not None:
         syslinux_entries.append(syslinux_entry)
 


### PR DESCRIPTION
We use a similar trick to having a `sysroot -> .` symlink on the real root
here to support both /boot on root as well as on a separate filesystem.  No
matter how it's mounted `/boot/xyz` will always refer to the file you'd
expect.

This is nicer than my previous attempts at this because there's no
configuration nor auto-detection required.

Fixes #1452

Replaces #1404, #1914 and #2145