### PR TITLE
pull: Also append bytes written

### DIFF
--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -64,7 +64,7 @@ fi
 # Try both syntaxes
 repo_init --no-sign-verify
 ${CMD_PREFIX} ostree --repo=repo pull origin main >out.txt
-assert_file_has_content out.txt "[1-9][0-9]* metadata, [1-9][0-9]* content objects fetched"
+assert_file_has_content out.txt "[1-9][0-9]* metadata, [1-9][0-9]* content objects fetched; [1-9][0-9]*.*written"
 ${CMD_PREFIX} ostree --repo=repo pull origin:main > out.txt
 assert_not_file_has_content out.txt "[1-9][0-9]* content objects fetched"
 ${CMD_PREFIX} ostree --repo=repo fsck


### PR DESCRIPTION
This is very useful information that we get from the transaction
stats.  Append it to the final display if we're not inheriting
the transaction.