### PR TITLE
ci: Constrain parallel build jobs

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,7 +2,8 @@
 
 stage("Build") {
 parallel normal: {
-  cosaPod(buildroot: true, runAsUser: 0) {
+  def n = 5
+  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
       stage("Core build") {
         shwrap("""
@@ -10,7 +11,7 @@ parallel normal: {
           git fetch origin --tags
           git submodule update --init
 
-          env SKIP_INSTALLDEPS=1 ./ci/build.sh
+          env MAKE_JOBS=${n} SKIP_INSTALLDEPS=1 ./ci/build.sh
         """)
       }
       stage("Unit tests") {
@@ -84,18 +85,19 @@ parallel fcos: {
   }
 },
 buildopts: {
-  cosaPod(buildroot: true, runAsUser: 0) {
+  def n = 5
+  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
       shwrap("""
         git submodule update --init
 
         git worktree add build-rust && cd build-rust
-        env CONFIGOPTS="--enable-rust" SKIP_INSTALLDEPS=1 ./ci/build.sh
+        env MAKE_JOBS=${n} CONFIGOPTS="--enable-rust" SKIP_INSTALLDEPS=1 ./ci/build.sh
         make check TESTS=tests/test-rollsum
         cd .. && rm -rf build-rust
 
         git worktree add build-libsoup && cd build-libsoup
-        env CONFIGOPTS="--without-curl --without-openssl --with-soup" SKIP_INSTALLDEPS=1 ./ci/build.sh
+        env MAKE_JOBS=${n} CONFIGOPTS="--without-curl --without-openssl --with-soup" SKIP_INSTALLDEPS=1 ./ci/build.sh
         make check
         cd .. && rm -rf build-libsoup
       """)

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -10,7 +10,7 @@ pkg_upgrade() {
 }
 
 make() {
-    /usr/bin/make -j $(getconf _NPROCESSORS_ONLN) "$@"
+    /usr/bin/make -j ${MAKE_JOBS:-$(getconf _NPROCESSORS_ONLN)} "$@"
 }
 
 build() {

--- a/tests/kolainst/nondestructive/itest-payload-link.sh
+++ b/tests/kolainst/nondestructive/itest-payload-link.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# FIXME just for webserver
+# kola: { "tags": "needs-internet" }
 #
 # Copyright (C) 2018 Red Hat, Inc.
 #

--- a/tests/kolainst/nondestructive/itest-pull.sh
+++ b/tests/kolainst/nondestructive/itest-pull.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-
+# FIXME just for webserver
+# kola: { "tags": "needs-internet" }
 # Using the host ostree, test HTTP pulls
 
 set -xeuo pipefail


### PR DESCRIPTION
The default `_NPROCESSORS_ONLN` heuristic we have isn't cgroups aware.
So it thinks it has e.g. 40 CPUs when running in a k8s pod. This can
then blow through our allocated resource limits.

Declare some modest amount of RAM and CPU resources and override `make`
parallelism.

This matches what rpm-ostree now does in
https://github.com/coreos/rpm-ostree/pull/2155.