### PR TITLE
app: Fix various CLI metavariable names

### DIFF
--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -44,7 +44,7 @@ gboolean
 ot_admin_builtin_switch (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context =
-    g_option_context_new ("REF");
+    g_option_context_new ("REFSPEC");
   g_autoptr(OstreeSysroot) sysroot = NULL;
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
                                           OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
@@ -53,7 +53,7 @@ ot_admin_builtin_switch (int argc, char **argv, OstreeCommandInvocation *invocat
 
   if (argc < 2)
     {
-      ot_util_usage_error (context, "REF must be specified", error);
+      ot_util_usage_error (context, "REFSPEC must be specified", error);
       return FALSE;
     }
 

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -65,7 +65,7 @@ static OstreeCommand admin_subcommands[] = {
     "List deployments" },
   { "switch", OSTREE_BUILTIN_FLAG_NO_REPO,
     ot_admin_builtin_switch,
-    "Construct new tree from REF and deploy it" },
+    "Construct new tree from REFSPEC and deploy it" },
   { "undeploy", OSTREE_BUILTIN_FLAG_NO_REPO,
     ot_admin_builtin_undeploy,
     "Delete deployment INDEX" },

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -94,7 +94,7 @@ parse_fsync_cb (const char  *option_name,
  */
 
 static GOptionEntry options[] = {
-  { "parent", 0, 0, G_OPTION_ARG_STRING, &opt_parent, "Parent ref, or \"none\"", "REF" },
+  { "parent", 0, 0, G_OPTION_ARG_STRING, &opt_parent, "Parent commit checksum, or \"none\"", "COMMIT" },
   { "subject", 's', 0, G_OPTION_ARG_STRING, &opt_subject, "One line subject", "SUBJECT" },
   { "body", 'm', 0, G_OPTION_ARG_STRING, &opt_body, "Full description", "BODY" },
   { "body-file", 'F', 0, G_OPTION_ARG_FILENAME, &opt_body_file, "Commit message from FILE path", "FILE" },
@@ -103,7 +103,7 @@ static GOptionEntry options[] = {
   { "orphan", 0, 0, G_OPTION_ARG_NONE, &opt_orphan, "Create a commit without writing a ref", NULL },
   { "no-bindings", 0, 0, G_OPTION_ARG_NONE, &opt_no_bindings, "Do not write any ref bindings", NULL },
   { "bind-ref", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_bind_refs, "Add a ref to ref binding commit metadata", "BRANCH" },
-  { "base", 0, 0, G_OPTION_ARG_STRING, &opt_base, "Start from the given commit as a base (no modifiers apply)", "REF" },
+  { "base", 0, 0, G_OPTION_ARG_STRING, &opt_base, "Start from the given commit as a base (no modifiers apply)", "REV" },
   { "tree", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_trees, "Overlay the given argument as a tree", "dir=PATH or tar=TARFILE or ref=COMMIT" },
   { "add-metadata-string", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_metadata_strings, "Add a key/value pair to metadata", "KEY=VALUE" },
   { "add-metadata", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_metadata_variants, "Add a key/value pair to metadata, where the KEY is a string, an VALUE is g_variant_parse() formatted", "KEY=VALUE" },

--- a/src/ostree/ot-builtin-log.c
+++ b/src/ostree/ot-builtin-log.c
@@ -95,7 +95,7 @@ ostree_builtin_log (int           argc,
   g_autofree char *checksum = NULL;
   OstreeDumpFlags flags = OSTREE_DUMP_NONE;
 
-  context = g_option_context_new ("REF");
+  context = g_option_context_new ("REV");
 
   if (!ostree_option_context_parse (context, options, &argc, &argv, invocation, &repo, cancellable, error))
     goto out;
@@ -105,7 +105,7 @@ ostree_builtin_log (int           argc,
 
   if (argc <= 1)
     {
-      ot_util_usage_error (context, "A ref argument is required", error);
+      ot_util_usage_error (context, "A rev argument is required", error);
       goto out;
     }
   rev = argv[1];


### PR DESCRIPTION
- Use `REV` instead of `REF` in places where we meant it.
- Fix `commit --parent` actually taking a commit checksum and not a ref.
- Fix `ostree admin switch` using `REF` instead of `REFSPEC`.