### PR TITLE
remount: Still remount /sysroot writable if not configured ro

### DIFF
--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -106,11 +106,11 @@ main(int argc, char *argv[])
       exit (EXIT_SUCCESS);
     }
 
-  /* Handle remounting /sysroot read-only now */
-  if (unlink (_OSTREE_SYSROOT_READONLY_STAMP) == 0)
-    {
-      do_remount ("/sysroot", false);
-    }
+  /* Handle remounting /sysroot; if it's explicitly marked as read-only (opt in)
+   * then ensure it's readonly, otherwise mount writable, the same as /
+   */
+  bool sysroot_configured_readonly = unlink (_OSTREE_SYSROOT_READONLY_STAMP) == 0;
+  do_remount ("/sysroot", !sysroot_configured_readonly);
 
   /* If /var was created as as an OSTree default bind mount (instead of being a separate filesystem)
     * then remounting the root mount read-only also remounted it.


### PR DESCRIPTION
Regression from https://github.com/ostreedev/ostree/pull/2113/commits/35642259175973617da937f3cab6ce5f13c95077
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1862568

We still need to remount writable if it's not configured on;
because it may need OS adjustments it needs to be opt-in.