### PR TITLE
ci: Fix ISO testing

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -79,7 +79,7 @@ parallel fcos: {
         coreos-assembler build
         coreos-assembler buildextend-metal
         coreos-assembler buildextend-metal4k
-        coreos-assembler buildextend-live
+        coreos-assembler buildextend-live --fast
         # Install the tests
         make -C tests/kolainst install
       """)
@@ -87,9 +87,9 @@ parallel fcos: {
     stage("Test") {
       parallel metal: {
         try {
-          shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,iso-offline-install --output-dir tmp/kola-testiso-metal")
+          shwrap("kola testiso -S --scenarios pxe-install,iso-offline-install --output-dir tmp/kola-testiso-metal")
         } finally {
-          shwrap("cd /srv/fcos && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
+          shwrap("tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
           archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
         }
       }, kola: {


### PR DESCRIPTION
Regression from
https://github.com/ostreedev/ostree/pull/2158/commits/5d7f897908dbf7f471ddfdbd6c29a84ac6bc0bda

I'm not sure how (or if) this passed before, the job logs have
been GC'd.

This is a bit confusing but basically right now ostree/rpm-ostree's
CI jobs don't use `/srv/fcos` - it might make sense to port
these to `fcosBuild` but that needs investigation.