### PR TITLE
Avoid need to download remote config when pulling

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -55,6 +55,8 @@ G_BEGIN_DECLS
 #define OSTREE_SUMMARY_EXPIRES "ostree.summary.expires"
 #define OSTREE_SUMMARY_COLLECTION_ID "ostree.summary.collection-id"
 #define OSTREE_SUMMARY_COLLECTION_MAP "ostree.summary.collection-map"
+#define OSTREE_SUMMARY_MODE "ostree.summary.mode"
+#define OSTREE_SUMMARY_TOMBSTONE_COMMITS "ostree.summary.tombstone-commits"
 
 #define _OSTREE_PAYLOAD_LINK_PREFIX "../"
 #define _OSTREE_PAYLOAD_LINK_PREFIX_LEN (sizeof (_OSTREE_PAYLOAD_LINK_PREFIX) - 1)

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5816,6 +5816,24 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
                                  g_variant_new_uint64 (GUINT64_TO_BE (g_get_real_time () / G_USEC_PER_SEC)));
   }
 
+  {
+    g_autofree char *remote_mode_str = NULL;
+    if (!ot_keyfile_get_value_with_default (self->config, "core", "mode", "bare",
+                                            &remote_mode_str, error))
+      return FALSE;
+    g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_MODE,
+                                 g_variant_new_string (remote_mode_str));
+  }
+
+  {
+    gboolean tombstone_commits = FALSE;
+    if (!ot_keyfile_get_boolean_with_default (self->config, "core", "tombstone-commits", FALSE,
+                                              &tombstone_commits, error))
+      return FALSE;
+    g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_TOMBSTONE_COMMITS,
+                                 g_variant_new_boolean (tombstone_commits));
+  }
+
   /* Add refs which have a collection specified, which could be in refs/mirrors,
    * refs/heads, and/or refs/remotes. */
   {

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -361,6 +361,22 @@ ot_dump_summary_bytes (GBytes          *summary_bytes,
           pretty_key = "Collection Map";
           value_str = g_strdup ("(printed above)");
         }
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_MODE) == 0)
+        {
+          OstreeRepoMode repo_mode;
+          const char *repo_mode_str = g_variant_get_string (value, NULL);
+
+          pretty_key = "Repository Mode";
+          if (!ostree_repo_mode_from_string (repo_mode_str, &repo_mode, NULL))
+            value_str = g_strdup_printf ("Invalid (‘%s’)", repo_mode_str);
+          else
+            value_str = g_strdup (repo_mode_str);
+        }
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_TOMBSTONE_COMMITS) == 0)
+        {
+          pretty_key = "Has Tombstone Commits";
+          value_str = g_strdup (g_variant_get_boolean (value) ? "Yes" : "No");
+        }
       else
         {
           value_str = g_variant_print (value, FALSE);

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -322,10 +322,11 @@ ot_dump_summary_bytes (GBytes          *summary_bytes,
   collection_map = g_variant_lookup_value (exts, OSTREE_SUMMARY_COLLECTION_MAP, G_VARIANT_TYPE ("a{sa(s(taya{sv}))}"));
   if (collection_map != NULL)
     {
+      g_autoptr(GVariant) collection_refs = NULL;
       g_variant_iter_init (&iter, collection_map);
 
-      while (g_variant_iter_loop (&iter, "{&s@a(s(taya{sv}))}", &collection_id, &refs))
-        dump_summary_refs (collection_id, refs);
+      while (g_variant_iter_loop (&iter, "{&s@a(s(taya{sv}))}", &collection_id, &collection_refs))
+        dump_summary_refs (collection_id, collection_refs);
     }
 
   /* Print out the additional metadata. */

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -64,5 +64,5 @@ echo "ok view summary"
 ${OSTREE} summary --raw > raw-summary.txt
 assert_file_has_content_literal raw-summary.txt "('main', ("
 assert_file_has_content_literal raw-summary.txt "('other', ("
-assert_file_has_content_literal raw-summary.txt "{'ostree.summary.last-modified': <uint64"
+assert_file_has_content_literal raw-summary.txt "'ostree.summary.last-modified': <uint64"
 echo "ok view summary raw"


### PR DESCRIPTION
Fixes #2165. See that and the commit messages for details.

This doesn’t need additional changes in flatpak for it to be used there too. It does require repositories to regenerate their `summary` files before the non-fallback code path is taken in clients, though. That’ll happen soon enough naturally.