### PR TITLE
Release 2020.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ dnl Seed the release notes with `git-shortlog-with-prs <previous-release>..`. Th
 dnl `git-evtag` to create the tag and push it. Finally, create a GitHub release and attach
 dnl the tarball from `make dist`.
 m4_define([year_version], [2020])
-m4_define([release_version], [5])
+m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
 is_release_build=yes

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ m4_define([year_version], [2020])
 m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION

Mainly to get https://github.com/ostreedev/ostree/pull/2160 out.
