### PR TITLE
admin/pin: Enforce that index is a number

### DIFF
--- a/src/ostree/ot-admin-builtin-pin.c
+++ b/src/ostree/ot-admin-builtin-pin.c
@@ -55,7 +55,14 @@ ot_admin_builtin_pin (int argc, char **argv, OstreeCommandInvocation *invocation
   for (unsigned int i = 1; i < argc; i++)
     {
       const char *deploy_index_str = argv[i];
-      const int deploy_index = atoi (deploy_index_str);
+      char *endptr = NULL;
+
+      errno = 0;
+      const guint64 deploy_index = g_ascii_strtoull (deploy_index_str, &endptr, 10);
+      if (*endptr != '\0')
+        return glnx_throw (error, "Invalid index: %s", deploy_index_str);
+      if (errno == ERANGE)
+        return glnx_throw (error, "Index too large: %s", deploy_index_str);
 
       g_autoptr(OstreeDeployment) target_deployment = ot_admin_get_indexed_deployment (sysroot, deploy_index, error);
       if (!target_deployment)

--- a/tests/test-admin-deploy-2.sh
+++ b/tests/test-admin-deploy-2.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # Exports OSTREE_SYSROOT so --sysroot not needed.
 setup_os_repository "archive" "syslinux"
 
-echo "1..7"
+echo "1..8"
 
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
@@ -101,6 +101,13 @@ assert_n_pinned 1
 ${CMD_PREFIX} ostree admin pin -u 0
 assert_n_pinned 0
 echo "ok pin unpin"
+
+for p in medal 0medal '' 5000 9999999999999999999999999999999999999; do
+    if ${CMD_PREFIX} ostree admin pin ${p}; then
+        fatal "created invalid pin ${p}"
+    fi
+done
+echo "ok invalid pin"
 
 ${CMD_PREFIX} ostree admin pin 0 1
 assert_n_pinned 2


### PR DESCRIPTION
Validate that we're parsing a number; we want to guard
against typos.

Closes: https://github.com/ostreedev/ostree/issues/2171