### PR TITLE
linuxfsutil: Pass int to ioctl, not long

### DIFF
--- a/src/libostree/ostree-linuxfsutil.c
+++ b/src/libostree/ostree-linuxfsutil.c
@@ -55,7 +55,7 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
   if (g_atomic_int_get (&no_alter_immutable))
     return TRUE;
 
-  unsigned long flags;
+  int flags = 0;
   int r = ioctl (fd, EXT2_IOC_GETFLAGS, &flags);
   if (r == -1)
     {


### PR DESCRIPTION
Otherwise it will fail on big-endian architectures like s390x.
Ref https://bugzilla.redhat.com/show_bug.cgi?id=1867601