### PR TITLE
configure.ac: Set is_release_build=no

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ m4_define([year_version], [2020])
 m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
We missed this during the post-release version bump.