### PR TITLE
tests/inst: Port to new sh-inline repo

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -14,7 +14,8 @@ structopt = "0.3"
 serde = "1.0.111"
 serde_derive = "1.0.111"
 serde_json = "1.0"
-commandspec = "0.12.2"
+# To be published on crates.io soon
+sh-inline = { git = "https://github.com/cgwalters/rust-sh-inline" }
 anyhow = "1.0"
 tempfile = "3.1.0"
 glib = "0.10"
@@ -43,8 +44,3 @@ with-procspawn-tempdir = { git = "https://github.com/cgwalters/with-procspawn-te
 
 # Internal crate for the test macro
 itest-macro = { path = "itest-macro" }
-
-[patch.crates-io]
-# See https://github.com/tcr/commandspec/pulls?q=is%3Apr+author%3Acgwalters+
-# If patches don't get reviewed I'll probably fork it.
-commandspec = { git = "https://github.com/cgwalters/commandspec", branch = 'walters-master' }

--- a/tests/inst/src/sysroot.rs
+++ b/tests/inst/src/sysroot.rs
@@ -35,6 +35,6 @@ fn test_sysroot_ro() -> Result<()> {
 #[itest]
 fn test_immutable_bit() -> Result<()> {
     // https://bugzilla.redhat.com/show_bug.cgi?id=1867601
-    cmd_has_output(commandspec::sh_command!("lsattr -d /").unwrap(), "-i-")?;
+    cmd_has_output(sh_inline::bash_command!("lsattr -d /").unwrap(), "-i-")?;
     Ok(())
 }

--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -237,8 +237,8 @@ mod tests {
     fn test_output() -> Result<()> {
         cmd_has_output(Command::new("true"), "")?;
         assert!(cmd_has_output(Command::new("true"), "foo").is_err());
-        cmd_has_output(commandspec::sh_command!("echo foobarbaz; echo fooblahbaz").unwrap(), "blah")?;
-        assert!(cmd_has_output(commandspec::sh_command!("echo foobarbaz").unwrap(), "blah").is_err());
+        cmd_has_output(sh_inline::bash_command!("echo foobarbaz; echo fooblahbaz").unwrap(), "blah")?;
+        assert!(cmd_has_output(sh_inline::bash_command!("echo foobarbaz").unwrap(), "blah").is_err());
         Ok(())
     }
 

--- a/tests/inst/src/treegen.rs
+++ b/tests/inst/src/treegen.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use commandspec::sh_execute;
+use sh_inline::bash;
 use openat_ext::{FileExt, OpenatDirExt};
 use rand::Rng;
 use std::fs::File;
@@ -140,7 +140,7 @@ pub(crate) fn update_os_tree<P: AsRef<Path>>(
     }
     assert!(mutated > 0);
     println!("Mutated ELF files: {}", mutated);
-    sh_execute!("ostree --repo={repo} commit --consume -b {ostref} --base={ostref} --tree=dir={tempdir} --owner-uid 0 --owner-gid 0 --selinux-policy-from-base --link-checkout-speedup --no-bindings --no-xattrs",
+    bash!("ostree --repo={repo} commit --consume -b {ostref} --base={ostref} --tree=dir={tempdir} --owner-uid 0 --owner-gid 0 --selinux-policy-from-base --link-checkout-speedup --no-bindings --no-xattrs",
         repo = repo_path.to_str().unwrap(),
         ostref = ostref,
         tempdir = tempdir.path().to_str().unwrap()).context("Failed to commit updated content")?;


### PR DESCRIPTION
I cleaned up my fork of commandspec (see git log) and am
planning to publish to crates.  Port to the new API in prep
for that.