### PR TITLE
Fix mkinitcpio with newer systemd versions

### DIFF
--- a/src/boot/mkinitcpio/ostree
+++ b/src/boot/mkinitcpio/ostree
@@ -5,6 +5,6 @@ build() {
     add_binary /usr/lib/ostree/ostree-remount
 
     add_file /usr/lib/systemd/system/ostree-prepare-root.service
-    add_symlink /usr/lib/systemd/system/initrd-switch-root.target.wants/ostree-prepare-root.service \
+    add_symlink /usr/lib/systemd/system/initrd-root-fs.target.wants/ostree-prepare-root.service \
         /usr/lib/systemd/system/ostree-prepare-root.service
 }


### PR DESCRIPTION
`ostree-prepare-root.service` may race with systemd failing to determine if `/sysroot` is valid because of `/etc/os-release` not being available yet.

Tested this under Arch Linux on multiple systems with different some having SSDs and some having HDDs.

Related: #1759