### PR TITLE
tests/inst: Update to published sh-inline crate

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -14,8 +14,7 @@ structopt = "0.3"
 serde = "1.0.111"
 serde_derive = "1.0.111"
 serde_json = "1.0"
-# To be published on crates.io soon
-sh-inline = { git = "https://github.com/cgwalters/rust-sh-inline" }
+sh-inline = "0.1.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
 glib = "0.10"

--- a/tests/inst/src/repobin.rs
+++ b/tests/inst/src/repobin.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use crate::test::*;
 use anyhow::{Context, Result};
-use sh_inline::{bash_command, bash};
+use sh_inline::{bash, bash_command};
 use with_procspawn_tempdir::with_procspawn_tempdir;
 
 #[itest]
@@ -45,9 +45,7 @@ fn test_mtime() -> Result<()> {
 "
     )?;
     let ts = Path::new("repo").metadata()?.modified().unwrap();
-    bash!(
-        r#"ostree --repo=repo commit -b test -s "bump mtime" --tree=dir=tmproot >/dev/null"#
-    )?;
+    bash!(r#"ostree --repo=repo commit -b test -s "bump mtime" --tree=dir=tmproot >/dev/null"#)?;
     assert_ne!(ts, Path::new("repo").metadata()?.modified().unwrap());
     Ok(())
 }
@@ -88,8 +86,8 @@ fn test_pull_basicauth() -> Result<()> {
         ostree --repo=repo remote add --set=gpg-verify=false origin-badauth {unauthuri}
         ostree --repo=repo remote add --set=gpg-verify=false origin-goodauth {authuri}
         "#,
-            osroot = osroot.to_str(),
-            serverrepo = serverrepo.to_str(),
+            osroot = osroot,
+            serverrepo = serverrepo,
             baseuri = baseuri.to_string(),
             unauthuri = unauthuri.to_string(),
             authuri = authuri.to_string()

--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -237,8 +237,13 @@ mod tests {
     fn test_output() -> Result<()> {
         cmd_has_output(Command::new("true"), "")?;
         assert!(cmd_has_output(Command::new("true"), "foo").is_err());
-        cmd_has_output(sh_inline::bash_command!("echo foobarbaz; echo fooblahbaz").unwrap(), "blah")?;
-        assert!(cmd_has_output(sh_inline::bash_command!("echo foobarbaz").unwrap(), "blah").is_err());
+        cmd_has_output(
+            sh_inline::bash_command!("echo foobarbaz; echo fooblahbaz").unwrap(),
+            "blah",
+        )?;
+        assert!(
+            cmd_has_output(sh_inline::bash_command!("echo foobarbaz").unwrap(), "blah").is_err()
+        );
         Ok(())
     }
 

--- a/tests/inst/src/treegen.rs
+++ b/tests/inst/src/treegen.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
-use sh_inline::bash;
 use openat_ext::{FileExt, OpenatDirExt};
 use rand::Rng;
+use sh_inline::bash;
 use std::fs::File;
 use std::io::prelude::*;
 use std::os::unix::fs::FileExt as UnixFileExt;
@@ -141,8 +141,8 @@ pub(crate) fn update_os_tree<P: AsRef<Path>>(
     assert!(mutated > 0);
     println!("Mutated ELF files: {}", mutated);
     bash!("ostree --repo={repo} commit --consume -b {ostref} --base={ostref} --tree=dir={tempdir} --owner-uid 0 --owner-gid 0 --selinux-policy-from-base --link-checkout-speedup --no-bindings --no-xattrs",
-        repo = repo_path.to_str().unwrap(),
+        repo = repo_path,
         ostref = ostref,
-        tempdir = tempdir.path().to_str().unwrap()).context("Failed to commit updated content")?;
+        tempdir = tempdir.path()).context("Failed to commit updated content")?;
     Ok(())
 }


### PR DESCRIPTION
And I made a few more API tweaks, such as supporting `Path`
objects directly and also not needing e.g. `commit = commit`, see

- https://github.com/cgwalters/rust-sh-inline/commit/cfa7c71126f23545a7d4782cad650eab60e74204
- https://github.com/cgwalters/rust-sh-inline/commit/679bce4cc7ce65641e0c9bd33654510575583de8