### PR TITLE
Fix read-only /etc when using sysroot=readonly and a separate /var mount

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -72,6 +72,12 @@ parallel fcos: {
         tar -C insttree -xzvf insttree.tar.gz
         rsync -rlv insttree/ /
         coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+        # XXX: We temporarily add these tests until they get merged into FCOS proper
+        (mkdir -p tests/kola/var-mount
+         cd tests/kola/var-mount
+         curl -L --remote-name-all \
+            https://raw.githubusercontent.com/jlebon/fedora-coreos-config/pr/var-mount/tests/kola/var-mount/{config.ign,test.sh}
+         chmod a+x test.sh)
         mkdir -p overrides/rootfs
         mv insttree/* overrides/rootfs/
         rmdir insttree

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -251,7 +251,7 @@ main(int argc, char *argv[])
        * sysroot, we still need a writable /etc.  And to avoid race conditions
        * we ensure it's writable in the initramfs, before we switchroot at all.
        */
-      if (mount ("/etc", "/etc", NULL, MS_BIND, NULL) < 0)
+      if (mount ("etc", "etc", NULL, MS_BIND, NULL) < 0)
         err (EXIT_FAILURE, "failed to make /etc a bind mount");
       /* Pass on the fact that we discovered a readonly sysroot to ostree-remount.service */
       int fd = open (_OSTREE_SYSROOT_READONLY_STAMP, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -112,6 +112,11 @@ main(int argc, char *argv[])
   bool sysroot_configured_readonly = unlink (_OSTREE_SYSROOT_READONLY_STAMP) == 0;
   do_remount ("/sysroot", !sysroot_configured_readonly);
 
+  /* And also make sure to make /etc rw again. We make this conditional on
+   * sysroot_configured_readonly because only in that case is it a bind-mount. */
+  if (sysroot_configured_readonly)
+    do_remount ("/etc", true);
+
   /* If /var was created as as an OSTree default bind mount (instead of being a separate filesystem)
     * then remounting the root mount read-only also remounted it.
     * So just like /etc, we need to make it read-write by default.


### PR DESCRIPTION
```
commit 1e5d53fcb6826d070798c3b680da1d0a07a0de5d
Date:   Fri Aug 28 12:35:28 2020 -0400

    ostree-prepare-root: Fix /etc bind mount

    We were bind-mounting the initramfs' `/etc` instead of the target
    deployment. Since we're already `chdir`'ed into it, we can just drop the
    leading slash.

commit 2a68463bdae0ba688d517b1240330f4a7cc726f6
Date:   Fri Aug 28 12:35:29 2020 -0400

    ostree-remount: Remount /etc rw if needed

    When we remount `/sysroot` as read-only, we also make `/etc` read-only.
    This is usually OK because we then remount `/var` read-write, which also
    flips `/etc` back to read-write... unless `/var` is a separate
    filesystem and not a bind-mount to the stateroot `/var`.

    Fix this by just remounting `/etc` read-write in the read-only sysroot
    case.

    Eventually, I think we should rework this to set everything up the way
    we want from the initramfs (#2115). This would also eliminate the window
    during which `/etc` is read-only while `ostree-remount` runs.

commit dde36d9bcecea3ccbd37039d9ae1d4aade9f4bcf
Date:   Fri Aug 28 12:49:32 2020 -0400

    ci: Temporarily import kola test from jlebon's FCOS fork

    That test will not make it into the fedora-coreos-config repo until the
    libostree fix gets percolated down. PR is:

    https://github.com/coreos/fedora-coreos-config/pull/586

    But we want to make sure that the fix does work and that we don't
    regress on it. So manually fetch it for now.
```