### PR TITLE
deploy: Add some error prefixing around xattr setting

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -313,7 +313,7 @@ copy_dir_recurse (int              src_parent_dfd,
 
   if (!dirfd_copy_attributes_and_xattrs (src_parent_dfd, name, src_dfd_iter.fd, dest_dfd,
                                          flags, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Copying attributes of %s", name);
 
   while (TRUE)
     {
@@ -340,7 +340,7 @@ copy_dir_recurse (int              src_parent_dfd,
                                   dest_dfd, dent->d_name,
                                   sysroot_flags_to_copy_flags (GLNX_FILE_COPY_OVERWRITE, flags),
                                   cancellable, error))
-            return FALSE;
+            return glnx_prefix_error (error, "Copying %s", dent->d_name);
         }
     }
 
@@ -488,7 +488,7 @@ copy_modified_config_file (int                 orig_etc_fd,
                               new_etc_fd, path,
                               sysroot_flags_to_copy_flags (GLNX_FILE_COPY_OVERWRITE, flags),
                               cancellable, error))
-        return FALSE;
+        return glnx_prefix_error (error, "Copying %s", path);
     }
   else
     {


### PR DESCRIPTION
Looking at
https://github.com/coreos/coreos-assembler/issues/1703
a user is getting a bare:
`error: fsetxattr: Permission denied`

I don't think it's these code paths since a deploy
isn't happening but on inspection I noticed we didn't
have error prefixing here.