### PR TITLE
Preparatory cleanup for summary work

### DIFF
--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -17,7 +17,7 @@
   Boston, MA 02111-1307, USA.
 ***/
 
-LIBOSTREE_2020.5 {
+LIBOSTREE_2020.6 {
 global:
   /* Add symbols here, and uncomment the bits in
    * Makefile-libostree.am to enable this too.

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -593,6 +593,9 @@ global:
   ostree_sysroot_set_mount_namespace_in_use;
 } LIBOSTREE_2019.6;
 
+/* No new symbols in 2020.2 */
+/* No new symbols in 2020.3 */
+
 /* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2020.4 {
 global:
@@ -615,7 +618,7 @@ global:
   ostree_sign_summary;
 } LIBOSTREE_2020.1;
 
-/* No new symbols in 2020.2 */
+/* No new symbols in 2020.5 */
 
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2675,7 +2675,7 @@ _ostree_detached_metadata_append_gpg_sig (GVariant   *existing_metadata,
                                _OSTREE_METADATA_GPGSIGS_NAME,
                                g_variant_builder_end (signature_builder));
 
-  return g_variant_dict_end (&metadata_dict);
+  return g_variant_ref_sink (g_variant_dict_end (&metadata_dict));
 }
 #endif /* OSTREE_DISABLE_GPGME */
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2513,10 +2513,7 @@ on_superblock_fetched (GObject   *src,
       const guchar *expected_summary_digest = g_hash_table_lookup (pull_data->summary_deltas_checksums, delta);
       guint8 actual_summary_digest[OSTREE_SHA256_DIGEST_LEN];
 
-      g_auto(OtChecksum) hasher = { 0, };
-      ot_checksum_init (&hasher);
-      ot_checksum_update_bytes (&hasher, delta_superblock_data);
-      ot_checksum_get_digest (&hasher, actual_summary_digest, sizeof (actual_summary_digest));
+      ot_checksum_bytes (delta_superblock_data, actual_summary_digest);
 
 #ifndef OSTREE_DISABLE_GPGME
       /* At this point we've GPG verified the data, so in theory

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -109,7 +109,7 @@ ostree_repo_list_static_delta_names (OstreeRepo                  *self,
             return FALSE;
           if (sub_dent == NULL)
             break;
-          if (dent->d_type != DT_DIR)
+          if (sub_dent->d_type != DT_DIR)
             continue;
 
           const char *name1 = dent->d_name;

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -54,6 +54,28 @@ _ostree_static_delta_parse_checksum_array (GVariant      *array,
   return TRUE;
 }
 
+GVariant *
+_ostree_repo_static_delta_superblock_digest (OstreeRepo    *repo,
+                                             const char    *from,
+                                             const char    *to,
+                                             GCancellable  *cancellable,
+                                             GError       **error)
+{
+  g_autofree char *superblock = _ostree_get_relative_static_delta_superblock_path ((from && from[0]) ? from : NULL, to);
+  glnx_autofd int superblock_file_fd = -1;
+  guint8 digest[OSTREE_SHA256_DIGEST_LEN];
+
+  if (!glnx_openat_rdonly (repo->repo_dir_fd, superblock, TRUE, &superblock_file_fd, error))
+    return NULL;
+
+  g_autoptr(GBytes) superblock_content = ot_fd_readall_or_mmap (superblock_file_fd, 0, error);
+  if (!superblock_content)
+    return NULL;
+
+  ot_checksum_bytes (superblock_content, digest);
+
+  return ot_gvariant_new_bytearray (digest, sizeof (digest));
+}
 
 /**
  * ostree_repo_list_static_delta_names:

--- a/src/libostree/ostree-repo-static-delta-private.h
+++ b/src/libostree/ostree-repo-static-delta-private.h
@@ -190,6 +190,12 @@ _ostree_repo_static_delta_query_exists (OstreeRepo                 *repo,
                                         gboolean                   *out_exists,
                                         GCancellable               *cancellable,
                                         GError                    **error);
+GVariant *
+_ostree_repo_static_delta_superblock_digest (OstreeRepo    *repo,
+                                             const char    *from,
+                                             const char    *to,
+                                             GCancellable  *cancellable,
+                                             GError       **error);
 
 gboolean
 _ostree_repo_static_delta_dump (OstreeRepo                 *repo,

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -275,3 +275,13 @@ ot_checksum_file_at (int             dfd,
   ot_checksum_get_hexdigest (&checksum, hexdigest, sizeof (hexdigest));
   return g_strdup (hexdigest);
 }
+
+void
+ot_checksum_bytes (GBytes *data,
+                   guint8 out_digest[_OSTREE_SHA256_DIGEST_LEN])
+{
+  g_auto(OtChecksum) hasher = { 0, };
+  ot_checksum_init (&hasher);
+  ot_checksum_update_bytes (&hasher, data);
+  ot_checksum_get_digest (&hasher, out_digest, _OSTREE_SHA256_DIGEST_LEN);
+}

--- a/src/libotutil/ot-checksum-utils.h
+++ b/src/libotutil/ot-checksum-utils.h
@@ -96,4 +96,7 @@ char * ot_checksum_file_at (int             dfd,
                             GCancellable   *cancellable,
                             GError        **error);
 
+void ot_checksum_bytes (GBytes *data,
+                        guint8 out_digest[_OSTREE_SHA256_DIGEST_LEN]);
+
 G_END_DECLS

--- a/src/libotutil/otutil.h
+++ b/src/libotutil/otutil.h
@@ -52,6 +52,31 @@
 #define ot_journal_print(...) {}
 #endif
 
+typedef GMainContext GMainContextPopDefault;
+static inline void
+_ostree_main_context_pop_default_destroy (void *p)
+{
+  GMainContext *main_context = p;
+
+  if (main_context)
+    {
+      g_main_context_pop_thread_default (main_context);
+      g_main_context_unref (main_context);
+    }
+}
+
+static inline GMainContextPopDefault *
+_ostree_main_context_new_default (void)
+{
+  GMainContext *main_context = g_main_context_new ();
+
+  g_main_context_push_thread_default (main_context);
+  return main_context;
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GMainContextPopDefault, _ostree_main_context_pop_default_destroy)
+
+
 #include <ot-keyfile-utils.h>
 #include <ot-gio-utils.h>
 #include <ot-fs-utils.h>

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -66,7 +66,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-1f83814b9a785f9f612ee8f707dadb86d0dcbdc22603937575b7beefb26b50cc  ${released_syms}
+55f21380aa7f9ecc447a680b5c091692f2a0b98aa96ea00fba6aa6406aa69a5a  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
I'm currently working on scalability issues with the summary files, but the changes there are kinda large. I'd like to land this preparatory work separately so that those become easier to review. If you're interested, that works starts with the #2188, and then continues in https://github.com/alexlarsson/ostree/tree/indexed-summaries.

This PR fixes some bugs:
 * Correct the file type check in the static delta listing code
 * Fix leak when signing
 * Actually mmap the summary files (old fix for this just mmaped the signatures)

And additionally it cleans things up by breaking out things into helper functions and moving things around. Mostly this is because the helper functions will be reused later by my new code, but sometimes it also removes duplication of code in the existing code. I think the cleaned up code is easier to read independent of the use in the later work I'm doing.

I'm hoping that this PR should be easy and fast to review as it doesn't change any behaviour (other than the bug fixes).