### PR TITLE
Avoid shadowing local variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ AS_IF([echo "$CFLAGS" | grep -q -E -e '-Werror($| )'], [], [
 CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -pipe \
   -Wall \
+  -Werror=shadow \
   -Werror=empty-body \
   -Werror=strict-prototypes \
   -Werror=missing-prototypes \

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -341,14 +341,14 @@ check_multi_info (OstreeFetcher *fetcher)
 
               if (req->idx + 1 == req->mirrorlist->len)
                 {
-                  g_autofree char *msg = g_strdup_printf ("Server returned HTTP %lu", response);
+                  g_autofree char *response_msg = g_strdup_printf ("Server returned HTTP %lu", response);
                   g_task_return_new_error (task, G_IO_ERROR, giocode,
-                                           "%s", msg);
+                                           "%s", response_msg);
                   if (req->fetcher->remote_name &&
                       !((req->flags & OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT) > 0 &&
                         giocode == G_IO_ERROR_NOT_FOUND))
                     _ostree_fetcher_journal_failure (req->fetcher->remote_name,
-                                                     eff_url, msg);
+                                                     eff_url, response_msg);
 
                 }
               else

--- a/src/libostree/ostree-repo-finder-avahi-parser.c
+++ b/src/libostree/ostree-repo-finder-avahi-parser.c
@@ -91,14 +91,14 @@ parse_txt_record (const guint8  *txt,
 
 /* TODO: Docs. Return value is only valid as long as @txt is. Reference: RFC 6763, §6. */
 GHashTable *
-_ostree_txt_records_parse (AvahiStringList *txt)
+_ostree_txt_records_parse (AvahiStringList *txt_list)
 {
   AvahiStringList *l;
   g_autoptr(GHashTable) out = NULL;
 
   out = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_bytes_unref);
 
-  for (l = txt; l != NULL; l = avahi_string_list_get_next (l))
+  for (l = txt_list; l != NULL; l = avahi_string_list_get_next (l))
     {
       const guint8 *txt;
       gsize txt_len;

--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -336,7 +336,6 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder                  *finde
       g_autoptr(GHashTable) repo_to_refs = NULL;  /* (element-type UriAndKeyring GHashTable) */
       GHashTable *supported_ref_to_checksum;  /* (element-type OstreeCollectionRef utf8) */
       GHashTableIter iter;
-      UriAndKeyring *repo;
       g_autoptr(GError) local_error = NULL;
 
       mount_name = g_mount_get_name (mount);
@@ -525,6 +524,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
       /* Aggregate the results. */
       g_hash_table_iter_init (&iter, repo_to_refs);
 
+      UriAndKeyring *repo;
       while (g_hash_table_iter_next (&iter, (gpointer *) &repo, (gpointer *) &supported_ref_to_checksum))
         {
           g_autoptr(OstreeRemote) remote = NULL;

--- a/src/libostree/ostree-repo-finder-override.c
+++ b/src/libostree/ostree-repo-finder-override.c
@@ -151,7 +151,6 @@ ostree_repo_finder_override_resolve_async (OstreeRepoFinder                  *fi
   GHashTable *supported_ref_to_checksum;  /* (element-type OstreeCollectionRef utf8) */
   GHashTableIter iter;
   const gchar *remote_uri;
-  OstreeRemote *remote;
 
   task = g_task_new (finder, cancellable, callback, user_data);
   g_task_set_source_tag (task, ostree_repo_finder_override_resolve_async);
@@ -242,6 +241,7 @@ ostree_repo_finder_override_resolve_async (OstreeRepoFinder                  *fi
   /* Aggregate the results. */
   g_hash_table_iter_init (&iter, repo_remote_to_refs);
 
+  OstreeRemote *remote;
   while (g_hash_table_iter_next (&iter, (gpointer *) &remote, (gpointer *) &supported_ref_to_checksum))
     g_ptr_array_add (results, ostree_repo_finder_result_new (remote, finder, priority, supported_ref_to_checksum, NULL, 0));
 

--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -1161,16 +1161,16 @@ write_directory_to_libarchive_recurse (OstreeRepo               *self,
           {
             guint8 buf[8192];
             g_autoptr(GInputStream) file_in = NULL;
-            g_autoptr(GFileInfo) file_info = NULL;
+            g_autoptr(GFileInfo) regular_file_info = NULL;
             const char *checksum;
 
             checksum = ostree_repo_file_get_checksum ((OstreeRepoFile*)path);
 
-            if (!ostree_repo_load_file (self, checksum, &file_in, &file_info, NULL,
+            if (!ostree_repo_load_file (self, checksum, &file_in, &regular_file_info, NULL,
                                         cancellable, error))
               goto out;
 
-            archive_entry_set_size (entry, g_file_info_get_size (file_info));
+            archive_entry_set_size (entry, g_file_info_get_size (regular_file_info));
 
             if (archive_write_header (a, entry) != ARCHIVE_OK)
               {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1625,13 +1625,13 @@ scan_commit_object (OtPullData                 *pull_data,
     }
   if (pull_data->timestamp_check_from_rev)
     {
-      g_autoptr(GVariant) commit = NULL;
+      g_autoptr(GVariant) timestamp_commit = NULL;
       if (!ostree_repo_load_commit (pull_data->repo, pull_data->timestamp_check_from_rev,
-                                    &commit, NULL, error))
+                                    &timestamp_commit, NULL, error))
         return glnx_prefix_error (error, "Reading %s for timestamp-check-from-rev",
                                   pull_data->timestamp_check_from_rev);
 
-      guint64 ts = ostree_commit_get_timestamp (commit);
+      guint64 ts = ostree_commit_get_timestamp (timestamp_commit);
       if (!_ostree_compare_timestamps (pull_data->timestamp_check_from_rev, ts, checksum, new_ts, error))
         return FALSE;
     }
@@ -3389,7 +3389,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   const char *url_override = NULL;
   gboolean inherit_transaction = FALSE;
   g_autoptr(GHashTable) updated_requested_refs_to_fetch = NULL;  /* (element-type OstreeCollectionRef utf8) */
-  int i;
+  gsize i;
   g_autofree char **opt_localcache_repos = NULL;
   g_autoptr(GVariantIter) ref_keyring_map_iter = NULL;
   g_autoptr(GVariant) summary_bytes_v = NULL;
@@ -3849,7 +3849,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   {
     g_autoptr(GBytes) bytes_sig = NULL;
-    gsize i, n;
+    gsize n;
     g_autoptr(GVariant) refs = NULL;
     g_autoptr(GVariant) deltas = NULL;
     g_autoptr(GVariant) additional_metadata = NULL;
@@ -5227,7 +5227,7 @@ find_remotes_process_refs (OstreeRepo                        *self,
 
 static void
 find_remotes_cb (GObject      *obj,
-                 GAsyncResult *result,
+                 GAsyncResult *async_result,
                  gpointer      user_data)
 {
   OstreeRepo *self;
@@ -5259,7 +5259,7 @@ find_remotes_cb (GObject      *obj,
   /* progress = data->progress; */
 
   /* Finish finding the remotes. */
-  results = ostree_repo_finder_resolve_all_finish (result, &error);
+  results = ostree_repo_finder_resolve_all_finish (async_result, &error);
 
   if (results == NULL)
     {

--- a/src/libostree/ostree-soup-uri.c
+++ b/src/libostree/ostree-soup-uri.c
@@ -348,7 +348,7 @@ soup_uri_new_with_base (SoupURI *base, const char *uri_string)
 {
 	SoupURI *uri, fixed_base;
 	const char *end, *hash, *colon, *at, *path, *question;
-	const char *p, *hostend;
+	const char *c, *hostend;
 	gboolean remove_dot_segments = TRUE;
 	int len;
 
@@ -402,17 +402,17 @@ soup_uri_new_with_base (SoupURI *base, const char *uri_string)
 	}
 
 	/* Find scheme */
-	p = uri_string;
-	while (p < end && (g_ascii_isalpha (*p) ||
-			   (p > uri_string && (g_ascii_isdigit (*p) ||
-					       *p == '.' ||
-					       *p == '+' ||
-					       *p == '-'))))
-		p++;
+	c = uri_string;
+	while (c < end && (g_ascii_isalpha (*c) ||
+			   (c > uri_string && (g_ascii_isdigit (*c) ||
+					       *c == '.' ||
+					       *c == '+' ||
+					       *c == '-'))))
+		c++;
 
-	if (p > uri_string && *p == ':') {
-		uri->scheme = soup_uri_parse_scheme (uri_string, p - uri_string);
-		uri_string = p + 1;
+	if (c > uri_string && *c == ':') {
+		uri->scheme = soup_uri_parse_scheme (uri_string, c - uri_string);
+		uri_string = c + 1;
 	}
 
 	if (uri_string == end && !base && !uri->fragment) {

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1945,8 +1945,8 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
 
   if (kernel_layout->devicetree_namever)
     {
-      g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_namever, NULL);
-      ostree_bootconfig_parser_set (bootconfig, "devicetree", boot_relpath);
+      g_autofree char * dt_boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_namever, NULL);
+      ostree_bootconfig_parser_set (bootconfig, "devicetree", dt_boot_relpath);
     }
   else if (kernel_layout->devicetree_srcpath)
     {
@@ -1954,8 +1954,8 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
        * want to point to a whole directory of device trees.
        * See: https://github.com/ostreedev/ostree/issues/1900
        */
-      g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_srcpath, NULL);
-      ostree_bootconfig_parser_set (bootconfig, "fdtdir", boot_relpath);
+      g_autofree char * dt_boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_srcpath, NULL);
+      ostree_bootconfig_parser_set (bootconfig, "fdtdir", dt_boot_relpath);
     }
 
   /* Note this is parsed in ostree-impl-system-generator.c */

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -95,7 +95,7 @@ ot_admin_builtin_set_origin (int argc, char **argv, OstreeCommandInvocation *inv
   { char **iter;
     g_autoptr(GVariantBuilder) optbuilder =
       g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
-    g_autoptr(GVariant) options = NULL;
+    g_autoptr(GVariant) remote_options = NULL;
 
     for (iter = opt_set; iter && *iter; iter++)
       {
@@ -110,12 +110,12 @@ ot_admin_builtin_set_origin (int argc, char **argv, OstreeCommandInvocation *inv
                                subkey, g_variant_new_variant (g_variant_new_string (subvalue)));
       }
 
-    options = g_variant_ref_sink (g_variant_builder_end (optbuilder));
+    remote_options = g_variant_ref_sink (g_variant_builder_end (optbuilder));
 
     if (!ostree_repo_remote_change (repo, NULL,
                                     OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS, 
                                     remotename, url,
-                                    options,
+                                    remote_options,
                                     cancellable, error))
       goto out;
   }

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -135,14 +135,14 @@ process_one_checkout (OstreeRepo           *repo,
       opt_bareuseronly_dirs || opt_union_identical ||
       opt_skiplist_file || opt_selinux_policy || opt_selinux_prefix)
     {
-      OstreeRepoCheckoutAtOptions options = { 0, };
+      OstreeRepoCheckoutAtOptions checkout_options = { 0, };
 
       /* do this early so option checking also catches force copy conflicts */
       if (opt_selinux_policy)
         opt_force_copy = TRUE;
 
       if (opt_user_mode)
-        options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
+        checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
       /* Can't union these */
       if (opt_union && opt_union_add)
         {
@@ -173,9 +173,9 @@ process_one_checkout (OstreeRepo           *repo,
           goto out;
         }
       else if (opt_union)
-        options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
+        checkout_options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
       else if (opt_union_add)
-        options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES;
+        checkout_options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_ADD_FILES;
       else if (opt_union_identical)
         {
           if (!opt_require_hardlinks)
@@ -184,12 +184,12 @@ process_one_checkout (OstreeRepo           *repo,
                            "--union-identical requires --require-hardlinks");
               goto out;
             }
-          options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL;
+          checkout_options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL;
         }
       if (opt_whiteouts)
-        options.process_whiteouts = TRUE;
+        checkout_options.process_whiteouts = TRUE;
       if (subpath)
-        options.subpath = subpath;
+        checkout_options.subpath = subpath;
 
       g_autoptr(OstreeSePolicy) policy = NULL;
       if (opt_selinux_policy)
@@ -203,8 +203,8 @@ process_one_checkout (OstreeRepo           *repo,
           policy = ostree_sepolicy_new_at (rootfs_dfd, cancellable, error);
           if (!policy)
             goto out;
-          options.sepolicy = policy;
-          options.sepolicy_prefix = opt_selinux_prefix;
+          checkout_options.sepolicy = policy;
+          checkout_options.sepolicy_prefix = opt_selinux_prefix;
         }
 
       g_autoptr(GHashTable) skip_list =
@@ -214,16 +214,16 @@ process_one_checkout (OstreeRepo           *repo,
           if (!ot_parse_file_by_line (opt_skiplist_file, handle_skiplist_line, skip_list,
                                       cancellable, error))
             goto out;
-          options.filter = checkout_filter;
-          options.filter_user_data = skip_list;
+          checkout_options.filter = checkout_filter;
+          checkout_options.filter_user_data = skip_list;
         }
 
-      options.no_copy_fallback = opt_require_hardlinks;
-      options.force_copy = opt_force_copy;
-      options.force_copy_zerosized = opt_force_copy_zerosized;
-      options.bareuseronly_dirs = opt_bareuseronly_dirs;
+      checkout_options.no_copy_fallback = opt_require_hardlinks;
+      checkout_options.force_copy = opt_force_copy;
+      checkout_options.force_copy_zerosized = opt_force_copy_zerosized;
+      checkout_options.bareuseronly_dirs = opt_bareuseronly_dirs;
 
-      if (!ostree_repo_checkout_at (repo, &options,
+      if (!ostree_repo_checkout_at (repo, &checkout_options,
                                     AT_FDCWD, destination,
                                     resolved_commit,
                                     cancellable, error))

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -614,10 +614,10 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
   if (opt_base)
     {
       g_autofree char *base_commit = NULL;
-      g_autoptr(GFile) root = NULL;
-      if (!ostree_repo_read_commit (repo, opt_base, &root, &base_commit, cancellable, error))
+      g_autoptr(GFile) base_root = NULL;
+      if (!ostree_repo_read_commit (repo, opt_base, &base_root, &base_commit, cancellable, error))
         goto out;
-      OstreeRepoFile *rootf = (OstreeRepoFile*) root;
+      OstreeRepoFile *rootf = (OstreeRepoFile*) base_root;
 
       mtree = ostree_mutable_tree_new_from_checksum (repo,
                                                      ostree_repo_file_tree_get_contents_checksum (rootf),

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -134,7 +134,7 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
   else if (!strcmp (op, "get"))
     {
       GKeyFile *readonly_config = NULL;
-      g_autofree char *value = NULL;
+      g_autofree char *read_value = NULL;
       if (opt_group)
         {
           if (argc < 3)
@@ -160,11 +160,11 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
         }
 
       readonly_config = ostree_repo_get_config (repo);
-      value = g_key_file_get_string (readonly_config, section, key, error);
-      if (value == NULL)
+      read_value = g_key_file_get_string (readonly_config, section, key, error);
+      if (read_value == NULL)
         return FALSE;
 
-      g_print ("%s\n", value);
+      g_print ("%s\n", read_value);
     }
   else if (!strcmp (op, "unset"))
     {

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -171,9 +171,8 @@ delete_signatures (OstreeRepo *repo,
 
       while (!g_queue_is_empty (&signatures))
         {
-          GVariant *child = g_queue_pop_head (&signatures);
-          g_variant_builder_add_value (&signature_builder, child);
-          g_variant_unref (child);
+          g_autoptr(GVariant) sigchild = g_queue_pop_head (&signatures);
+          g_variant_builder_add_value (&signature_builder, sigchild);
         }
 
       g_variant_dict_insert_value (&metadata_dict,

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -271,7 +271,7 @@ ostree_builtin_pull (int argc, char **argv, OstreeCommandInvocation *invocation,
 
   {
     GVariantBuilder builder;
-    g_autoptr(GVariant) options = NULL;
+    g_autoptr(GVariant) pull_options = NULL;
     g_auto(GLnxConsoleRef) console = { 0, };
     g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
 
@@ -378,9 +378,9 @@ ostree_builtin_pull (int argc, char **argv, OstreeCommandInvocation *invocation,
 #endif /* OSTREE_DISABLE_GPGME */
       }
 
-    options = g_variant_ref_sink (g_variant_builder_end (&builder));
+    pull_options = g_variant_ref_sink (g_variant_builder_end (&builder));
 
-    if (!ostree_repo_pull_with_options (repo, remote, options,
+    if (!ostree_repo_pull_with_options (repo, remote, pull_options,
                                         progress, cancellable, error))
       goto out;
 

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -167,7 +167,7 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
       if ((n_key_ids == 0) || opt_filename)
         {
           g_autoptr (GVariantBuilder) builder = NULL;
-          g_autoptr (GVariant) options = NULL;
+          g_autoptr (GVariant) sign_options = NULL;
 
           builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
           /* Use custom directory with public and revoked keys instead of system-wide directories */
@@ -176,9 +176,9 @@ ostree_builtin_sign (int argc, char **argv, OstreeCommandInvocation *invocation,
           /* The last chance for verification source -- system files */
           if (opt_filename)
             g_variant_builder_add (builder, "{sv}", "filename", g_variant_new_string (opt_filename));
-          options = g_variant_builder_end (builder);
+          sign_options = g_variant_builder_end (builder);
 
-          if (!ostree_sign_load_pk (sign, options, error))
+          if (!ostree_sign_load_pk (sign, sign_options, error))
             goto out;
 
           if (ostree_sign_commit_verify (sign,

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -104,7 +104,6 @@ ot_remote_builtin_add (int argc, char **argv, OstreeCommandInvocation *invocatio
   g_autoptr(GString) sign_verify = NULL;
   const char *remote_name;
   const char *remote_url;
-  char **iter;
   g_autoptr(GVariantBuilder) optbuilder = NULL;
   g_autoptr(GVariant) options = NULL;
   gboolean ret = FALSE;
@@ -161,7 +160,7 @@ ot_remote_builtin_add (int argc, char **argv, OstreeCommandInvocation *invocatio
     g_variant_builder_add (optbuilder, "{s@v}",
                            "contenturl", g_variant_new_variant (g_variant_new_string (opt_contenturl)));
 
-  for (iter = opt_set; iter && *iter; iter++)
+  for (char **iter = opt_set; iter && *iter; iter++)
     {
       const char *keyvalue = *iter;
       g_autofree char *subkey = NULL;

--- a/tests/repo-finder-mount.c
+++ b/tests/repo-finder-mount.c
@@ -93,16 +93,16 @@ main (int argc, char **argv)
 
   g_ptr_array_add (refs, NULL);  /* NULL terminator */
 
-  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(GAsyncResult) async_result = NULL;
   ostree_repo_finder_resolve_async (OSTREE_REPO_FINDER (finder),
                                     (const OstreeCollectionRef * const *) refs->pdata,
-                                    parent_repo, NULL, result_cb, &result);
+                                    parent_repo, NULL, result_cb, &async_result);
 
-  while (result == NULL)
+  while (async_result == NULL)
     g_main_context_iteration (context, TRUE);
 
   g_autoptr(GPtrArray) results = ostree_repo_finder_resolve_finish (OSTREE_REPO_FINDER (finder),
-                                                                    result, &error);
+                                                                    async_result, &error);
   g_assert_no_error (error);
 
   /* Check that the results are correct: the invalid refs should have been

--- a/tests/test-repo-finder-config.c
+++ b/tests/test-repo-finder-config.c
@@ -230,7 +230,7 @@ test_repo_finder_config_mixed_configs (Fixture       *fixture,
 {
   g_autoptr(OstreeRepoFinderConfig) finder = NULL;
   g_autoptr(GMainContext) context = NULL;
-  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(GAsyncResult) async_result = NULL;
   g_autoptr(GPtrArray) results = NULL;  /* (element-type OstreeRepoFinderResult) */
   g_autoptr(GError) error = NULL;
   gsize i;
@@ -266,13 +266,13 @@ test_repo_finder_config_mixed_configs (Fixture       *fixture,
 
   /* Resolve the refs. */
   ostree_repo_finder_resolve_async (OSTREE_REPO_FINDER (finder), refs,
-                                    fixture->parent_repo, NULL, result_cb, &result);
+                                    fixture->parent_repo, NULL, result_cb, &async_result);
 
-  while (result == NULL)
+  while (async_result == NULL)
     g_main_context_iteration (context, TRUE);
 
   results = ostree_repo_finder_resolve_finish (OSTREE_REPO_FINDER (finder),
-                                               result, &error);
+                                               async_result, &error);
   g_assert_no_error (error);
   g_assert_nonnull (results);
   g_assert_cmpuint (results->len, ==, 3);

--- a/tests/test-repo-finder-mount.c
+++ b/tests/test-repo-finder-mount.c
@@ -317,7 +317,7 @@ test_repo_finder_mount_mixed_mounts (Fixture       *fixture,
   g_autoptr(OstreeRepoFinderMount) finder = NULL;
   g_autoptr(GVolumeMonitor) monitor = NULL;
   g_autoptr(GMainContext) context = NULL;
-  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(GAsyncResult) async_result = NULL;
   g_autoptr(GPtrArray) results = NULL;  /* (element-type OstreeRepoFinderResult) */
   g_autoptr(GError) error = NULL;
   g_autoptr(GList) mounts = NULL;  /* (element-type OstreeMockMount)  */
@@ -395,13 +395,13 @@ test_repo_finder_mount_mixed_mounts (Fixture       *fixture,
   /* Resolve the refs. */
   ostree_repo_finder_resolve_async (OSTREE_REPO_FINDER (finder), refs,
                                     fixture->parent_repo,
-                                    NULL, result_cb, &result);
+                                    NULL, result_cb, &async_result);
 
-  while (result == NULL)
+  while (async_result == NULL)
     g_main_context_iteration (context, TRUE);
 
   results = ostree_repo_finder_resolve_finish (OSTREE_REPO_FINDER (finder),
-                                               result, &error);
+                                               async_result, &error);
   g_assert_no_error (error);
   g_assert_nonnull (results);
   g_assert_cmpuint (results->len, ==, 4);
@@ -466,7 +466,7 @@ test_repo_finder_mount_well_known (Fixture       *fixture,
   g_autoptr(OstreeRepoFinderMount) finder = NULL;
   g_autoptr(GVolumeMonitor) monitor = NULL;
   g_autoptr(GMainContext) context = NULL;
-  g_autoptr(GAsyncResult) result = NULL;
+  g_autoptr(GAsyncResult) async_result = NULL;
   g_autoptr(GPtrArray) results = NULL;  /* (element-type OstreeRepoFinderResult) */
   g_autoptr(GError) error = NULL;
   g_autoptr(GList) mounts = NULL;  /* (element-type OstreeMockMount)  */
@@ -507,13 +507,13 @@ test_repo_finder_mount_well_known (Fixture       *fixture,
   /* Resolve the refs. */
   ostree_repo_finder_resolve_async (OSTREE_REPO_FINDER (finder), refs,
                                     fixture->parent_repo,
-                                    NULL, result_cb, &result);
+                                    NULL, result_cb, &async_result);
 
-  while (result == NULL)
+  while (async_result == NULL)
     g_main_context_iteration (context, TRUE);
 
   results = ostree_repo_finder_resolve_finish (OSTREE_REPO_FINDER (finder),
-                                               result, &error);
+                                               async_result, &error);
   g_assert_no_error (error);
   g_assert_nonnull (results);
   g_assert_cmpuint (results->len, ==, 2);


### PR DESCRIPTION
This should help with code readability.

Fixes https://github.com/ostreedev/ostree/issues/2194