### PR TITLE
checkout: Ensure copies of unreadable usermode checkouts are readable

### DIFF
--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -75,6 +75,8 @@ $OSTREE fsck
 rm test2-checkout -rf
 $OSTREE checkout -U -H test2-unreadable test2-checkout
 assert_file_has_mode test2-checkout/unreadable 400
+# Should not be hardlinked
+assert_streq $(stat -c "%h" test2-checkout/unreadable) 1
 echo "ok bare-user handled unreadable file"
 
 cd ${test_tmpdir}


### PR DESCRIPTION
The extreme special case of "zero mode" files like `/etc/shadow`
comes up again.  What we want is for "user mode" checkouts to
override it to make the file readable; otherwise when operating
as non-root without `CAP_DAC_OVERRIDE` it becomes very difficult
to work with.

Previously, we were hardlinking these files, but then it intersects
with *another* special case around zero sized files, which is
*also* true for `/etc/shadow`.

Trying to avoid hardlinking there unveiled this bug - when
we go to do a copy checkout, we need to override the mode.