### PR TITLE
Various minor versioning related tweaks

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -182,9 +182,9 @@ libostree_1_la_SOURCES += \
 endif # USE_GPGME
 
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
-#if BUILDOPT_IS_DEVEL_BUILD
+if BUILDOPT_IS_DEVEL_BUILD
 symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-#endif
+endif
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=
 EXTRA_DIST += \

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -17,7 +17,7 @@
   Boston, MA 02111-1307, USA.
 ***/
 
-LIBOSTREE_2020.6 {
+LIBOSTREE_2020.7 {
 global:
   /* Add symbols here, and uncomment the bits in
    * Makefile-libostree.am to enable this too.

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -620,6 +620,8 @@ global:
 
 /* No new symbols in 2020.5 */
 
+/* No new symbols in 2020.6 */
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -317,6 +317,8 @@ _ostree_repo_static_delta_verify_signature (OstreeRepo       *self,
  * The directory must be named with the form "FROM-TO", where both are
  * checksums, and it must contain a file named "superblock", along with at least
  * one part.
+ *
+ * Since: 2020.7
  */
 gboolean
 ostree_repo_static_delta_execute_offline_with_signature (OstreeRepo   *self,
@@ -1082,7 +1084,7 @@ _ostree_repo_static_delta_dump (OstreeRepo                    *self,
  * Returns: TRUE if the signature of static delta file is valid using the
  * signature engine provided, FALSE otherwise.
  *
- * Since: 2020.1
+ * Since: 2020.7
  */
 gboolean
 ostree_repo_static_delta_verify_signature (OstreeRepo       *self,

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -66,7 +66,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-55f21380aa7f9ecc447a680b5c091692f2a0b98aa96ea00fba6aa6406aa69a5a  ${released_syms}
+f341345be2da30ab8043ac3d555f75edaae25aaad9f81a933fb4e33a47fe7cc4  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
```
commit 75342035d5902f299be53d7b541724407463d62c
Date:   Fri Sep 25 14:59:45 2020 -0400

    Makefile-libostree.am: Uncomment BUILDOPT_IS_DEVEL_BUILD conditional

    We shouldn't have to toggle the conditional itself during release
    builds. It should only evaluate to true during devel builds.

commit 68489f647832e3ab9f3856513e459a0cc296ef84
Date:   Fri Sep 25 15:01:09 2020 -0400

    lib: Minor versioning related fixes

    Fix/add the `Since` marker to the new static delta APIs, and update the
    symbol versioning templates/comments.
```