### PR TITLE
Add Packit integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,11 @@
+# build into f32-coreos-continuous on every commit to master
+jobs:
+    - job: production_build
+      trigger: commit
+      metadata:
+          branch: master
+          targets: f32-coreos-continuous
+specfile_path: ostree.spec
+actions:
+    # https://packit.dev/faq/#how-can-i-download-rpm-spec-file-if-it-is-not-part-of-upstream-repository
+    post-upstream-clone: "wget https://src.fedoraproject.org/rpms/ostree/raw/master/f/ostree.spec"


### PR DESCRIPTION
This is a basic `.packit.yaml` integration file which will allow us have
continuous builds of OSTree in cosa and upstream CI. If things go well,
we'll likely deploy this in other build tools like rpm-ostree.

Prompted by wanting to get #2155 out to unblock
https://github.com/coreos/rpm-ostree/pull/2170.