### PR TITLE
Support kargs.d directories for default kargs (rebased)

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -98,6 +98,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-deploy-syslinux.sh \
 	tests/test-admin-deploy-2.sh \
 	tests/test-admin-deploy-karg.sh \
+	tests/test-admin-deploy-karg-default.sh \
 	tests/test-admin-deploy-switch.sh \
 	tests/test-admin-deploy-etcmerge-cornercases.sh \
 	tests/test-admin-deploy-uboot.sh \

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -92,6 +92,9 @@ struct OstreeSysroot {
 #define _OSTREE_SYSROOT_BOOT_INITRAMFS_OVERLAYS "ostree/initramfs-overlays"
 #define _OSTREE_SYSROOT_INITRAMFS_OVERLAYS "boot/" _OSTREE_SYSROOT_BOOT_INITRAMFS_OVERLAYS
 
+#define _OSTREE_SYSROOT_KARGS_HOST "etc/ostree/kargs.d"
+#define _OSTREE_SYSROOT_KARGS_BASE "usr/lib/ostree-boot/kargs.d"
+
 gboolean
 _ostree_sysroot_ensure_writable (OstreeSysroot      *self,
                                  GError            **error);

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -544,6 +544,15 @@ os_repository_new_commit ()
     cd ${test_tmpdir}
 }
 
+os_tree_write_file ()
+{
+    path=${1}
+    contents="${2}"
+    cd ${test_tmpdir}/osdata
+    echo "${contents}" > ${path}
+    cd ${test_tmpdir}
+}
+
 _have_user_xattrs=''
 have_user_xattrs() {
     assert_has_setfattr

--- a/tests/test-admin-deploy-karg-default.sh
+++ b/tests/test-admin-deploy-karg-default.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 Robert Fairley <rfairley@redhat.com>
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive" "syslinux"
+
+echo "1..7"
+
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+assert_has_dir sysroot/boot/ostree/testos-${bootcsum}
+# Check we generate kargs from the kargs.d configs from the first deployment.
+assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+initial_rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+echo "initial_rev=${initial_rev}"
+
+# Configure kargs stored in the ostree commit.
+mkdir -p osdata/usr/lib/ostree-boot/kargs.d
+os_tree_write_file "usr/lib/ostree-boot/kargs.d/4000_FOO" "FOO=USR_1"
+os_tree_write_file "usr/lib/ostree-boot/kargs.d/4001_FOO2" "FOO2=USR_2"
+os_repository_new_commit
+
+# Upgrade to tree with newly-committed kargs files.
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos file://$(pwd)/testos-repo testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin upgrade --os=testos
+# Sanity check a new boot directory was created after upgrading.
+assert_has_dir sysroot/boot/ostree/testos-${bootcsum}
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=USR_1.*FOO2=USR_2'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs base config"
+
+# Configure kargs stored in the default configuration (/usr/etc).
+mkdir -p osdata/usr/etc/ostree/kargs.d
+os_tree_write_file "usr/etc/ostree/kargs.d/8000_MOO" "MOO=ETC_USR_1"
+os_tree_write_file "usr/etc/ostree/kargs.d/8001_MOO2" "MOO2=ETC_USR_2"
+os_repository_new_commit
+
+${CMD_PREFIX} ostree admin upgrade --os=testos
+assert_has_dir sysroot/boot/ostree/testos-${bootcsum}
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=USR_1.*FOO2=USR_2.*MOO=ETC_USR_1.*MOO2=ETC_USR_2'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs default config"
+
+# Configure kargs through the host config file.
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+echo "rev=${rev}"
+etc=sysroot/ostree/deploy/testos/deploy/${rev}.0/etc
+assert_has_dir ${etc}
+mkdir -p ${etc}/ostree/kargs.d
+# Configure a new karg (append).
+echo "HELLO=ETC_1" > ${etc}/ostree/kargs.d/2000_HELLO
+# Overwrite existing karg from /usr/etc/ostree/kargs.d (replace).
+echo "MOO=ETC_2" > ${etc}/ostree/kargs.d/8000_MOO
+# Overwrite existing karg from /usr/lib/ostree-boot/kargs.d (replace).
+echo "FOO=ETC_3" > ${etc}/ostree/kargs.d/4000_FOO
+
+# Re-deploy with host-configured kernel args.
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*HELLO=ETC_1.*FOO=ETC_3.*FOO2=USR_2.*MOO=ETC_2.*MOO2=ETC_USR_2'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'MOO=ETC_USR_1'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'FOO=USR_1'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs host config"
+
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+echo "rev=${rev}"
+etc=sysroot/ostree/deploy/testos/deploy/${rev}.1/etc
+mkdir -p ${etc}/ostree/kargs.d
+# Clear base kargs by writing an empty file which overrides them (delete).
+echo "" > ${etc}/ostree/kargs.d/8000_MOO
+echo "" > ${etc}/ostree/kargs.d/4000_FOO
+
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*HELLO=ETC_1.*FOO2=USR_2.*MOO2=ETC_USR_2'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'MOO\>'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'FOO\>'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs delete empty file"
+
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+echo "rev=${rev}"
+etc=sysroot/ostree/deploy/testos/deploy/${rev}.2/etc
+mkdir -p ${etc}/ostree/kargs.d
+rm ${etc}/ostree/kargs.d/8000_MOO
+rm ${etc}/ostree/kargs.d/4000_FOO
+# Clear base kargs by symlinking to /dev/null.
+ln -s /dev/null ${etc}/ostree/kargs.d/8000_MOO
+ln -s /dev/null ${etc}/ostree/kargs.d/4000_FOO
+
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*HELLO=ETC_1.*FOO2=USR_2.*MOO2=ETC_USR_2'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'MOO\>'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'FOO\>'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs delete /dev/null"
+
+${CMD_PREFIX} ostree admin upgrade --os=testos --allow-downgrade --override-commit=${initial_rev}
+
+# Only the config in /etc/ostree/kargs.d remains.
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*HELLO=ETC_1'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'MOO=ETC_USR_1'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'MOO2=ETC_USR_2'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'FOO=USR_1'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'FOO2=USR_2'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs downgrade"
+
+${CMD_PREFIX} ostree admin deploy --os=testos --karg-append=TESTARG=TESTVALUE testos:testos/buildmaster/x86_64-runtime
+
+# Check we carry over previous deployment kargs, after passing in a kargs
+# override.
+assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*HELLO=ETC_1.*TESTARG=TESTVALUE'
+# Check we won't regenerate from the config again.
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok default kargs overridden"

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -26,13 +26,15 @@ set -euo pipefail
 # Exports OSTREE_SYSROOT so --sysroot not needed.
 setup_os_repository "archive" "syslinux"
 
-echo "1..3"
+echo "1..5"
 
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 export rev
 # This initial deployment gets kicked off with some kernel arguments 
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+# Check the kargs are not being updated from the kargs.d configs.
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'ostree-kargs-generated-from-config.*true'
 ${CMD_PREFIX} ostree admin deploy --karg=FOO=BAR --os=testos testos:testos/buildmaster/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=TESTARG=TESTVALUE --os=testos testos:testos/buildmaster/x86_64-runtime
 assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
@@ -61,13 +63,30 @@ echo "ok deploy --karg-proc-cmdline"
 ${CMD_PREFIX} ostree admin status
 ${CMD_PREFIX} ostree admin undeploy 0
 
-${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=APPENDARG=VALAPPEND --karg-append=APPENDARG=2NDAPPEND testos:testos/buildmaster/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos --karg-append=APPENDARG=VALAPPEND --karg-append=APPENDARG=2NDAPPEND testos:testos/buildmaster/x86_64-runtime
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=BAR'
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+# Check the kargs are still not being updated from the kargs.d configs.
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
 
 # Check correct ordering of different-valued args of the same key.
 ${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=FOO=TESTORDERED --karg-append=APPENDARG=3RDAPPEND testos:testos/buildmaster/x86_64-runtime
 assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND .*FOO=TESTORDERED .*APPENDARG=3RDAPPEND'
 
 echo "ok deploy --karg-append"
+
+${CMD_PREFIX} ostree admin status
+${CMD_PREFIX} ostree admin undeploy 0
+
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok no true kargs generated from config flag"
+
+${CMD_PREFIX} ostree admin status
+
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'ostree-kargs-generated-from-config.*true'
+
+echo "ok no true kargs generated from config flag persists"


### PR DESCRIPTION
This is a rebased version of #1836. The rebase mainly required trivial conflict fixes. There was one larger conflict with https://github.com/ostreedev/ostree/commits/52a6224606e4a057b806225d93a2d0239a004723 which required a bit more in depth changes to preserve/adhere to the idea of that change. All unit tests run by `make check` are passing.

We would like a method to set and update kernel arguments via vanilla OSTree updates. Besides this approach we were also considering using OSTree metadata. But it seems this approach with files in-tree is more flexible. Feedback welcome!


Add the following config directories for setting default kernel
arguments:

/etc/ostree/kargs.d (host config)
/usr/lib/ostree-boot/kargs.d (base config)

These directories contain files whose contents consist of a karg
snippet, which is a collection kernel parameter keys and values.
Example of a snippet:

```
KEY=FOO KEYFLAG ANOTHERKEY=VALUE1 ANOTHERKEY=VALUE2
```

Snippets are read in alphanumeric order of the karg snippet filename
when generating the final kernel options from the host and base config
directories. Ordering may be specified by prefixing a number, e.g.
`/etc/ostree/kargs.d/4000_localhost`.

The bootconfig key `ostree-kargs-generated-from-config` indicates
whether the kargs were generated by ostree from the kargs.d directories
(`true`), or copied from the previous deployment (`false`). Editing the
kargs through the command line (e.g. `ostree admin deploy --karg=`) will
set the flag to `false`, and kargs will be copied from the previous
deployment for subsequent deployments.

Also add support for `ostree admin instutil set-kargs` so that installer
programs using this command (such as Anaconda) remain managed by the
kargs.d directories from the first deployment.

Closes: #479

[rebased to master]
Signed-off-by: Stefan Agner <stefan.agner@toradex.com>
