### PR TITLE
ostree-prepare-root: print st_dev and st_ino as 64-bit ints

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -152,8 +152,8 @@ resolve_deploy_path (const char * root_mountpoint)
                    "MESSAGE_ID=" SD_ID128_FORMAT_STR,
                    SD_ID128_FORMAT_VAL(OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG),
                    "DEPLOYMENT_PATH=%s", resolved_path,
-                   "DEPLOYMENT_DEVICE=%u", stbuf.st_dev,
-                   "DEPLOYMENT_INODE=%u", stbuf.st_ino,
+                   "DEPLOYMENT_DEVICE=%" PRIu64, (uint64_t) stbuf.st_dev,
+                   "DEPLOYMENT_INODE=%" PRIu64, (uint64_t) stbuf.st_ino,
                    NULL);
 #endif
   return deploy_path;


### PR DESCRIPTION
This matches what systemd does and should work fine on all platforms.

Possibly resolves: bugzilla.redhat.com/show_bug.cgi?id=1888436