### PR TITLE
Bootloader probing and construction refactoring

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -373,7 +373,9 @@ Boston, MA 02111-1307, USA.
         <term><varname>bootloader</varname></term>
         <listitem><para>Configure the bootloader that OSTree uses when
         deploying the sysroot.  This may take the values
-        <literal>bootloader=none</literal> or <literal>bootloader=auto</literal>.
+        <literal>bootloader=none</literal>, <literal>bootloader=auto</literal>,
+        <literal>bootloader=grub2</literal>, <literal>bootloader=syslinux</literal>,
+        <literal>bootloader=uboot</literal> or <literal>bootloader=zipl</literal>.
         Default is <literal>auto</literal>.
         </para>
         <para>
@@ -387,6 +389,11 @@ Boston, MA 02111-1307, USA.
           uboot, and syslinux bootloaders.  If one of the bootloaders is found,
           then OSTree will generate a config for the bootloader found.  For
           example, <literal>grub2-mkconfig</literal> is run for the grub2 case.
+        </para>
+        <para>
+          A specific bootloader type may also be explicitly requested by choosing
+          <literal>grub2</literal>, <literal>syslinux</literal>, <literal>uboot</literal> or
+          <literal>zipl</literal>.
         </para>
         </listitem>
       </varlistentry>

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -110,6 +110,22 @@ typedef enum {
   _OSTREE_FEATURE_YES,
 } _OstreeFeatureSupport;
 
+/* Possible values for the sysroot.bootloader configuration variable */
+typedef enum {
+  CFG_SYSROOT_BOOTLOADER_OPT_AUTO = 0,
+  CFG_SYSROOT_BOOTLOADER_OPT_NONE,
+  CFG_SYSROOT_BOOTLOADER_OPT_ZIPL,
+  /* Non-exhaustive */
+} OstreeCfgSysrootBootloaderOpt;
+
+static const char* const CFG_SYSROOT_BOOTLOADER_OPTS_STR[] = {
+  /* This must be kept in the same order as the enum */
+  "auto",
+  "none",
+  "zipl",
+  NULL,
+};
+
 /**
  * OstreeRepo:
  *
@@ -193,7 +209,7 @@ struct OstreeRepo {
   guint64 payload_link_threshold;
   gint fs_support_reflink; /* The underlying filesystem has support for ioctl (FICLONE..) */
   gchar **repo_finders;
-  gchar *bootloader; /* Configure which bootloader to use. */
+  OstreeCfgSysrootBootloaderOpt bootloader; /* Configure which bootloader to use. */
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -114,6 +114,9 @@ typedef enum {
 typedef enum {
   CFG_SYSROOT_BOOTLOADER_OPT_AUTO = 0,
   CFG_SYSROOT_BOOTLOADER_OPT_NONE,
+  CFG_SYSROOT_BOOTLOADER_OPT_GRUB2,
+  CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX,
+  CFG_SYSROOT_BOOTLOADER_OPT_UBOOT,
   CFG_SYSROOT_BOOTLOADER_OPT_ZIPL,
   /* Non-exhaustive */
 } OstreeCfgSysrootBootloaderOpt;
@@ -122,6 +125,9 @@ static const char* const CFG_SYSROOT_BOOTLOADER_OPTS_STR[] = {
   /* This must be kept in the same order as the enum */
   "auto",
   "none",
+  "grub2",
+  "syslinux",
+  "uboot",
   "zipl",
   NULL,
 };

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -6323,7 +6323,7 @@ ostree_repo_get_default_repo_finders (OstreeRepo *self)
  * Get the bootloader configured. See the documentation for the
  * "sysroot.bootloader" config key.
  *
- * Returns: bootloader configuration for the sysroot
+ * Returns: (transfer none): bootloader configuration for the sysroot
  * Since: 2019.2
  */
 const gchar *

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1048,7 +1048,6 @@ ostree_repo_finalize (GObject *object)
   g_mutex_clear (&self->txn_lock);
   g_free (self->collection_id);
   g_strfreev (self->repo_finders);
-  g_free (self->bootloader);
 
   g_clear_pointer (&self->remotes, g_hash_table_destroy);
   g_mutex_clear (&self->remotes_lock);
@@ -3186,28 +3185,28 @@ reload_sysroot_config (OstreeRepo          *self,
                        GCancellable        *cancellable,
                        GError             **error)
 {
-  { g_autofree char *bootloader = NULL;
+  g_autofree char *bootloader = NULL;
 
-    if (!ot_keyfile_get_value_with_default_group_optional (self->config, "sysroot",
-                                                           "bootloader", "auto",
-                                                           &bootloader, error))
-      return FALSE;
+  if (!ot_keyfile_get_value_with_default_group_optional (self->config, "sysroot",
+                                                         "bootloader", "auto",
+                                                         &bootloader, error))
+    return FALSE;
 
-    /* TODO: possibly later add support for specifying a generic bootloader
-     * binary "x" in /usr/lib/ostree/bootloaders/x). See:
-     * https://github.com/ostreedev/ostree/issues/1719
-     * https://github.com/ostreedev/ostree/issues/1801
-     * Also, dedup these strings with the bootloader implementations
-     */
-    if (!(g_str_equal (bootloader, "auto") || g_str_equal (bootloader, "none")
-          || g_str_equal (bootloader, "zipl")))
-      return glnx_throw (error, "Invalid bootloader configuration: '%s'", bootloader);
+  /* TODO: possibly later add support for specifying a generic bootloader
+   * binary "x" in /usr/lib/ostree/bootloaders/x). See:
+   * https://github.com/ostreedev/ostree/issues/1719
+   * https://github.com/ostreedev/ostree/issues/1801
+   */
+  for (int i = 0; CFG_SYSROOT_BOOTLOADER_OPTS_STR[i]; i++)
+    {
+      if (g_str_equal (bootloader, CFG_SYSROOT_BOOTLOADER_OPTS_STR[i]))
+        {
+          self->bootloader = (OstreeCfgSysrootBootloaderOpt) i;
+          return TRUE;
+        }
+    }
 
-    g_free (self->bootloader);
-    self->bootloader = g_steal_pointer (&bootloader);
-  }
-
-  return TRUE;
+  return glnx_throw (error, "Invalid bootloader configuration: '%s'", bootloader);
 }
 
 /**
@@ -6331,7 +6330,7 @@ ostree_repo_get_bootloader (OstreeRepo   *self)
 {
   g_return_val_if_fail (OSTREE_IS_REPO (self), NULL);
 
-  return self->bootloader;
+  return CFG_SYSROOT_BOOTLOADER_OPTS_STR[self->bootloader];
 }
 
 

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1354,7 +1354,6 @@ _ostree_sysroot_new_bootloader_by_type (
  * ostree_sysroot_query_bootloader:
  * @sysroot: Sysroot
  * @out_bootloader: (out) (transfer full) (allow-none): Return location for bootloader, may be %NULL
- * @out_bootloader_config: (out) (transfer none) (allow-none): Return location for value of ostree repo config variable sysroot.bootloader, may be %NULL
  * @cancellable: Cancellable
  * @error: Error
  */

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1352,6 +1352,15 @@ _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
       /* No bootloader specified; do not query bootloaders to run. */
       ret_loader = NULL;
       break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_GRUB2:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_grub2_new (sysroot);
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_syslinux_new (sysroot);
+      break;
+    case CFG_SYSROOT_BOOTLOADER_OPT_UBOOT:
+      ret_loader = (OstreeBootloader*) _ostree_bootloader_uboot_new (sysroot);
+      break;
     case CFG_SYSROOT_BOOTLOADER_OPT_ZIPL:
       /* We never consider zipl as active by default, so it can only be created
        * if it's explicitly requested in the config */

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1325,6 +1325,31 @@ ostree_sysroot_repo (OstreeSysroot *self)
   return self->repo;
 }
 
+static OstreeBootloader*
+_ostree_sysroot_new_bootloader_by_type (
+    OstreeSysroot                 *sysroot,
+    OstreeCfgSysrootBootloaderOpt  bl_type)
+{
+  switch (bl_type)
+    {
+    case CFG_SYSROOT_BOOTLOADER_OPT_NONE:
+      /* No bootloader specified; do not query bootloaders to run. */
+      return NULL;
+    case CFG_SYSROOT_BOOTLOADER_OPT_GRUB2:
+      return (OstreeBootloader*) _ostree_bootloader_grub2_new (sysroot);
+    case CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX:
+      return (OstreeBootloader*) _ostree_bootloader_syslinux_new (sysroot);
+    case CFG_SYSROOT_BOOTLOADER_OPT_UBOOT:
+      return (OstreeBootloader*) _ostree_bootloader_uboot_new (sysroot);
+    case CFG_SYSROOT_BOOTLOADER_OPT_ZIPL:
+      /* We never consider zipl as active by default, so it can only be created
+       * if it's explicitly requested in the config */
+      return (OstreeBootloader*) _ostree_bootloader_zipl_new (sysroot);
+    default:
+      g_assert_not_reached ();
+    }
+}
+
 /**
  * ostree_sysroot_query_bootloader:
  * @sysroot: Sysroot
@@ -1346,58 +1371,31 @@ _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
       CFG_SYSROOT_BOOTLOADER_OPTS_STR[bootloader_config]);
 
   g_autoptr(OstreeBootloader) ret_loader = NULL;
-  switch (repo->bootloader)
+  if (bootloader_config == CFG_SYSROOT_BOOTLOADER_OPT_AUTO)
     {
-    case CFG_SYSROOT_BOOTLOADER_OPT_NONE:
-      /* No bootloader specified; do not query bootloaders to run. */
-      ret_loader = NULL;
-      break;
-    case CFG_SYSROOT_BOOTLOADER_OPT_GRUB2:
-      ret_loader = (OstreeBootloader*) _ostree_bootloader_grub2_new (sysroot);
-      break;
-    case CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX:
-      ret_loader = (OstreeBootloader*) _ostree_bootloader_syslinux_new (sysroot);
-      break;
-    case CFG_SYSROOT_BOOTLOADER_OPT_UBOOT:
-      ret_loader = (OstreeBootloader*) _ostree_bootloader_uboot_new (sysroot);
-      break;
-    case CFG_SYSROOT_BOOTLOADER_OPT_ZIPL:
-      /* We never consider zipl as active by default, so it can only be created
-       * if it's explicitly requested in the config */
-      ret_loader = (OstreeBootloader*) _ostree_bootloader_zipl_new (sysroot);
-      break;
-    case CFG_SYSROOT_BOOTLOADER_OPT_AUTO:
-      {
-        gboolean is_active;
-        ret_loader = (OstreeBootloader*)_ostree_bootloader_syslinux_new (sysroot);
-        if (!_ostree_bootloader_query (ret_loader, &is_active,
-                                      cancellable, error))
-          return FALSE;
-
-        if (!is_active)
-          {
-            g_object_unref (ret_loader);
-            ret_loader = (OstreeBootloader*)_ostree_bootloader_grub2_new (sysroot);
-            if (!_ostree_bootloader_query (ret_loader, &is_active,
-                                          cancellable, error))
-              return FALSE;
-          }
-        if (!is_active)
-          {
-            g_object_unref (ret_loader);
-            ret_loader = (OstreeBootloader*)_ostree_bootloader_uboot_new (sysroot);
-            if (!_ostree_bootloader_query (ret_loader, &is_active, cancellable, error))
-              return FALSE;
-          }
-        if (!is_active)
-          g_clear_object (&ret_loader);
-        break;
-      }
-    default:
-      g_assert_not_reached ();
+      OstreeCfgSysrootBootloaderOpt probe[] = {
+        CFG_SYSROOT_BOOTLOADER_OPT_SYSLINUX,
+        CFG_SYSROOT_BOOTLOADER_OPT_GRUB2,
+        CFG_SYSROOT_BOOTLOADER_OPT_UBOOT,
+      };
+      for (int i = 0; i < G_N_ELEMENTS (probe); i++)
+        {
+          g_autoptr(OstreeBootloader) bl = _ostree_sysroot_new_bootloader_by_type (
+              sysroot, probe[i]);
+          gboolean is_active = FALSE;
+          if (!_ostree_bootloader_query (bl, &is_active, cancellable, error))
+            return FALSE;
+          if (is_active)
+            {
+              ret_loader = g_steal_pointer (&bl);
+              break;
+            }
+        }
     }
+  else
+    ret_loader = _ostree_sysroot_new_bootloader_by_type (sysroot, bootloader_config);
 
-  ot_transfer_out_value(out_bootloader, &ret_loader);
+  ot_transfer_out_value (out_bootloader, &ret_loader)
   return TRUE;
 }
 

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1345,6 +1345,9 @@ _ostree_sysroot_new_bootloader_by_type (
       /* We never consider zipl as active by default, so it can only be created
        * if it's explicitly requested in the config */
       return (OstreeBootloader*) _ostree_bootloader_zipl_new (sysroot);
+    case CFG_SYSROOT_BOOTLOADER_OPT_AUTO:
+      /* "auto" is handled by ostree_sysroot_query_bootloader so we should
+       * never get here: Fallthrough */
     default:
       g_assert_not_reached ();
     }

--- a/tests/bootloader-entries-crosscheck.py
+++ b/tests/bootloader-entries-crosscheck.py
@@ -20,113 +20,118 @@
 import os
 import sys
 
-if len(sys.argv) == 1:
-    sysroot = ''
-else:
-    sysroot = sys.argv[1]
 
-bootloader = sys.argv[2]
-loaderpath = sysroot + '/boot/loader/entries'
-syslinuxpath = sysroot + '/boot/syslinux/syslinux.cfg'
+def main(argv):
+    _, sysroot, bootloader = argv
 
-if bootloader == "grub2":
-    sys.stdout.write('GRUB2 configuration validation not implemented.\n')
-    sys.exit(0)
+    if bootloader == "grub2":
+        sys.stdout.write('GRUB2 configuration validation not implemented.\n')
+        return 0
+    else:
+        return validate_syslinux(sysroot)
+
 
 def fatal(msg):
     sys.stderr.write(msg)
     sys.stderr.write('\n')
     sys.exit(1)
 
-def entry_get_version(entry):
-    return int(entry['version'])
 
 def get_ostree_option(optionstring):
     for o in optionstring.split():
         if o.startswith('ostree='):
             return o[8:]
-    raise ValueError('ostree= not found')
-            
-entries = []
-syslinux_entries = []
+    raise ValueError('ostree= not found in %r' % (optionstring,))
 
-# Parse loader configs
-for fname in os.listdir(loaderpath):
-    path = os.path.join(loaderpath, fname)
-    with open(path) as f:
+
+def parse_loader_configs(sysroot):
+    loaderpath = sysroot + '/boot/loader/entries'
+    entries = []
+
+    # Parse loader configs
+    for fname in os.listdir(loaderpath):
+        path = os.path.join(loaderpath, fname)
         entry = {}
-        for line in f:
-            line = line.strip()
-            if (line == '' or line.startswith('#')):
-                continue
-            s = line.find(' ')
-            assert s > 0
-            k = line[0:s]
-            v = line[s+1:]
-            entry[k] = v
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if (line == '' or line.startswith('#')):
+                    continue
+                k, v = line.split(' ', 1)
+                entry[k] = v
         entries.append(entry)
-    entries.sort(key=entry_get_version, reverse=True)
+    entries.sort(key=lambda e: int(e['version']), reverse=True)
+    return entries
 
-# Parse SYSLINUX config
-with open(syslinuxpath) as f:
-    in_ostree_config = False
-    syslinux_entry = None
-    syslinux_default = None
-    for line in f:
-        try:
-            k, v = line.strip().split(" ", 1)
-        except ValueError:
-            continue
-        if k == 'DEFAULT':
-            if syslinux_entry is not None:
-                syslinux_default = v
-        elif k == 'LABEL':
-            if syslinux_entry is not None:
-                syslinux_entries.append(syslinux_entry)
-            syslinux_entry = {}
-            syslinux_entry['title'] = v
-        elif k == 'KERNEL':
-            syslinux_entry['linux'] = v
-        elif k == 'INITRD':
-            syslinux_entry['initrd'] = v
-        elif k == 'APPEND':
-            syslinux_entry['options'] = v
-    if syslinux_entry is not None:
-        syslinux_entries.append(syslinux_entry)
 
-if len(entries) != len(syslinux_entries):
-    fatal("Found {0} loader entries, but {1} SYSLINUX entries\n".format(len(entries), len(syslinux_entries)))
+def validate_syslinux(sysroot):
+    syslinuxpath = sysroot + '/boot/syslinux/syslinux.cfg'
+
+    entries = parse_loader_configs(sysroot)
+    syslinux_entries = []
+
+    # Parse SYSLINUX config
+    with open(syslinuxpath) as f:
+        syslinux_entry = None
+        for line in f:
+            try:
+                k, v = line.strip().split(" ", 1)
+            except ValueError:
+                continue
+            if k == 'DEFAULT':
+                if syslinux_entry is not None:
+                    syslinux_default = v
+            elif k == 'LABEL':
+                if syslinux_entry is not None:
+                    syslinux_entries.append(syslinux_entry)
+                syslinux_entry = {}
+                syslinux_entry['title'] = v
+            elif k == 'KERNEL':
+                syslinux_entry['linux'] = v
+            elif k == 'INITRD':
+                syslinux_entry['initrd'] = v
+            elif k == 'APPEND':
+                syslinux_entry['options'] = v
+        if syslinux_entry is not None:
+            syslinux_entries.append(syslinux_entry)
+
+    if len(entries) != len(syslinux_entries):
+        fatal("Found {0} loader entries, but {1} SYSLINUX entries\n".format(
+            len(entries), len(syslinux_entries)))
+
+    def assert_key_same_file(a, b, key):
+        aval = a[key]
+        bval = b[key]
+        sys.stderr.write("aval: %r\nbval: %r\n" % (aval, bval))
+
+        # Paths in entries are always relative to /boot
+        entry = os.stat(sysroot + "/boot" + aval)
+
+        # Syslinux entries can be relative to /boot (if it's on another filesystem)
+        # or relative to / if /boot is on /.
+        s1 = os.stat(sysroot + bval)
+        s2 = os.stat(sysroot + "/boot" + bval)
+
+        # A symlink ensures that no matter what they point at the same file
+        assert_eq(entry, s1)
+        assert_eq(entry, s2)
+
+    for i, (entry, syslinuxentry) in enumerate(zip(entries, syslinux_entries)):
+        assert_key_same_file(entry, syslinuxentry, 'linux')
+        assert_key_same_file(entry, syslinuxentry, 'initrd')
+        entry_ostree = get_ostree_option(entry['options'])
+        syslinux_ostree = get_ostree_option(syslinuxentry['options'])
+        if entry_ostree != syslinux_ostree:
+            fatal("Mismatch on ostree option: {0} != {1}".format(
+                entry_ostree, syslinux_ostree))
+
+    sys.stdout.write('SYSLINUX configuration validated\n')
+    return 0
 
 
 def assert_eq(a, b):
     assert a == b, "%r == %r" % (a, b)
 
 
-def assert_key_same_file(a, b, key):
-    aval = a[key]
-    bval = b[key]
-    sys.stderr.write("aval: %r\nbval: %r\n" % (aval, bval))
-
-    # Paths in entries are always relative to /boot
-    entry = os.stat(sysroot + "/boot" + aval)
-
-    # Syslinux entries can be relative to /boot (if it's on another filesystem)
-    # or relative to / if /boot is on /.
-    s1 = os.stat(sysroot + bval)
-    s2 = os.stat(sysroot + "/boot" + bval)
-
-    # A symlink ensures that no matter what they point at the same file
-    assert_eq(entry, s1)
-    assert_eq(entry, s2)
-
-
-for i,(entry,syslinuxentry) in enumerate(zip(entries, syslinux_entries)):
-    assert_key_same_file(entry, syslinuxentry, 'linux')
-    assert_key_same_file(entry, syslinuxentry, 'initrd')
-    entry_ostree = get_ostree_option(entry['options'])
-    syslinux_ostree = get_ostree_option(syslinuxentry['options'])
-    if entry_ostree != syslinux_ostree:
-        fatal("Mismatch on ostree option: {0} != {1}".format(entry_ostree, syslinux_ostree))
-
-sys.stdout.write('SYSLINUX configuration validated\n')
-sys.exit(0)
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
These are some refactorings I made a little while ago in preparation for adding a new bootloader class, but the new bootloader wasn't necessary after all.  I think the refactorings still have value though.

I'm raising this now so it can be used in the `OstreeBootloaderRpi` implementation.  See discussion on #2223.