### PR TITLE
lib/fetch-curl: Unref timeout source

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -426,12 +426,9 @@ static gboolean
 timer_cb (gpointer data)
 {
   OstreeFetcher *fetcher = data;
-  GSource *orig_src = fetcher->timer_event;
-
+  g_clear_pointer (&fetcher->timer_event, (GDestroyNotify)destroy_and_unref_source);
   (void)curl_multi_socket_action (fetcher->multi, CURL_SOCKET_TIMEOUT, 0, &fetcher->curl_running);
   check_multi_info (fetcher);
-  if (fetcher->timer_event == orig_src)
-    fetcher->timer_event = NULL;
 
   return G_SOURCE_REMOVE;
 }

--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -433,7 +433,7 @@ timer_cb (gpointer data)
   if (fetcher->timer_event == orig_src)
     fetcher->timer_event = NULL;
 
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 /* Update the event timer after curl_multi library calls */


### PR DESCRIPTION
The timeout timer should always be one-shot, so let's just always
destroy it in the callback. The main context has its own ref on it, so
it won't be freed behind its back.

This *should* fix a leak that was brought up in
https://bugzilla.redhat.com/show_bug.cgi?id=1891761.

Reported-by: Milan Crha <mcrha@redhat.com>