### PR TITLE
Drop use of `volatile`

### DIFF
--- a/src/libostree/ostree-diff.h
+++ b/src/libostree/ostree-diff.h
@@ -42,7 +42,7 @@ typedef enum {
 typedef struct _OstreeDiffItem OstreeDiffItem;
 struct _OstreeDiffItem
 {
-  volatile gint refcount;
+  gint refcount;  /* atomic */
 
   GFile *src;
   GFile *target;

--- a/src/libostree/ostree-enumtypes.c.template
+++ b/src/libostree/ostree-enumtypes.c.template
@@ -36,9 +36,9 @@
 GType
 _@enum_name@_get_type (void)
 {
-  static volatile gsize the_type__volatile = 0;
+  static gsize static_the_type = 0;
 
-  if (g_once_init_enter (&the_type__volatile))
+  if (g_once_init_enter (&static_the_type))
     {
       static const G@Type@Value values[] = {
 /*** END value-header ***/
@@ -57,10 +57,10 @@ _@enum_name@_get_type (void)
         g_intern_static_string ("@EnumName@"),
         values);
 
-      g_once_init_leave (&the_type__volatile, the_type);
+      g_once_init_leave (&static_the_type, the_type);
     }
 
-  return the_type__volatile;
+  return static_the_type;
 }
 
 /*** END value-tail ***/

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -49,7 +49,7 @@ typedef enum {
 } OstreeFetcherState;
 
 typedef struct {
-  volatile int ref_count;
+  int ref_count;  /* atomic */
 
   SoupSession *session;  /* not referenced */
   GMainContext *main_context;
@@ -77,7 +77,7 @@ typedef struct {
 } ThreadClosure;
 
 typedef struct {
-  volatile int ref_count;
+  int ref_count;  /* atomic */
 
   ThreadClosure *thread_closure;
   GPtrArray *mirrorlist; /* list of base URIs */

--- a/src/libostree/ostree-remote-private.h
+++ b/src/libostree/ostree-remote-private.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
  * remote which this one inherits from, and is what should be used in refspecs
  * for pulls from this remote. If it’s %NULL, @name should be used instead. */
 struct OstreeRemote {
-  volatile int ref_count;
+  int ref_count;  /* atomic */
   char *name;  /* (not nullable) */
   char *refspec_name;  /* (nullable) */
   char *group;   /* group name in options (not nullable) */

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -72,7 +72,7 @@ typedef enum {
 } OstreeRepoTestErrorFlags;
 
 struct OstreeRepoCommitModifier {
-  volatile gint refcount;
+  gint refcount;  /* atomic */
 
   OstreeRepoCommitModifierFlags flags;
   OstreeRepoCommitFilter filter;

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -682,9 +682,9 @@ ostree_sysroot_upgrader_deploy (OstreeSysrootUpgrader  *self,
 GType
 ostree_sysroot_upgrader_flags_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize static_g_define_type_id = 0;
 
-  if (g_once_init_enter (&g_define_type_id__volatile))
+  if (g_once_init_enter (&static_g_define_type_id))
     {
       static const GFlagsValue values[] = {
         { OSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED, "OSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED", "ignore-unconfigured" },
@@ -692,8 +692,8 @@ ostree_sysroot_upgrader_flags_get_type (void)
       };
       GType g_define_type_id =
         g_flags_register_static (g_intern_static_string ("OstreeSysrootUpgraderFlags"), values);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+      g_once_init_leave (&static_g_define_type_id, g_define_type_id);
     }
 
-  return g_define_type_id__volatile;
+  return static_g_define_type_id;
 }


### PR DESCRIPTION
As detailed in
https://gitlab.gnome.org/GNOME/glib/-/issues/600#note_877282, volatile
isn't actually needed in these contexts because the atomic operations
already give us strong enough guarantees. In GCC 11, this triggers a
diagnostic due to the volatile qualifier getting dropped anyway.

There is a WIP to do the same in glib:
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1719

This obsoletes this downstream patch:
https://src.fedoraproject.org/rpms/ostree/c/b8c5a6fb