### PR TITLE
pull: Don't save into cache passed in GByte summaries

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4545,7 +4545,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
             }
         }
 
-      if (!summary_from_cache && bytes_summary && bytes_sig)
+      if (!summary_from_cache && bytes_summary && bytes_sig && summary_sig_bytes_v == NULL)
         {
           if (!pull_data->remote_repo_local &&
               !_ostree_repo_cache_summary (self,


### PR DESCRIPTION
The cache shouldn't be affected by the user passing in some other
summary as it may not be the "official one".

I ran into this in flatpak where the passed summary was correct, but
the re-saving of the cache updated the mtime of the cached file which
led to later http If-Modified-Since calls failing to update.