### PR TITLE
ci/travis: move to newer base distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-dist: trusty
 sudo: required
 
 env:


### PR DESCRIPTION
This removes the old pinned distro (Ubuntu Trusty 14.04) from Travis,
moving to the newer default distro (Ubuntu Xenial 16.04).