### PR TITLE
ci: run ci-release-build.sh on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+---
+name: Release sanity
+
+on:
+  pull_request:
+    branches: [master]
+    types: [labeled]
+
+jobs:
+  ci-release-build:
+    name: "Sanity check release commits"
+    if: ${{ github.event.label.name == 'kind/release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+      - name: Checkout (HEAD)
+        run: git checkout HEAD
+      - name: Check release sanity (HEAD)
+        run: ci/ci-release-build.sh
+      - name: Checkout (HEAD^)
+        run: git checkout HEAD^
+      - name: Check release sanity (HEAD^)
+        run: ci/ci-release-build.sh

--- a/ci/ci-release-build.sh
+++ b/ci/ci-release-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Makes sure that is_release_build is only set to yes in a release commit. A
@@ -10,6 +10,7 @@ set -euo pipefail
 HEAD=${PAPR_COMMIT:-HEAD}
 
 git log --format=%B -n 1 $HEAD > log.txt
+trap "rm -f log.txt" EXIT
 
 if grep -q ^is_release_build=yes configure.ac; then
     echo "*** is_release_build is set to yes ***"


### PR DESCRIPTION
This adds a GitHub action in order to run ci-release-build.sh on
release PRs (detected via the `kind/release` label).