### PR TITLE
workflows/release: pattern-match on PR title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,14 @@
 ---
-name: Release sanity
+name: Release
 
 on:
   pull_request:
     branches: [master]
-    types: [labeled]
 
 jobs:
   ci-release-build:
     name: "Sanity check release commits"
-    if: ${{ github.event.label.name == 'kind/release' }}
+    if: ${{ github.event.label.name == 'kind/release' || startsWith(github.event.pull_request.title, 'Release') }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
This adds an additional condition in order to sanity check all
PRs starting with `Release` (case-insensitive).

Ref: https://github.com/ostreedev/ostree/pull/2239#discussion_r524422740

/cc @jlebon 