### PR TITLE
Release 2020.8

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -184,9 +184,12 @@ libostree_1_la_SOURCES += \
 endif # USE_GPGME
 
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+
+## Uncomment this include when adding new development symbols.
+#if BUILDOPT_IS_DEVEL_BUILD
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#endif
+
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=
 EXTRA_DIST += \

--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,10 @@ dnl Seed the release notes with `git-shortlog-with-prs <previous-release>..`. Th
 dnl `git-evtag` to create the tag and push it. Finally, create a GitHub release and attach
 dnl the tarball from `make dist`.
 m4_define([year_version], [2020])
-m4_define([release_version], [8])
+m4_define([release_version], [9])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ m4_define([year_version], [2020])
 m4_define([release_version], [8])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -15,14 +15,12 @@
   License along with this library; if not, write to the
   Free Software Foundation, Inc., 59 Temple Place - Suite 330,
   Boston, MA 02111-1307, USA.
-***/
 
-LIBOSTREE_2020.8 {
-global:
-  ostree_repo_list_static_delta_indexes;
-  ostree_repo_static_delta_reindex;
-  ostree_repo_gpg_sign_data;
-} LIBOSTREE_2020.7;
+  How to introduce the first new symbol for a development version:
+   - copy the stub content below to a new entry
+   - replace templated value as noted
+   - uncomment the include in Makefile-libostree.am
+*/
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -596,7 +596,6 @@ global:
 /* No new symbols in 2020.2 */
 /* No new symbols in 2020.3 */
 
-/* Add new symbols here.  Release commits should copy this section into -released.sym. */
 LIBOSTREE_2020.4 {
 global:
   ostree_repo_commit_modifier_set_sepolicy_from_commit;
@@ -619,14 +618,10 @@ global:
 } LIBOSTREE_2020.1;
 
 /* No new symbols in 2020.5 */
-
 /* No new symbols in 2020.6 */
 
 LIBOSTREE_2020.7 {
 global:
-  /* Add symbols here, and uncomment the bits in
-   * Makefile-libostree.am to enable this too.
-   */
   ostree_repo_static_delta_execute_offline_with_signature;
   ostree_repo_static_delta_verify_signature;
   ostree_bootconfig_parser_get_overlay_initrds;
@@ -635,6 +630,13 @@ global:
   ostree_sysroot_stage_tree_with_options;
   ostree_sysroot_stage_overlay_initrd;
 } LIBOSTREE_2020.4;
+
+LIBOSTREE_2020.8 {
+global:
+  ostree_repo_list_static_delta_indexes;
+  ostree_repo_static_delta_reindex;
+  ostree_repo_gpg_sign_data;
+} LIBOSTREE_2020.7;
 
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -66,7 +66,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-540ee37ff081a8649fd1b1fa3cf1b80f7b8abb01f6ba71eead0b3b828d6cb696  ${released_syms}
+3e677623543b7fdc57b0e3d9c66eb477105b014411259762a328c1b5e82068f0  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
This release mostly contains scalability improvements and bugfixes.

Caching-related HTTP headers are now supported on summaries and signatures, so that they do not have to be re-downloaded if not changed in the meanwhile.

Summaries and delta have been reworked to allow more fine-grained fetching.
It is now possible to store deltas in detached metadata outside of summary files, so that only relevant ones can be pulled when downloading a particular commit.
In particular, deltas can now be stored in a separate directory indexed by target commit, thus grouping the subset of deltas affecting it. These indexes are updated when the summary is updated and the in-summary delta index would normally be updated.

Related to the above, a new core option has been added to drop the deltas from the summary. However, as that would break older versions looking for the deltas there, it is off by default. 

Finally, this fixes several bugs related to atomic variables, HTTP timeouts, and 32-bit architectures.

---

```
Alexander Larsson (16):
      deltas: Add _ostree_get_relative_static_delta_index_path()
      deltas: Add ostree_repo_list_static_delta_indexes() function
      deltas: Update delta indexes when updating summary
      deltas: Add and document no-deltas-in-summary config option
      deltas: Make ostree_repo_static_delta_reindex() public
      deltas: Add CLI ops to list and reindex delta-indexes
      deltas: Use delta indexes when pulling
      deltas: Add tests for delta indexes
      deltas: Take a shared repo lock while reindexing deltas
      deltas: Set `indexed-deltas` key in the config and summary
      pull: Only download summary if we need it for the pull operation
      tests: Add a testcase to ensure we're not using the summary if we don't need it
      Add ostree_repo_gpg_sign_data()
      ostree pull: Add more g_debug spew around fetching deltas
      ostree_repo_gpg_sign_data: Fix API doc argument name
      pull: Don't save into cache passed in GByte summaries

Colin Walters (7):
      Post-release version bump
      deploy: Remove (transfer none) from fd arg
      travis: Add a 32 bit build
      sysroot: Fix up some GI nullable annotations
      bin/checkout: Port some to new style
      deployment: Add a bunch of docs and fix annotations
      deployment: Ensure query_deployments_for returns nullable values

Dan Nicholson (1):
      lib/deltas: Annotate from checksum as nullable

Felix Krull (1):
      lib: fix GI parameter tags

Jonathan Lebon (4):
      ostree-prepare-root: print st_dev and st_ino as 64-bit ints
      lib/fetcher-curl: Use G_SOURCE_REMOVE instead of FALSE
      lib/fetch-curl: Unref timeout source
      Drop use of `volatile`

Kelvin Fan (1):
      docs: Fix various typos

Luca BRUNO (5):
      ci/travis: move to newer base distro
      ci: run ci-release-build.sh on GitHub
      workflows/release: pattern-match on PR title

Philip Withnall (5):
      libostree: Add support for ETag and Last-Modified headers
      lib/pull: Hook up HTTP caching headers for summary and summary.sig
      tests: Add simple test for summary file caching
      ostree/trivial-httpd: Add Last-Modified/ETag support
      tests: Split RFC 2616 date parsing code out and add tests

William Manley (8):
      ostree_repo_get_bootloader: Document transfer none
      Refactor: Centralise choosing the appropriate bootloader
      Refactor: sysroot.bootloader: Store enum value rather than string
      Add support for explicitly requesting any specific bootloader type
      Refactor `ostree_sysroot_query_bootloader`
      Tests: Refactor bootloader-entries-crosscheck
```