### PR TITLE
workflow/release: further refinements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: Release
 on:
   pull_request:
     branches: [master]
+    paths:
+      - 'configure.ac'
 
 jobs:
   ci-release-build:
@@ -14,6 +16,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: 'recursive'
           fetch-depth: '0'
       - name: Checkout (HEAD)


### PR DESCRIPTION
This tweaks the release GH workflow further so that it only triggers
when the `configure.ac` file (which owns the version) changes.
Plus it properly checkouts the PR branch to avoid wrongly looking
at a synthetic merge commit.

Ref: https://github.com/ostreedev/ostree/pull/2241#issuecomment-728989765

/cc @jlebon 