### PR TITLE
commit: Optionally translate ima xattr

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -543,20 +543,20 @@ gboolean ostree_repo_remote_list_collection_refs (OstreeRepo    *self,
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_variant (OstreeRepo  *self,
                                         OstreeObjectType objtype,
-                                        const char    *sha256, 
+                                        const char    *sha256,
                                         GVariant     **out_variant,
                                         GError       **error);
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_variant_if_exists (OstreeRepo  *self,
                                                   OstreeObjectType objtype,
-                                                  const char    *sha256, 
+                                                  const char    *sha256,
                                                   GVariant     **out_variant,
                                                   GError       **error);
 
 _OSTREE_PUBLIC
 gboolean      ostree_repo_load_commit (OstreeRepo            *self,
-                                       const char            *checksum, 
+                                       const char            *checksum,
                                        GVariant             **out_commit,
                                        OstreeRepoCommitState *out_state,
                                        GError               **error);
@@ -582,7 +582,7 @@ gboolean ostree_repo_load_object_stream (OstreeRepo         *self,
 _OSTREE_PUBLIC
 gboolean      ostree_repo_query_object_storage_size (OstreeRepo           *self,
                                                      OstreeObjectType      objtype,
-                                                     const char           *sha256, 
+                                                     const char           *sha256,
                                                      guint64              *out_size,
                                                      GCancellable         *cancellable,
                                                      GError              **error);
@@ -617,7 +617,7 @@ gboolean      ostree_repo_fsck_object (OstreeRepo           *self,
                                        GCancellable         *cancellable,
                                        GError              **error);
 
-/** 
+/**
  * OstreeRepoCommitFilterResult:
  * @OSTREE_REPO_COMMIT_FILTER_ALLOW: Do commit this object
  * @OSTREE_REPO_COMMIT_FILTER_SKIP: Ignore this object
@@ -650,6 +650,7 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo    *r
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED: Emit an error if configured SELinux policy does not provide a label
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME: Delete added files/directories after commit; Since: 2017.13
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL: If a devino cache hit is found, skip modifier filters (non-directories only); Since: 2017.14
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_IMA_TRANSLATE: Translate from the user.ima extended attribute to security.ima
  */
 typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE = 0,
@@ -659,6 +660,7 @@ typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED = (1 << 3),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME = (1 << 4),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL = (1 << 5),
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_IMA_TRANSLATE = (1 << 6),
 } OstreeRepoCommitModifierFlags;
 
 /**

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -55,6 +55,7 @@ static char *opt_tar_pathname_filter;
 static gboolean opt_no_xattrs;
 static char *opt_selinux_policy;
 static gboolean opt_selinux_policy_from_base;
+static gboolean opt_translate_ima_xattr;
 static gboolean opt_canonical_permissions;
 static gboolean opt_ro_executables;
 static gboolean opt_consume;
@@ -116,6 +117,7 @@ static GOptionEntry options[] = {
   { "no-xattrs", 0, 0, G_OPTION_ARG_NONE, &opt_no_xattrs, "Do not import extended attributes", NULL },
   { "selinux-policy", 0, 0, G_OPTION_ARG_FILENAME, &opt_selinux_policy, "Set SELinux labels based on policy in root filesystem PATH (may be /)", "PATH" },
   { "selinux-policy-from-base", 'P', 0, G_OPTION_ARG_NONE, &opt_selinux_policy_from_base, "Set SELinux labels based on first --tree argument", NULL },
+  { "ima-xattr-translate", 'P', 0, G_OPTION_ARG_NONE, &opt_translate_ima_xattr, "Translate the user.ima extended attribute to security.ima in the repository", NULL },
   { "link-checkout-speedup", 0, 0, G_OPTION_ARG_NONE, &opt_link_checkout_speedup, "Optimize for commits of trees composed of hardlinks into the repository", NULL },
   { "devino-canonical", 'I', 0, G_OPTION_ARG_NONE, &opt_devino_canonical, "Assume hardlinked objects are unmodified.  Implies --link-checkout-speedup", NULL },
   { "tar-autocreate-parents", 0, 0, G_OPTION_ARG_NONE, &opt_tar_autocreate_parents, "When loading tar archives, automatically create parent directories as needed", NULL },
@@ -568,6 +570,8 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES;
   if (opt_disable_fsync)
     ostree_repo_set_disable_fsync (repo, TRUE);
+  if (opt_translate_ima_xattr)
+    flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_IMA_TRANSLATE;
   if (opt_selinux_policy && opt_selinux_policy_from_base)
     {
       glnx_throw (error, "Cannot specify both --selinux-policy and --selinux-policy-from-base");


### PR DESCRIPTION
The security.ima extended attribute can only be written by root, but
there is the user.ima attribute that can be set by e.g. ima-evm-utils.
Allowing translation from user.ima to security.ima means that the tree
can be prepared with user.ima attributes, and after translation, stored
as security.ima in the tree.

This would result in a deployed security.ima attribute without needing
to run the tree compose as root.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>