### PR TITLE
CI: run as non-root and add sanitizer build+check

### DIFF
--- a/ci/build-check-sanitized.sh
+++ b/ci/build-check-sanitized.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+# Build with ASAN and UBSAN + unit tests.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+export CFLAGS='-fsanitize=address -fsanitize=undefined -fsanitize-undefined-trap-on-error'
+# We leak global state in a few places, fixing that is hard.
+export ASAN_OPTIONS='detect_leaks=0'
+${dn}/build.sh
+make check

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -7,7 +7,7 @@ set -xeuo pipefail
 # cosa buildroot container
 # https://github.com/coreos/coreos-assembler/pull/730
 # And using `yum` at all means we can flake on fetching rpm metadata
-if [ -n "${SKIP_INSTALLDEPS:-}" ]; then
+if [ -n "${SKIP_INSTALLDEPS:-}" ] || test "$(id -u)" != 0; then
     exit 0
 fi
 


### PR DESCRIPTION
ci: Don't install deps if running as non-root

This way we run in Prow too.

---

ci: Add new build-check-sanitized.sh

All C/C++ projects should use the sanitizers (and static analysis)
in their CI.  We had this but lost it in one of our CI shuffles;
let's readd it.

