### PR TITLE
tests/ext/destructive: enhance test logic

### DIFF
--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -393,6 +393,8 @@ fn impl_transaction_test<M: AsRef<str>>(
     // then we'll exit implicitly via the reboot, and reenter the function
     // above.
     loop {
+        // Make sure previously failed services (if any) can run.
+        bash!("systemctl reset-failed || true")?;
         // Save the previous strategy as a string so we can use it in error
         // messages below
         let prev_strategy_str = format!("{:?}", live_strategy);


### PR DESCRIPTION
This enhances external-tests logic, ensuring that destructive tests
have some retries and context to pinpoint failures, and that failed-state services
are reset between iterations.