### PR TITLE
Add --enable-sanitizers, fix `make check` with it

### DIFF
--- a/ci/build-check-sanitized.sh
+++ b/ci/build-check-sanitized.sh
@@ -5,8 +5,7 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-export CFLAGS='-fsanitize=address -fsanitize=undefined -fsanitize-undefined-trap-on-error'
 # We leak global state in a few places, fixing that is hard.
 export ASAN_OPTIONS='detect_leaks=0'
-${dn}/build.sh
+build --disable-gtk-doc --with-curl --with-openssl --enable-sanitizers
 make check

--- a/configure.ac
+++ b/configure.ac
@@ -51,16 +51,17 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
 ])])
 AC_SUBST(WARN_CFLAGS)
 
-AC_MSG_CHECKING([for -fsanitize=address in CFLAGS])
-if echo $CFLAGS | grep -q -e -fsanitize=address; then
-  AC_MSG_RESULT([yes])
-  using_asan=yes
-else
-  AC_MSG_RESULT([no])
-fi
-AM_CONDITIONAL(BUILDOPT_ASAN, [test x$using_asan = xyes])
-AM_COND_IF([BUILDOPT_ASAN],
-  [AC_DEFINE([BUILDOPT_ASAN], 1, [Define if we are building with -fsanitize=address])])
+AC_ARG_ENABLE(sanitizers,
+              AS_HELP_STRING([--enable-sanitizers],
+                             [Enable ASAN and UBSAN (default: no)]),,
+              [enable_sanitizers=no])
+AM_CONDITIONAL(BUILDOPT_ASAN, [test x$enable_sanitizers != xno])
+AM_COND_IF([BUILDOPT_ASAN], [
+  sanitizer_flags="-fsanitize=address -fsanitize=undefined -fsanitize-undefined-trap-on-error"
+  CFLAGS="$CFLAGS ${sanitizer_flags}"
+  CXXFLAGS="$CXXFLAGS ${sanitizer_flags}"
+  AC_DEFINE([BUILDOPT_ASAN], 1, [Define if we are building with asan and ubsan])
+])
 
 AC_MSG_CHECKING([for -fsanitize=thread in CFLAGS])
 if echo $CFLAGS | grep -q -e -fsanitize=thread; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -147,6 +147,9 @@ fi
 
 # This is substituted by the build for installed tests
 BUILT_WITH_ASAN=""
+if test -n "${ASAN_OPTIONS:-}"; then
+    BUILT_WITH_ASAN=1
+fi
 
 if test -n "${OT_TESTS_VALGRIND:-}"; then
     CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"


### PR DESCRIPTION
It's cleaner if this is an build option rather than being
kludged into the CI layer.

Notably we can't use `LD_PRELOAD` anymore with ASAN, so update
our tests to check for `ASAN_OPTIONS`.