### PR TITLE
ostree-repo-pull: Fix a leak of the summary data if loading from cache

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -6674,7 +6674,7 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo    *self,
         return FALSE;
     }
 
-  if (signatures)
+  if (signatures && !summary)
     {
       if (!_ostree_repo_load_cache_summary_if_same_sig (self,
                                                         name,


### PR DESCRIPTION
If the `summary_sig_not_modified` branch is taken above, both
`signatures` and `summary` are loaded from the cache. This makes the
`_ostree_repo_load_cache_summary_if_same_sig()` call below redundant (it
checks `signatures` matches the file it was just loaded from, and then
loads `summary` again) — but that call also currently overwrites
`summary` without clearing the old value.

Fix this by only making that call if `signatures` was retrieved, but the
server said the local `summary` cache was invalid.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>