### PR TITLE
Fix translation of file:// URIs into paths

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4117,8 +4117,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
      */
     if (g_str_equal (first_scheme, "file") && !pull_data->require_static_deltas)
       {
-        g_autofree char *path = _ostree_fetcher_uri_get_path (first_uri);
-        g_autoptr(GFile) remote_repo_path = g_file_new_for_path (path);
+        g_autofree char *uri = _ostree_fetcher_uri_to_string (first_uri);
+        g_autoptr(GFile) remote_repo_path = g_file_new_for_uri (uri);
         pull_data->remote_repo_local = ostree_repo_new (remote_repo_path);
         if (!ostree_repo_open (pull_data->remote_repo_local, cancellable, error))
           goto out;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4104,24 +4104,25 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                            &configured_branches, error))
     goto out;
 
-  /* TODO reindent later */
-  { OstreeFetcherURI *first_uri = pull_data->meta_mirrorlist->pdata[0];
+  /* Handle file:// URIs */
+  {
+    OstreeFetcherURI *first_uri = pull_data->meta_mirrorlist->pdata[0];
     g_autofree char *first_scheme = _ostree_fetcher_uri_get_scheme (first_uri);
 
-  /* NB: we don't support local mirrors in mirrorlists, so if this passes, it
-   * means that we're not using mirrorlists (see also fetch_mirrorlist())
-   * Also, we explicitly disable the "local repo" path if static deltas
-   * were explicitly requested to be required; this is going to happen
-   * most often for testing deltas without setting up a HTTP server.
-   */
-  if (g_str_equal (first_scheme, "file") && !pull_data->require_static_deltas)
-    {
-      g_autofree char *path = _ostree_fetcher_uri_get_path (first_uri);
-      g_autoptr(GFile) remote_repo_path = g_file_new_for_path (path);
-      pull_data->remote_repo_local = ostree_repo_new (remote_repo_path);
-      if (!ostree_repo_open (pull_data->remote_repo_local, cancellable, error))
-        goto out;
-    }
+    /* NB: we don't support local mirrors in mirrorlists, so if this passes, it
+     * means that we're not using mirrorlists (see also fetch_mirrorlist())
+     * Also, we explicitly disable the "local repo" path if static deltas
+     * were explicitly requested to be required; this is going to happen
+     * most often for testing deltas without setting up a HTTP server.
+     */
+    if (g_str_equal (first_scheme, "file") && !pull_data->require_static_deltas)
+      {
+        g_autofree char *path = _ostree_fetcher_uri_get_path (first_uri);
+        g_autoptr(GFile) remote_repo_path = g_file_new_for_path (path);
+        pull_data->remote_repo_local = ostree_repo_new (remote_repo_path);
+        if (!ostree_repo_open (pull_data->remote_repo_local, cancellable, error))
+          goto out;
+      }
   }
 
   /* Change some option defaults if we're actually pulling from a local


### PR DESCRIPTION
Currently if a file path contains a special character such as '\', and
that character is encoded into a file:// URI that is passed to
ostree_repo_pull_with_options(), the percent encoding will remain in the
path passed to g_file_new() (in the case of backslash %5C) and the pull
will then fail with a file not found error. This is an important edge
case to handle because by default on many Linux distributions a
filesystem with no label is mounted at a path based on its UUID, and
this is then passed to systemd-escape by Flatpak (when
--enable-auto-sideloading was used at compile time) to create a symbolic
link such as this which contains backslashes:

$ ls -l /run/flatpak/sideload-repos/
total 0
lrwxrwxrwx 1 mwleeds mwleeds 55 Mar  9 14:21
'automount-run-media-mwleeds-29419e8f\x2dc680\x2d4e95\x2d9a31\x2d2cc907d421cb'
-> /run/media/mwleeds/29419e8f-c680-4e95-9a31-2cc907d421cb

And Flatpak then passes libostree a file:// URI containing that path, to
implement sideloading (pulling content from the USB drive).

This results in an error like:

Error: While pulling app/org.videolan.VLC/x86_64/stable from remote
flathub:
/run/flatpak/sideload-repos/automount-run-media-mwleeds-29419e8f%5Cx2dc680%5Cx2d4e95%5Cx2d9a31%5Cx2d2cc907d421cb/.ostree/repo:
opendir(/run/flatpak/sideload-repos/automount-run-media-mwleeds-29419e8f%5Cx2dc680%5Cx2d4e95%5Cx2d9a31%5Cx2d2cc907d421cb/.ostree/repo):
No such file or directory

This patch avoids such errors by using libsoup to %-decode sequences
such as %5C and any others that represent printable characters.
Technically a filename could contain unprintable characters like 0x7F
(DEL) but I'm not sure we need to support that.

Bug report by user:
https://community.endlessos.com/t/can-not-install-vlc-from-usb-drive-3-9-3/16353