### PR TITLE
Add configure option for unsuffixed GRUB2 commands linux/initrd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -548,6 +548,14 @@ AM_COND_IF(BUILDOPT_SYSTEMD_AND_LIBMOUNT,
   AC_DEFINE([BUILDOPT_LIBSYSTEMD_AND_LIBMOUNT], 1, [Define if systemd and libmount]))
 if test x$with_libsystemd = xyes; then OSTREE_FEATURES="$OSTREE_FEATURES systemd"; fi
 
+AC_ARG_WITH(modern-grub,
+	    AS_HELP_STRING([--with-modern-grub],
+                           [Omit grub linux and initrd suffixes for EFI/BIOS booting on GRUB >2.02 (default: no)]),,
+              [with_modern_grub=no])
+AS_IF([ test x$with_modern_grub = xyes], [
+  AC_DEFINE([WITH_MODERN_GRUB], 1, [Define if we have a GRUB version newer than 2.02])
+])
+
 AC_ARG_WITH(builtin-grub2-mkconfig,
             AS_HELP_STRING([--with-builtin-grub2-mkconfig],
                            [Use a builtin minimal grub2-mkconfig to generate a GRUB2 configuration file (default: no)]),,

--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -28,25 +28,26 @@
 
 #include <string.h>
 
-/* I only did some cursory research here, but it appears
- * that we only want to use "linux16" for x86 platforms.
- * At least, I got a report that "linux16" is definitely wrong
- * for ppc64.  See
- * http://pkgs.fedoraproject.org/cgit/rpms/grub2.git/tree/0036-Use-linux16-when-appropriate-880840.patch?h=f25
- * https://bugzilla.redhat.com/show_bug.cgi?id=1108296
- * among others.
+/* Maintain backwards compatibility with legacy GRUB
+ * installations that might rely on the -16 suffix
+ * for real-mode booting.
+ * Allow us to override this at build time if we're
+ * using a modern GRUB installation.
  */
-#if defined(__i386__) || defined(__x86_64__)
+#if !defined(WITH_MODERN_GRUB) && ( defined(__i386__) || defined(__x86_64__) )
 #define GRUB2_SUFFIX "16"
 #else
 #define GRUB2_SUFFIX ""
 #endif
-/* https://github.com/projectatomic/rpm-ostree-toolbox/issues/102#issuecomment-316483554
- * https://github.com/rhboot/grubby/blob/34b1436ccbd56eab8024314cab48f2fc880eef08/grubby.c#L63
- *
- * This is true at least on Fedora/Red Hat Enterprise Linux for aarch64.
+/* Maintain backwards compatibility with legacy GRUB
+ * installations that might rely on the -efi suffix
+ * for RHEL/fedora-based distros.
+ * Allow us to override this at build time if we're
+ * using a modern GRUB installation that makes the
+ * suffix-less linux/initrd commands synonymous for
+ * both EFI and BIOS booting.
  */
-#if defined(__aarch64__)
+#if defined(WITH_MODERN_GRUB) || defined(__aarch64__)
 #define GRUB2_EFI_SUFFIX ""
 #else
 #define GRUB2_EFI_SUFFIX "efi"


### PR DESCRIPTION
GRUB starting with version 2.02 permits the use of the standard `linux` and `initrd` commands for both EFI boot in *-efi installations, as well as 32-bit BIOS boot in i386-pc installations.

This makes the use of the -16 and -efi suffixes for BIOS and EFI boot obsolete in modern distros (The efi suffix is a RHEL/Fedora-ism anyway that doesn't apply to distros not based on these).

Additionally, booting the kernel in real-mode on x86 BIOS systems with the linux16/initrd16 commands should be an exception and not the default.

All modern distros, including RHEL and Fedora versions starting with RHEL 8 and Fedora 28, include or are based on a grub >2.02 release, so I think moving forward ostree should drop these suffixes for generated grub configurations.

Closes: #1009