### PR TITLE
build-sys: Include all mkinitcpio bits

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -65,7 +65,7 @@ endif
 
 EXTRA_DIST += src/boot/dracut/module-setup.sh \
 	src/boot/dracut/ostree.conf \
-	src/boot/mkinitcpio/ostree \
+	src/boot/mkinitcpio \
 	src/boot/ostree-prepare-root.service \
 	src/boot/ostree-finalize-staged.path \
 	src/boot/ostree-remount.service \


### PR DESCRIPTION
It's still so tempting to switch to `git archive` to ship sources.

Closes: https://github.com/ostreedev/ostree/issues/2312