### PR TITLE
build-sys: Remove --enable-experimental-api

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -48,7 +48,7 @@ minimal: {
         ./configure --without-curl --without-soup --disable-gtk-doc --disable-man \
           --disable-rust --without-libarchive --without-selinux --without-smack \
           --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
-          --disable-experimental-api --without-libsodium
+          --without-libsodium
         make
       """)
   }

--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -147,14 +147,6 @@ libostree_1_la_SOURCES += \
 	src/libostree/ostree-tls-cert-interaction.h \
 	$(NULL)
 endif
-libostree_experimental_headers = \
-	$(NULL)
-if !ENABLE_EXPERIMENTAL_API
-libostree_1_la_SOURCES += $(libostree_experimental_headers)
-else # if ENABLE_EXPERIMENTAL_API
-libostree_1_la_SOURCES += \
-	$(NULL)
-endif
 
 if USE_AVAHI
 libostree_1_la_SOURCES += \
@@ -281,13 +273,9 @@ OSTree-1.0.gir: libostree-1.la Makefile
 OSTree_1_0_gir_EXPORT_PACKAGES = ostree-1
 OSTree_1_0_gir_INCLUDES = Gio-2.0
 OSTree_1_0_gir_CFLAGS = $(libostree_1_la_CFLAGS)
-if ENABLE_EXPERIMENTAL_API
-# When compiling this is set via config.h, but g-ir-scanner can't use that
-OSTree_1_0_gir_CFLAGS += -DOSTREE_ENABLE_EXPERIMENTAL_API=1
-endif
 OSTree_1_0_gir_LIBS = libostree-1.la
 OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree $(GI_SCANNERFLAGS)
-OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h $(libostree_experimental_headers),$(libostree_1_la_SOURCES))
+OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h,$(libostree_1_la_SOURCES))
 INTROSPECTION_GIRS += OSTree-1.0.gir
 gir_DATA += OSTree-1.0.gir
 typelib_DATA += OSTree-1.0.typelib

--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -60,11 +60,6 @@ nodist_ostree_SOURCES = \
 	src/ostree/parse-datetime.c \
 	$(NULL)
 
-if ENABLE_EXPERIMENTAL_API
-ostree_SOURCES += \
-	$(NULL)
-endif
-
 if USE_GPGME
 ostree_SOURCES += \
 	src/ostree/ot-builtin-gpg-sign.c \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -156,8 +156,6 @@ _installed_or_uninstalled_test_scripts += \
 	$(NULL)
 endif
 
-experimental_test_scripts = \
-	$(NULL)
 test_extra_programs = \
 	tests/get-byte-order \
 	tests/repo-finder-mount \
@@ -170,12 +168,6 @@ tests_get_byte_order_LDADD = $(GLIB_LIBS)
 tests_repo_finder_mount_SOURCES = tests/repo-finder-mount.c
 tests_repo_finder_mount_CFLAGS = $(common_tests_cflags)
 tests_repo_finder_mount_LDADD = $(common_tests_ldadd) libostreetest.la
-
-if ENABLE_EXPERIMENTAL_API
-_installed_or_uninstalled_test_scripts += $(experimental_test_scripts)
-else
-EXTRA_DIST += $(experimental_test_scripts)
-endif
 
 if BUILDOPT_FUSE
 _installed_or_uninstalled_test_scripts += tests/test-rofiles-fuse.sh

--- a/apidoc/Makefile.am
+++ b/apidoc/Makefile.am
@@ -122,7 +122,6 @@ include $(top_srcdir)/gtk-doc.make
 EXTRA_DIST += \
 	version.xml \
 	ostree-sections.txt \
-	ostree-experimental-sections.txt \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -107,6 +107,7 @@ OSTREE_SUMMARY_GVARIANT_STRING
 OSTREE_SUMMARY_GVARIANT_FORMAT
 ostree_metadata_variant_type
 ostree_validate_checksum_string
+ostree_validate_collection_id
 ostree_checksum_to_bytes
 ostree_checksum_to_bytes_v
 ostree_checksum_from_bytes
@@ -304,6 +305,7 @@ ostree_repo_is_system
 ostree_repo_is_writable
 ostree_repo_create_at
 ostree_repo_create
+ostree_repo_get_collection_id
 ostree_repo_get_bootloader
 ostree_repo_get_path
 ostree_repo_get_mode
@@ -319,6 +321,7 @@ ostree_repo_remote_delete
 OstreeRepoRemoteChange
 ostree_repo_remote_change
 ostree_repo_remote_list
+ostree_repo_remote_list_collection_refs
 ostree_repo_remote_get_url
 ostree_repo_remote_get_gpg_verify
 ostree_repo_remote_get_gpg_verify_summary
@@ -337,10 +340,13 @@ ostree_repo_prepare_transaction
 ostree_repo_commit_transaction
 ostree_repo_abort_transaction
 ostree_repo_transaction_set_refspec
+ostree_repo_transaction_set_collection_ref
 ostree_repo_transaction_set_ref
 ostree_repo_set_ref_immediate
 ostree_repo_set_alias_ref_immediate
 ostree_repo_set_cache_dir
+ostree_repo_set_collection_id
+ostree_repo_set_collection_ref_immediate
 ostree_repo_sign_delta
 ostree_repo_has_object
 ostree_repo_mark_commit_partial
@@ -360,7 +366,9 @@ ostree_repo_resolve_rev_ext
 ostree_repo_list_refs
 OstreeRepoListRefsExtFlags
 ostree_repo_list_refs_ext
+ostree_repo_list_collection_refs
 ostree_repo_remote_list_refs
+ostree_repo_resolve_collection_ref
 ostree_repo_load_variant
 OstreeRepoCommitState
 ostree_repo_load_commit
@@ -619,7 +627,7 @@ ostree_remote_get_type
 </SECTION>
 
 <SECTION>
-<FILE>ostree-repo-experimental</FILE>
+<FILE>ostree-repo-remote-finder</FILE>
 ostree_repo_find_remotes_async
 ostree_repo_find_remotes_finish
 ostree_repo_pull_from_remotes_async
@@ -681,18 +689,6 @@ ostree_repo_finder_override_new
 ostree_repo_finder_override_add_uri
 <SUBSECTION Standard>
 ostree_repo_finder_override_get_type
-</SECTION>
-
-<SECTION>
-<FILE>ostree-misc-experimental</FILE>
-ostree_repo_get_collection_id
-ostree_repo_set_collection_id
-ostree_validate_collection_id
-ostree_repo_list_collection_refs
-ostree_repo_remote_list_collection_refs
-ostree_repo_set_collection_ref_immediate
-ostree_repo_transaction_set_collection_ref
-ostree_repo_resolve_collection_ref
 </SECTION>
 
 <SECTION>

--- a/configure.ac
+++ b/configure.ac
@@ -560,21 +560,6 @@ AS_IF([test "x$found_introspection" = xyes && test x$using_asan != xyes], [
 ], [have_gjs=no])
 AM_CONDITIONAL(BUILDOPT_GJS, test x$have_gjs = xyes)
 
-# Do we enable building experimental (non-stable) API?
-# The OSTREE_ENABLE_EXPERIMENTAL_API #define is used internally and in public
-# headers, so any consumer of libostree who wants to use experimental API must
-#    #define OSTREE_ENABLE_EXPERIMENTAL_API 1
-# before including libostree headers. This means the name in the AC_DEFINE below
-# is public API.
-AC_ARG_ENABLE([experimental-api],
-  [AS_HELP_STRING([--enable-experimental-api],
-                  [Enable unstable experimental API in libostree [default=no]])],,
-  [enable_experimental_api=no])
-AS_IF([test x$enable_experimental_api = xyes],
-  [AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if experimental API should be enabled])
-   OSTREE_FEATURES="$OSTREE_FEATURES experimental"]
-)
-AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API],[test x$enable_experimental_api = xyes])
 AM_CONDITIONAL([BUILDOPT_IS_DEVEL_BUILD],[test x$is_release_build != xyes])
 AM_COND_IF([BUILDOPT_IS_DEVEL_BUILD],
             AC_DEFINE([BUILDOPT_IS_DEVEL_BUILD], [1], [Define if doing a development build])
@@ -622,8 +607,7 @@ echo "
     gjs-based tests:                              $have_gjs
     dracut:                                       $with_dracut
     mkinitcpio:                                   $with_mkinitcpio
-    Static compiler for ostree-prepare-root:      $with_static_compiler
-    Experimental API                              $enable_experimental_api"
+    Static compiler for ostree-prepare-root:      $with_static_compiler"
 AS_IF([test x$with_builtin_grub2_mkconfig = xyes], [
     echo "    builtin grub2-mkconfig (instead of system):   $with_builtin_grub2_mkconfig"
 ], [

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -637,12 +637,6 @@ skip_without_fuse () {
     [ -e /etc/mtab ] || skip "no /etc/mtab"
 }
 
-skip_without_experimental () {
-    if ! ostree --version | grep -q -e '- experimental'; then
-        skip "No experimental API is compiled in"
-    fi
-}
-
 has_gpgme () {
     local ret
     ${CMD_PREFIX} ostree --version > version.txt

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -31,25 +31,15 @@ if echo "$OSTREE_FEATURES" | grep --quiet --no-messages "devel"; then
 else
     devel_syms=
 fi
-if echo "$OSTREE_FEATURES" | grep --quiet --no-messages "experimental"; then
-  experimental_sym="${G_TEST_SRCDIR}/src/libostree/libostree-experimental.sym"
-  experimental_sections="${G_TEST_SRCDIR}/apidoc/ostree-experimental-sections.txt"
-else
-  experimental_sym=""
-  experimental_sections=""
-fi
 
 echo "Verifying all expected symbols are actually exported..."
-grep --no-filename ' ostree_[A-Za-z0-9_]*;' ${released_syms} ${devel_syms} ${experimental_sym} | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
+grep --no-filename ' ostree_[A-Za-z0-9_]*;' ${released_syms} ${devel_syms} | sed -e 's,^ *\([A-Za-z0-9_]*\);,\1,' | sort -u > expected-symbols.txt
 eu-readelf -a ${G_TEST_BUILDDIR}/.libs/libostree-1.so | grep 'FUNC.*GLOBAL.*DEFAULT.*@@LIBOSTREE_' | sed -e 's,^.* \(ostree_[A-Za-z0-9_]*\)@@LIBOSTREE_[0-9A-Z_.]*,\1,' |sort -u > found-symbols.txt
 diff -u expected-symbols.txt found-symbols.txt
 
 echo "Checking that the example symbol wasn't copy-pasted..."
 if test -f ${devel_syms}; then
   assert_file_has_content_once ${devel_syms} "someostree_symbol_deleteme"
-fi
-if test -f ${experimental_sym}; then
-  assert_not_file_has_content ${experimental_sym} "someostree_symbol_deleteme"
 fi
 assert_not_file_has_content ${released_syms} "someostree_symbol_deleteme"
 
@@ -59,7 +49,7 @@ echo "ok exports"
 grep -E -v '(ostree_cmd__private__)|(ostree_fetcher_config_flags_get_type)' found-symbols.txt > expected-documented.txt
 
 echo "Verifying all public symbols are documented:"
-grep --no-filename '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt $experimental_sections |sort -u > found-documented.txt
+grep --no-filename '^ostree_' ${G_TEST_SRCDIR}/apidoc/ostree-sections.txt |sort -u > found-documented.txt
 diff -u expected-documented.txt found-documented.txt
 
 echo 'ok documented symbols'


### PR DESCRIPTION
It was added for the collections bits, but we made that stable.
It's now just cruft and we're very unlikely to reuse the infrastructure
again.

Motivated by a unit test failure when running from a tarball:
https://github.com/ostreedev/ostree/issues/2313