### PR TITLE
Various patches for tests/inst

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 tempfile = "3.1.0"
 glib = "0.10"
 gio = "0.9"
-ostree = { version = "0.8.0", features = ["v2020_1"] }
+ostree = { version = "0.10.0", features = ["v2021_1"] }
 libtest-mimic = "0.3.0"
 twoway = "0.2.1"
 hyper = "0.13"

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -38,8 +38,7 @@ openat = "0.1.19"
 openat-ext = "0.1.4"
 nix = "0.17.0"
 # See discussion in https://github.com/coreos/rpm-ostree/pull/2569#issuecomment-780569188
-# Currently pinned to a hash, but after the next stable release let's switch to tags
-rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", rev = "170095bd60ec8802afeea42d120fb2e88298648f" }
+rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", tag = "v2021.3" }
 
 # This one I might publish to crates.io, not sure yet
 with-procspawn-tempdir = { git = "https://github.com/cgwalters/with-procspawn-tempdir" }

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -46,7 +46,3 @@ with-procspawn-tempdir = { git = "https://github.com/cgwalters/with-procspawn-te
 
 # Internal crate for the test macro
 itest-macro = { path = "itest-macro" }
-
-[patch.crates-io]
-# PR openat (pun intended) https://github.com/tailhook/openat/pull/36
-openat = { git = 'https://github.com/cgwalters/openat', branch = 'libc-rename-signed' }

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -22,11 +22,11 @@ gio = "0.9"
 ostree = { version = "0.10.0", features = ["v2021_1"] }
 libtest-mimic = "0.3.0"
 twoway = "0.2.1"
-hyper = "0.13"
+hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }
+hyper-staticfile = "0.6.0"
 futures = "0.3.4"
 http = "0.2.0"
-hyper-staticfile = "0.5.1"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full"] }
 futures-util = "0.3.1"
 base64 = "0.12.0"
 procspawn = "0.8"
@@ -36,7 +36,7 @@ strum = "0.18.0"
 strum_macros = "0.18.0"
 openat = "0.1.19"
 openat-ext = "0.1.4"
-nix = "0.17.0"
+nix = "0.20.0"
 # See discussion in https://github.com/coreos/rpm-ostree/pull/2569#issuecomment-780569188
 rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", tag = "v2021.3" }
 

--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -279,7 +279,7 @@ fn parse_and_validate_reboot_mark<M: AsRef<str>>(
         // Update the target state
         let srvrepo_obj = ostree::Repo::new(&gio::File::new_for_path(SRVREPO));
         srvrepo_obj.open(gio::NONE_CANCELLABLE)?;
-        commitstates.target = srvrepo_obj.resolve_rev(TESTREF, false)?.into();
+        commitstates.target = srvrepo_obj.resolve_rev(TESTREF, false)?.unwrap().into();
     } else if commitstates.booted == commitstates.orig || commitstates.booted == commitstates.prev {
         println!(
             "Failed update to {} (booted={})",
@@ -353,11 +353,12 @@ fn impl_transaction_test<M: AsRef<str>>(
 
         CommitStates {
             booted: booted_commit.to_string(),
-            orig: sysrepo_obj.resolve_rev(ORIGREF, false)?.into(),
+            orig: sysrepo_obj.resolve_rev(ORIGREF, false)?.unwrap().into(),
             prev: srvrepo_obj
                 .resolve_rev(&format!("{}^", TESTREF), false)?
+                .unwrap()
                 .into(),
-            target: srvrepo_obj.resolve_rev(TESTREF, false)?.into(),
+            target: srvrepo_obj.resolve_rev(TESTREF, false)?.unwrap().into(),
         }
     };
 

--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -158,7 +158,7 @@ where
     F: Send + 'static,
 {
     let path = path.as_ref();
-    let mut rt = Runtime::new()?;
+    let rt = Runtime::new()?;
     rt.block_on(async move {
         let addr = http_server(path, *opts).await?;
         tokio::task::spawn_blocking(move || f(&addr)).await?


### PR DESCRIPTION
tests: Drop openat override

No longer needed.

---

tests/inst: Update ostree crate

---

tests/inst: Update rpm-ostree client

---

tests/inst: Update tokio, hyper and nix

---

