### PR TITLE
travis: Don't ask any debconf questions when installing packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-ed25519-libsodium" ci_pkgs="libsodium-dev"
   - ci_docker=debian:buster-slim ci_distro=debian ci_suite=stretch ci_configopts="--with-curl --with-ed25519-libsodium --without-gpgme" ci_pkgs="libsodium-dev"
   - ci_docker=ubuntu:focal ci_distro=ubuntu ci_suite=focal
-  - ci_docker=i386/ubuntu:focal ci_distro=ubuntu ci_suite=focal
   - ci_docker=ubuntu:groovy ci_distro=ubuntu ci_suite=groovy
 
 script:

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -82,6 +82,10 @@ esac
 
 case "$ci_distro" in
     (debian|ubuntu)
+        # Make debconf run non-interactively since its questions can't
+        # be answered.
+        export DEBIAN_FRONTEND=noninteractive
+
         # TODO: fetch this list from the Debian packaging git repository?
         $sudo apt-get -y update
         $sudo apt-get -y install \


### PR DESCRIPTION
Currently the Ubuntu builds are stuck waiting for an answer on what
timezone to use. That could be fixed, but generally the way to do these
types of installs is to set the DEBIAN_FRONTEND environment variable to
`noninteractive` so that debconf just chooses a default. This is what
debootstrap does, for instance. I tested installing tzdata on a local
focal container this way and it just chooses `Etc/UTC` as the timezone.