### PR TITLE
tests/inst: Make nondestructive tests runnable as unit tests

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -431,8 +431,11 @@ if ENABLE_INSTALLED_TESTS_EXCLUSIVE
 dist_installed_test_scripts = $(_installed_or_uninstalled_test_scripts)
 installed_test_programs = $(_installed_or_uninstalled_test_programs)
 check-local:
+	echo "NOTE: Run the Rust installed tests (uninstalled) with ./tests/run-installed"
 	echo "NOTE: Exclusive installed tests are enabled; to run them, make install, then: gnome-desktop-testing-runner -p 0 libostree/"
 else
+check-local:
+	echo "NOTE: Run the Rust installed tests (uninstalled) with ./tests/run-installed"
 dist_test_scripts += $(_installed_or_uninstalled_test_scripts)
 test_programs += $(_installed_or_uninstalled_test_programs)
 endif

--- a/tests/inst/src/sysroot.rs
+++ b/tests/inst/src/sysroot.rs
@@ -6,10 +6,14 @@ use ostree::prelude::*;
 
 use crate::test::*;
 
+fn skip_non_ostree_host() -> bool {
+    !std::path::Path::new("/run/ostree-booted").exists()
+}
+
 #[itest]
 fn test_sysroot_ro() -> Result<()> {
     // TODO add a skipped identifier
-    if !std::path::Path::new("/run/ostree-booted").exists() {
+    if skip_non_ostree_host() {
         return Ok(());
     }
     let cancellable = Some(gio::Cancellable::new());
@@ -34,6 +38,9 @@ fn test_sysroot_ro() -> Result<()> {
 
 #[itest]
 fn test_immutable_bit() -> Result<()> {
+    if skip_non_ostree_host() {
+        return Ok(());
+    }
     // https://bugzilla.redhat.com/show_bug.cgi?id=1867601
     cmd_has_output(sh_inline::bash_command!("lsattr -d /").unwrap(), "-i-")?;
     Ok(())

--- a/tests/run-installed
+++ b/tests/run-installed
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Run this script after e.g. `sudo make install` in a development container/host
+# to run tests which operate on the installed binaries.
+set -xeuo pipefail
+dn=$(dirname $0)
+(cd ${dn}/../tests/inst && cargo run --release)


### PR DESCRIPTION
Ideally in the future we change more of our unit tests to
support running installed; we've tried this in the past with
https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests

I'd like to pick that back up again.  This takes a step
towards that by having our Rust tests.

To make this even easier, add a `tests/run-installed`
which runs the installed tests (uninstalled, confusingly
but conveniently for now).