### PR TITLE
libtest: On failure, make it clearer what has happened

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -46,6 +46,14 @@ run_exit_cmds() {
 }
 trap run_exit_cmds EXIT
 
+report_err () {
+  local exit_status="$?"
+  { { local BASH_XTRACEFD=3; } 2> /dev/null
+  echo "Unexpected nonzero exit status $exit_status while running: $BASH_COMMAND" >&2
+  } 3> /dev/null
+}
+trap report_err ERR
+
 save_core() {
   if [ -e core ]; then
     cp core "$test_srcdir/core"


### PR DESCRIPTION
If we fail as a result of `set -x`, It's often not completely obvious
which command failed or how. Use a trap on ERR to show the command that
failed, and its exit status.