### PR TITLE
tests: Test without a cache directory by default

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3291,7 +3291,7 @@ ostree_repo_open (OstreeRepo    *self,
   if (!glnx_opendirat (self->repo_dir_fd, "tmp", TRUE, &self->tmp_dir_fd, error))
     return FALSE;
 
-  if (self->writable)
+  if (self->writable && getenv ("OSTREE_SKIP_CACHE") == NULL)
     {
       if (!glnx_shutil_mkdir_p_at (self->tmp_dir_fd, _OSTREE_CACHE_DIR, DEFAULT_DIRECTORY_MODE, cancellable, error))
         return FALSE;

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -86,6 +86,11 @@ unset TAR_OPTIONS
 # easily clean up.
 export OSTREE_SYSROOT_DEBUG=mutable-deployments
 
+# By default, don't use a cache directory since it makes the tests racy.
+# Tests that are explicitly testing the cache operation should unset
+# this.
+export OSTREE_SKIP_CACHE=1
+
 export TEST_GPG_KEYID_1="7FCA23D8472CDAFA"
 export TEST_GPG_KEYFPR_1="5E65DE75AB1C501862D476347FCA23D8472CDAFA"
 export TEST_GPG_KEYID_2="D8228CFECA950D41"

--- a/tests/test-pull-summary-caching.sh
+++ b/tests/test-pull-summary-caching.sh
@@ -31,6 +31,9 @@ if ! has_gpgme; then
     exit 0
 fi
 
+# Ensure repo caching is in use.
+unset OSTREE_SKIP_CACHE
+
 COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 
 echo "1..1"

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -23,6 +23,9 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+# Ensure repo caching is in use.
+unset OSTREE_SKIP_CACHE
+
 COMMIT_SIGN=""
 if has_gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 
 echo "1..14"
 
+# Ensure repo caching is in use.
+unset OSTREE_SKIP_CACHE
+
 # This is explicitly opt in for testing
 export OSTREE_DUMMY_SIGN_ENABLED=1
 


### PR DESCRIPTION
Several tests generate summaries and then expect to use the generated
summary immediately. However, this can cause intermittent test failures
when they inadvertantly get a cached summary file. This typically
happens when the test is run on a filesystem that doesn't support user
extended attributes. In that case, the caching code can only use the
last modified time, which only has 1 second granularity. If tests don't
carefully manage the summary modification times or the repo cache then
they are likely subject to races in some test environments.

This introduces an environment variable `OSTREE_SKIP_CACHE` that
prevents the repo from using a cache directory. This is enabled by
default in tests and disabled for tests that are a explicitly trying to
test the caching behavior.

Fixes: #2313
Fixes: #2351