### PR TITLE
ci: Fix GH action for rustfmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
           default: true
           components: rustfmt, clippy
       - name: cargo fmt (check)
-        run: cd tests/inst && cargo fmt -- --check -l
+        run: cargo fmt -- --check -l


### PR DESCRIPTION
Since we now have a toplevel workspace, just use that.