### PR TITLE
Publish libostree API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+---
+name: Docs
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # This is taken from ci/travis-install.sh but should probably be
+      # refactored.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            attr \
+            bison \
+            cpio \
+            debhelper \
+            dh-autoreconf \
+            dh-systemd \
+            docbook-xml \
+            docbook-xsl \
+            e2fslibs-dev \
+            elfutils \
+            fuse \
+            gjs \
+            gnome-desktop-testing \
+            gobject-introspection \
+            gtk-doc-tools \
+            libarchive-dev \
+            libattr1-dev \
+            libcap-dev \
+            libfuse-dev \
+            libgirepository1.0-dev \
+            libglib2.0-dev \
+            libgpgme11-dev \
+            liblzma-dev \
+            libmount-dev \
+            libselinux1-dev \
+            libsoup2.4-dev \
+            libcurl4-openssl-dev \
+            procps \
+            zlib1g-dev \
+            python3-yaml
+
+      - name: Build and publish jekyll docs
+        uses: helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          jekyll_src: docs
+          target_branch: gh-pages
+          # Only publish when pushing to main.
+          # XXX: Maybe this should only run on the release event?
+          build_only: ${{ github.ref == 'refs/heads/main' && 'false' || 'true' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,11 @@ jobs:
             zlib1g-dev \
             python3-yaml
 
+      - name: Build API docs
+        run: |
+          ./autogen.sh --enable-gtk-doc
+          make -C apidoc
+
       - name: Build and publish jekyll docs
         uses: helaili/jekyll-action@v2
         with:
@@ -60,3 +65,5 @@ jobs:
           # Only publish when pushing to main.
           # XXX: Maybe this should only run on the release event?
           build_only: ${{ github.ref == 'refs/heads/main' && 'false' || 'true' }}
+          # Run the prep script to put the API docs in place.
+          pre_build_commands: ./docs/prep-docs.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,14 @@ GITIGNOREFILES += fastbuild-*.qcow2 _kola_temp/
 # Rust stuff
 GITIGNOREFILES += target/ Cargo.lock
 
+# Jekyll docs
+GITIGNOREFILES += \
+	docs/.bundle/ \
+	docs/Gemfile.lock \
+	docs/_site/ \
+	docs/vendor/ \
+	$(NULL)
+
 SUBDIRS += .
 
 if ENABLE_GTK_DOC

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ GITIGNOREFILES += \
 	docs/.bundle/ \
 	docs/Gemfile.lock \
 	docs/_site/ \
+	docs/reference/ \
 	docs/vendor/ \
 	$(NULL)
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,14 @@
+# Bundler setup for jekyll to be deployed on github pages.
+
+source "https://rubygems.org"
+
+# Note that we're using the github-pages gem to mimic the GitHub pages
+# automated setup. That installs jekyll, a default set of jekyll
+# plugins, and a modified jekyll configuration.
+group :jekyll_plugins do
+  gem "github-pages"
+  gem "jekyll-remote-theme"
+end
+
+# Prefer the GitHub flavored markdown version of kramdown.
+gem "kramdown-parser-gfm"

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,10 @@ bundle config set --local path vendor/bundle
 bundle install
 ```
 
-Finally, render and serve the site locally with Jekyll:
+Finally, run the `prep-docs.sh` script and then render and serve the
+site locally with Jekyll:
+
 ```
+./prep-docs.sh
 bundle exec jekyll serve
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+This documentation is written in [Jekyll](https://jekyllrb.com/) format
+to be published on [GitHub Pages](https://pages.github.com/). The
+rendered HTML will be automatically built and published, but you can
+also use Jekyll locally to test changes.
+
+First you need to install [Ruby](https://www.ruby-lang.org/en/) and
+[RubyGems](https://rubygems.org/) to get Jekyll and the other gem
+dependencies. This is easiest using the distro's packages. On RedHat
+systems this is `rubygems` and on Debian systems this is
+`ruby-rubygems`.
+
+Next [Bundler](https://bundler.io/) is needed to install the gems using
+the provided [Gemfile](Gemfile). You can do this by running `gem install
+bundler` or using distro packages. On RedHat systems this is
+`rubygem-bundler` and on Debian systems this is `ruby-bundler`.
+
+Now you can prepare the Jekyll environment. Change to this directory and
+run:
+
+```
+bundle config set --local path vendor/bundle
+bundle install
+```
+
+Finally, render and serve the site locally with Jekyll:
+```
+bundle exec jekyll serve
+```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,7 +13,12 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+  - prep-docs.sh
   - vendor/
+
+# This is a copy of the apidoc/html directory. Run prep-docs.sh before
+# jekyll to put it in place.
+include: [reference]
 
 remote_theme: coreos/just-the-docs
 plugins:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,14 @@ url: "https://ostreedev.github.io"
 permalink: /:title/
 markdown: kramdown
 
+# Exclude the README and the bundler files that would normally be
+# ignored by default.
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+
 remote_theme: coreos/just-the-docs
 plugins:
   - jekyll-remote-theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,7 +143,7 @@ make install DESTDIR=/path/to/dest
 
 ## Contributing
 
-See [Contributing](docs/CONTRIBUTING.md).
+See [Contributing]({{ site.baseurl }}{% link CONTRIBUTING.md %}).
 
 ## Licensing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -141,6 +141,10 @@ make
 make install DESTDIR=/path/to/dest
 ```
 
+## API Reference
+
+The libostree API documentation is available in [Reference](reference/).
+
 ## Contributing
 
 See [Contributing]({{ site.baseurl }}{% link CONTRIBUTING.md %}).

--- a/docs/prep-docs.sh
+++ b/docs/prep-docs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Prepare docs directory for running jekyll. This would be better as a
+# local Jekyll plugin, but those aren't allowed by the github-pages gem.
+
+set -e
+
+docsdir=$(dirname "$0")
+topdir="$docsdir/.."
+
+# Make sure the API docs have been generated and copy them to the
+# reference directory.
+apidocs="$topdir/apidoc/html"
+refdir="$docsdir/reference"
+if [ ! -d "$apidocs" ]; then
+    echo "error: API docs $apidocs have not been generated" >&2
+    echo "Rebuild with --enable-gtk-doc option" >&2
+    exit 1
+fi
+
+echo "Copying $apidocs to $refdir"
+rm -rf "$refdir"
+cp -r "$apidocs" "$refdir"


### PR DESCRIPTION
This adds a GitHub workflow to build the Jekyll docs with Jekyll Actions and push it to the `gh-pages` rather than use GitHub's fully automated flow. The reason to do this is to build the gtk-doc API docs and then include them into the Jekyll static site.

I'm no jekyll or github pages expert, but it seems to work correctly as you can see it at the following pages:

https://dbnicholson.github.io/ostree/
https://dbnicholson.github.io/ostree/#api-reference
https://dbnicholson.github.io/ostree/reference/

In order to put this in place the ostree repo Pages settings would need to be changed to use `gh-pages` as the branch with the root directory.

Fixes: #2362