### PR TITLE
workflow/docs: Give token write permission to push gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ jobs:
   docs:
     name: Build documentation
     runs-on: ubuntu-latest
+    permissions:
+      # This job pushes to the gh-pages branch, so the token needs write
+      # privileges for repo contents.
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The ostree repo has read permissions set for workflows, which prevents
the documentation job from pushing the built docs to the gh-pages
branch. Raise the job's permissions to write for repo contents to allow
that.