### PR TITLE
tests/gpg: Don't assert subkey expiration when only primary expired

### DIFF
--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -235,7 +235,6 @@ assert_file_has_content test2-show "${key1_id}"
 assert_file_has_content test2-show "${key2_sub_id}"
 assert_file_has_content test2-show 'Good signature from "Test Key 1 <>"'
 assert_file_has_content test2-show 'BAD signature from "Test Key 2 <>"'
-assert_not_file_has_content test2-show 'Key expired'
 assert_file_has_content test2-show "Primary key ID ${key2_id}"
 assert_file_has_content test2-show 'Primary key expired'
 


### PR DESCRIPTION
In gnupg 2.3.0[1], if a primary key is expired and a subkey does not
have an expiration or its expiration is older than the primary key, the
subkey's expiration will be reported as the primary's. Previously a
subkey without an expiration would not report one that regardless of the
primary key's expiration.

This caused a regression in a test setting an expiration on a primary
key. The test was checking that the subkey was not expired by asserting
that there was no `Key expired` line in the signature verification
output. With gnupg 2.3.0+, it will show as expired, causing the test to
fail.

Remove the assertion since it's not consistent across gnupg versions. In
practice we don't care whether the subkey is considered expired or not
as long as the signature verification fails when the primary key is
expired.

1. https://dev.gnupg.org/T3343

Fixes: #2359