### PR TITLE
repo: Use g_new for OstreeRepoAutoLock

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -678,7 +678,7 @@ ostree_repo_auto_lock_push (OstreeRepo          *self,
   if (!ostree_repo_lock_push (self, lock_type, cancellable, error))
     return NULL;
 
-  OstreeRepoAutoLock *auto_lock = g_slice_new (OstreeRepoAutoLock);
+  OstreeRepoAutoLock *auto_lock = g_new (OstreeRepoAutoLock, 1);
   auto_lock->repo = self;
   auto_lock->lock_type = lock_type;
   return auto_lock;
@@ -707,7 +707,7 @@ ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *auto_lock)
 
       errno = errsv;
 
-      g_slice_free (OstreeRepoAutoLock, auto_lock);
+      g_free (auto_lock);
     }
 }
 


### PR DESCRIPTION
GSlice is effectively deprecated and has little to no advantage over
using the system allocator on Linux.

This was discussed in https://github.com/ostreedev/ostree/pull/2348#discussion_r645864806. I started swapping out all the GSlice usage tree-wide, but I wasn't totally sure if that was wanted. If you prefer, I can finish that off.