### PR TITLE
Fix small typo in ostree-sysroot.c

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1063,7 +1063,7 @@ _ostree_sysroot_reload_staged (OstreeSysroot *self,
   return TRUE;
 }
 
-/* Loads the current bootversion, subbootversion, and deplyments, starting from the
+/* Loads the current bootversion, subbootversion, and deployments, starting from the
  * bootloader configs which are the source of truth.
  */
 static gboolean


### PR DESCRIPTION
Stumbled upon it while reading about deployments.