### PR TITLE
Use generator to enable ostree-remount.service and ostree-finalize-staged.path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -499,6 +499,7 @@ AS_IF([test "x$with_libsystemd" = "xyes"], [
               [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
   AS_IF([test "x$with_systemdsystemunitdir" != "xno"], [
     AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+    AC_DEFINE_UNQUOTED([SYSTEM_DATA_UNIT_PATH], ["$with_systemdsystemunitdir"], ["unit path"])
   ])
   AC_ARG_WITH([systemdsystemgeneratordir],
               AS_HELP_STRING([--with-systemdsystemgeneratordir=DIR], [Directory for systemd generators]),

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3106,28 +3106,6 @@ ostree_sysroot_stage_tree_with_options (OstreeSysroot     *self,
   if (booted_deployment == NULL)
     return glnx_prefix_error (error, "Cannot stage deployment");
 
-  /* This is used by the testsuite to exercise the path unit, until it becomes the default
-   * (which is pending on the preset making it everywhere). */
-  if ((self->debug_flags & OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH) == 0)
-    {
-  /* This is a bit of a hack.  When adding a new service we have to end up getting
-   * into the presets for downstream distros; see e.g. https://src.fedoraproject.org/rpms/ostree/pull-request/7
-   *
-   * Then again, it's perhaps a bit nicer to only start the service on-demand anyways.
-   */
-  const char *const systemctl_argv[] = {"systemctl", "start", "ostree-finalize-staged.service", NULL};
-  int estatus;
-  if (!g_spawn_sync (NULL, (char**)systemctl_argv, NULL, G_SPAWN_SEARCH_PATH,
-                     NULL, NULL, NULL, NULL, &estatus, error))
-    return FALSE;
-  if (!g_spawn_check_exit_status (estatus, error))
-    return FALSE;
-    }
-  else
-    {
-      g_print ("test-staged-path: Not running `systemctl start`\n");
-    } /* OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH */
-
   g_autoptr(OstreeDeployment) deployment = NULL;
   if (!sysroot_initialize_deployment (self, osname, revision, origin, opts, &deployment,
                                       cancellable, error))

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -37,8 +37,7 @@ typedef enum {
   OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE = 1 << 2,
   /* This is a temporary flag until we fully drop the explicit `systemctl start
    * ostree-finalize-staged.service` so that tests can exercise the new path unit. */
-  OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH = 1 << 3,
-  OSTREE_SYSROOT_DEBUG_TEST_NO_DTB = 1 << 4, /* https://github.com/ostreedev/ostree/issues/2154 */
+  OSTREE_SYSROOT_DEBUG_TEST_NO_DTB = 1 << 3, /* https://github.com/ostreedev/ostree/issues/2154 */
 } OstreeSysrootDebugFlags;
 
 typedef enum {

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -190,7 +190,6 @@ ostree_sysroot_init (OstreeSysroot *self)
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },
     { "test-fifreeze", OSTREE_SYSROOT_DEBUG_TEST_FIFREEZE },
     { "no-xattrs", OSTREE_SYSROOT_DEBUG_NO_XATTRS },
-    { "test-staged-path", OSTREE_SYSROOT_DEBUG_TEST_STAGED_PATH },
     { "no-dtb", OSTREE_SYSROOT_DEBUG_TEST_NO_DTB },
   };
 


### PR DESCRIPTION
We struggled for a long time with enablement of our "internal units",
trying to follow the philosophy that units should only be enabled
by explicit preset.

See https://bugzilla.redhat.com/show_bug.cgi?id=1451458
and https://github.com/coreos/rpm-ostree/pull/1482
etc.

And I just saw chat (RH internal on a proprietary system sadly) where
someone hit `ostree-remount.service` not being enabled in CentOS8.

Thinking about this more, I realized we've shipped a systemd generator
for a long time and while its only role until now was to generate `var.mount`,
but by using it to force on our internal units, we don't require
people to deal with presets anymore.

Basically we're inverting things so that "if ostree= is on the kernel
cmdline, then enable our units" and not "enable our units, but have
them use ConditionKernelCmdline=ostree to skip".

Drop the weird gyrations we were doing around `ostree-finalize-staged.path`
too; forking `systemctl start` is just asking for bugs.

So after this, hopefully we won't ever again have to think about
distribution presets and our units.