### PR TITLE
rofiles-fuse: Build using FUSE 3 if possible, falling back to FUSE 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,22 +44,24 @@ jobs:
           # oldstable-backports and unstable.
           #
           # https://hub.docker.com/_/debian
-          - name: Debian Stable with sign-ed25519
+          - name: Debian Stable with sign-ed25519 and FUSE 2
             image: debian:stable-slim
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
             extra-packages: >-
+              libfuse-dev
               libsodium-dev
             configure-options: >-
               --with-ed25519-libsodium
 
-          - name: Debian Stable with curl, sign-ed25519 and no gpgme
+          - name: Debian Stable with curl, sign-ed25519, no gpgme, FUSE 3
             image: debian:stable-slim
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
             extra-packages: >-
+              libfuse3-dev
               libsodium-dev
             configure-options: >-
               --with-curl

--- a/ci/gh-install.sh
+++ b/ci/gh-install.sh
@@ -43,6 +43,19 @@ case "$ID" in
         # Ubuntu package data:
         # https://packages.ubuntu.com/source/impish/ostree
         #
+        # Use libfuse3-dev unless otherwise specified
+        case " $* " in
+            (*\ libfuse-dev\ *)
+                ;;
+
+            (*\ libfuse3-dev\ *)
+                ;;
+
+            (*)
+                set -- "$@" libfuse3-dev
+                ;;
+        esac
+
         # TODO: fetch this list from the Debian packaging git repository?
 
         # First construct a list of Build-Depends common to all

--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,7 @@ AS_IF([test x$with_ed25519_libsodium != xno], [
 AM_CONDITIONAL(USE_LIBSODIUM, test "x$have_libsodium" = xyes)
 
 LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
+FUSE3_DEPENDENCY="fuse3 >= 3.1.1"
 # What's in RHEL7.2.
 FUSE_DEPENDENCY="fuse >= 2.9.2"
 
@@ -448,8 +449,22 @@ AC_ARG_ENABLE(rofiles-fuse,
                               [generate rofiles-fuse helper [default=yes]])],,
               enable_rofiles_fuse=yes)
 AS_IF([ test x$enable_rofiles_fuse != xno ], [
-    PKG_CHECK_MODULES(BUILDOPT_FUSE, $FUSE_DEPENDENCY)
-], [enable_rofiles_fuse=no])
+    PKG_CHECK_MODULES([FUSE3], [$FUSE3_DEPENDENCY],
+                      [
+                        FUSE_USE_VERSION=31
+                        BUILDOPT_FUSE_CFLAGS="$FUSE3_CFLAGS"
+                        BUILDOPT_FUSE_LIBS="$FUSE3_LIBS"
+                      ],
+                      [PKG_CHECK_MODULES([FUSE], [$FUSE_DEPENDENCY],
+                                         [
+                                           FUSE_USE_VERSION=26
+                                           BUILDOPT_FUSE_CFLAGS="$FUSE_CFLAGS"
+                                           BUILDOPT_FUSE_LIBS="$FUSE_LIBS"
+                                         ])])
+    AC_DEFINE_UNQUOTED([FUSE_USE_VERSION], [$FUSE_USE_VERSION], [Define to the FUSE API version])
+    AC_SUBST([BUILDOPT_FUSE_CFLAGS])
+    AC_SUBST([BUILDOPT_FUSE_LIBS])
+    ], [enable_rofiles_fuse=no])
 AM_CONDITIONAL(BUILDOPT_FUSE, test x$enable_rofiles_fuse = xyes)
 
 AC_ARG_WITH(dracut,


### PR DESCRIPTION
This adds build-time configuration logic to automatically detect
and switch between libfuse 2.x and 3.x.

Fixes: https://github.com/ostreedev/ostree/issues/1881
Signed-off-by: Simon McVittie <smcv@collabora.com>
Co-authored-by: Luca BRUNO <luca.bruno@coreos.com>