### PR TITLE
libtest-core: Add some improvements from bubblewrap

### DIFF
--- a/tests/kolainst/libtest-core.sh
+++ b/tests/kolainst/libtest-core.sh
@@ -5,7 +5,7 @@
 #
 # Known copies are in the following repos:
 #
-# - https://github.com/projectatomic/rpm-ostree
+# - https://github.com/coreos/rpm-ostree
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>
 #

--- a/tests/kolainst/libtest-core.sh
+++ b/tests/kolainst/libtest-core.sh
@@ -83,6 +83,18 @@ _fatal_print_file() {
     fatal "$@"
 }
 
+_fatal_print_files() {
+    file1="$1"
+    shift
+    file2="$1"
+    shift
+    ls -al "$file1" >&2
+    sed -e 's/^/# /' < "$file1" >&2
+    ls -al "$file2" >&2
+    sed -e 's/^/# /' < "$file2" >&2
+    fatal "$@"
+}
+
 assert_not_has_file () {
     if test -f "$1"; then
         _fatal_print_file "$1" "File '$1' exists"
@@ -153,6 +165,12 @@ assert_symlink_has_content () {
 assert_file_empty() {
     if test -s "$1"; then
         _fatal_print_file "$1" "File '$1' is not empty"
+    fi
+}
+
+assert_files_equal() {
+    if ! cmp "$1" "$2"; then
+        _fatal_print_files "$1" "$2" "File '$1' and '$2' is not equal"
     fi
 }
 

--- a/tests/kolainst/libtest-core.sh
+++ b/tests/kolainst/libtest-core.sh
@@ -5,6 +5,7 @@
 #
 # Known copies are in the following repos:
 #
+# - https://github.com/containers/bubblewrap
 # - https://github.com/coreos/rpm-ostree
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>

--- a/tests/kolainst/libtest-core.sh
+++ b/tests/kolainst/libtest-core.sh
@@ -179,3 +179,11 @@ skip() {
     echo "1..0 # SKIP" "$@"
     exit 0
 }
+
+report_err () {
+  local exit_status="$?"
+  { { local BASH_XTRACEFD=3; } 2> /dev/null
+  echo "Unexpected nonzero exit status $exit_status while running: $BASH_COMMAND" >&2
+  } 3> /dev/null
+}
+trap report_err ERR


### PR DESCRIPTION
If this PR and containers/bubblewrap#433 are both accepted, then `libtest-core.sh` will be identical in both projects. Maintainers of both projects, like @cgwalters, are probably in the best position to make this happen.

* libtest-core: Add assert_files_equal

    From: @alexlarsson 
    
    [Originally from bubblewrap commits c5c999a7 "tests: test --userns"
    and 3e5fe1bf "tests: Better error message if assert_files_equal fails";
    separated into this commit by Simon McVittie.]

* libtest-core: On failure, make it clearer what has happened
    
    If we fail as a result of `set -x`, It's often not completely obvious
    which command failed or how. Use a trap on ERR to show the command that
    failed, and its exit status.

* libtest-core: Update URL of rpm-ostree

* libtest-core: Mention bubblewrap as a user of this file