### PR TITLE
Don't fail build when systemd unit path not defined

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -120,6 +120,7 @@ require_internal_units (const char *normal_dir,
                         const char *late_dir,
                         GError    **error)
 {
+#ifdef SYSTEM_DATA_UNIT_PATH
   GCancellable *cancellable = NULL;
 
   glnx_autofd int normal_dir_dfd = -1;
@@ -137,6 +138,9 @@ require_internal_units (const char *normal_dir,
     return glnx_throw_errno_prefix (error, "symlinkat");
 
   return TRUE;
+#else
+  return glnx_throw (error, "Not implemented");
+#endif
 }
 
 /* Generate var.mount */


### PR DESCRIPTION
In configure the systemd unit path is optional, but in the code it's
assumed to be defined. Add an `#ifdef` that throws an error when it's
not defined like the handling of `HAVE_LIBMOUNT` below it.