### PR TITLE
Update GitHub Tests workflow configurations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,13 @@ jobs:
 
       matrix:
         include:
-          - name: Debian Buster (10) with sign-ed25519
-            image: debian:buster-slim
+          # Debian builds. Currently stable and testing are tested.
+          # Other options would be stable-backports, oldstable,
+          # oldstable-backports and unstable.
+          #
+          # https://hub.docker.com/_/debian
+          - name: Debian Stable with sign-ed25519
+            image: debian:stable-slim
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
@@ -45,8 +50,8 @@ jobs:
             configure-options: >-
               --with-ed25519-libsodium
 
-          - name: Debian Buster (10) with curl, sign-ed25519 and no gpgme
-            image: debian:buster-slim
+          - name: Debian Stable with curl, sign-ed25519 and no gpgme
+            image: debian:stable-slim
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
@@ -59,8 +64,8 @@ jobs:
 
           # A 32 bit build to act as a proxy for frequently deployed 32
           # bit armv7
-          - name: Debian Buster (10) 32 bit
-            image: i386/debian:buster-slim
+          - name: Debian Stable 32 bit
+            image: i386/debian:stable-slim
             # This is pretty nasty. The checkout action uses an x86_64
             # node binary in the container, so we need to provide an
             # x86_64 ld.so and libstdc++.
@@ -69,14 +74,26 @@ jobs:
               apt-get update
               apt-get install -y git libc6:amd64 libstdc++6:amd64
 
-          - name: Ubuntu Focal (20.04)
-            image: ubuntu:focal
+          - name: Debian Testing
+            image: debian:testing-slim
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
 
-          - name: Ubuntu Groovy (20.10)
-            image: ubuntu:groovy
+          # Ubuntu builds. Unfortunately, when the latest release is
+          # also the latest LTS, latest and rolling are the same. Other
+          # options would be to test the previous LTS by name or to test
+          # the devel tag, which is the unreleased version.
+          #
+          # https://hub.docker.com/_/ubuntu
+          - name: Ubuntu Latest LTS
+            image: ubuntu:latest
+            pre-checkout-setup: |
+              apt-get update
+              apt-get install -y git
+
+          - name: Ubuntu Latest Release
+            image: ubuntu:rolling
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
     #
     # configure-options: Options to pass to `configure`.
     strategy:
+      # Let other configurations continue if one fails.
+      fail-fast: false
+
       matrix:
         include:
           - name: Debian Buster (10) with sign-ed25519

--- a/ci/gh-build.sh
+++ b/ci/gh-build.sh
@@ -32,6 +32,8 @@ srcdir="$(pwd)"
 mkdir ci-build
 cd ci-build
 
+# V=1 shows the full build commands. VERBOSE=1 dumps test-suite.log on
+# failures.
 make="make V=1 VERBOSE=1"
 
 ../configure \
@@ -40,20 +42,9 @@ make="make V=1 VERBOSE=1"
 
 ${make}
 
-# Run the tests both using check and distcheck and dump the logs on
-# failures. For distcheck the logs will be inside the dist directory, so
-# tell make to use the current directory.
-if ! ${make} check; then
-    cat test-suite.log || :
-    exit 1
-fi
-if ! ${make} distcheck \
-    TEST_SUITE_LOG=$(pwd)/test-suite.log \
-    DISTCHECK_CONFIGURE_FLAGS="$*"
-then
-    cat test-suite.log || :
-    exit 1
-fi
+# Run the tests both using check and distcheck.
+${make} check
+${make} distcheck DISTCHECK_CONFIGURE_FLAGS="$*"
 
 # Show the installed files
 ${make} install DESTDIR=$(pwd)/DESTDIR


### PR DESCRIPTION
This changes the existing Debian and Ubuntu configurations to use the release stage tags instead of the codename tags. A Debian testing build is added while the Ubuntu groovy build is changed from groovy to hirsute via the `rolling` tag. An Alpine Linux build is added, too.

CC @smcv