### PR TITLE
libtest.sh: Remove duplicate ERR trap and report_err()

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -46,14 +46,6 @@ run_exit_cmds() {
 }
 trap run_exit_cmds EXIT
 
-report_err () {
-  local exit_status="$?"
-  { { local BASH_XTRACEFD=3; } 2> /dev/null
-  echo "Unexpected nonzero exit status $exit_status while running: $BASH_COMMAND" >&2
-  } 3> /dev/null
-}
-trap report_err ERR
-
 save_core() {
   if [ -e core ]; then
     cp core "$test_srcdir/core"


### PR DESCRIPTION
Since #2377 was merged, this is in libtest-core.sh, which is sourced by
libtest.sh.