### PR TITLE
lib/commit: respect SOURCE_DATE_EPOCH for commit timestamp

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -69,6 +69,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-remote-add.sh \
 	tests/test-remote-headers.sh \
 	tests/test-commit-sign.sh \
+	tests/test-commit-timestamp.sh \
 	tests/test-export.sh \
 	tests/test-help.sh \
 	tests/test-libarchive.sh \

--- a/tests/test-commit-timestamp.sh
+++ b/tests/test-commit-timestamp.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: LGPL-2.0+
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+TZ='UTC'
+LANG='C'
+
+echo "1..2"
+
+# Explicit timestamp via CLI flag.
+mkdir testrepo
+ostree_repo_init testrepo --mode="archive"
+mkdir testrepo-files
+cd testrepo-files
+echo first > firstfile
+cd ..
+${CMD_PREFIX} ostree --repo=./testrepo commit -b cli --timestamp='@1234567890' -s "cli timestamp"
+${CMD_PREFIX} ostree --repo=./testrepo show cli > show-cli.txt
+rm -rf testrepo testrepo-files
+assert_file_has_content_literal show-cli.txt 'Date:  2009-02-13 23:31:30 +0000'
+echo "ok commit with CLI timestamp"
+
+# Reproducible timestamp via env flag.
+mkdir testrepo
+ostree_repo_init testrepo --mode="archive"
+mkdir testrepo-files
+cd testrepo-files
+echo first > firstfile
+cd ..
+${CMD_PREFIX} SOURCE_DATE_EPOCH='1234567890' ostree --repo=./testrepo commit -b env -s "env timestamp"
+if (${CMD_PREFIX} SOURCE_DATE_EPOCH='invalid' ostree --repo=./testrepo commit -b env -s "invalid timestamp") 2> commit-invalid.txt; then
+    assert_not_reached "commit with invalid timestamp succeeded"
+fi
+if (${CMD_PREFIX} SOURCE_DATE_EPOCH='12345678901234567890' ostree --repo=./testrepo commit -b env -s "overflowing timestamp") 2> commit-overflowing.txt; then
+    assert_not_reached "commit with overflowing timestamp succeeded"
+fi
+${CMD_PREFIX} ostree --repo=./testrepo show env > show-env.txt
+rm -rf testrepo testrepo-files
+assert_file_has_content_literal commit-invalid.txt 'Failed to convert SOURCE_DATE_EPOCH'
+assert_file_has_content_literal commit-overflowing.txt 'Parsing SOURCE_DATE_EPOCH: Numerical result out of range'
+assert_file_has_content_literal show-env.txt 'Date:  2009-02-13 23:31:30 +0000'
+echo "ok commit with env timestamp"


### PR DESCRIPTION
This tweaks `ostree_repo_write_commit` so that it checks for the
envinroment variable `SOURCE_DATE_EPOCH` as a way to override
the current time, which is used as the commit timestamp.

Ref: https://reproducible-builds.org/docs/source-date-epoch/
Ref: https://reproducible-builds.org/specs/source-date-epoch/
Closes: https://github.com/ostreedev/ostree/issues/2385