### PR TITLE
Release 2021.3

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -173,9 +173,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+#if BUILDOPT_IS_DEVEL_BUILD
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2021])
 m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2021])
-m4_define([release_version], [3])
+m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -22,14 +22,6 @@
    - uncomment the include in Makefile-libostree.am
 */
 
-LIBOSTREE_2021.3 {
-global:
-  ostree_repo_auto_lock_push;
-  ostree_repo_auto_lock_cleanup;
-  ostree_repo_lock_push;
-  ostree_repo_lock_pop;
-} LIBOSTREE_2021.2;
-
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -653,6 +653,14 @@ global:
   ostree_content_writer_finish;
 } LIBOSTREE_2021.1;
 
+LIBOSTREE_2021.3 {
+global:
+  ostree_repo_auto_lock_push;
+  ostree_repo_auto_lock_cleanup;
+  ostree_repo_lock_push;
+  ostree_repo_lock_pop;
+} LIBOSTREE_2021.2;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -56,7 +56,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-d42f7000de88e3c7280c2d55ad3a5e2e7a8d968758fe1d66a95863e2f5269d3c  ${released_syms}
+d4eb6d642150d9285b399c7a429603124aeda4215d3f62b92ad3956f04dd2dfe  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
This release adds new repository-locking methods to the API, in order to make lock handling more granular and better suited for multi-threaded consumers of the library.

Several bugs have been fixed related to service unit ordering and enablement. Pulling from remotes with unknown schemes now produces more friendly error messages.

API documentation is now automatically published to <https://ostreedev.github.io/ostree/reference/>.

By default, commit timestamps now respect the 'SOURCE_DATE_EPOCH' environment flag, improving support for reproducible outputs.

On the community side, the default git development branch has been renamed to 'main' and the IRC channel moved to the libera.chat network.

---

```
Alexander Larsson (1):
      libtest-core: Add assert_files_equal

Benjamin Gilbert (1):
      OWNERS: remove

Christian Kellner (1):
      Fix small typo in ostree-sysroot.c

Colin Walters (9):
      build-sys: Add toplevel workspace Cargo.toml
      tests/inst: Make nondestructive tests runnable as unit tests
      configure: post-release version bump
      ci: Fix GH action for rustfmt
      pull: Cleanly error out on unknown schemes
      ci: Fix staged-delay to work with newer systemd
      repo: Make locking APIs public
      deploy: Warn if we find content in the deployment's /var
      Use generator to enable ostree-remount.service and ostree-finalize-staged.path

Dan Nicholson (27):
      tests: Test without a cache directory by default
      docs: Fix CONTRIBUTING link
      docs: Provide bundler setup for building site locally
      docs: Add github workflow for building and publishing docs
      docs: Copy in API docs and add link
      workflow/docs: Give token write permission to push gh-pages
      tests/gpg: Don't assert subkey expiration when only primary expired
      repo: Require lock type in ostree_repo_lock_pop
      build-sys: Bump required GLib to 2.44
      repo: Make locking per-OstreeRepo
      repo: Make locking precondition failures fatal
      test-concurrency: Lower lock timeout
      tests: Add single process repo locking tests
      repo: Use g_new for OstreeRepoAutoLock
      Don't fail build when systemd unit path not defined
      ci: Rename GitHub Actions rust workflow metadata file
      ci: Add GitHub Actions workflow for test suite
      ci: So long, Travis CI
      ci: Disable fail-fast in GitHub Tests workflow
      ci: Drop special handling of test-suite.log
      ci: Update Debian and Ubuntu build dependencies
      ci: Use Debian and Ubuntu release stage tags

Jonathan Lebon (2):
      docs: Add more details about 3-way merge
      ostree-remount: Order before systemd-rfkill.*

Luca BRUNO (2):
      lib/commit: respect SOURCE_DATE_EPOCH for commit timestamp
      ci/release-build: evaluate package_version from m4 definition

Micah Abbott (1):
      docs: typo fix for /usr/etc

Philip Withnall (1):
      docs: Change IRC channel to libera.chat from freenode

Simon McVittie (5):
      libtest: On failure, make it clearer what has happened
      libtest-core: On failure, make it clearer what has happened
      libtest-core: Update URL of rpm-ostree
      libtest-core: Mention bubblewrap as a user of this file
      libtest.sh: Remove duplicate ERR trap and report_err()

Timothée Ravier (4):
      packit: update for F34, rawhide branch & master rename
      *: rename master branch to main
      *: rename master to main in tests & examples
      *: rename master branch to main (external repos)
```