### PR TITLE
tests: Unset SOURCE_DATE_EPOCH

### DIFF
--- a/ci/gh-build.sh
+++ b/ci/gh-build.sh
@@ -44,6 +44,11 @@ ${make}
 
 # Run the tests both using check and distcheck.
 ${make} check
+
+# Some tests historically failed when package builds set this.
+# By setting it for distcheck but not check, we exercise both ways.
+export SOURCE_DATE_EPOCH=$(date '+%s')
+
 ${make} distcheck DISTCHECK_CONFIGURE_FLAGS="$*"
 
 # Show the installed files

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -69,6 +69,10 @@ if ! test -f .testtmp; then
     touch .testtmp
 fi
 
+# Some distribution builds set this, but some of our build-time tests
+# assume this won't be used when committing
+unset SOURCE_DATE_EPOCH
+
 # Also, unbreak `tar` inside `make check`...Automake will inject
 # TAR_OPTIONS: --owner=0 --group=0 --numeric-owner presumably so that
 # tarballs are predictable, except we don't want this in our tests.


### PR DESCRIPTION
Some distributions set this during build in order to have reproducible
builds from the same source code: for example, Debian uses the date
from debian/changelog.

However, some of our tests assume that `ostree commit` will result in
a commit with the current date/time, and SOURCE_DATE_EPOCH breaks that
assumption. Unset it for our build-time tests.

Resolves: https://github.com/ostreedev/ostree/issues/2405