### PR TITLE
builtins/commit: check for conflicting permissions options

### DIFF
--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -555,6 +555,23 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
       detached_metadata = g_variant_ref_sink (g_variant_builder_end (builder));
     }
 
+  /* Check for conflicting options */
+  if (opt_canonical_permissions && opt_owner_uid > 0)
+    {
+      glnx_throw (error, "Cannot specify both --canonical-permissions and non-zero --owner-uid");
+      goto out;
+    }
+  if (opt_canonical_permissions && opt_owner_gid > 0)
+    {
+      glnx_throw (error, "Cannot specify both --canonical-permissions and non-zero --owner-gid");
+      goto out;
+    }
+  if (opt_selinux_policy && opt_selinux_policy_from_base)
+    {
+      glnx_throw (error, "Cannot specify both --selinux-policy and --selinux-policy-from-base");
+      goto out;
+    }
+
   if (opt_no_xattrs)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS;
   if (opt_consume)
@@ -570,11 +587,6 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES;
   if (opt_disable_fsync)
     ostree_repo_set_disable_fsync (repo, TRUE);
-  if (opt_selinux_policy && opt_selinux_policy_from_base)
-    {
-      glnx_throw (error, "Cannot specify both --selinux-policy and --selinux-policy-from-base");
-      goto out;
-    }
 
   if (flags != 0
       || opt_owner_uid >= 0

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -437,7 +437,7 @@ echo "ok user checkout"
 $OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit" --tree=ref=test2
 echo "ok commit from ref"
 
-$OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit with modifier" --tree=ref=test2 --owner-uid=`id -u`
+$OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit with modifier" --tree=ref=test2 --owner-uid=0
 echo "ok commit from ref with modifier"
 
 $OSTREE commit ${COMMIT_ARGS} -b trees/test2 -s 'ref with / in it' --tree=ref=test2


### PR DESCRIPTION
This explicitly checks for commit command options asking for both
non-zero UID/GID and canonical permissions at the same time,
which are incompatible.