### PR TITLE
lib/commit: autofix permissions for bare-user-only

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -678,10 +678,14 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo    *r
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE: No special flags
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS: Do not process extended attributes
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_GENERATE_SIZES: Generate size information.
- * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS: Canonicalize permissions for bare-user-only mode.
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS: Canonicalize permissions.
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED: Emit an error if configured SELinux policy does not provide a label
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME: Delete added files/directories after commit; Since: 2017.13
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL: If a devino cache hit is found, skip modifier filters (non-directories only); Since: 2017.14
+ *
+ * Flags modifying commit behavior. In bare-user-only mode, @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS
+ * is automatically enabled.
+ *
  */
 typedef enum {
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE = 0,

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -31,7 +31,7 @@ if is_bare_user_only_repo repo; then
     # In bare-user-only repos we can only represent files with uid/gid 0, no
     # xattrs and canonical permissions, so we need to commit them as such, or
     # we end up with repos that don't pass fsck
-    COMMIT_ARGS="--canonical-permissions --no-xattrs"
+    COMMIT_ARGS="--no-xattrs"
     DIFF_ARGS="--owner-uid=0 --owner-gid=0 --no-xattrs"
     # Also, since we can't check out uid=0 files we need to check out in user mode
     CHECKOUT_U_ARG="-U"

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 mode="bare-user-only"
 setup_test_repository "$mode"
-extra_basic_tests=6
+extra_basic_tests=7
 . $(dirname $0)/basic-test.sh
 
 $CMD_PREFIX ostree --version > version.yaml
@@ -112,3 +112,15 @@ $OSTREE checkout --force-copy perms out
 $OSTREE checkout ${CHECKOUT_H_ARGS} --union-identical perms out
 $OSTREE fsck
 echo "ok checkout checksum with canonical perms"
+
+cd ${test_tmpdir}
+rm repo -rf
+ostree_repo_init repo init --mode=bare-user-only
+rm files -rf && mkdir files
+echo afile > files/afile
+$OSTREE commit ${COMMIT_ARGS} -b perms files
+rm out -rf
+$OSTREE checkout --force-copy perms out
+$OSTREE checkout ${CHECKOUT_H_ARGS} --union-identical perms out
+$OSTREE fsck
+echo "ok automatic canonical perms for bare-user-only"


### PR DESCRIPTION
This tweaks commit logic to detect bare-user-only repositories and
canonicalize permissions automatically.