### PR TITLE
builtins/commit: move commit modifier to auto-cleanup

### DIFF
--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -432,7 +432,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
   g_autoptr(GHashTable) skip_list = NULL;
   OstreeRepoCommitModifierFlags flags = 0;
   g_autoptr(OstreeSePolicy) policy = NULL;
-  OstreeRepoCommitModifier *modifier = NULL;
+  g_autoptr(OstreeRepoCommitModifier) modifier = NULL;
   OstreeRepoTransactionStats stats;
   struct CommitFilterData filter_data = { 0, };
   g_autofree char *commit_body = NULL;
@@ -968,7 +968,5 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
  out:
   if (repo)
     ostree_repo_abort_transaction (repo, cancellable, NULL);
-  if (modifier)
-    ostree_repo_commit_modifier_unref (modifier);
   return ret;
 }


### PR DESCRIPTION
This reduces the usage of goto cleanup logic by porting the commit
modifier pointer to autoptr.