### PR TITLE
lib/diff: ignore xattrs if disabled on either repos

### DIFF
--- a/src/libostree/ostree-diff.c
+++ b/src/libostree/ostree-diff.c
@@ -268,15 +268,18 @@ ostree_diff_dirs_with_options (OstreeDiffFlags        flags,
   /* If we're diffing versus a repo, and either of them have xattrs disabled,
    * then disable for both.
    */
-  OstreeRepo *repo;
   if (OSTREE_IS_REPO_FILE (a))
-    repo = ostree_repo_file_get_repo ((OstreeRepoFile*)a);
-  else if (OSTREE_IS_REPO_FILE (b))
-    repo = ostree_repo_file_get_repo ((OstreeRepoFile*)b);
-  else
-    repo = NULL;
-  if (repo != NULL && repo->disable_xattrs)
-    flags |= OSTREE_DIFF_FLAGS_IGNORE_XATTRS;
+    {
+      OstreeRepo *repo = ostree_repo_file_get_repo ((OstreeRepoFile*)a);
+      if (repo->disable_xattrs)
+        flags |= OSTREE_DIFF_FLAGS_IGNORE_XATTRS;
+    }
+  if (OSTREE_IS_REPO_FILE (b))
+    {
+      OstreeRepo *repo = ostree_repo_file_get_repo ((OstreeRepoFile*)b);
+      if (repo->disable_xattrs)
+        flags |= OSTREE_DIFF_FLAGS_IGNORE_XATTRS;
+    }
 
   if (a == NULL)
     {


### PR DESCRIPTION
This fixes the logic to detect whether xattrs should be automatically
ignored when diffing.

---

Context: I was skimming through this code; unless I misread something, the comment and the current code do not agree.
This should fix the code to match the logic described in the comment.