### PR TITLE
lib: unify user-mode canonical mask to 0775

### DIFF
--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -36,6 +36,9 @@ G_BEGIN_DECLS
 #define DEFAULT_DIRECTORY_MODE 0775
 #define DEFAULT_REGFILE_MODE 0660
 
+/* Mask to sanitize permissions into a safe canonical subset, for user-bare-only mode. */
+#define USERMODE_CANONICAL_MASK 0775
+
 /* This file contains private implementation data format definitions
  * read by multiple implementation .c files.
  */

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2288,7 +2288,7 @@ _ostree_validate_bareuseronly_mode (guint32     content_mode,
 {
   if (S_ISREG (content_mode))
     {
-      const guint32 invalid_modebits = ((content_mode & ~S_IFMT) & ~0775);
+      const guint32 invalid_modebits = ((content_mode & ~S_IFMT) & ~USERMODE_CANONICAL_MASK);
       if (invalid_modebits > 0)
         return glnx_throw (error, "Content object %s: invalid mode 0%04o with bits 0%04o",
                            checksum, content_mode, invalid_modebits);

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1097,7 +1097,7 @@ checkout_tree_at_recurse (OstreeRepo                        *self,
        * See also: https://github.com/ostreedev/ostree/pull/909 i.e. 0c4b3a2b6da950fd78e63f9afec602f6188f1ab0
        */
       if (self->mode == OSTREE_REPO_MODE_BARE_USER_ONLY || options->bareuseronly_dirs)
-        canonical_mode = (mode & 0775) | S_IFDIR;
+        canonical_mode = (mode & USERMODE_CANONICAL_MASK) | S_IFDIR;
       else
         canonical_mode = mode;
       if (TEMP_FAILURE_RETRY (fchmod (destination_dfd, canonical_mode)) < 0)

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -789,10 +789,8 @@ $OSTREE commit ${COMMIT_ARGS} -b content-with-dir-world-writable --tree=dir=file
 $OSTREE fsck
 rm dir-co -rf
 $OSTREE checkout -U -H -M content-with-dir-world-writable dir-co
-if is_bare_user_only_repo repo; then
-    assert_file_has_mode dir-co/worldwritable-dir 755
-else
-    assert_file_has_mode dir-co/worldwritable-dir 775
+assert_file_has_mode dir-co/worldwritable-dir 775
+if ! is_bare_user_only_repo repo; then
     rm dir-co -rf
     $CMD_PREFIX ostree --repo=repo checkout -U -H content-with-dir-world-writable dir-co
     assert_file_has_mode dir-co/worldwritable-dir 777

--- a/tests/test-basic-user-only.sh
+++ b/tests/test-basic-user-only.sh
@@ -111,7 +111,7 @@ $OSTREE commit ${COMMIT_ARGS} -b perms files
 $OSTREE fsck
 rm out -rf
 $OSTREE checkout --force-copy perms out
-assert_file_has_mode out/afile 755
+assert_file_has_mode out/afile 775
 $OSTREE checkout ${CHECKOUT_H_ARGS} --union-identical perms out
-assert_file_has_mode out/afile 755
+assert_file_has_mode out/afile 775
 echo "ok automatic canonical perms for bare-user-only"


### PR DESCRIPTION
This aligns all canonical permissions masks to 0775, which is relevant
for bare-user-only mode.
Such mask is already used for user-mode pulls and checkouts; however
the commit logic/modifier was using a different and smaller mask (0755),
which resulted in asymmetries across operations.

---

Context: I noticed some misalignment around this while touching https://github.com/ostreedev/ostree/issues/2410. 
I guess it was supposed to be done in https://github.com/ostreedev/ostree/pull/913, but somehow it didn't happen there.
I did some history reading and found https://github.com/flatpak/flatpak/pull/837#issuecomment-306737654 which seems to suggest this larger would be beneficial for some flatpak content.