### PR TITLE
tests: Revert to using --owner-uid=$(id -u)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,8 +120,11 @@ jobs:
       - name: Install dependencies
         run: ./ci/gh-install.sh ${{ matrix.extra-packages }}
 
+      - name: Add non-root user
+        run: "useradd builder && chown -R -h builder: ."
+
       - name: Build and test
-        run: ./ci/gh-build.sh ${{ matrix.configure-options }}
+        run: runuser -u builder -- ./ci/gh-build.sh ${{ matrix.configure-options }}
         env:
           # GitHub hosted runners currently have 2 CPUs, so run 2
           # parallel make jobs.

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -481,6 +481,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
     }
   else if (errno == EEXIST)
     {
+      int saved_errno = errno;
       /* When we get EEXIST, we need to handle the different overwrite modes. */
       switch (options->overwrite_mode)
         {
@@ -566,6 +567,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
             else
               {
                 g_assert_cmpint (options->overwrite_mode, ==, OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL);
+                errno = saved_errno;
                 return glnx_throw_errno_prefix (error, "Hardlinking %s to %s", loose_path, destination_name);
               }
             break;

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -372,7 +372,7 @@ create_file_copy_from_input_at (OstreeRepo     *repo,
                  * checkout_file_hardlink().
                  */
                 OstreeChecksumFlags flags = 0;
-                if (repo->disable_xattrs)
+                if (repo->disable_xattrs || repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)
                   flags |= OSTREE_CHECKSUM_FLAGS_IGNORE_XATTRS;
 
                 if (repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)
@@ -528,7 +528,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
                  * shouldn't hit this anymore. https://github.com/ostreedev/ostree/pull/1258
                  * */
                 OstreeChecksumFlags flags = 0;
-                if (self->disable_xattrs)
+                if (self->disable_xattrs || self->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)
                   flags |= OSTREE_CHECKSUM_FLAGS_IGNORE_XATTRS;
 
                 if (self->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -3117,7 +3117,7 @@ ostree_repo_write_commit_with_time (OstreeRepo      *self,
  * ostree_repo_read_commit_detached_metadata:
  * @self: Repo
  * @checksum: ASCII SHA256 commit checksum
- * @out_metadata: (out) (transfer full): Metadata associated with commit in with format "a{sv}", or %NULL if none exists
+ * @out_metadata: (out) (nullable) (transfer full): Metadata associated with commit in with format "a{sv}", or %NULL if none exists
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -3132,6 +3132,8 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
                                            GCancellable    *cancellable,
                                            GError         **error)
 {
+  g_assert (out_metadata != NULL);
+
   char buf[_OSTREE_LOOSE_PATH_MAX];
   _ostree_loose_path (buf, checksum, OSTREE_OBJECT_TYPE_COMMIT_META, self->mode);
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -435,7 +435,7 @@ echo "ok user checkout"
 $OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit" --tree=ref=test2
 echo "ok commit from ref"
 
-$OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit with modifier" --tree=ref=test2 --owner-uid=0
+$OSTREE commit ${COMMIT_ARGS} -b test2 -s "Another commit with modifier" --tree=ref=test2 --mode-ro-executables
 echo "ok commit from ref with modifier"
 
 $OSTREE commit ${COMMIT_ARGS} -b trees/test2 -s 'ref with / in it' --tree=ref=test2

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -455,11 +455,21 @@ $OSTREE commit ${COMMIT_ARGS} --skip-if-unchanged -b trees/test2 -s 'should not 
 $OSTREE ls -R -C test2
 new_rev=$($OSTREE rev-parse test2)
 assert_streq "${old_rev}" "${new_rev}"
+$OSTREE fsck
 echo "ok commit --skip-if-unchanged"
 
-cd ${test_tmpdir}/checkout-test2-4
-$OSTREE commit ${COMMIT_ARGS} -b test2 -s "no xattrs" --no-xattrs
-echo "ok commit with no xattrs"
+if have_selinux_relabel; then
+    # Unfortunately later tests depend on this right now, so commit anyways
+    cd ${test_tmpdir}/checkout-test2-4
+    $OSTREE commit ${COMMIT_ARGS} -b test2
+    echo "ok # SKIP we get an injected security.selinux xattr regardless, so we can't do this"
+else
+    cd ${test_tmpdir}/checkout-test2-4
+    $OSTREE commit ${COMMIT_ARGS} -b test2-noxattrs -s "no xattrs" --no-xattrs
+    # Validate our assumptions
+    $OSTREE fsck
+    echo "ok commit with no xattrs"
+fi
 
 mkdir tree-A tree-B
 touch tree-A/file-a tree-B/file-b


### PR DESCRIPTION
This allows the test suite to run as non-root again.  When operating
on a bare non-root repo, we can't `chown()`.

(Arguably, non-root `bare` repos are not very useful and we shouldn't
 test them or potentially even support them, but that's a whole
 other thing)