### PR TITLE
ci: Run GH action CI build+test as non-root

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,8 +120,11 @@ jobs:
       - name: Install dependencies
         run: ./ci/gh-install.sh ${{ matrix.extra-packages }}
 
+      - name: Add non-root user
+        run: "useradd builder && chown -R -h builder: ."
+
       - name: Build and test
-        run: ./ci/gh-build.sh ${{ matrix.configure-options }}
+        run: runuser -u builder -- ./ci/gh-build.sh ${{ matrix.configure-options }}
         env:
           # GitHub hosted runners currently have 2 CPUs, so run 2
           # parallel make jobs.


### PR DESCRIPTION
This is really the standard best practice, matching how
e.g. dpkg/rpm work, as well as most local development
environments (including mine) with e.g. `toolbox`.