### PR TITLE
checkout: Save errno when re-throwing

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -481,6 +481,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
     }
   else if (errno == EEXIST)
     {
+      int saved_errno = errno;
       /* When we get EEXIST, we need to handle the different overwrite modes. */
       switch (options->overwrite_mode)
         {
@@ -566,6 +567,7 @@ checkout_file_hardlink (OstreeRepo                          *self,
             else
               {
                 g_assert_cmpint (options->overwrite_mode, ==, OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL);
+                errno = saved_errno;
                 return glnx_throw_errno_prefix (error, "Hardlinking %s to %s", loose_path, destination_name);
               }
             break;


### PR DESCRIPTION
I was seeing an `EPERM`  here which was confusing.
It turned out the real error was `EEXIST`.

Since we're referring to the original error, but we do a
lot of computation in the middle, we need to save errno.