### PR TITLE
Add support for "custom remotes"

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -355,6 +355,14 @@ Boston, MA 02111-1307, USA.
         <listitem><para>If set, pulls from this remote will fail with the configured text.  This is intended for OS vendors which have a subscription process to access content.</para></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>custom-backend</varname></term>
+        <listitem><para>If set, pulls from this remote via libostree will fail with an error that mentions the value.
+                        It is recommended to make this a software identifier token (e.g. "examplecorp-fetcher"), not freeform text ("ExampleCorp Fetcher").
+                        This is intended to be used by higher level software that wants to fetch ostree commits via some other mechanism, while still reusing the core libostree infrastructure around e.g. signatures.
+                        </para></listitem>
+      </varlistentry>
+
     </variablelist>
 
   </refsect1>

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3965,6 +3965,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   else
     {
       g_autofree char *unconfigured_state = NULL;
+      g_autofree char *custom_backend = NULL;
 
       g_free (pull_data->remote_name);
       pull_data->remote_name = g_strdup (remote_name_or_baseurl);
@@ -3994,6 +3995,20 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                        "remote unconfigured-state: %s", unconfigured_state);
+          goto out;
+        }
+
+      if (!ostree_repo_get_remote_option (self, pull_data->remote_name,
+                                          "custom-backend", NULL,
+                                          &custom_backend,
+                                          error))
+        goto out;
+
+      if (custom_backend)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Cannot fetch via libostree - remote '%s' uses custom backend '%s'", 
+                       pull_data->remote_name, custom_backend);
           goto out;
         }
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1589,7 +1589,6 @@ impl_repo_remote_add (OstreeRepo     *self,
                       GError        **error)
 {
   g_return_val_if_fail (name != NULL, FALSE);
-  g_return_val_if_fail (url != NULL, FALSE);
   g_return_val_if_fail (options == NULL || g_variant_is_of_type (options, G_VARIANT_TYPE ("a{sv}")), FALSE);
 
   if (!ostree_validate_remote_name (name, error))
@@ -1637,10 +1636,13 @@ impl_repo_remote_add (OstreeRepo     *self,
       remote->file = g_file_get_child (etc_ostree_remotes_d, basename);
     }
 
-  if (g_str_has_prefix (url, "metalink="))
-    g_key_file_set_string (remote->options, remote->group, "metalink", url + strlen ("metalink="));
-  else
-    g_key_file_set_string (remote->options, remote->group, "url", url);
+  if (url)
+    {
+      if (g_str_has_prefix (url, "metalink="))
+        g_key_file_set_string (remote->options, remote->group, "metalink", url + strlen ("metalink="));
+      else
+        g_key_file_set_string (remote->options, remote->group, "url", url);
+    }
 
   if (options)
     keyfile_set_from_vardict (remote->options, remote->group, options);
@@ -1676,7 +1678,7 @@ impl_repo_remote_add (OstreeRepo     *self,
  * ostree_repo_remote_add:
  * @self: Repo
  * @name: Name of remote
- * @url: URL for remote (if URL begins with metalink=, it will be used as such)
+ * @url: (allow-none): URL for remote (if URL begins with metalink=, it will be used as such)
  * @options: (allow-none): GVariant of type a{sv}
  * @cancellable: Cancellable
  * @error: Error
@@ -1789,7 +1791,6 @@ impl_repo_remote_replace (OstreeRepo     *self,
                           GError        **error)
 {
   g_return_val_if_fail (name != NULL, FALSE);
-  g_return_val_if_fail (url != NULL, FALSE);
   g_return_val_if_fail (options == NULL || g_variant_is_of_type (options, G_VARIANT_TYPE ("a{sv}")), FALSE);
 
   if (!ostree_validate_remote_name (name, error))
@@ -1815,11 +1816,14 @@ impl_repo_remote_replace (OstreeRepo     *self,
       if (!g_key_file_remove_group (remote->options, remote->group, error))
         return FALSE;
 
-      if (g_str_has_prefix (url, "metalink="))
-        g_key_file_set_string (remote->options, remote->group, "metalink",
-                               url + strlen ("metalink="));
-      else
-        g_key_file_set_string (remote->options, remote->group, "url", url);
+      if (url)
+        {
+          if (g_str_has_prefix (url, "metalink="))
+            g_key_file_set_string (remote->options, remote->group, "metalink",
+                                   url + strlen ("metalink="));
+          else
+            g_key_file_set_string (remote->options, remote->group, "url", url);
+        }
 
       if (options != NULL)
         keyfile_set_from_vardict (remote->options, remote->group, options);
@@ -1866,7 +1870,7 @@ impl_repo_remote_replace (OstreeRepo     *self,
  * @sysroot: (allow-none): System root
  * @changeop: Operation to perform
  * @name: Name of remote
- * @url: URL for remote (if URL begins with metalink=, it will be used as such)
+ * @url: (allow-none): URL for remote (if URL begins with metalink=, it will be used as such)
  * @options: (allow-none): GVariant of type a{sv}
  * @cancellable: Cancellable
  * @error: Error


### PR DESCRIPTION
This will be helpful for the "ostree native container" work in
https://github.com/ostreedev/ostree-rs-ext/

Basically in order to reuse GPG/signapi verification, we need
to support adding a remote, even though it can't be used via
`ostree pull`.  (At least, not until we merge ostree-rs-ext into ostree, but
 even then I think the principle stands)