### PR TITLE
repo-pull: legacy_transaction_resuming flag ignored

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2439,7 +2439,7 @@ get_best_static_delta_start_for (OtPullData *pull_data,
       if (!ostree_repo_load_commit (pull_data->repo, to_revision,
                                     NULL, &to_rev_state, error))
         return FALSE;
-      if (!(to_rev_state & OSTREE_REPO_COMMIT_STATE_PARTIAL))
+      if (!(commitstate_is_partial(pull_data, to_rev_state)))
         {
           /* We already have this commit, we're done! */
           out_result->result = DELTA_SEARCH_RESULT_UNCHANGED;


### PR DESCRIPTION
Hello ostreedev maintainers

When trying to do a pull form a remote with the --require-static-delta flag set after a previous attempt was aborted it would always indicate that everything was already pulled. But doing an deploy of the commit afterwards would throw an error that files are missing.
Investigating the problem i found out that the legacy_transaction_resuming flag was not considered in the delta-path, so it would always mark an legacy_transaction as done/not partial, even if files were missing. Using the commitstate_is_partial function will correctly assess which deltaparts are missing and redownload the missing parts.

With regards
RBuddel