### PR TITLE
two small unit test patches

### DIFF
--- a/tests/kolainst/libtest-core.sh
+++ b/tests/kolainst/libtest-core.sh
@@ -35,6 +35,17 @@ assert_not_reached () {
     fatal "$@"
 }
 
+# Output an ok message for TAP
+n_tap_tests=0
+tap_ok() {
+    echo "ok" "$@"
+    n_tap_tests=$(($n_tap_tests+1))
+}
+
+tap_end() {
+    echo "1..${n_tap_tests}"
+}
+
 # Some tests look for specific English strings. Use a UTF-8 version
 # of the C (POSIX) locale if we have one, or fall back to en_US.UTF-8
 # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -54,11 +54,12 @@ function verify_initial_contents() {
     assert_file_has_content baz/cow '^moo$'
 }
 
+n_base_tests=35
+gpg_tests=3
 if has_gpgme; then
-    echo "1..38"
+    echo "1..$(($n_base_tests+$gpg_tests))"
 else
-    # 3 tests needs GPG support
-    echo "1..35"
+    echo "1..$((n_base_tests))"
 fi
 
 # Try both syntaxes

--- a/tests/test-admin-deploy-etcmerge-cornercases.sh
+++ b/tests/test-admin-deploy-etcmerge-cornercases.sh
@@ -26,8 +26,6 @@ set -euo pipefail
 # Exports OSTREE_SYSROOT so --sysroot not needed.
 setup_os_repository "archive" "syslinux"
 
-echo "1..2"
-
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
 export rev
@@ -89,7 +87,7 @@ test -L ${newetc}/a/link-to-no-such-file || assert_not_reached "should have syml
 assert_has_dir ${newroot}/usr/etc/testdirectory
 assert_not_has_dir ${newetc}/testdirectory
 
-echo "ok"
+tap_ok first
 
 # Add /etc/initially-empty
 cd "${test_tmpdir}/osdata"
@@ -141,4 +139,6 @@ assert_not_has_file sysroot/ostree/deploy/testos/deploy/${rev}.0/usr/etc/initial
 assert_has_file sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/initially-empty/mynewfile
 rm ${newconfpath}
 
-echo "ok"
+tap_ok second
+
+tap_end


### PR DESCRIPTION
tests/pull-test: Avoid duplicating test numbers

We do this in other places; avoids touching two numbers when
adding tests.  Let computers do the addition.

---

tests: Add new TAP APIs

Having to touch a global test counter when adding tests is
a recipe for conflicts between PRs.

The TAP protocol allows *ending* with the expected number of
tests, so the best way to do this is to have an explicit
API like our `tap_ok` which bumps a counter, then end with `tap_end`.

I ported one test as a demo.

---

