### PR TITLE
lib: Add an API to construct a MutableTree from a commit

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -268,6 +268,7 @@ OstreeLzmaDecompressorClass
 <FILE>ostree-mutable-tree</FILE>
 OstreeMutableTree
 ostree_mutable_tree_new
+ostree_mutable_tree_new_from_commit
 ostree_mutable_tree_new_from_checksum
 ostree_mutable_tree_check_error
 ostree_mutable_tree_set_metadata_checksum

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -25,6 +25,7 @@
 LIBOSTREE_2021.5 {
 global:
   ostree_sepolicy_new_from_commit;
+  ostree_mutable_tree_new_from_commit;
 } LIBOSTREE_2021.4;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-mutable-tree.h
+++ b/src/libostree/ostree-mutable-tree.h
@@ -53,6 +53,12 @@ _OSTREE_PUBLIC
 OstreeMutableTree *ostree_mutable_tree_new (void);
 
 _OSTREE_PUBLIC
+OstreeMutableTree *
+ostree_mutable_tree_new_from_commit (OstreeRepo *repo,
+                                     const char *rev,
+                                     GError    **error);
+
+_OSTREE_PUBLIC
 OstreeMutableTree * ostree_mutable_tree_new_from_checksum (OstreeRepo *repo,
                                                            const char *contents_checksum,
                                                            const char *metadata_checksum);

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -638,20 +638,14 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
 
   if (opt_base)
     {
-      g_autofree char *base_commit = NULL;
-      g_autoptr(GFile) base_root = NULL;
-      if (!ostree_repo_read_commit (repo, opt_base, &base_root, &base_commit, cancellable, error))
+      mtree = ostree_mutable_tree_new_from_commit (repo, opt_base, error);
+      if (!mtree)
         goto out;
-      OstreeRepoFile *rootf = (OstreeRepoFile*) base_root;
-
-      mtree = ostree_mutable_tree_new_from_checksum (repo,
-                                                     ostree_repo_file_tree_get_contents_checksum (rootf),
-                                                     ostree_repo_file_tree_get_metadata_checksum (rootf));
 
       if (opt_selinux_policy_from_base)
         {
           g_assert (modifier);
-          if (!ostree_repo_commit_modifier_set_sepolicy_from_commit (modifier, repo, base_commit, cancellable, error))
+          if (!ostree_repo_commit_modifier_set_sepolicy_from_commit (modifier, repo, opt_base, cancellable, error))
             goto out;
           /* Don't try to handle it twice */
           opt_selinux_policy_from_base = FALSE;


### PR DESCRIPTION

lib: Add an API to construct a `MutableTree` from a commit

This is nicer than having the caller parse the commit
object, or indirect via the `OstreeRepoFile*` object of the root.

Will be used in ostree-rs-ext around tar parsing.

---

