### PR TITLE
tests: Use ostree-ext 0.3.0

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -17,9 +17,7 @@ serde_json = "1.0"
 sh-inline = "0.1.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
-glib = "0.10"
-gio = "0.9"
-ostree = { version = "0.10.0", features = ["v2021_1"] }
+ostree-ext = { version = "0.3.0" }
 libtest-mimic = "0.3.0"
 twoway = "0.2.1"
 hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }

--- a/tests/inst/src/sysroot.rs
+++ b/tests/inst/src/sysroot.rs
@@ -1,8 +1,8 @@
 //! Tests that mostly use the API and access the booted sysroot read-only.
 
 use anyhow::Result;
-use gio::prelude::*;
-use ostree::prelude::*;
+use ostree_ext::prelude::*;
+use ostree_ext::{gio, ostree};
 
 use crate::test::*;
 
@@ -21,11 +21,11 @@ fn test_sysroot_ro() -> Result<()> {
     sysroot.load(cancellable.as_ref())?;
     assert!(sysroot.is_booted());
 
-    let booted = sysroot.get_booted_deployment().expect("booted deployment");
+    let booted = sysroot.booted_deployment().expect("booted deployment");
     assert!(!booted.is_staged());
     let repo = sysroot.repo().expect("repo");
 
-    let csum = booted.get_csum().expect("booted csum");
+    let csum = booted.csum().expect("booted csum");
     let csum = csum.as_str();
 
     let (root, rev) = repo.read_commit(csum, cancellable.as_ref())?;


### PR DESCRIPTION
This updates to the modern glib 0.14 and paves the way for
some reverse dependency testing by using ostree-ext's code.