### PR TITLE
fsck: Print a success message

### DIFF
--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -459,5 +459,8 @@ ostree_builtin_fsck (int argc, char **argv, OstreeCommandInvocation *invocation,
   if (n_fsck_partial > 0)
     return glnx_throw (error, "%u partial commits from fsck-detected corruption", n_partial);
 
+  g_print ("object fsck of %d commits completed successfully - no errors found.\n", 
+           (guint)g_hash_table_size (commits));
+
   return TRUE;
 }


### PR DESCRIPTION
There's a general Unix philosophy that "silence is golden".
However, when one is explicitly invoking an error check it's nice
to see explicit success.

We already print various statistics, so ending with a happy
note has no extra cost.