### PR TITLE
libarchive: Always ensure we have a label

### DIFF
--- a/src/libostree/ostree-repo-libarchive.c
+++ b/src/libostree/ostree-repo-libarchive.c
@@ -27,6 +27,7 @@
 #include "ostree.h"
 #include "ostree-core-private.h"
 #include "ostree-repo-private.h"
+#include "ostree-sepolicy-private.h"
 
 #ifdef HAVE_LIBARCHIVE
 #include <archive.h>
@@ -167,8 +168,8 @@ builder_add_label (GVariantBuilder  *builder,
   if (!sepolicy)
     return TRUE;
 
-  if (!ostree_sepolicy_get_label (sepolicy, path, mode, &label,
-                                  cancellable, error))
+  if (!_ostree_sepolicy_require_label (sepolicy, path, mode, &label,
+                                       cancellable, error))
     return FALSE;
 
   if (label)

--- a/src/libostree/ostree-sepolicy-private.h
+++ b/src/libostree/ostree-sepolicy-private.h
@@ -38,6 +38,11 @@ gboolean _ostree_sepolicy_preparefscreatecon (OstreeSepolicyFsCreatecon *con,
                                               guint32           mode,
                                               GError          **error);
 
+gboolean
+_ostree_sepolicy_require_label (OstreeSePolicy *policy, const char *relpath,
+                                guint32 unix_mode, char **out_label, 
+                                GCancellable *cancellable, GError **error);
+
 GVariant *_ostree_filter_selinux_xattr (GVariant *xattrs);
 
 G_END_DECLS

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -599,6 +599,25 @@ ostree_sepolicy_get_label (OstreeSePolicy    *self,
   return TRUE;
 }
 
+// If policy doesn't specify a label, try a fallback.
+gboolean
+_ostree_sepolicy_require_label (OstreeSePolicy *policy, const char *relpath,
+                                guint32 unix_mode, char **out_label, 
+                                GCancellable *cancellable, GError **error)
+{
+  char *label = NULL;
+  if (!ostree_sepolicy_get_label (policy, relpath, unix_mode, &label, cancellable, error))
+    return FALSE;
+  if (!label)
+    {
+      if (!ostree_sepolicy_get_label (policy, "/usr/share/some-generic-thing", unix_mode, &label, cancellable, error))
+        return FALSE;
+    }
+  *out_label = label;
+  return TRUE;
+}
+
+
 /**
  * ostree_sepolicy_restorecon:
  * @self: Self

--- a/tests/kolainst/destructive/itest-label-selinux.sh
+++ b/tests/kolainst/destructive/itest-label-selinux.sh
@@ -107,7 +107,9 @@ echo "ok commit --selinux-policy-from-base"
 
 rm rootfs -rf
 mkdir rootfs
-mkdir -p rootfs/usr/{bin,lib,etc}
+mkdir -p rootfs/usr/{bin,lib,etc} rootfs/var/tmp
+# Fedora's SELinux policy doesn't give whiteouts a label, so this tests our force-labeling
+touch rootfs/var/tmp/.wh..wh..opq
 echo 'somebinary' > rootfs/usr/bin/somebinary
 ls -Z rootfs/usr/bin/somebinary > lsz.txt
 assert_not_file_has_content lsz.txt ':bin_t:'
@@ -116,4 +118,5 @@ tar -C rootfs -cf rootfs.tar .
 ostree commit -b newbase --selinux-policy / --tree=tar=rootfs.tar
 ostree ls -X newbase /usr/bin/somebinary > newls.txt
 assert_file_has_content newls.txt ':bin_t:'
+ostree fsck
 echo "ok commit --selinux-policy with --tree=tar"


### PR DESCRIPTION
The way SELinux works, there isn't a concept of "something without
a label".  There *is* the `unlabeled_t` type that the kernel makes
up when it finds no label on a mounted filesystem.  But that's still
a label, it's just a kernel fallback.

When we go to import a tar archive, in most cases it won't
have SELinux labels, and even if it does, we want to overwrite it.

Now, the concept of a "whiteout" file arose relatively recently
as a special file type that's used in the container ecosystem alongside
overlayfs.

For some reason, presumably due to its special nature, at least the
Fedora SELinux policy doesn't define a label for it.

However, when it lands on disk, the kernel will still assign it
a default label.

And that's the problem - the computed checksum won't match, which
will appear as corruption.

One doesn't see this problem when e.g. extracting a tarball
temporarily to disk, and then committing it because the act of extracting
to disk will assign a label.

This problem was hit when importing container layers for ostree-container
work in ostree-rs-ext.