### PR TITLE
deploy: Ignore sockets, fifos in /etc during merge

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -488,9 +488,7 @@ copy_modified_config_file (int                 orig_etc_fd,
     }
   else
     {
-      return glnx_throw (error,
-                         "Unsupported non-regular/non-symlink file in /etc '%s'",
-                         path);
+      ot_journal_print (LOG_INFO, "Ignoring non-regular/non-symlink file found during /etc merge: %s", path);
     }
 
   return TRUE;

--- a/tests/test-admin-deploy-etcmerge-cornercases.sh
+++ b/tests/test-admin-deploy-etcmerge-cornercases.sh
@@ -51,6 +51,9 @@ chmod 700 ${etc}/a/long/dir/forking
 # Symlink to nonexistent path, to ensure we aren't walking symlinks
 ln -s no-such-file ${etc}/a/link-to-no-such-file
 
+# fifo which should be ignored
+mkfifo "${etc}/fifo-to-ignore"
+
 # Remove a directory
 rm ${etc}/testdirectory -rf
 
@@ -65,6 +68,10 @@ newetc=${newroot}/etc
 
 assert_file_has_content ${newroot}/usr/etc/NetworkManager/nm.conf "a default daemon file"
 assert_file_has_content ${newetc}/NetworkManager/nm.conf "a modified config file"
+
+if test -e "${newetc}"/fifo-to-ignore; then
+  fatal "Should not have copied fifo!"
+fi
 
 assert_file_has_mode() {
   stat -c '%a' $1 > mode.txt


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1945274 is an issue where a privileged
kubernetes daemonset is writing a socket into `/etc`.  This makes ostree upgrades barf.

Now, they should clearly move it to `/run`.  However, one option is for us to
just ignore it instead of erroring out.  Some brief investigation shows that
e.g. `git add somesocket` is a silent no-op, which is an argument in favor of ignoring it.

Closes: https://github.com/ostreedev/ostree/issues/2446