### PR TITLE
test-commit-sign.sh: Skip a unit test when running as an installed-test

### DIFF
--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -88,8 +88,12 @@ assert_file_has_content_literal show.txt 'Found 1 signature'
 echo "ok pull verify"
 
 # Run tests written in C
-${OSTREE_UNINSTALLED}/tests/test-commit-sign-sh-ext
-echo "ok extra C tests"
+if [ -n "${OSTREE_UNINSTALLED:-}" ]; then
+  ${OSTREE_UNINSTALLED}/tests/test-commit-sign-sh-ext
+  echo "ok extra C tests"
+else
+  echo "ok # SKIP test only available when running uninstalled"
+fi
 
 # Clean things up and reinit
 rm repo -rf


### PR DESCRIPTION
`test-commit-sign-sh-ext` isn't installed, so it can't be run as an installed-test.

(Or it could be installed and run from `${test_builddir}`, if you'd prefer.)