### PR TITLE
docs: Do not convert -- & --- to en/em-dash

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,10 @@ url: "https://ostreedev.github.io"
 # url: "http://localhost:4000"
 permalink: /:title/
 markdown: kramdown
+kramdown:
+  typographic_symbols:
+    ndash: "--"
+    mdash: "---"
 
 # Exclude the README and the bundler files that would normally be
 # ignored by default.


### PR DESCRIPTION
'--' is frequently used for command line options and was thus
incorrectly rendered as a special en-dash symbol.