### PR TITLE
tests/var-mount: tweak test setup

### DIFF
--- a/tests/kolainst/destructive/var-mount.sh
+++ b/tests/kolainst/destructive/var-mount.sh
@@ -6,12 +6,9 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "") 
-    require_writable_sysroot
-    # Hack this off for now
-    chattr -i /sysroot
-    cp -a /var /sysroot/myvar
-    touch /sysroot/myvar/somenewfile
-    echo '/sysroot/myvar /var none bind 0 0' >> /etc/fstab
+    touch "/var/somenewfile"
+    stateroot=$(ostree admin status 2> /dev/null | grep '^\*' | cut -d ' ' -f2 || true)
+    echo "/sysroot/ostree/deploy/${stateroot}/var /var none bind 0 0" >> /etc/fstab
     /tmp/autopkgtest-reboot "2"
     ;;
   "2")


### PR DESCRIPTION
This reworks the var-mount destructive test in order to properly use
the datadir for the current stateroot instead of a duplicated one.
In turn, it ensures that the resulting `var.mount` after reboot is
correctly pointing to the same location which hosted `/var` on the
previous boot.

Ref: https://github.com/ostreedev/ostree/issues/2115#issuecomment-945533931