### PR TITLE
lib: Fix a bad call to g_file_get_child

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1389,7 +1389,7 @@ ostree_repo_checkout_at (OstreeRepo                        *self,
   g_autoptr(GFile) target_dir = NULL;
 
   if (strcmp (options->subpath, "/") != 0)
-    target_dir = g_file_get_child (commit_root, options->subpath);
+    target_dir = g_file_resolve_relative_path (commit_root, options->subpath);
   else
     target_dir = g_object_ref (commit_root);
   g_autoptr(GFileInfo) target_info =


### PR DESCRIPTION
In Glib, since commit 3a6e8bc8876e149c36b6b14c6a25a718edb581ed,
`g_file_get_child` does not accept absolute path as paramater anymore.

The broken assertion was encountered during `ostree admin deploy`
command for the checkout of subpath `etc`.

Example of error log:
```
(ostree admin deploy:1640): GLib-GIO-CRITICAL **: 03:42:00.570: g_file_get_child: assertion '!g_path_is_absolute (name)' failed

(ostree admin deploy:1640): GLib-GIO-CRITICAL **: 03:42:00.570: g_file_query_info: assertion 'G_IS_FILE (file)' failed
**
OSTree:ERROR:src/ostree/ot-main.c:232:ostree_run: assertion failed: (success || error)
Bail out! OSTree:ERROR:src/ostree/ot-main.c:232:ostree_run: assertion failed: (success || error)
```