### PR TITLE
ci: Require `libcap2-bin` for `capsh`

### DIFF
--- a/ci/gh-install.sh
+++ b/ci/gh-install.sh
@@ -84,6 +84,7 @@ case "$ID" in
             libsoup2.4-dev
             libsystemd-dev
             libtool
+            libcap2-bin
             procps
             python3
             python3-yaml


### PR DESCRIPTION
This was previously pulled in indirectly, but it looks like we need
to require it explicitly in newer Ubuntu.