### PR TITLE
lib: Avoid dereferencing NULL error values

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -457,9 +457,15 @@ ostree_repo_static_delta_execute_offline_with_signature (OstreeRepo   *self,
 
       if (sign)
         {
-          verified = _ostree_repo_static_delta_verify_signature (self, meta_fd, sign, NULL, error);
-          if (*error)
-            return FALSE;
+          g_autoptr(GError) local_error = NULL;
+
+          verified = _ostree_repo_static_delta_verify_signature (self, meta_fd, sign, NULL, &local_error);
+          if (local_error != NULL)
+            {
+              g_propagate_error (error, g_steal_pointer (&local_error));
+              return FALSE;
+            }
+
           if (!verified)
             return glnx_throw (error, "Delta signature verification failed");
         }

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -487,12 +487,16 @@ _load_pk_from_stream (OstreeSign *self,
   while (TRUE)
     {
       gsize len = 0;
-      g_autofree char *line = g_data_input_stream_read_line (key_data_in, &len, NULL, error);
       g_autoptr (GVariant) pk = NULL;
       gboolean added = FALSE;
+      g_autoptr(GError) local_error = NULL;
+      g_autofree char *line = g_data_input_stream_read_line (key_data_in, &len, NULL, &local_error);
 
-      if (*error != NULL)
-        return FALSE;
+      if (local_error != NULL)
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
 
       if (line == NULL)
         return ret;


### PR DESCRIPTION
Otherwise, this will segfault when callers don't need any exact errors.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>