### PR TITLE
Release 2021.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2021])
 m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2021])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This is a bugfix release.
Most of the fixes are related to warnings highlighted by `gcc -fanalyzer` static source analysis.
Performance of pruning logic has been improved, avoiding unnecessary trips through redundant serialization (#2484).
A regression has been fixed so that `ostree` is properly behaving again when used from the initramfs, at a point where `/sysroot` may not be mounted yet (#2486).
A race condition related to `sysroot.readonly` has been addressed by directly setting up sysroot readonly in initramfs (#2187).

---

```
Colin Walters (14):
      Remove OstreeTlsCertInteraction bits from introspection
      remote: Fix gcc `-fanalyzer` warning
      deployment: Fix gcc `-fanalyzer` warning
      sysroot: Fix gcc `-fanalyzer` warning
      fetcher/soup: Fix gcc `-fanalyzer` warning
      static-delta: Fix probably not actually possible NULL deref
      utils: Fix unreachable `NULL` deref by adding assertion
      variantutil: Fix gcc `-fanalyzer` warnin
      Attempt to update packit flow to build in COPR
      libglnx: Bump to ef502aabf7d3a0d37f9c4d228f870ac93404447b
      ci: Enable -fanalyzer
      tests/rollsum: Use `g_malloc` not `malloc`
      prepare-root: Set up sysroot readonly in initramfs
      ci: Require `libcap2-bin` for `capsh`

Dan Nicholson (1):
      lib/prune: Avoid unnecessary object serialization

Jonathan Lebon (1):
      app: Only remount /sysroot if needed

Luca BRUNO (8):
      prepare-root: tweak log messages to clarify errors
      repo/private: move OstreeRepoAutoTransaction to a boxed type
      tests/var-mount: tweak test setup
      prepare-root: make all mount operations silent
      prepare-root: check return codes for errors when assembling paths
      prepare-root: get rid of a global variable
      prepare-root: check for read-only sysroot status early on
      Release 2021.6

Ryan Gonzalez (1):
      lib: Avoid dereferencing NULL error values

Simon McVittie (1):
      test-commit-sign.sh: Skip a unit test when running as an installed-test

Timothée Ravier (1):
      docs: Do not convert -- & --- to en/em-dash

Valentin David (1):
      lib: Fix a bad call to g_file_get_child

Šimon (Simon) Rataj (1):
      Added Fedora Kinoite link
```