### PR TITLE
lib: misc static analysis fixes

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -770,8 +770,8 @@ initiate_next_curl_request (FetcherRequest *req,
     curl_easy_setopt (req->easy, CURLOPT_URL, uri);
   }
 
-  curl_easy_setopt (req->easy, CURLOPT_USERAGENT,
-                    self->custom_user_agent ?: OSTREE_FETCHER_USERAGENT_STRING);
+  (void) curl_easy_setopt (req->easy, CURLOPT_USERAGENT,
+                           self->custom_user_agent ?: OSTREE_FETCHER_USERAGENT_STRING);
 
   /* Set caching request headers */
   if (req->if_none_match != NULL)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1683,8 +1683,8 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
   /* Set up to abort the transaction if we return early from this function.
    * This needs to be manually built here due to a circular dependency. */
   g_autoptr(OstreeRepoAutoTransaction) txn = g_malloc(sizeof(OstreeRepoAutoTransaction));
+  g_assert (txn != NULL);
   txn->repo = self;
-  (void) txn; /* Add use to silence static analysis */
 
   memset (&self->txn.stats, 0, sizeof (OstreeRepoTransactionStats));
 

--- a/tests/test-commit-sign-sh-ext.c
+++ b/tests/test-commit-sign-sh-ext.c
@@ -44,6 +44,7 @@ corrupt (GBytes *input)
   g_assert_cmpint (len, >, 0);
   g_assert_cmpint (len, <, G_MAXINT);
   g_autofree char *newbuf = g_memdup (buf, len);
+  g_assert (newbuf != NULL);
   int o = g_random_int_range (0, len);
   newbuf[o] = (newbuf[0] + 1);
 


### PR DESCRIPTION
This fixes a few warnings from coverity, none of which really
interesting.