### PR TITLE
s390x: add secure-execution support

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -184,7 +184,8 @@ EXTRA_DIST += \
 
 libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree -I$(builddir)/src/libostree \
 	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_CRYPTO_CFLAGS) \
-	-fvisibility=hidden '-D_OSTREE_PUBLIC=__attribute__((visibility("default"))) extern'
+	-fvisibility=hidden '-D_OSTREE_PUBLIC=__attribute__((visibility("default"))) extern' \
+	-DPKGLIBEXECDIR=\"$(pkglibexecdir)\"
 libostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions $(addprefix $(wl_versionscript_arg),$(symbol_files))
 libostree_1_la_LIBADD = libotutil.la libglnx.la libbsdiff.la $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) \
                         $(OT_DEP_LZMA_LIBS) $(OT_DEP_ZLIB_LIBS) $(OT_DEP_CRYPTO_LIBS)
@@ -292,8 +293,12 @@ EXTRA_DIST += src/libostree/README-gpg src/libostree/bupsplit.h \
 		src/libostree/ostree-enumtypes.c.template \
 		src/libostree/ostree-deployment-private.h \
 		src/libostree/ostree-repo-deprecated.h \
-		src/libostree/ostree-version.h
+		src/libostree/ostree-version.h \
+		src/libostree/s390x-se-luks-gencpio
 
 install-mkdir-remotes-d-hook:
 	mkdir -p $(DESTDIR)$(sysconfdir)/ostree/remotes.d
 INSTALL_DATA_HOOKS += install-mkdir-remotes-d-hook
+
+# Secure Execution: script for creating new initramdisk with LUKS key and config
+pkglibexec_SCRIPTS += src/libostree/s390x-se-luks-gencpio

--- a/src/libostree/ostree-bootloader-zipl.h
+++ b/src/libostree/ostree-bootloader-zipl.h
@@ -30,5 +30,4 @@ typedef struct _OstreeBootloaderZipl OstreeBootloaderZipl;
 GType _ostree_bootloader_zipl_get_type (void) G_GNUC_CONST;
 
 OstreeBootloaderZipl * _ostree_bootloader_zipl_new (OstreeSysroot *sysroot);
-
 G_END_DECLS

--- a/src/libostree/ostree-bootloader.c
+++ b/src/libostree/ostree-bootloader.c
@@ -65,13 +65,14 @@ _ostree_bootloader_write_config (OstreeBootloader  *self,
 
 gboolean
 _ostree_bootloader_post_bls_sync (OstreeBootloader  *self,
+                                  int bootversion,
                                   GCancellable  *cancellable,
                                   GError       **error)
 {
   g_return_val_if_fail (OSTREE_IS_BOOTLOADER (self), FALSE);
 
   if (OSTREE_BOOTLOADER_GET_IFACE (self)->post_bls_sync)
-    return OSTREE_BOOTLOADER_GET_IFACE (self)->post_bls_sync (self, cancellable, error);
+    return OSTREE_BOOTLOADER_GET_IFACE (self)->post_bls_sync (self, bootversion, cancellable, error);
 
   return TRUE;
 }

--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -46,6 +46,7 @@ struct _OstreeBootloaderInterface
                                                    GCancellable  *cancellable,
                                                    GError       **error);
   gboolean             (* post_bls_sync)          (OstreeBootloader  *self,
+                                                   int bootversion,
                                                    GCancellable  *cancellable,
                                                    GError       **error);
   gboolean             (* is_atomic)              (OstreeBootloader  *self);
@@ -68,6 +69,7 @@ gboolean _ostree_bootloader_write_config (OstreeBootloader  *self,
                                           GError       **error);
 
 gboolean _ostree_bootloader_post_bls_sync (OstreeBootloader  *self,
+                                           int bootversion,
                                            GCancellable  *cancellable,
                                            GError       **error);
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2097,7 +2097,7 @@ swap_bootloader (OstreeSysroot  *sysroot,
    **/
   if (bootloader)
     {
-      if (!_ostree_bootloader_post_bls_sync (bootloader, cancellable, error))
+      if (!_ostree_bootloader_post_bls_sync (bootloader, new_bootversion, cancellable, error))
         return FALSE;
     }
 

--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -1,0 +1,22 @@
+ #!/usr/bin/bash
+ # This script creates new initramdisk with LUKS config within
+set -euo pipefail
+
+old_initrd=$1
+new_initrd=$2
+
+# Unpacking existing initramdisk
+workdir=$(mktemp -d -p /tmp se-initramfs-XXXXXX)
+cd ${workdir}
+gzip -cd ${old_initrd} | cpio -imd --quiet
+
+# Adding LUKS root key and crypttab config
+mkdir -p etc/luks
+cp -f /etc/luks/root etc/luks/
+cp -f /etc/crypttab etc/
+
+# Creating new initramdisk image
+find . | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
+
+# Cleanup
+rm -rf ${workdir}


### PR DESCRIPTION
This enables Secure Execution. 
System could be installed (or qcow2 image used) with an ignition config, which provides `ibm-z-hostkey(s)`, and later used with SecureExecution. Upgrades, LUKS (key stored only within `sd-boot` encryped image), modification of initramfs/kargs are supported and were tested on `s390x zKVM` environment.

Requires - https://github.com/coreos/fedora-coreos-config/pull/1353