### PR TITLE
lib/repo: fix problematic invariant checks

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1599,7 +1599,8 @@ _ostree_repo_update_mtime (OstreeRepo        *self,
 GKeyFile *
 ostree_repo_get_config (OstreeRepo *self)
 {
-  g_return_val_if_fail (self->inited, NULL);
+  g_assert (self != NULL);
+  g_assert (self->inited);
 
   return self->config;
 }
@@ -1617,7 +1618,8 @@ ostree_repo_copy_config (OstreeRepo *self)
   char *data;
   gsize len;
 
-  g_return_val_if_fail (self->inited, NULL);
+  g_assert (self != NULL);
+  g_assert (self->inited);
 
   copy = g_key_file_new ();
   data = g_key_file_to_data (self->config, &len, NULL);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3816,7 +3816,8 @@ ostree_repo_equal (OstreeRepo *a,
 OstreeRepoMode
 ostree_repo_get_mode (OstreeRepo  *self)
 {
-  g_return_val_if_fail (self->inited, FALSE);
+  g_assert (self != NULL);
+  g_assert (self->inited);
 
   return self->mode;
 }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1560,8 +1560,10 @@ gboolean
 ostree_repo_is_writable (OstreeRepo *self,
                          GError **error)
 {
-  g_return_val_if_fail (self->inited, FALSE);
+  g_assert (self != NULL);
+  g_assert (self->inited);
 
+  g_assert (self->writable == (self->writable_error == NULL));
   if (error != NULL && self->writable_error != NULL)
     *error = g_error_copy (self->writable_error);
 


### PR DESCRIPTION
This tweaks a few invariant checks, turning them into safer assertions instead.
For more details on each, see individual commits.
One of them came up through casual code reading, so I did also check the rest of the file while at it.