### PR TITLE
tests: assert mandatory values are present

### DIFF
--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -31,12 +31,14 @@ gboolean
 ot_test_run_libtest (const char *cmd, GError **error)
 {
   const char *srcdir = g_getenv ("G_TEST_SRCDIR");
-  g_autoptr(GPtrArray) argv = g_ptr_array_new ();
-  g_autoptr(GString) cmdstr = g_string_new ("");
+  g_assert (srcdir != NULL);
+  g_assert (cmd != NULL);
 
+  g_autoptr(GPtrArray) argv = g_ptr_array_new ();
   g_ptr_array_add (argv, "bash");
   g_ptr_array_add (argv, "-c");
 
+  g_autoptr(GString) cmdstr = g_string_new ("");
   g_string_append (cmdstr, "set -xeuo pipefail; . ");
   g_string_append (cmdstr, srcdir);
   g_string_append (cmdstr, "/tests/libtest.sh; ");


### PR DESCRIPTION
I added this locally while looking into https://github.com/ostreedev/ostree/issues/2495 to make sure the environment was sane.
Current status looks ok with regards to that, but leaving these assertions may help future investigation crossing that same codepath.

---

This adds a couple of string assertions to make sure that the test run is sane.