### PR TITLE
main: add support for CLI extensions via external binaries

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -62,6 +62,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-basic-user.sh \
 	tests/test-basic-user-only.sh \
 	tests/test-basic-root.sh \
+	tests/test-cli-extensions.sh \
 	tests/test-pull-subpath.sh \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
-#include <locale.h>
 
 #include "ot-main.h"
 #include "ot-builtins.h"
@@ -131,22 +130,16 @@ int
 main (int    argc,
       char **argv)
 {
-  g_autoptr(GError) error = NULL;
-  int ret;
+  g_assert (argc > 0);
 
-  setlocale (LC_ALL, "");
-
-  g_set_prgname (argv[0]);
-
-  ret = ostree_run (argc, argv, commands, &error);
-
-  if (error != NULL)
+  g_autofree gchar *ext_command = ostree_command_lookup_external (argc, argv, commands);
+  if (ext_command != NULL)
     {
-      g_printerr ("%s%serror:%s%s %s\n",
-                  ot_get_red_start (), ot_get_bold_start (),
-                  ot_get_bold_end (), ot_get_red_end (),
-                  error->message);
+      argv[0] = ext_command;
+      return ostree_command_exec_external (argv);
     }
-
-  return ret;
+  else
+    {
+      return ostree_main (argc, argv, commands);
+    }
 }

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -58,9 +58,15 @@ struct OstreeCommandInvocation {
   OstreeCommand *command;
 };
 
+int ostree_main (int argc, char **argv, OstreeCommand *commands);
+
 int ostree_run (int argc, char **argv, OstreeCommand *commands, GError **error);
 
 int ostree_usage (OstreeCommand *commands, gboolean is_error);
+
+char* ostree_command_lookup_external (int argc, char **argv, OstreeCommand *commands);
+
+int ostree_command_exec_external (char **argv);
 
 gboolean ostree_parse_sysroot_or_repo_option (GOptionContext *context,
                                               const char *sysroot_path,

--- a/tests/test-cli-extensions.sh
+++ b/tests/test-cli-extensions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 Red Hat Inc.
+# SPDX-License-Identifier: LGPL-2.0+
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo '1..2'
+
+mkdir -p ./localbin
+export PATH="./localbin/:${PATH}"
+ln -s /usr/bin/env ./localbin/ostree-env
+${CMD_PREFIX} ostree env --help >out.txt
+assert_file_has_content out.txt "with an empty environment"
+rm -rf -- localbin
+
+echo 'ok CLI extension localbin ostree-env'
+
+if ${CMD_PREFIX} ostree nosuchcommand 2>err.txt; then
+    assert_not_reached "missing CLI extension ostree-nosuchcommand succeeded"
+fi
+assert_file_has_content err.txt "Unknown command 'nosuchcommand'"
+rm -f -- err.txt
+
+echo 'ok CLI extension unknown ostree-nosuchcommand'


### PR DESCRIPTION
This adds some logic to detect and dispatch unknown subcommands to
extensions available in `$PATH`. Additional commands can be
implemented by adding relevant `ostree-$verb` binaries to the system.

As an example, if a `/usr/bin/ostree-extcommand` extension is provided,
the execution of `ostree extcommand --help` will be dispatched to that
as `ostree-extcommand extcommand --help`.

Closes: https://github.com/ostreedev/ostree/issues/2480