### PR TITLE
tests/cli-extensions: tweak test logic

### DIFF
--- a/tests/test-cli-extensions.sh
+++ b/tests/test-cli-extensions.sh
@@ -10,10 +10,14 @@ set -euo pipefail
 echo '1..2'
 
 mkdir -p ./localbin
+ORIG_PATH="${PATH}"
 export PATH="./localbin/:${PATH}"
 ln -s /usr/bin/env ./localbin/ostree-env
-${CMD_PREFIX} ostree env --help >out.txt
-assert_file_has_content out.txt "with an empty environment"
+export A_CUSTOM_TEST_FLAG="myvalue"
+${CMD_PREFIX} ostree env >out.txt
+assert_file_has_content out.txt "^A_CUSTOM_TEST_FLAG=myvalue"
+PATH="${ORIG_PATH}"
+export -n A_CUSTOM_TEST_FLAG
 rm -rf -- localbin
 
 echo 'ok CLI extension localbin ostree-env'


### PR DESCRIPTION
This updates the test logic for CLI extensions, actually checking
for functional output from the subcommand.
It also cleans up some environmental leftover.

Ref: https://github.com/ostreedev/ostree/pull/2500