### PR TITLE
two minor clang-analyzer fixes

### DIFF
--- a/src/libostree/ostree-soup-uri.c
+++ b/src/libostree/ostree-soup-uri.c
@@ -16,8 +16,6 @@
 char *soup_uri_decoded_copy (const char *str, int length, int *decoded_length);
 char *soup_uri_to_string_internal (SoupURI *uri, gboolean just_path_and_query,
 				   gboolean force_port);
-gboolean soup_uri_is_http (SoupURI *uri, char **aliases);
-gboolean soup_uri_is_https (SoupURI *uri, char **aliases);
 
 /* OSTREECHANGE: import soup-misc's char helpers */
 #define SOUP_CHAR_URI_PERCENT_ENCODED 0x01
@@ -1434,49 +1432,6 @@ soup_uri_host_equal (gconstpointer v1, gconstpointer v2)
 		return FALSE;
 
 	return g_ascii_strcasecmp (one->host, two->host) == 0;
-}
-
-gboolean
-soup_uri_is_http (SoupURI *uri, char **aliases)
-{
-	int i;
-
-	if (uri->scheme == SOUP_URI_SCHEME_HTTP)
-		return TRUE;
-	else if (uri->scheme == SOUP_URI_SCHEME_HTTPS)
-		return FALSE;
-	else if (!aliases)
-		return FALSE;
-
-	for (i = 0; aliases[i]; i++) {
-		if (uri->scheme == aliases[i])
-			return TRUE;
-	}
-
-	if (!aliases[1] && !strcmp (aliases[0], "*"))
-		return TRUE;
-	else
-		return FALSE;
-}
-
-gboolean
-soup_uri_is_https (SoupURI *uri, char **aliases)
-{
-	int i;
-
-	if (uri->scheme == SOUP_URI_SCHEME_HTTPS)
-		return TRUE;
-	else if (uri->scheme == SOUP_URI_SCHEME_HTTP)
-		return FALSE;
-	else if (!aliases)
-		return FALSE;
-
-	for (i = 0; aliases[i]; i++) {
-		if (uri->scheme == aliases[i])
-			return TRUE;
-	}
-
-	return FALSE;
 }
 
 /* OSTREECHANGE: drop boxed type definition */

--- a/tests/test-commit-sign-sh-ext.c
+++ b/tests/test-commit-sign-sh-ext.c
@@ -80,26 +80,26 @@ run (GError **error)
   if (ostree_repo_signature_verify_commit_data (repo, "origin", commit_bytes, detached_meta_bytes, 
                                                 OSTREE_REPO_VERIFY_FLAGS_NO_GPG | OSTREE_REPO_VERIFY_FLAGS_NO_SIGNAPI, 
                                                 &verify_report, error))
-    g_error ("Should not have validated");
+    return glnx_throw (error, "Should not have validated");
   assert_error_contains (error, "No commit verification types enabled");
 
   // No signatures
   g_autoptr(GBytes) empty = g_bytes_new_static ("", 0);
   if (ostree_repo_signature_verify_commit_data (repo, "origin", commit_bytes, empty, 0, 
                                                  &verify_report, error))
-    g_error ("Should not have validated");
+    return glnx_throw (error, "Should not have validated");
   assert_error_contains (error, "no signatures found");
   // No such remote
   if (ostree_repo_signature_verify_commit_data (repo, "nosuchremote", commit_bytes, detached_meta_bytes, 0, 
                                                  &verify_report, error))
-    g_error ("Should not have validated");
+    return glnx_throw (error, "Should not have validated");
   assert_error_contains (error, "Remote \"nosuchremote\" not found");
 
   // Corrupted commit
   g_autoptr(GBytes) corrupted_commit = corrupt (commit_bytes);
   if (ostree_repo_signature_verify_commit_data (repo, "origin", corrupted_commit, detached_meta_bytes, 0, 
                                                  &verify_report, error))
-    g_error ("Should not have validated");
+    return glnx_throw (error, "Should not have validated");
   assert_error_contains (error, "BAD signature");
 
   return TRUE;


### PR DESCRIPTION
soup-uri: Fix clang-analyzer warning

Fixes `Argument with 'nonnull' attribute passed null`.

(In upstream libsoup this code is gone, it uses `GUri` from glib,
 which we probably could now too, but one thing at a time)

---

tests: Fix clang-analyzer not seeing through `g_error()`

Basically due to the glib structured logging rework we lost the
`noreturn` attribute on `g_error()`.
This is fixed in glib as of https://gitlab.gnome.org/GNOME/glib/-/commit/f97ff20adf4eb7b952dd83e2c13046fe9e282f50

But we might as well just throw an error here.

---

