### PR TITLE
lib: use ostree-content-writer header

### DIFF
--- a/Makefile-libostree-defines.am
+++ b/Makefile-libostree-defines.am
@@ -22,6 +22,7 @@ libostree_public_headers = \
 	src/libostree/ostree.h \
 	src/libostree/ostree-async-progress.h \
 	src/libostree/ostree-autocleanups.h \
+	src/libostree/ostree-content-writer.h \
 	src/libostree/ostree-core.h \
 	src/libostree/ostree-dummy-enumtypes.h \
 	src/libostree/ostree-mutable-tree.h \

--- a/src/libostree/ostree.h
+++ b/src/libostree/ostree.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <ostree-async-progress.h>
+#include <ostree-content-writer.h>
 #include <ostree-core.h>
 #include <ostree-repo.h>
 #include <ostree-repo-os.h>


### PR DESCRIPTION
This installs and exposes the content of `ostree-content-writer.h`,
so that library consumers can properly reference symbols defined
in that header.

Fixes: https://github.com/ostreedev/ostree-rs/issues/8