### PR TITLE
lib/static-delta: throw a proper error on bspatch failure

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -456,7 +456,7 @@ dispatch_bspatch (OstreeRepo                 *repo,
                    buf,
                    state->content_size,
                    &stream) < 0)
-        return FALSE;
+        return glnx_throw (error, "bsdiff patch failed");
 
       if (!_ostree_repo_bare_content_write (repo, &state->content_out,
                                             buf, state->content_size,


### PR DESCRIPTION
This makes sure that a populated GError is returned when bsdiff
patching fails. The human-friendly label also helps in debugging.