### PR TITLE
Release 2022.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2022])
-m4_define([release_version], [1])
+m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
-m4_define([year_version], [2021])
-m4_define([release_version], [7])
+m4_define([year_version], [2022])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
New year, new ostree version!
This release adds transparent support for external sub-commands on the `ostree` binary. Custom binaries present in PATH in the form of `ostree-<subcmd>` will be now used as a fallback for sub-commands that are not natively implemented.
For example, this means that a custom `/usr/bin/ostree-my-command` binary can be used to transparently provide `ostree my-command`.

Build logic has been updated to support both libfuse 2.x and 3.x. Auto-detection is performed at configuration time, and the 3.x library is preferred from now on. Legacy 2.x support will be deprecated and removed in the future. 

Several fixes and safety improvements have been merged, also addressing some static analysis warnings. The git submodule for `bsdiff` has been updated to latest upstream revision, picking up additional bound-checks and fixing CVE-2014-9862.

---

```
Colin Walters (3):
      repo: Change locking for summary regeneration to be shared
      soup-uri: Fix clang-analyzer warning by dropping dead code
      tests: Fix clang-analyzer not seeing through `g_error()`

Joseph Marrero (1):
      Update FSF license notices to use URL instead of address

Luca BRUNO (11):
      lib: misc static analysis fixes
      lib/repo: assert that writable state and error agree
      lib/repo: do no return an arbitrary mode on failure
      lib/repo: do no return a NULL on failure
      tests: assert mandatory values are present
      main: add support for CLI extensions via external binaries
      tests/cli-extensions: tweak test logic
      lib: use ostree-content-writer header
      bsdiff: bump submodule, pick up fix for CVE-2014-9862
      lib/static-delta: throw a proper error on bspatch failure
      github: add dependabot config

Simon McVittie (1):
      rofiles-fuse: Build using FUSE 3 if possible, falling back to FUSE 2
```