### PR TITLE
libotutil: avoid leaking builder memory on error

### DIFF
--- a/src/libotutil/ot-variant-builder.c
+++ b/src/libotutil/ot-variant-builder.c
@@ -760,9 +760,9 @@ ot_variant_builder_info_new (OtVariantBuilder *builder, const GVariantType *type
 {
   OtVariantBuilderInfo *info;
 
-  info = (OtVariantBuilderInfo *) g_slice_new0 (OtVariantBuilderInfo);
-
   g_return_val_if_fail (g_variant_type_is_container (type), NULL);
+
+  info = (OtVariantBuilderInfo *) g_slice_new0 (OtVariantBuilderInfo);
 
   info->builder = builder;
   info->type = g_variant_type_copy (type);
@@ -845,9 +845,9 @@ ot_variant_builder_new (const GVariantType *type,
 {
   OtVariantBuilder *builder;
 
-  builder = (OtVariantBuilder *) g_slice_new0 (OtVariantBuilder);
-
   g_return_val_if_fail (g_variant_type_is_container (type), NULL);
+
+  builder = (OtVariantBuilder *) g_slice_new0 (OtVariantBuilder);
 
   builder->head = ot_variant_builder_info_new (builder, type);
   builder->ref_count = 1;


### PR DESCRIPTION
This swaps the order of a couple of input sanity checks, in order
to fix a minor memory leak due to an early-return on the error
path.
Memory for the result is now allocated only after input has been
sanity-checked.
It fixes a static analysis warning highlighted by Coverity.