### PR TITLE
ostree: check g_setenv return value

### DIFF
--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -422,7 +422,10 @@ initable_init (GInitable     *initable,
     {
       const char *policy_rootpath = gs_file_get_path_cached (policy_root);
 
-      g_setenv ("LIBSELINUX_DISABLE_PCRE_PRECOMPILED", "1", FALSE);
+      /* TODO(lucab): get rid of this setenv(), it may be unsafe in a multi-thread context. */
+      if (!g_setenv ("LIBSELINUX_DISABLE_PCRE_PRECOMPILED", "1", FALSE))
+        return glnx_throw (error, "Failed to set environment variable LIBSELINUX_DISABLE_PCRE_PRECOMPILED");
+
       if (selinux_set_policy_root (policy_rootpath) != 0)
         return glnx_throw_errno_prefix (error, "selinux_set_policy_root(%s)", policy_rootpath);
 

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -253,7 +253,11 @@ ostree_run (int    argc,
   int in, out;
 
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  if (!g_setenv ("GIO_USE_VFS", "local", TRUE))
+    {
+      (void) glnx_throw (res_error, "Failed to set environment variable GIO_USE_FVS");
+      return 1;
+    }
 
   g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, message_handler, NULL);
 

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -155,7 +155,8 @@ ot_test_setup_sysroot (GCancellable *cancellable,
     }
 
   /* Make sure deployments are mutable */
-  g_setenv ("OSTREE_SYSROOT_DEBUG", buf->str, TRUE);
+  if (!g_setenv ("OSTREE_SYSROOT_DEBUG", buf->str, TRUE))
+    return glnx_null_throw (error, "Failed to set environment variable OSTREE_SYSROOT_DEBUG");
 
   g_autoptr(GFile) sysroot_path = g_file_new_for_path ("sysroot");
   return ostree_sysroot_new (sysroot_path);

--- a/tests/test-gpg-verify-result.c
+++ b/tests/test-gpg-verify-result.c
@@ -78,7 +78,8 @@ test_fixture_setup (TestFixture *fixture,
    * certificates for certain test cases. */
 
   homedir = g_test_build_filename (G_TEST_DIST, "tests/gpg-verify-data", NULL);
-  g_setenv ("GNUPGHOME", homedir, TRUE);
+  gboolean is_ok = g_setenv ("GNUPGHOME", homedir, TRUE);
+  g_assert (is_ok == TRUE);
 
   result = g_initable_new (OSTREE_TYPE_GPG_VERIFY_RESULT,
                            NULL, &local_error, NULL);

--- a/tests/test-rollsum-cli.c
+++ b/tests/test-rollsum-cli.c
@@ -35,7 +35,8 @@ main (int argc, char **argv)
   OstreeRollsumMatches *matches;
   GMappedFile *mfile;
 
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  gboolean is_ok = g_setenv ("GIO_USE_VFS", "local", TRUE);
+  g_assert (is_ok == TRUE);
 
   if (argc < 3)
     return 1;

--- a/tests/test-varint.c
+++ b/tests/test-varint.c
@@ -58,7 +58,8 @@ int
 main (int argc, char **argv)
 {
 
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  gboolean is_ok = g_setenv ("GIO_USE_VFS", "local", TRUE);
+  g_assert (is_ok == TRUE);
 
   g_test_init (&argc, &argv, NULL);
 


### PR DESCRIPTION
This adds proper return-value checks on g_setenv calls.
It fixes a static analysis warning highlighted by Coverity.