### PR TITLE
libostree/sepolicy: get rid of a g_setenv() call

### DIFF
--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -422,10 +422,6 @@ initable_init (GInitable     *initable,
     {
       const char *policy_rootpath = gs_file_get_path_cached (policy_root);
 
-      /* TODO(lucab): get rid of this setenv(), it may be unsafe in a multi-thread context. */
-      if (!g_setenv ("LIBSELINUX_DISABLE_PCRE_PRECOMPILED", "1", FALSE))
-        return glnx_throw (error, "Failed to set environment variable LIBSELINUX_DISABLE_PCRE_PRECOMPILED");
-
       if (selinux_set_policy_root (policy_rootpath) != 0)
         return glnx_throw_errno_prefix (error, "selinux_set_policy_root(%s)", policy_rootpath);
 


### PR DESCRIPTION
This removes a 'g_setenv()' call, which could potentially be unsafe
in a multi-thread context.
The current libselinux codebase does not seem to check for
`LIBSELINUX_DISABLE_PCRE_PRECOMPILED`, so I think this has no effects
nowadays.
Additionally, I could not find any reference to it in libselinux
git history, so I'm not sure if it ever played any role at all.

My current understanding is that this is coming from version
incompatibilities between an older libselinux in the build environment
and a newer policy (with precompiled regexs) in the target.
But from the ML discussion I found, I think it eventually got
solved in a different way, possibly by avoiding the policy binary
caches.

Refs:
 * https://www.spinics.net/lists/selinux/msg14822.html
 * https://github.com/ostreedev/ostree/pull/2513#discussion_r781042884