### PR TITLE
main: Also support CLI extensions in `/usr/libexec/libostree/ext`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,10 @@ AC_SUBST([YEAR_VERSION], [year_version])
 AC_SUBST([RELEASE_VERSION], [release_version])
 AC_SUBST([PACKAGE_VERSION], [package_version])
 
+dnl automake variables we want in pkg-config
+pkglibexecdir=$libexecdir/$PACKAGE
+AC_SUBST(pkglibexecdir)
+
 AS_IF([echo "$CFLAGS" | grep -q -E -e '-Werror($| )'], [], [
 CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -pipe \

--- a/src/libostree/ostree-1.pc.in
+++ b/src/libostree/ostree-1.pc.in
@@ -3,6 +3,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 features=@OSTREE_FEATURES@
+cliextdir=@pkglibexecdir@/ext
 
 Name: OSTree
 Description: Git for operating system binaries

--- a/tests/kolainst/destructive/basic-misc.sh
+++ b/tests/kolainst/destructive/basic-misc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Random misc tests
+
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libinsttest.sh
+
+echo "1..1"
+date
+
+# Test CLI extensions installed alongside the system
+extdir=/usr/libexec/libostree/ext/
+mkdir -p "${extdir}"
+ln -sr /usr/bin/env ${extdir}/ostree-env
+
+env TESTENV=foo ostree env > out.txt
+assert_file_has_content out.text TESTENV=foo
+rm -vf "${extdir}/ostree-env"
+echo "ok env"
+
+# End test
+date

--- a/tests/test-cli-extensions.sh
+++ b/tests/test-cli-extensions.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 
 echo '1..2'
 
+# Test CLI extensions via $PATH.  If you change this, you may
+# also want to change the corresponding destructive version in
+# tests/kolainst/destructive/basic-misc.sh
 mkdir -p ./localbin
 ORIG_PATH="${PATH}"
 export PATH="./localbin/:${PATH}"


### PR DESCRIPTION
In fixing https://github.com/coreos/rpm-ostree/pull/3323
I felt that it was a bit ugly we're installing `/usr/bin/ostree-container`.

It's kind of an implementation detail.  We want users to use
`ostree container`.

Let's support values outside of $PATH too.

For example, this also ensures that TAB completion for `ost` expands
to `ostree ` with a space.