### PR TITLE
sysroot: Add a public `#define OSTREE_PATH_BOOTED`

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -973,7 +973,7 @@ ostree_sysroot_initialize (OstreeSysroot  *self,
        * we'll use it to sanity check that we found a booted deployment for example.
        * Second, we also find out whether sysroot == /.
        */
-      if (!glnx_fstatat_allow_noent (AT_FDCWD, "/run/ostree-booted", NULL, 0, error))
+      if (!glnx_fstatat_allow_noent (AT_FDCWD, OSTREE_PATH_BOOTED, NULL, 0, error))
         return FALSE;
       const gboolean ostree_booted = (errno == 0);
 
@@ -1106,11 +1106,11 @@ sysroot_load_from_bootloader_configs (OstreeSysroot  *self,
         return FALSE;
       if (errno == ENOENT)
         {
-          return glnx_throw (error, "Unexpected state: /run/ostree-booted found, but no /boot/loader directory");
+          return glnx_throw (error, "Unexpected state: %s found, but no /boot/loader directory", OSTREE_PATH_BOOTED);
         }
       else
         {
-          return glnx_throw (error, "Unexpected state: /run/ostree-booted found and in / sysroot, but bootloader entry not found");
+          return glnx_throw (error, "Unexpected state: %s found and in / sysroot, but bootloader entry not found", OSTREE_PATH_BOOTED);
         }
      }
 

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -24,6 +24,14 @@
 
 G_BEGIN_DECLS
 
+/**
+ * OSTREE_PATH_BOOTED:
+ * Filesystem path that is created on an ostree-booted system.
+ *
+ * Since: 2022.2
+ */
+#define OSTREE_PATH_BOOTED "/run/ostree-booted"
+
 #define OSTREE_TYPE_SYSROOT ostree_sysroot_get_type()
 #define OSTREE_SYSROOT(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSTREE_TYPE_SYSROOT, OstreeSysroot))

--- a/src/ostree/ot-admin-builtin-finalize-staged.c
+++ b/src/ostree/ot-admin-builtin-finalize-staged.c
@@ -45,7 +45,7 @@ ot_admin_builtin_finalize_staged (int argc, char **argv, OstreeCommandInvocation
   /* Just a sanity check; we shouldn't be called outside of the service though.
    */
   struct stat stbuf;
-  if (fstatat (AT_FDCWD, "/run/ostree-booted", &stbuf, 0) < 0)
+  if (fstatat (AT_FDCWD, OSTREE_PATH_BOOTED, &stbuf, 0) < 0)
     return TRUE;
 
   g_autoptr(GOptionContext) context = g_option_context_new ("");

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -120,7 +120,7 @@ maybe_setup_mount_namespace (gboolean    *out_ns,
     return TRUE;
 
   /* If the system isn't booted via libostree, also nothing to do */
-  if (!glnx_fstatat_allow_noent (AT_FDCWD, "/run/ostree-booted", NULL, 0, error))
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, OSTREE_PATH_BOOTED, NULL, 0, error))
     return FALSE;
   if (errno == ENOENT)
     return TRUE;


### PR DESCRIPTION
This is public API.  Motivated by
https://github.com/coreos/rpm-ostree/pull/3325/files#diff-56528694f6f3213d6fb88d872f77291412dceec263b57166519843b13eca9a4dR30