### PR TITLE
deploy: Also log to journal if we time out global sync()

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1647,7 +1647,10 @@ full_system_sync (OstreeSysroot     *self,
       while (!syncdata->success)
         {
           if (!g_cond_wait_until (&syncdata->cond, &syncdata->mutex, end_time))
-            break;
+            {
+              ot_journal_print (LOG_INFO, "Timed out waiting for global sync()");
+              break;
+            }
         }
       g_mutex_unlock (&syncdata->mutex);
       sync_data_unref (syncdata);


### PR DESCRIPTION
We do implicitly have this data because we log timings via structured
metadata in a later journal entry, but it's quite common to lose
the structured metadata because a lot of tooling just grabs the default
syslog-compatible text from `journalctl`.

Let's be louder when we hit this case as a general rule too; I think
most people shipping ostree systems want to see if it's happening.