### PR TITLE
Add COPR integration Makefile

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,8 @@
+srpm:
+	dnf install -y git
+	ci/make-git-snapshot.sh
+	curl -LO https://src.fedoraproject.org/rpms/ostree/raw/rawhide/f/ostree.spec
+	sed -ie "s,^Version:.*,Version: $$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,')," ostree.spec
+	sed -ie 's/^Patch/# Patch/g' ostree.spec  # we don't want any downstream patches
+	rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" ostree.spec
+	mv *.src.rpm $$outdir

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -6,7 +6,7 @@ OS_ID=$(. /etc/os-release; echo $ID)
 OS_VERSION_ID=$(. /etc/os-release; echo $VERSION_ID)
 
 pkg_upgrade() {
-    yum -y distro-sync
+    dnf -y distro-sync
 }
 
 make() {
@@ -20,7 +20,7 @@ build() {
 }
 
 pkg_install() {
-    yum -y install "$@"
+    dnf -y install "$@"
 }
 
 pkg_install_if_os() {
@@ -39,25 +39,15 @@ pkg_install_buildroot() {
             # https://github.com/projectatomic/rpm-ostree/pull/1889/commits/9ff611758bea22b0ad4892cc16182dd1f7f47e89
             # https://fedoraproject.org/wiki/Common_F30_bugs#Conflicts_between_fedora-release_packages_when_installing_package_groups
             if rpm -q fedora-release-container; then
-                yum -y swap fedora-release{-container,}
+                dnf -y swap fedora-release{-container,}
             fi
             pkg_install dnf-plugins-core @buildsys-build;;
-        centos) pkg_install yum-utils
-                # Base buildroot, copied from the mock config sadly
-                pkg_install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ \
-                            grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar \
-                            unzip util-linux which xz;;
         *) fatal "pkg_install_buildroot(): Unhandled OS ${OS_ID}";;
     esac
 }
 
 pkg_builddep() {
-    # This is sadly the only case where it's a different command
-    if test -x /usr/bin/dnf; then
-        dnf builddep -y "$@"
-    else
-        yum-builddep -y "$@"
-    fi
+    dnf builddep -y "$@"
 }
 
 # Install both build and runtime dependencies for $pkg

--- a/ci/make-git-snapshot.sh
+++ b/ci/make-git-snapshot.sh
@@ -11,6 +11,10 @@ PKG_VER="${name}-${version}"
 TARFILE=${PKG_VER}.tar
 TARFILE_TMP=${TARFILE}.tmp
 
+if ! test -f ${TOP}/libglnx/README.md || ! test -f ${TOP}/bsdiff/README.md; then
+    git submodule update --init
+fi
+
 echo "Archiving ${PKG_VER} at ${GITREV} to ${TARFILE_TMP}"
 (cd ${TOP}; git archive --format=tar --prefix=${PKG_VER}/ ${GITREV}) > ${TARFILE_TMP}
 ls -al ${TARFILE_TMP}

--- a/ci/make-git-snapshot.sh
+++ b/ci/make-git-snapshot.sh
@@ -26,3 +26,4 @@ ls -al ${TARFILE_TMP}
     rm submodule.tar
 done
 mv ${TARFILE_TMP} ${TARFILE}
+xz "${TARFILE}"

--- a/ci/make-git-snapshot.sh
+++ b/ci/make-git-snapshot.sh
@@ -5,7 +5,7 @@ TOP=$(git rev-parse --show-toplevel)
 GITREV=$(git rev-parse HEAD)
 gitdescribe=$(git describe --always --tags $GITREV)
 version=$(echo "$gitdescribe" | sed -e 's,-,\.,g' -e 's,^v,,')
-name=$(basename $(pwd))
+name=libostree
 PKG_VER="${name}-${version}"
 
 TARFILE=${PKG_VER}.tar


### PR DESCRIPTION
I'd like to enable auto-builds of this repo to
[copr.fedorainfracloud.org/coprs/g/CoreOS/continuous](https://copr.fedorainfracloud.org/coprs/g/CoreOS/continuous/) so it could
eventually feed into
https://github.com/coreos/fedora-coreos-tracker/issues/910.