### PR TITLE
lib/repo: Add commit version metadata to summary metadata

### DIFF
--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -183,6 +183,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     Latest Commit (4.2 MB):
       9828ab80f357459b4ab50f0629beab2ae3b67318fc3d161d10a89fae353afa90
     Timestamp (ostree.commit.timestamp): 2017-11-21T01:41:10-08
+    Version (ostree.commit.version): 1.2.3
 
 Last-Modified (ostree.summary.last-modified): 2018-01-12T22:06:38-08
 </programlisting>

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -164,6 +164,8 @@ typedef enum {
  * The currently defined keys for the `a{sv}` of additional metadata for each commit are:
  *  - key: `ostree.commit.timestamp`, value: `t`, timestamp (seconds since the
  *    Unix epoch in UTC, big-endian) when the commit was committed
+ *  - key: `ostree.commit.version`, value: `s`, the `version` value from the
+ *    commit's metadata if it was defined. Since: 2022.2
  */
 #define OSTREE_SUMMARY_GVARIANT_STRING "(a(s(taya{sv}))a{sv})"
 #define OSTREE_SUMMARY_GVARIANT_FORMAT G_VARIANT_TYPE (OSTREE_SUMMARY_GVARIANT_STRING)

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -63,6 +63,7 @@ G_BEGIN_DECLS
 /* Well-known keys for the additional metadata field in a commit in a ref entry
  * in a summary file. */
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
+#define OSTREE_COMMIT_VERSION "ostree.commit.version"
 
 typedef enum {
   OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0),

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -249,6 +249,11 @@ dump_summary_ref (const char   *collection_id,
           pretty_key = "Timestamp";
           value_str = uint64_secs_to_iso8601 (GUINT64_FROM_BE (g_variant_get_uint64 (value)));
         }
+      else if (g_strcmp0 (key, OSTREE_COMMIT_VERSION) == 0)
+        {
+          pretty_key = "Version";
+          value_str = g_strdup (g_variant_get_string (value, NULL));
+        }
       else
         {
           value_str = g_variant_print (value, FALSE);

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -56,6 +56,7 @@ assert_file_has_content_literal summary.txt "* main"
 assert_file_has_content_literal summary.txt "* other"
 assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
 assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp): "
+assert_file_has_content_literal summary.txt "Version (ostree.commit.version): 3.2"
 echo "ok view summary"
 
 # Check the summary can be viewed raw too.


### PR DESCRIPTION
The commit metadata `version` key is well established but getting it for
a remote commit is cumbersome since the commit object needs to be
fetched and loaded. Including it in the summary additional metadata
allows a much more convenient view of what each of the remote refs
represents.

I was working on our release process at Endless and thought it would be so much easier to query the current OS version. I think the `version` metadata is well established enough to warrant inclusion in the summary.