### PR TITLE
lib/gpg-verify-result: Add missing floating annotation

### DIFF
--- a/src/libostree/ostree-gpg-verify-result-dummy.c
+++ b/src/libostree/ostree-gpg-verify-result-dummy.c
@@ -143,7 +143,7 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result,
  * an invalid @signature_index.  Use ostree_gpg_verify_result_count_all() to
  * find the number of signatures in @result.
  *
- * Returns: a new, floating, #GVariant tuple
+ * Returns: (transfer floating): a new, floating, #GVariant tuple
  **/
 GVariant *
 ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
@@ -184,7 +184,7 @@ ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
  * ostree_gpg_verify_result_count_all() to find the number of signatures in
  * @result.
  *
- * Returns: a new, floating, #GVariant tuple
+ * Returns: (transfer floating): a new, floating, #GVariant tuple
  **/
 GVariant *
 ostree_gpg_verify_result_get_all (OstreeGpgVerifyResult *result,

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -298,7 +298,7 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result,
  * an invalid @signature_index.  Use ostree_gpg_verify_result_count_all() to
  * find the number of signatures in @result.
  *
- * Returns: a new, floating, #GVariant tuple
+ * Returns: (transfer floating): a new, floating, #GVariant tuple
  **/
 GVariant *
 ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
@@ -490,7 +490,7 @@ ostree_gpg_verify_result_get (OstreeGpgVerifyResult *result,
  * ostree_gpg_verify_result_count_all() to find the number of signatures in
  * @result.
  *
- * Returns: a new, floating, #GVariant tuple
+ * Returns: (transfer floating): a new, floating, #GVariant tuple
  **/
 GVariant *
 ostree_gpg_verify_result_get_all (OstreeGpgVerifyResult *result,


### PR DESCRIPTION
I think I'm hitting issues due to this while using the Rust bindings:
https://github.com/coreos/rpm-ostree/pull/3406#issuecomment-1033084956

The bindings for those APIs use `from_glib_full` which says:

> Because ownership can only be transferred if something is already
> referenced, this is unsuitable for floating references.