### PR TITLE
core: Mark `ostree_create_directory_metadata` as `(not nullable)`

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1141,7 +1141,7 @@ _ostree_compare_object_checksum (OstreeObjectType objtype,
  * @dir_info: a #GFileInfo containing directory information
  * @xattrs: (allow-none): Optional extended attributes
  *
- * Returns: (transfer full): A new #GVariant containing %OSTREE_OBJECT_TYPE_DIR_META
+ * Returns: (transfer full) (not nullable): A new #GVariant containing %OSTREE_OBJECT_TYPE_DIR_META
  */
 GVariant *
 ostree_create_directory_metadata (GFileInfo    *dir_info,


### PR DESCRIPTION
So I can drop an unnecessary use of `unwrap()` in Rust.