### PR TITLE
finalize-staged: Ensure /boot and /sysroot automounts don't expire

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -41,6 +41,7 @@ systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
 	src/boot/ostree-boot-complete.service \
 	src/boot/ostree-finalize-staged.service \
 	src/boot/ostree-finalize-staged.path \
+	src/boot/ostree-finalize-staged-hold.service \
 	$(NULL)
 systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_systemdtmpfiles_DATA = src/boot/ostree-tmpfiles.conf
@@ -70,6 +71,7 @@ EXTRA_DIST += src/boot/dracut/module-setup.sh \
 	src/boot/ostree-finalize-staged.path \
 	src/boot/ostree-remount.service \
 	src/boot/ostree-finalize-staged.service \
+	src/boot/ostree-finalize-staged-hold.service \
 	src/boot/grub2/grub2-15_ostree \
 	src/boot/grub2/ostree-grub-generator \
 	$(NULL)

--- a/src/boot/ostree-finalize-staged-hold.service
+++ b/src/boot/ostree-finalize-staged-hold.service
@@ -1,0 +1,35 @@
+# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2022 Endless OS Foundation LLC
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+# See https://github.com/ostreedev/ostree/pull/2543 for background.
+[Unit]
+Description=Hold /boot Open for OSTree Finalize Staged Deployment
+Documentation=man:ostree(1)
+ConditionPathExists=/run/ostree-booted
+DefaultDependencies=no
+
+RequiresMountsFor=/sysroot /boot
+After=local-fs.target
+Before=basic.target final.target
+
+[Service]
+Type=exec
+
+# This is explicitly run in the root namespace to ensure an automounted
+# /boot doesn't time out since autofs doesn't handle mount namespaces.
+#
+# https://bugzilla.redhat.com/show_bug.cgi?id=2056090
+ExecStart=+/usr/bin/ostree admin finalize-staged --hold

--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -29,6 +29,11 @@ Before=basic.target final.target
 After=systemd-journal-flush.service
 Conflicts=final.target
 
+# Start the hold unit and ensure it stays active throughout this
+# service.
+Wants=ostree-finalize-staged-hold.service
+After=ostree-finalize-staged-hold.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -36,6 +36,7 @@ typedef enum {
   OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER = (1 << 0),
   OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED = (1 << 1),
   OSTREE_ADMIN_BUILTIN_FLAG_NO_SYSROOT = (1 << 2),
+  OSTREE_ADMIN_BUILTIN_FLAG_NO_LOAD = (1 << 3),
 } OstreeAdminBuiltinFlags;
 
 
@@ -90,6 +91,11 @@ gboolean ostree_admin_option_context_parse (GOptionContext *context,
                                             OstreeCommandInvocation *invocation,
                                             OstreeSysroot **out_sysroot,
                                             GCancellable *cancellable, GError **error);
+
+gboolean ostree_admin_sysroot_load (OstreeSysroot            *sysroot,
+                                    OstreeAdminBuiltinFlags   flags,
+                                    GCancellable             *cancellable,
+                                    GError                  **error);
 
 gboolean ostree_ensure_repo_writable (OstreeRepo *repo, GError **error);
 

--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -463,6 +463,7 @@ fn impl_transaction_test<M: AsRef<str>>(
             "
             systemctl stop rpm-ostreed
             systemctl stop ostree-finalize-staged
+            systemctl stop ostree-finalize-staged-hold
             ostree reset testrepo:${testref} ${booted_commit}
             rpm-ostree cleanup -pbrm
             ",
@@ -504,7 +505,8 @@ fn impl_transaction_test<M: AsRef<str>>(
                 InterruptStrategy::Force(ForceInterruptStrategy::Kill9) => {
                     bash!(
                         "systemctl kill -s KILL rpm-ostreed || true
-                      systemctl kill -s KILL ostree-finalize-staged || true"
+                      systemctl kill -s KILL ostree-finalize-staged || true
+                      systemctl kill -s KILL ostree-finalize-staged-hold || true"
                     )?;
                     live_strategy = Some(strategy);
                 }
@@ -528,7 +530,8 @@ fn impl_transaction_test<M: AsRef<str>>(
                 InterruptStrategy::Polite(PoliteInterruptStrategy::Stop) => {
                     bash!(
                         "systemctl stop rpm-ostreed || true
-                      systemctl stop ostree-finalize-staged || true"
+                      systemctl stop ostree-finalize-staged || true
+                      systemctl stop ostree-finalize-staged-hold || true"
                     )?;
                     live_strategy = Some(strategy);
                 }

--- a/tests/kolainst/destructive/boot-automount.sh
+++ b/tests/kolainst/destructive/boot-automount.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# https://github.com/ostreedev/ostree/issues/2543
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libinsttest.sh
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    # Ensure boot is mount point
+    mountpoint /boot
+
+    # Create an automount unit with an extremely short timeout
+    cat > /etc/systemd/system/boot.automount <<"EOF"
+[Automount]
+Where=/boot
+TimeoutIdleSec=1
+
+[Install]
+WantedBy=local-fs.target
+EOF
+    systemctl daemon-reload
+    systemctl enable boot.automount
+
+    # Unmount /boot, start the automount unit, and ensure the units are
+    # in the correct states.
+    umount /boot
+    systemctl start boot.automount
+    boot_state=$(systemctl show -P ActiveState boot.mount)
+    boot_auto_state=$(systemctl show -P ActiveState boot.automount)
+    assert_streq "${boot_state}" inactive
+    assert_streq "${boot_auto_state}" active
+
+    # Trigger a new staged deployment and check that the relevant units
+    # are enabled.
+    ostree admin deploy --stage --karg-append=somedummykarg=1 "${host_commit}"
+    rpm-ostree status --json
+    deployment_staged=$(rpmostree_query_json '.deployments[0].staged')
+    assert_streq "${deployment_staged}" true
+    test -f /run/ostree/staged-deployment
+    finalize_staged_state=$(systemctl show -P ActiveState ostree-finalize-staged.service)
+    finalize_staged_hold_state=$(systemctl show -P ActiveState ostree-finalize-staged-hold.service)
+    assert_streq "${finalize_staged_state}" active
+    assert_streq "${finalize_staged_hold_state}" active
+
+    # Sleep 1 second to ensure the boot automount idle timeout has
+    # passed and then check that /boot is still mounted.
+    sleep 1
+    boot_state=$(systemctl show -P ActiveState boot.mount)
+    assert_streq "${boot_state}" active
+
+    /tmp/autopkgtest-reboot "2"
+    ;;
+  "2")
+    rpm-ostree status --json
+    deployment_staged=$(rpmostree_query_json '.deployments[0].staged')
+    assert_streq "${deployment_staged}" false
+    test ! -f /run/ostree/staged-deployment
+    assert_file_has_content_literal /proc/cmdline somedummykarg=1
+
+    # Check that the finalize and hold services succeeded in the
+    # previous boot. Dump them to the test log to help debugging.
+    prepare_tmpdir
+    journalctl -b -1 -o short-monotonic \
+        -u ostree-finalize-staged.service \
+        -u ostree-finalize-staged-hold.service \
+        -u boot.mount \
+        -u boot.automount \
+        > logs.txt
+    cat logs.txt
+    assert_file_has_content logs.txt 'ostree-finalize-staged.service: \(Succeeded\|Deactivated successfully\)'
+    assert_file_has_content logs.txt 'ostree-finalize-staged-hold.service: \(Succeeded\|Deactivated successfully\)'
+
+    # Check that the hold service remained active and kept /boot mounted until
+    # the finalize service completed.
+    finalize_stopped=$(journalctl -b -1 -o json -g Stopped -u ostree-finalize-staged.service | tail -n1 | jq -r .__MONOTONIC_TIMESTAMP)
+    hold_stopping=$(journalctl -b -1 -o json -g Stopping -u ostree-finalize-staged-hold.service | tail -n1 | jq -r .__MONOTONIC_TIMESTAMP)
+    hold_stopped=$(journalctl -b -1 -o json -g Stopped -u ostree-finalize-staged-hold.service | tail -n1 | jq -r .__MONOTONIC_TIMESTAMP)
+    boot_unmounting=$(journalctl -b -1 -o json -g Unmounting -u boot.mount | tail -n1 | jq -r .__MONOTONIC_TIMESTAMP)
+    test "${finalize_stopped}" -lt "${hold_stopping}"
+    test "${hold_stopped}" -lt "${boot_unmounting}"
+    ;;
+  *) fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}" ;;
+esac


### PR DESCRIPTION
If `/boot` or `/sysroot` are automounts, then the unit will be stopped
as soon as the automounts expire. That's would defeat the purpose of
using systemd to delay finalizing the deployment until shutdown. This is
not uncommon as `systemd-gpt-auto-generator` will create an automount
unit for `/boot` when it's the EFI System Partition and there's no fstab
entry.

Instead of relying on systemd to run the command via `ExecStop` at the
appropriate time, have `finalize-staged` open `/boot` and `/sysroot` and
then block on `SIGTERM`. Having the directories open will prevent the
automounts from expiring, and then we presume that systemd will send
`SIGTERM` when it's time for the service to stop. Finalizing the
deployment still happens when the service is stopped. The difference is
that the process is already running.

In order to keep from blocking legitimate sysroot activity prior to
shutdown, the sysroot lock is only taken after the signal has been
received. Similarly, the sysroot is reloaded to ensure the state of the
deployments is current.

Fixes: #2543