### PR TITLE
.lgtm.yml: Fix gpgme dependency

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,7 +29,7 @@ extraction:
       - "libfuse-dev"
       - "libgirepository1.0-dev"
       - "libglib2.0-dev"
-      - "libgpgme11-dev"
+      - "libgpgme-dev"
       - "liblzma-dev"
       - "libmount-dev"
       - "libselinux1-dev"


### PR DESCRIPTION
Since Ubuntu 18.04, libgpgme-dev is the real package and libgpgme11-dev
is a virtual package provided by it. Apparently LGTM running on Ubuntu
20.04 no longer resolves the virtual package:

```
WARNING: Package 'libgpgme11-dev' requested by configuration file was not found
```

That ends up causing the build to fail:

```
configure: error: Need GPGME_PTHREAD version 1.1.8 or later
```