### PR TITLE
build-sys: Drop `-Werror=aggregate-return`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -Werror=undef \
   -Werror=incompatible-pointer-types \
   -Werror=misleading-indentation \
-  -Werror=missing-include-dirs -Werror=aggregate-return \
+  -Werror=missing-include-dirs  \
   -Wstrict-aliasing=2 \
   -Werror=unused-result \
 ])])


### PR DESCRIPTION
This is failing for me as of recently but only when I build
without optimization.  I don't think we've ever written any
code that returned a large structure by value.

Let's just drop this one.