### PR TITLE
 mtree: Load traversed subdirs when creating parents

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -463,13 +463,11 @@ ostree_mutable_tree_ensure_parent_dirs (OstreeMutableTree  *self,
   OstreeMutableTree *subdir = self; /* nofree */
   for (guint i = 0; i+1 < split_path->len; i++)
     {
-      OstreeMutableTree *next;
       const char *name = split_path->pdata[i];
-
       if (g_hash_table_lookup (subdir->files, name))
         return glnx_throw (error, "Can't replace file with directory: %s", name);
 
-      next = g_hash_table_lookup (subdir->subdirs, name);
+      OstreeMutableTree *next = g_hash_table_lookup (subdir->subdirs, name);
       if (!next)
         {
           invalidate_contents_checksum (subdir);
@@ -580,11 +578,9 @@ ostree_mutable_tree_walk (OstreeMutableTree     *self,
     }
   else
     {
-      OstreeMutableTree *subdir;
       if (!_ostree_mutable_tree_make_whole (self, NULL, error))
         return FALSE;
-
-      subdir = g_hash_table_lookup (self->subdirs, split_path->pdata[start]);
+      OstreeMutableTree *subdir = g_hash_table_lookup (self->subdirs, split_path->pdata[start]);
       if (!subdir)
         return set_error_noent (error, (char*)split_path->pdata[start]);
 

--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -477,6 +477,9 @@ ostree_mutable_tree_ensure_parent_dirs (OstreeMutableTree  *self,
         }
 
       subdir = next;
+      g_assert (subdir);
+      if (!_ostree_mutable_tree_make_whole (subdir, NULL, error))
+        return FALSE;
     }
 
   if (out_parent)


### PR DESCRIPTION
mtree: Use declare-and-initialize style

Prep for further work.

---

mtree: Load traversed subdirs when creating parents

I'm working on enhancing the ostree-rs-ext test suite and I hit
a bug where walking a mtree and creating a parent would fail to
load lazy intermediate directories, e.g.:

/ -> usr -> bin

If we walked we'd load `/` but keep `usr` lazy, and then invalidation
would crash because it wasn't loaded.

If we're going to mutate a subdir, we need to have all the parents
loaded.

I know this is missing tests, but...it's a bit tedious to do with
the existing C tests.  Eventually soon we'll execute on merging
all 3 repos, and better share test suites.

---

