### PR TITLE
Release 2022.2

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -171,9 +171,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+#if BUILDOPT_IS_DEVEL_BUILD
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2022])
-m4_define([release_version], [2])
+m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2022])
 m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,10 +20,7 @@
    - uncomment the include in Makefile-libostree.am
 */
 
-LIBOSTREE_2022.2 {
-global:
-  ostree_repo_traverse_commit_with_flags;
-} LIBOSTREE_2021.5;
+
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -672,6 +672,11 @@ global:
   ostree_mutable_tree_new_from_commit;
 } LIBOSTREE_2021.4;
 
+LIBOSTREE_2022.2 {
+global:
+  ostree_repo_traverse_commit_with_flags;
+} LIBOSTREE_2021.5;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-165d3d940b7e6e09f39221b983fd17efae8ae40b8b2136a84b422a21e402f771  ${released_syms}
+4f0600ad7af4ba937f463dc0bdc38aef6f53b154e88730b935552330c6a19a3f  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
A usual collection of bugfixes and smaller enhancements.  There is at least one bugfix worth calling out, which is https://github.com/ostreedev/ostree/pull/2549 that affects reliability of pulls with static deltas.  It's a nicely self contained change, and if you aren't in a position to update to this latest release, we suggest cherry picking it.

On the feature side, there's a new `ostree prune --commit-only` which allow decoupling deleting unreachable (or undesired) commits from actually deleting the referenced objects, so object garbage collection can be delayed for a later time, or amortized.

The summary file now contains version information, which can help avoid fetching commits just to display that (often desired) metadata.

Another notable feature is initial read side support for the new `bare-split-xattrs` repository mode that was created as part of the "ostree native containers" work in https://github.com/ostreedev/ostree-rs-ext/  We haven't yet committed to marking that as production ready and stable ~forever, but it's getting close.

Thanks to all contributors!

```
Christian Hergert (2):
      lib/util: add syslog.h for ot_journal_print()
      lib/bootloader: use ot_journal_print() instead of sd-journal

Colin Walters (11):
      main: Also support CLI extensions in `/usr/libexec/libostree/ext`
      sysroot: Add a public `#define OSTREE_PATH_BOOTED`
      deploy: Add a 5s max timeout on global filesystem `sync()`
      deploy: Also log to journal if we time out global sync()
      core: Mark `ostree_create_directory_metadata` as `(not nullable)`
      lib/tar: Add some error prefixing
      build-sys: Drop `-Werror=aggregate-return`
      mtree: Use declare-and-initialize style
      mtree: Load traversed subdirs when creating parents
      Release 2022.2
      configure: post-release version bump

Dan Nicholson (3):
      github: Workaround glib/seccomp issue on Ubuntu impish
      lib/repo: Add commit version metadata to summary metadata
      .lgtm.yml: Fix gpgme dependency

Jonathan Lebon (9):
      lib/deploy: When deleting staged deployment, delete any lock
      ostree/deploy: Test finalization locking
      tests/kolainst: Avoid recursive symlinks
      ci/libbuild.sh: drop yum/CentOS support
      ci/make-git-snapshot.sh: fix archive name
      ci/make-git-snapshot.sh: auto-initialize submodules
      ci/make-git-snapshot.sh: xz the archive
      Add COPR integration Makefile
      lib/gpg-verify-result: Add missing floating annotation

Luca BRUNO (14):
      configure: post-release version bump
      libotutil: avoid leaking builder memory on error
      ostree: check g_setenv return value
      libostree/sepolicy: get rid of a g_setenv() call
      lib/commit: always validate metadata
      lib/commit: reject empty metadata keys
      builtin: use GCancellable and GError everywhere
      lib/repo: open file only if required
      lib/commit: clean up assertions
      lib/core: introduce two new object types for split xattrs
      lib/core: introduce 'bare-split-xattrs' mode
      lib/repo: read split xattrs content from file-xattrs-link objects
      lib/commit: disallow writing content in 'bare-split-xattrs' mode
      tests/basic-bare-split-xattrs: add fixture, check read logic

Marco Melorio (2):
      man: Fix typo in ostree-admin-switch
      man: Fix typo in ostree-find-remotes

Nikita Dubrovskii (2):
      s390x: add "IBM Secure Execution for Linux" support
      s390x: add LUKS keyfile to 'sd-boot'

Phaedrus Leeds (2):
      Fix marking static delta commits as partial
      lib/repo-refs: Remove misleading newline

Saqib Ali (4):
      src/ostree: Add --commit-only option to ostree prune
      man/prune, bash: Add --commit-only flag for ostree prune
      tests/test-prune.sh: expand testing for --commit-only
      tests/test-prune.sh: Use TAP API

Simon McVittie (2):
      libotutil: Avoid infinite recursion during error unwinding
      Update submodule: libglnx

dependabot[bot] (2):
      build(deps): bump libglnx from `803adaf` to `88da8dd`
      build(deps): bump libglnx from `88da8dd` to `c71f7ae`
```

Closes: https://github.com/ostreedev/ostree/issues/2555