### PR TITLE
Fix shebang in s390x-se-luks-gencpio

### DIFF
--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -1,5 +1,5 @@
- #!/usr/bin/bash
- # This script creates new initramdisk with LUKS config within
+#!/usr/bin/bash
+# This script creates new initramdisk with LUKS config within
 set -euo pipefail
 
 old_initrd=$1

--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # This script creates new initramdisk with LUKS config within
 set -euo pipefail
 


### PR DESCRIPTION
* s390x-se-luks-gencpio: Fix shebang syntax
    
    An indented `#!` is technically meaningless, although many shells will
    run text files with the shell if asked to execute them.

* s390x-se-luks-gencpio: Use interoperable path for bash
    
    On OSs that do not consistently merge /usr/bin with /bin, the path to
    bash has traditionally been /bin/bash.

---

New installations of Debian 11 are merged-/usr by default, but existing installations that were not already merged-/usr are not automaticlly merged. Debian 12 is meant to require merged-/usr, but the automatic migration path isn't yet in place, and individual packages in Debian 12 will still need to cope with non-merged-/usr to avoid over-constraining upgrade paths.

Users of entirely non-FHS OSs like NixOS might ask you to use `/usr/bin/env bash` instead of `/bin/bash`. I'm happy with either.