### PR TITLE
test-prune: Read to the end of cut(1) output

### DIFF
--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -350,7 +350,7 @@ tap_ok --commit-only and --delete-commit
 # Test --delete-commit when it creates orphaned commits
 reinitialize_commit_only_test_repo
 # get the current HEAD's parent on dev branch
-COMMIT_TO_DELETE=$(${CMD_PREFIX} ostree --repo=repo log dev | grep ^commit | cut -f 2 -d' ' | head -n 2 | tail -n 1)
+COMMIT_TO_DELETE=$(${CMD_PREFIX} ostree --repo=repo log dev | grep ^commit | cut -f 2 -d' ' | sed -ne '2p')
 ${CMD_PREFIX} ostree --repo=repo prune --commit-only --refs-only --delete-commit=$COMMIT_TO_DELETE
 # we deleted a commit that orphaned another, so we lose two commits
 assert_repo_has_n_commits repo 4


### PR DESCRIPTION
If we use head(1) to take only the first two lines, then cut(1) and
earlier pipeline entries are killed by SIGPIPE (if they have not already
terminated), and that's flagged as an error under `set -o pipefail`.
Use an equivalent sed command to take exactly the second line, but
without SIGPIPE.

---

The fact that I need to know this does not say great things about the Unix pipeline philosophy.