### PR TITLE
ostree-repo-pull: Take correct out path on error

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4020,7 +4020,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                      &pull_data->signapi_commit_verifiers,
                                      &pull_data->signapi_summary_verifiers,
                                      error))
-        return FALSE;
+        goto out;
     }
 
   pull_data->phase = OSTREE_PULL_PHASE_FETCHING_REFS;


### PR DESCRIPTION
Like every other error return path in this function, jump to the `out`
label on error here. Returning directly will cause leaks.

Spotted by reading the code, not actually necessarily encountered in the
wild.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>