### PR TITLE
tmpfiles: Create `/run/ostree`

### DIFF
--- a/src/boot/ostree-tmpfiles.conf
+++ b/src/boot/ostree-tmpfiles.conf
@@ -13,5 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+# ostree runtime configuration
+d /run/ostree 0755 root root -
 # https://github.com/ostreedev/ostree/issues/393
 R! /var/tmp/ostree-unlock-ovl.*


### PR DESCRIPTION
This is referenced by https://github.com/ostreedev/ostree-rs-ext/blob/9645cee4f29786ba51ae9d62a52eeef9230146fd/lib/src/globals.rs#L16
specifically used for the (container image) pull secret in
`/run/ostree/auth.json`.

Let's pre-create the directory so users don't have to.

Motivated by https://github.com/openshift/machine-config-operator/pull/3007#discussion_r824172564