### PR TITLE
README.md: update ostree-rs language binding link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ write higher level manual bindings on top; this is more common
 for statically compiled languages.  Here's a list of such bindings:
 
  - [ostree-go](https://github.com/ostreedev/ostree-go/)
- - [ostree-rs](https://gitlab.com/fkrull/ostree-rs/)
+ - [ostree-rs](https://github.com/ostreedev/ostree-rs/)
 
 ## Building
 


### PR DESCRIPTION
According to the description on https://gitlab.com/fkrull/ostree-rs/ the repository is now moved to https://github.com/ostreedev/ostree-rs