### PR TITLE
tests/test-cli-extensions: Fix with single-binary coreutils

### DIFF
--- a/tests/test-cli-extensions.sh
+++ b/tests/test-cli-extensions.sh
@@ -15,7 +15,9 @@ echo '1..2'
 mkdir -p ./localbin
 ORIG_PATH="${PATH}"
 export PATH="./localbin/:${PATH}"
-ln -s /usr/bin/env ./localbin/ostree-env
+echo '#!/bin/sh' >> ./localbin/ostree-env
+echo 'env "$@"' >> ./localbin/ostree-env
+chmod +x ./localbin/ostree-env
 export A_CUSTOM_TEST_FLAG="myvalue"
 ${CMD_PREFIX} ostree env >out.txt
 assert_file_has_content out.txt "^A_CUSTOM_TEST_FLAG=myvalue"


### PR DESCRIPTION
On systems where `coreutils` are built with `--enable-single-binary=symlinks` like Nix, `/usr/bin/env` is symlinked to `/usr/bin/coreutils` and uses `argv[0]` to determine which program to run. Since the `test-cli-extensions.sh` created a new symlink named `ostree-env`, coreutils would be confused about the utility to choose, so running it would fail:

	ostree-env: unknown program ‘ostree-env’
	Try 'ostree-env --help' for more information.

Fixes: https://github.com/ostreedev/ostree/issues/2553
