### PR TITLE
Publish man pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Install dependencies
         run: ./ci/installdeps.sh
 
-      - name: Build API docs
+      - name: Build API docs and manpages
         run: |
-          ./autogen.sh --enable-gtk-doc
+          ./autogen.sh --enable-gtk-doc --enable-man --enable-man-html
           make -C apidoc
+          make manhtml
 
       - name: Build and publish jekyll docs
         uses: helaili/jekyll-action@v2

--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -19,6 +19,8 @@
 
 if ENABLE_MAN
 
+# If you add a new man page here, add a reference to it in index.xml and
+# ostree.xml.
 man1_files = ostree.1 ostree-admin-cleanup.1				\
 ostree-admin-config-diff.1 ostree-admin-deploy.1			\
 ostree-admin-init-fs.1 ostree-admin-instutil.1 ostree-admin-os-init.1	\
@@ -53,6 +55,7 @@ man1_MANS = $(addprefix man/,$(man1_files))
 man5_MANS = $(addprefix man/,$(man5_files))
 
 manhtml_files = \
+	man/html/index.html \
 	$(addprefix man/html/,$(man1_files:.1=.html)) \
 	$(addprefix man/html/,$(man5_files:.5=.html)) \
 	$(NULL)
@@ -65,7 +68,7 @@ manhtml: $(manhtml_files)
 .PHONY: manhtml
 endif
 
-EXTRA_DIST += $(man1_MANS:.1=.xml) $(man5_MANS:.5=.xml)
+EXTRA_DIST += man/index.xml $(man1_MANS:.1=.xml) $(man5_MANS:.5=.xml)
 
 XSLT_MAN_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
 XSLT_HTML_STYLESHEET = man/html.xsl

--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -52,9 +52,23 @@ man5_files = ostree.repo.5 ostree.repo-config.5
 man1_MANS = $(addprefix man/,$(man1_files))
 man5_MANS = $(addprefix man/,$(man5_files))
 
+manhtml_files = \
+	$(addprefix man/html/,$(man1_files:.1=.html)) \
+	$(addprefix man/html/,$(man5_files:.5=.html)) \
+	$(NULL)
+
+if ENABLE_MAN_HTML
+noinst_DATA += $(manhtml_files)
+
+# Convenience target for building the just the HTML man pages
+manhtml: $(manhtml_files)
+.PHONY: manhtml
+endif
+
 EXTRA_DIST += $(man1_MANS:.1=.xml) $(man5_MANS:.5=.xml)
 
-XSLT_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
+XSLT_MAN_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
+XSLT_HTML_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl
 
 XSLTPROC_FLAGS = \
         --nonet \
@@ -67,14 +81,19 @@ XSLTPROC_FLAGS = \
 XSLTPROC_MAN = $(XSLTPROC) $(XSLTPROC_FLAGS)
 
 %.1: %.xml
-	$(AM_V_GEN) $(XSLTPROC_MAN) --output $@ $(XSLT_STYLESHEET) $<
+	$(AM_V_GEN) $(XSLTPROC_MAN) --output $@ $(XSLT_MAN_STYLESHEET) $<
 
 %.5: %.xml
-	$(AM_V_GEN) $(XSLTPROC_MAN) --output $@ $(XSLT_STYLESHEET) $<
+	$(AM_V_GEN) $(XSLTPROC_MAN) --output $@ $(XSLT_MAN_STYLESHEET) $<
+
+man/html/%.html: man/%.xml
+	@mkdir -p man/html
+	$(AM_V_GEN) $(XSLTPROC_MAN) --output $@ $(XSLT_HTML_STYLESHEET) $<
 
 CLEANFILES += \
 	$(man1_MANS) \
 	$(man5_MANS) \
+	$(manhtml_files) \
 	$(NULL)
 
 endif

--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -68,7 +68,8 @@ endif
 EXTRA_DIST += $(man1_MANS:.1=.xml) $(man5_MANS:.5=.xml)
 
 XSLT_MAN_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
-XSLT_HTML_STYLESHEET = http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl
+XSLT_HTML_STYLESHEET = man/html.xsl
+EXTRA_DIST += $(XSLT_HTML_STYLESHEET)
 
 XSLTPROC_FLAGS = \
         --nonet \

--- a/configure.ac
+++ b/configure.ac
@@ -292,6 +292,16 @@ AS_IF([test "$enable_man" != no], [
 ])
 AM_CONDITIONAL(ENABLE_MAN, test "$enable_man" != no)
 
+AC_ARG_ENABLE([man-html],
+              [AS_HELP_STRING([--enable-man-html],
+                              [generate man HTML pages [default=no]])],,
+              enable_man_html=no)
+
+AS_IF([test "$enable_man_html" = yes && test "$enable_man" = no], [
+  AC_MSG_ERROR([--enable-man is required for --enable-man-html])
+])
+AM_CONDITIONAL(ENABLE_MAN_HTML, test "$enable_man_html" = yes)
+
 AC_ARG_WITH(libarchive,
 	    AS_HELP_STRING([--without-libarchive], [Do not use libarchive]),
 	    :, with_libarchive=maybe)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,9 +20,9 @@ exclude:
   - prep-docs.sh
   - vendor/
 
-# This is a copy of the apidoc/html directory. Run prep-docs.sh before
-# jekyll to put it in place.
-include: [reference]
+# These are copies of the apidoc/html and man/html directories. Run
+# prep-docs.sh before jekyll to put it in place.
+include: [reference, man]
 
 remote_theme: coreos/just-the-docs
 plugins:

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,6 +146,10 @@ make install DESTDIR=/path/to/dest
 
 The libostree API documentation is available in [Reference](reference/).
 
+## Manual Pages
+
+The ostree manual pages are available in [Manual](man/).
+
 ## Contributing
 
 See [Contributing]({{ site.baseurl }}{% link CONTRIBUTING.md %}).

--- a/docs/prep-docs.sh
+++ b/docs/prep-docs.sh
@@ -21,3 +21,17 @@ fi
 echo "Copying $apidocs to $refdir"
 rm -rf "$refdir"
 cp -r "$apidocs" "$refdir"
+
+# Make sure the manpages have been generated and copy them to the man
+# directory.
+manhtml="$topdir/man/html"
+mandir="$docsdir/man"
+if [ ! -d "$manhtml" ]; then
+    echo "error: HTML manpages $manhtml have not been generated" >&2
+    echo "Rebuild with --enable-man option and run `make manhtml`" >&2
+    exit 1
+fi
+
+echo "Copying $manhtml to $mandir"
+rm -rf "$mandir"
+cp -r "$manhtml" "$mandir"

--- a/man/html.xsl
+++ b/man/html.xsl
@@ -1,0 +1,37 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+
+<!--
+Copyright © 2022 Endless OS Foundation LLC
+
+SPDX-License-Identifier: LGPL-2.0+
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library. If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+
+<!-- translate man page references to links to html pages -->
+<xsl:template match="citerefentry">
+  <a>
+    <xsl:attribute name="href">
+      <xsl:value-of select="refentrytitle"/>
+      <xsl:text>.html</xsl:text>
+    </xsl:attribute>
+    <xsl:call-template name="inline.charseq"/>
+  </a>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/man/index.xml
+++ b/man/index.xml
@@ -1,0 +1,202 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+
+<!--
+Copyright © 2022 Endless OS Foundation LLC
+
+SPDX-License-Identifier: LGPL-2.0+
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library. If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<index id="index">
+    <title>OSTree Manual</title>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-cleanup</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-config-diff</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-deploy</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-init-fs</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-instutil</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-os-init</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-pin</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-set-origin</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-status</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-switch</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-undeploy</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-unlock</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin-upgrade</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-admin</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-cat</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-checkout</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-checksum</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-commit</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-config</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-create-usb</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-diff</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-export</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-fsck</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-gpg-sign</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-init</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-log</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-ls</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-prune</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-pull-local</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-pull</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-refs</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-remote</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree.repo-config</refentrytitle><manvolnum>5</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree.repo</refentrytitle><manvolnum>5</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-reset</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-rev-parse</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-show</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-sign</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-static-delta</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-summary</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>ostree-trivial-httpd</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+
+    <indexentry><primaryie><citerefentry>
+        <refentrytitle>rofiles-fuse</refentrytitle><manvolnum>1</manvolnum>
+    </citerefentry></primaryie></indexentry>
+</index>

--- a/man/ostree.xml
+++ b/man/ostree.xml
@@ -151,7 +151,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-cleanup</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Delete untagged
+                    Delete untagged
                     deployments and repository objects.
                 </para></listitem>
             </varlistentry>
@@ -160,7 +160,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                  <term><citerefentry><refentrytitle>ostree-admin-config-diff</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;See changes to
+                    See changes to
                     <filename>/etc</filename> as compared
                     to the current default (from
                     <filename>/usr/etc</filename>).
@@ -171,7 +171,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                  <term><citerefentry><refentrytitle>ostree-admin-deploy</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Takes a particular
+                    Takes a particular
                     commit or revision, and sets it up for
                     the next boot.
                 </para></listitem>
@@ -181,7 +181,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                  <term><citerefentry><refentrytitle>ostree-admin-init-fs</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Initialize a root filesystem
+                    Initialize a root filesystem
                     in a specified path.
                 </para></listitem>
             </varlistentry>
@@ -190,7 +190,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-instutil</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Utility functions intended primarily for operating system installation programs
+                    Utility functions intended primarily for operating system installation programs
                 </para></listitem>
             </varlistentry>
 
@@ -198,7 +198,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                  <term><citerefentry><refentrytitle>ostree-admin-os-init</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Initialize the
+                    Initialize the
                     deployment location for an operating
                     system with  a specified name.
                 </para></listitem>
@@ -208,7 +208,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-status</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Show and list the deployments.
+                    Show and list the deployments.
                 </para></listitem>
             </varlistentry>
 
@@ -216,7 +216,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-switch</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Choose a different ref
+                    Choose a different ref
                     to track from the same remote as the
                     current tree.
                 </para></listitem>
@@ -226,7 +226,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-undeploy</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Remove the previously
+                    Remove the previously
                     <replaceable>INDEX</replaceable>
                     deployed tree from the bootloader
                     configuration.
@@ -237,7 +237,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-admin-upgrade</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Download the latest version for the
+                    Download the latest version for the
                     current ref, and deploy it.
                 </para></listitem>
             </varlistentry>
@@ -253,7 +253,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-cat</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Concatenate contents of files
+                    Concatenate contents of files
                 </para></listitem>
             </varlistentry>
 
@@ -261,7 +261,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-checkout</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Check out a commit into a filesystem tree.
+                    Check out a commit into a filesystem tree.
                 </para></listitem>
             </varlistentry>
 
@@ -269,7 +269,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-checksum</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Gives checksum of any file.
+                    Gives checksum of any file.
                 </para></listitem>
             </varlistentry>
 
@@ -277,7 +277,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-commit</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Given one or more
+                    Given one or more
                     trees, create a new commit using those contents.
                 </para></listitem>
             </varlistentry>
@@ -286,7 +286,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-config</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Change settings.
+                    Change settings.
                 </para></listitem>
             </varlistentry>
 
@@ -294,7 +294,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-create-usb</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Put the given refs on an external drive for P2P distribution.
+                    Put the given refs on an external drive for P2P distribution.
                 </para></listitem>
             </varlistentry>
 
@@ -302,7 +302,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-diff</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Concisely list
+                    Concisely list
                     differences between the given refs.
                 </para></listitem>
             </varlistentry>
@@ -311,7 +311,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Find remotes to serve the given refs.
+                    Find remotes to serve the given refs.
                 </para></listitem>
             </varlistentry>
 
@@ -319,7 +319,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-fsck</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Check a repository for consistency.
+                    Check a repository for consistency.
                 </para></listitem>
             </varlistentry>
 
@@ -327,7 +327,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-init</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Initialize a new repository.
+                    Initialize a new repository.
                 </para></listitem>
             </varlistentry>
             
@@ -335,7 +335,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-log</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Show revision log.
+                    Show revision log.
                 </para></listitem>
             </varlistentry>
 
@@ -343,7 +343,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-ls</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;List the contents of a given commit.
+                    List the contents of a given commit.
                 </para></listitem>
             </varlistentry>
 
@@ -351,7 +351,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-prune</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Search for unreachable objects.
+                    Search for unreachable objects.
                 </para></listitem>
             </varlistentry>
 
@@ -359,7 +359,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-pull-local</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Copy data from source-repo.
+                    Copy data from source-repo.
                 </para></listitem>
             </varlistentry>
 
@@ -367,7 +367,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-pull</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Download data from remote repo.  If you have libsoup.
+                    Download data from remote repo.  If you have libsoup.
                 </para></listitem>
             </varlistentry>
 
@@ -375,7 +375,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-refs</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;List refs.
+                    List refs.
                 </para></listitem>
             </varlistentry>
 
@@ -383,7 +383,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-remote</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Manipulate remote archive configuration.
+                    Manipulate remote archive configuration.
                 </para></listitem>
             </varlistentry>
 
@@ -391,7 +391,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Reset a ref to a previous commit.
+                    Reset a ref to a previous commit.
                 </para></listitem>
             </varlistentry>
 
@@ -399,7 +399,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-rev-parse</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Show the SHA256 corresponding to a given rev.
+                    Show the SHA256 corresponding to a given rev.
                 </para></listitem>
             </varlistentry>
 
@@ -407,7 +407,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-show</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Given an OSTree SHA256 checksum, display its contents.
+                    Given an OSTree SHA256 checksum, display its contents.
                 </para></listitem>
             </varlistentry>
 
@@ -415,7 +415,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-static-delta</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Manage static delta files.
+                    Manage static delta files.
                 </para></listitem>
             </varlistentry>
 
@@ -423,7 +423,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-summary</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
-                    &nbsp;Regenerate the repository summary metadata.
+                    Regenerate the repository summary metadata.
                 </para></listitem>
             </varlistentry>
 
@@ -431,7 +431,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><citerefentry><refentrytitle>ostree-trivial-httpd</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
                 
                 <listitem><para>
-                    &nbsp;Simple webserver.
+                    Simple webserver.
                 </para></listitem>
             </varlistentry>
         </variablelist>


### PR DESCRIPTION
I'm sure this could be polished more (the systemd setup is a solid reference), but this publishes the manpages in the hosted ostree docs. I'm a little unsure the build system integration is the best. Right now it requires a separate configure option and is part of a normal automake target, but I also have a much simpler version that just adds the custom `manhtml` target.