### PR TITLE
s390x: generate sd-boot at its own partition

### DIFF
--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -12,11 +12,11 @@ gzip -cd ${old_initrd} | cpio -imd --quiet
 
 # Adding LUKS root key and crypttab config
 mkdir -p etc/luks
-cp -f /etc/luks/root etc/luks/
+cp -f /etc/luks/* etc/luks/
 cp -f /etc/crypttab etc/
 
 # Creating new initramdisk image
-find . | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
+find . -mindepth 1 | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
 
 # Cleanup
 rm -rf ${workdir}


### PR DESCRIPTION
SE-qcow2 image comes with extra partition for `sd-boot`.  
Required by: https://github.com/coreos/coreos-assembler/pull/2822