### PR TITLE
Fix abort-on-error behaviour of transactions

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1689,10 +1689,10 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
   g_debug ("Preparing transaction in repository %p", self);
 
   /* Set up to abort the transaction if we return early from this function.
-   * This needs to be manually built here due to a circular dependency. */
-  g_autoptr(OstreeRepoAutoTransaction) txn = g_malloc(sizeof(OstreeRepoAutoTransaction));
+   * We can't call _ostree_repo_auto_transaction_start() here, because that
+   * would be a circular dependency; use the lower-level version instead. */
+  g_autoptr(OstreeRepoAutoTransaction) txn = _ostree_repo_auto_transaction_new (self);
   g_assert (txn != NULL);
-  txn->repo = self;
 
   memset (&self->txn.stats, 0, sizeof (OstreeRepoTransactionStats));
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -554,4 +554,8 @@ GType _ostree_repo_auto_transaction_get_type (void);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoAutoTransaction, _ostree_repo_auto_transaction_unref);
 
+/* Internal function to break a circular dependency:
+ * should not be made into public API, even if the rest is */
+OstreeRepoAutoTransaction *_ostree_repo_auto_transaction_new (OstreeRepo *repo);
+
 G_END_DECLS

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -711,6 +711,32 @@ ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *auto_lock)
 }
 
 /**
+ * _ostree_repo_auto_transaction_new:
+ * @repo: (not nullable): an #OsreeRepo object
+ * @cancellable: Cancellable
+ * @error: a #GError
+ *
+ * Return a guard for a transaction in @repo.
+ *
+ * Do not call this function outside the OstreeRepo transaction implementation.
+ * Use _ostree_repo_auto_transaction_start() instead.
+ *
+ * Returns: (transfer full): an #OstreeRepoAutoTransaction guard on success,
+ * %NULL otherwise.
+ */
+OstreeRepoAutoTransaction *
+_ostree_repo_auto_transaction_new (OstreeRepo *repo)
+{
+  g_assert (repo != NULL);
+
+  OstreeRepoAutoTransaction *txn = g_malloc(sizeof(OstreeRepoAutoTransaction));
+  txn->atomic_refcount = 1;
+  txn->repo = g_object_ref (repo);
+
+  return g_steal_pointer (&txn);
+}
+
+/**
  * _ostree_repo_auto_transaction_start:
  * @repo: (not nullable): an #OsreeRepo object
  * @cancellable: Cancellable
@@ -731,11 +757,7 @@ _ostree_repo_auto_transaction_start (OstreeRepo     *repo,
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     return NULL;
 
-  OstreeRepoAutoTransaction *txn = g_malloc(sizeof(OstreeRepoAutoTransaction));
-  txn->atomic_refcount = 1;
-  txn->repo = g_object_ref (repo);
-
-  return g_steal_pointer (&txn);
+  return _ostree_repo_auto_transaction_new (repo);
 }
 
 /**


### PR DESCRIPTION
* repo: Factor out _ostree_repo_auto_transaction_new()
    
    This will allow the direct allocation in
    ostree_repo_prepare_transaction() to be replaced with a call to this
    function, avoiding breaking encapsulation.

* repo: Correctly initialize refcount of temporary transaction
    
    Previously, the reference count was left uninitialized as a result of
    bypassing the constructor, and the intended abort-on-error usually
    wouldn't have happened.
    
    Fixes: 8a9737a "repo/private: move OstreeRepoAutoTransaction to a boxed type"
    Resolves: https://github.com/ostreedev/ostree/issues/2592