### PR TITLE
ci: use cargo-deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,3 +66,11 @@ jobs:
         run: cargo fmt -p ostree -- --check -l
       - name: cargo clippy (warnings)
         run: cargo clippy -p ostree --features=${{ env['CARGO_PROJECT_FEATURES'] }} -- -D warnings
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        log-level: warn
+        command: check bans sources licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,10 @@
+[licenses]
+unlicensed = "deny"
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause"]
+
+[bans]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []


### PR DESCRIPTION
Copied from https://github.com/ostreedev/ostree-rs-ext/pull/291

Part of unifying our CI.