### PR TITLE
ostree-systroot-deploy: parse bls-append-except-default key

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -404,6 +404,17 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>bls-append-except-default</varname></term>
+        <listitem><para>A semicolon seperated string list of key-value pairs. For example:
+        <literal>bls-append-except-default=key1=value1;key2=value2</literal>. These key-value 
+        pairs will be injected into the generated BLS fragments of the non-default deployments.
+        In other words, the BLS fragment of the default deployment will be unaffected by
+        <literal>bls-append-except-default</literal>.
+        </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
 
   </refsect1>

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2082,6 +2082,50 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   g_autofree char *options_key = ostree_kernel_args_to_string (kargs);
   ostree_bootconfig_parser_set (bootconfig, "options", options_key);
 
+  g_autoptr(GError) local_error = NULL;
+  GKeyFile *config = ostree_repo_get_config (repo);
+  gchar **read_values = g_key_file_get_string_list (config, "sysroot", "bls-append-except-default", NULL, &local_error);
+  /* We can ignore not found errors */
+  if (!read_values)
+    {
+      gboolean not_found = g_error_matches (local_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) || \
+                           g_error_matches (local_error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND);
+      if (not_found)
+        {
+          g_clear_error (&local_error);
+        }
+      else
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+    }
+
+  /* Only append to this BLS config if:
+   * - this is not the default deployment
+   */
+   /* If deployment was prepended, it is the new default */
+  gboolean is_new_default = (ostree_deployment_get_index (deployment) == 0);
+  gboolean allow_append = !is_new_default;
+  if (allow_append)
+    {
+      /* get all key value pairs in bls-append */
+      for (char **iter = read_values; iter && *iter; iter++)
+        {
+          const char *key_value = *iter;
+          const char *sep = strchr (key_value, '=');
+          if (sep == NULL)
+            {
+              glnx_throw (error, "bls-append-except-default key must be of the form \"key1=value1;key2=value2...\"");
+              return FALSE;
+            }
+          g_autofree char *key = g_strndup (key_value, sep - key_value);
+          g_autofree char *value = g_strdup (sep + 1);
+          ostree_bootconfig_parser_set (bootconfig, key, value);
+        }
+
+    }
+
   glnx_autofd int bootconf_dfd = -1;
   if (!glnx_opendirat (sysroot->boot_fd, bootconfdir, TRUE, &bootconf_dfd, error))
     return FALSE;


### PR DESCRIPTION
We want to parse a new "bls-append-except-default" key from ostree config. The
key-value pairs specified by this key will be added to the generated
BLS fragments of non-default deployments. They must follow the format
"key1,value1;key2,value2" and so on.

This change will allow us to land GRUB password support in FCOS.

closes: https://github.com/ostreedev/ostree/issues/2591 