### PR TITLE
ci: Move codestyle and min build to GH actions

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,7 +1,6 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
 
 stage("Build") {
-parallel normal: {
   def n = 5
   buildPod(memory: "2Gi", cpu: "${n}") {
       checkout scm
@@ -36,34 +35,6 @@ parallel normal: {
       }
       stash includes: "installed/", name: 'build'
   }
-},
-// A minimal build, helps test our build options
-minimal: {
-  buildPod() {
-      checkout scm
-      shwrap("""
-        git submodule update --init
-
-        env NOCONFIGURE=1 ./autogen.sh
-        ./configure --without-curl --without-soup --disable-gtk-doc --disable-man \
-          --disable-rust --without-libarchive --without-selinux --without-smack \
-          --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
-          --without-libsodium
-        make
-      """)
-  }
-},
-codestyle: {
-  buildPod() {
-      checkout scm
-      shwrap("""
-        # Jenkins by default only fetches the branch it's testing. Explicitly fetch main
-        # for ci-commitmessage-submodules.sh
-        git fetch origin +refs/heads/main:refs/remotes/origin/main
-        ci/ci-commitmessage-submodules.sh
-      """)
-  }
-}
 }
 
 // Build FCOS and do a kola basic run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,39 @@ permissions:
   contents: read
 
 jobs:
+  codestyle:
+    name: "Code style"
+    runs-on: ubuntu-latest
+    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Test style
+        run: ./ci/ci-commitmessage-submodules.sh
+  minimal:
+    name: "Build - FCOS minimal"
+    runs-on: ubuntu-latest
+    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build
+        run: |
+          env NOCONFIGURE=1 ./autogen.sh &&
+          ./configure --without-curl --without-soup --disable-gtk-doc --disable-man \
+          --disable-rust --without-libarchive --without-selinux --without-smack \
+          --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
+          --without-libsodium &&
+          make
   tests:
     # Distro configuration matrix
     #

--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -39,6 +39,7 @@ gitdir=$(realpath $(pwd))
 # try to read the submodules from the Internet again.  If we wanted to
 # require a newer git, we could use `git worktree`.
 cp -a ${gitdir} ${tmpd}/workdir
+git config --global --add safe.directory "${tmpd}/workdir"
 cd ${tmpd}/workdir
 git log --pretty=oneline origin/main..$HEAD | while read logline; do
     commit=$(echo ${logline} | cut -f 1 -d ' ')


### PR DESCRIPTION
Part of general momentum to leave heavy lifting (e.g. VM tests)
to Jenkins and Prow and use the cheaper/faster GH actions for
plain builds.