### PR TITLE
Remove dup "--os=OSNAME" line in output of "ostree admin config-diff --help"

### DIFF
--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -87,22 +87,22 @@ ot_admin_builtin_deploy (int argc, char **argv, OstreeCommandInvocation *invocat
     }
 
   if (opt_kernel_proc_cmdline && opt_kernel_arg_none)
-  {
-    ot_util_usage_error (context, "Can't specify both --karg-proc-cmdline and --karg-none", error);
-    return FALSE;
-  }
+    {
+      ot_util_usage_error (context, "Can't specify both --karg-proc-cmdline and --karg-none", error);
+      return FALSE;
+    }
 
   if (opt_kernel_arg_none && opt_kernel_argv_delete)
-  {
-    ot_util_usage_error (context, "Can't specify both --karg-none and --karg-delete", error);
-    return FALSE;
-  }
+    {
+      ot_util_usage_error (context, "Can't specify both --karg-none and --karg-delete", error);
+      return FALSE;
+    }
 
   if (opt_no_merge && opt_kernel_argv_delete)
-  {
-    ot_util_usage_error (context, "Can't specify both --no-merge and --karg-delete", error);
-    return FALSE;
-  }
+    {
+      ot_util_usage_error (context, "Can't specify both --no-merge and --karg-delete", error);
+      return FALSE;
+    }
 
   const char *refspec = argv[1];
 

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -39,7 +39,6 @@ gboolean
 ot_admin_builtin_diff (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
-  g_option_context_add_main_entries (context, options, NULL);
 
   g_autoptr(OstreeSysroot) sysroot = NULL;
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,


### PR DESCRIPTION
- Small fix for https://github.com/ostreedev/ostree/issues/2594
- Fix GNU style of two spaces for indent in https://github.com/ostreedev/ostree/pull/2612