### PR TITLE
copr: mark git checkout as safe

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,7 @@
 srpm:
 	dnf install -y git
+	# similar to https://github.com/actions/checkout/issues/760, but for COPR
+	git config --global --add safe.directory '*'
 	ci/make-git-snapshot.sh
 	curl -LO https://src.fedoraproject.org/rpms/ostree/raw/rawhide/f/ostree.spec
 	sed -ie "s,^Version:.*,Version: $$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,')," ostree.spec


### PR DESCRIPTION
Recent git became more strict wrt git repos in parent dirs owned by
other users. This broke our COPR builds due to the git checkout being
created by a different user and mounted in. We need to explicitly mark
the repo as safe.

For more information, see:
https://github.com/actions/checkout/issues/760