### PR TITLE
Fix annotations on ostree_mutable_tree_lookup()

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -403,8 +403,8 @@ ostree_mutable_tree_ensure_dir (OstreeMutableTree *self,
  * ostree_mutable_tree_lookup:
  * @self: Tree
  * @name: name
- * @out_file_checksum: (out) (transfer full): checksum
- * @out_subdir: (out) (transfer full): subdirectory
+ * @out_file_checksum: (out) (transfer full) (nullable) (optional): checksum
+ * @out_subdir: (out) (transfer full) (nullable) (optional): subdirectory
  * @error: a #GError
  */
 gboolean


### PR DESCRIPTION
(nullable) and (optional) were missing on lookup()'s out parameters, which caused the rust bindings for the function to not work. Due to the missing (nullable), it would return a `Result<(GString, MutableTree), _>`, not a `Result<(Option<GString>, Option<MutableTree>), _>`, which led to panics.