### PR TITLE
Drop `OSTREE_BUILT_FEATURES` from introspection

### DIFF
--- a/src/libostree/ostree-version.h.in
+++ b/src/libostree/ostree-version.h.in
@@ -98,4 +98,6 @@
  *
  * Since: 2019.3
  */
+#ifndef __GI_SCANNER__
 #define OSTREE_BUILT_FEATURES "@OSTREE_FEATURES@"
+#endif


### PR DESCRIPTION
It inherently depends on the individual build, and can't
really be an official stable API for introspection users.
I've noticed the value of this flip flop when doing local builds.

I'm fairly certain no one is trying to use it from a higher level
language.

It'd probably make sense to even drop from the official C API,
but I'm trying to be conservative with that.