### PR TITLE
rust: Bump semver, add feature for current release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_PROJECT_FEATURES: "v2021_3"
+  CARGO_PROJECT_FEATURES: "v2021_5"
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.54.0
   # Pinned toolchain for linting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs"
-version = "0.13.6"
+version = "0.14.0"
 
 exclude = [
     "rust-bindings/conf/**",
@@ -32,7 +32,7 @@ members = [".", "rust-bindings/sys"]
 bitflags = "1.2.1"
 cap-std = { version = "0.24", optional = true}
 io-lifetimes = { version = "0.5", optional = true}
-ffi = { package = "ostree-sys", path = "rust-bindings/sys", version = "0.9.1" }
+ffi = { package = "ostree-sys", path = "rust-bindings/sys", version = "0.10.0" }
 gio = "0.14"
 glib = "0.14.4"
 hex = "0.4.2"
@@ -92,3 +92,4 @@ v2021_2 = ["v2021_1", "ffi/v2021_2"]
 v2021_3 = ["v2021_2", "ffi/v2021_3"]
 v2021_4 = ["v2021_3", "ffi/v2021_4"]
 v2021_5 = ["v2021_4", "ffi/v2021_5"]
+v2022_5 = ["v2021_5", "ffi/v2022_5"]

--- a/rust-bindings/sys/Cargo.toml
+++ b/rust-bindings/sys/Cargo.toml
@@ -56,6 +56,7 @@ v2021_3 = ["v2021_2"]
 v2021_4 = ["v2021_3"]
 v2021_5 = ["v2021_4"]
 v2022_2 = ["v2021_5"]
+v2022_5 = ["v2022_2"]
 
 [lib]
 name = "ostree_sys"
@@ -71,7 +72,7 @@ license = "MIT"
 links = "ostree-1"
 name = "ostree-sys"
 repository = "https://github.com/ostreedev/ostree-rs"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2018"
 [package.metadata.docs.rs]
 features = ["dox"]
@@ -207,3 +208,6 @@ version = "2021.5"
 
 [package.metadata.system-deps.ostree_1.v2022_2]
 version = "2022.2"
+
+[package.metadata.system-deps.ostree_1.v2022_5]
+version = "2022.5"


### PR DESCRIPTION
There were some changes to the sys API for introspection fixes.
And add a feature for the current release, which is something
I'll add to the checklist for releases.