### PR TITLE
ci: Add a flow that does a git libostree + git rust-bindings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_PROJECT_FEATURES: "v2021_5"
+  # TODO: Automatically query this from the C side
+  LATEST_LIBOSTREE: "v2022_5"
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.54.0
   # Pinned toolchain for linting
@@ -47,6 +49,24 @@ jobs:
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
       - name: cargo build
         run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+  build-git-libostree:
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: Build libostree
+        run: ./ci/build.sh
+      - name: Install libostree
+        run: make install
+      - name: Rust build
+        run: cargo test --no-run --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
+      - name: Run tests
+        run: cargo test --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
   linting:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest


### PR DESCRIPTION
In https://github.com/ostreedev/ostree/pull/2633 I realized
that our CI only builds git of libostree or git of rust-bindings,
not git of both.  And we definitely want to test the latter too,
so e.g. the Rust tests *also* become tests for changes to the C code.