### PR TITLE
tests/inst: Bump the version of ostree-ext

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 sh-inline = "0.2.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
-ostree-ext = { version = "0.6.0" }
+ostree-ext = { version = "0.7.0" }
 libtest-mimic = "0.3.0"
 twoway = "0.2.1"
 hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }


### PR DESCRIPTION
In the interest of cross-testing and keeping things up to date.

Hmm, I think we need to set up dependabot here.