### PR TITLE
Rust bindings cargo updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 keywords = ["ostree", "libostree"]
 license = "MIT"
 name = "ostree"
-readme = "README.md"
+readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
 version = "0.14.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ repository = "https://github.com/ostreedev/ostree"
 version = "0.14.0"
 
 exclude = [
-    "rust-bindings/conf/**",
-    "rust-bindings/gir-files/**",
-    "rust-bindings/sys/**",
-    ".gitlab-ci.yml",
-    "LICENSE.LGPL*",
+    "/*.am", "/apidoc", "/autogen.sh", "/bash", "/bsdiff",
+    "/build-aux", "/buildutil", "/*.mk", "/ci", "/coccinelle",
+    "/*.ac", "/docs", "/libglnx", "/man", "/manual-tests",
+    "/*.yml", "/*.doap", "/src", "/tests",
+    "/.github", "/.cci.jenkinsfile", "/.dir-locals.el", "/.editorconfig",
+    "/.vimrc", "/.copr", "/.packit.yaml", "/GNUmakefile", "TODO",
+    "/rust-bindings/conf/**",
+    "/rust-bindings/gir-files/**",
+    "/rust-bindings/sys/**",
 ]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["ostree", "libostree"]
 license = "MIT"
 name = "ostree"
 readme = "README.md"
-repository = "https://github.com/ostreedev/ostree-rs"
+repository = "https://github.com/ostreedev/ostree"
 version = "0.14.0"
 
 exclude = [


### PR DESCRIPTION
rust-bindings: Fix repository reference

Since the repo merge.

---

rust-bindings: use correct README.md

I noticed at https://crates.io/crates/ostree/0.14.0
that the `README.md` was wrong...

---

rust-bindings: Update cargo package list

When we did the merger, it turns out cargo by default is basically
going to include all of stuff in the git repository root directory
which is "libostree".  We just want the stuff in `rust-bindings/`.

I initially tried adding `include = "rust-bindings/"` but
according to
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields
specifying `include` means that `exclude` is
ignored, which is kind of annoying.  Further, doing so *also*
turns off the cargo automatic rules for handling e.g. `gitignore`.

So for now I went with the approach of adding everything from the C
library stuff into `exclude/`.

---

