### PR TITLE
rust: Switch to 2021 edition, bump MSRV, a few `format!` updates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_5"
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.54.0
+  ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.56.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Felix Krull"]
 description = "Rust bindings for libostree"
 documentation = "https://docs.rs/ostree"
-edition = "2018"
+edition = "2021"
 keywords = ["ostree", "libostree"]
 license = "MIT"
 name = "ostree"

--- a/rust-bindings/src/object_name.rs
+++ b/rust-bindings/src/object_name.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn should_stringify_object_name() {
         let object_name = ObjectName::new("abcdef123456", ObjectType::DirTree);
-        let stringified = format!("{}", object_name);
+        let stringified = format!("{object_name}");
         assert_eq!(stringified, "abcdef123456.dirtree");
     }
 

--- a/rust-bindings/sys/Cargo.toml
+++ b/rust-bindings/sys/Cargo.toml
@@ -73,7 +73,7 @@ links = "ostree-1"
 name = "ostree-sys"
 repository = "https://github.com/ostreedev/ostree-rs"
 version = "0.10.0"
-edition = "2018"
+edition = "2021"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.ostree_1]

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ostree-test"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -363,7 +363,7 @@ fn impl_transaction_test<M: AsRef<str>>(
             booted: booted_commit.to_string(),
             orig: sysrepo_obj.resolve_rev(ORIGREF, false)?.unwrap().into(),
             prev: srvrepo_obj
-                .resolve_rev(&format!("{}^", TESTREF), false)?
+                .resolve_rev(&format!("{TESTREF}^"), false)?
                 .unwrap()
                 .into(),
             target: srvrepo_obj.resolve_rev(TESTREF, false)?.unwrap().into(),
@@ -568,7 +568,7 @@ pub(crate) fn itest_transactionality() -> Result<()> {
         ..Default::default()
     };
     with_webserver_in(&srvrepo, &webserver_opts, move |addr| {
-        let url = format!("http://{}", addr);
+        let url = format!("http://{addr}");
         bash!(
             "ostree remote delete --if-exists testrepo
              ostree remote add --set=gpg-verify=false testrepo ${url}",

--- a/tests/inst/src/treegen.rs
+++ b/tests/inst/src/treegen.rs
@@ -31,9 +31,9 @@ pub(crate) fn mkvroot<P: AsRef<Path>>(p: P, v: u32) -> Result<()> {
         std::fs::create_dir_all(p.join(v))?;
     }
     let verpath = p.join("etc/.mkrootversion");
-    write_file(&verpath, &format!("{}", v))?;
-    write_file(p.join("usr/bin/somebinary"), &format!("somebinary v{}", v))?;
-    write_file(p.join("etc/someconf"), &format!("someconf v{}", v))?;
+    write_file(&verpath, &format!("{v}"))?;
+    write_file(p.join("usr/bin/somebinary"), &format!("somebinary v{v}"))?;
+    write_file(p.join("etc/someconf"), &format!("someconf v{v}"))?;
     write_file(p.join("usr/bin/vmod2"), &format!("somebinary v{}", v % 2))?;
     write_file(p.join("usr/bin/vmod3"), &format!("somebinary v{}", v % 3))?;
     Ok(())
@@ -134,7 +134,7 @@ pub(crate) fn update_os_tree<P: AsRef<Path>>(
                 tempdir.ensure_dir(v, 0o755)?;
                 let dest = tempdir.sub_dir(v)?;
                 mutated += mutate_executables_to(&src, &dest, percentage)
-                    .with_context(|| format!("Replacing binaries in {}", v))?;
+                    .with_context(|| format!("Replacing binaries in {v}"))?;
             }
         }
     }


### PR DESCRIPTION
rust: Switch to 2021 edition

No real changes.

```
$ cargo fix --edition
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  libc v0.2.126 removed features: extra_traits

The following differences only apply when building with dev-dependencies:

  getrandom v0.2.6 removed features: std
```

which looks OK to me.

---

ci: Bump MSRV

To match what's in ostree-rs-ext.

---

rust: Use inline `format!` variables in a few places

Since our MSRV now supports it.

---
