### PR TITLE
 fsck: Don't load all object names into memory

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4999,7 +4999,7 @@ ostree_repo_list_objects (OstreeRepo                  *self,
 /**
  * ostree_repo_list_commit_objects_starting_with:
  * @self: Repo
- * @start: List commits starting with this checksum
+ * @start: List commits starting with this checksum (empty string for all)
  * @out_commits: (out) (transfer container) (element-type GVariant GVariant):
  * Map of serialized commit name to variant data
  * @cancellable: Cancellable
@@ -5007,6 +5007,8 @@ ostree_repo_list_objects (OstreeRepo                  *self,
  *
  * This function synchronously enumerates all commit objects starting
  * with @start, returning data in @out_commits.
+ *
+ * To list all commit objects, provide the empty string `""` for @start.
  *
  * Returns: %TRUE on success, %FALSE on error, and @error will be set
  */


### PR DESCRIPTION
repo: Document non-obvious way to list all commits

I was going to add an API for this and then realized the empty
string does it.

---

fsck: Don't load all object names into memory

We recently discovered `list_objects()` is inefficient with memory.
The more efficient `list_objects_set()` API isn't yet public, but
this fsck code actually just skips over non-commit objects, and
we already have an API to list just those.

---

