### PR TITLE
rust-bindings: Wire up `tests/`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ features = ["dox"]
 name = "ostree"
 path = "rust-bindings/src/lib.rs"
 
+[[test]]
+name = "integration"
+path = "rust-bindings/tests/tests.rs"
+
 [workspace]
 members = [".", "rust-bindings/sys"]
 

--- a/rust-bindings/tests/util/mod.rs
+++ b/rust-bindings/tests/util/mod.rs
@@ -53,10 +53,7 @@ pub fn create_mtree(repo: &ostree::Repo) -> ostree::MutableTree {
     assert_eq!(mtree.copy_files().len(), 0);
     assert_eq!(mtree.copy_subdirs().len(), 0);
     let file = gio::File::for_path(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("data")
-            .join("test.tar"),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("rust-bindings/tests/data/test.tar"),
     );
     repo.write_archive_to_mtree(&file, &mtree, None, true, NONE_CANCELLABLE)
         .expect("test mtree");


### PR DESCRIPTION
Because the source is in a subdirectory, we lose out on cargo target
autodiscovery.

I noticed this when I edited one of the tests in a way that
should have failed, but didn't...