### PR TITLE
cli: a few "Port to C99 style"

### DIFF
--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -35,35 +35,29 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_os_init (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GOptionContext) context = g_option_context_new ("OSNAME");
+
   g_autoptr(OstreeSysroot) sysroot = NULL;
-  gboolean ret = FALSE;
-  const char *osname = NULL;
-
-  context = g_option_context_new ("OSNAME");
-
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
                                           OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                           invocation, &sysroot, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (!ostree_sysroot_ensure_initialized (sysroot, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (argc < 2)
     {
       ot_util_usage_error (context, "OSNAME must be specified", error);
-      goto out;
+      return FALSE;
     }
 
-  osname = argv[1];
+  const char *osname = argv[1];
 
   if (!ostree_sysroot_init_osname (sysroot, osname, cancellable, error))
-    goto out;
+    return FALSE;
 
   g_print ("ostree/deploy/%s initialized as OSTree root\n", osname);
 
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -34,15 +34,9 @@ static GOptionEntry options[] = {
 gboolean
 ot_admin_builtin_undeploy (int argc, char **argv, OstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GOptionContext) context = g_option_context_new ("INDEX");
+
   g_autoptr(OstreeSysroot) sysroot = NULL;
-  const char *deploy_index_str;
-  int deploy_index;
-  g_autoptr(GPtrArray) current_deployments = NULL;
-  g_autoptr(OstreeDeployment) target_deployment = NULL;
-
-  context = g_option_context_new ("INDEX");
-
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
                                           OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           invocation, &sysroot, cancellable, error))
@@ -54,12 +48,13 @@ ot_admin_builtin_undeploy (int argc, char **argv, OstreeCommandInvocation *invoc
       return FALSE;
     }
 
-  current_deployments = ostree_sysroot_get_deployments (sysroot);
+  g_autoptr(GPtrArray) current_deployments = ostree_sysroot_get_deployments (sysroot);
 
-  deploy_index_str = argv[1];
-  deploy_index = atoi (deploy_index_str);
+  const char *deploy_index_str = argv[1];
+  int deploy_index = atoi (deploy_index_str);
 
-  target_deployment = ot_admin_get_indexed_deployment (sysroot, deploy_index, error);
+  g_autoptr(OstreeDeployment) target_deployment =
+    ot_admin_get_indexed_deployment (sysroot, deploy_index, error);
   if (!target_deployment)
     return FALSE;
 


### PR DESCRIPTION
cli/os-init: Port to C99 style

General background cleanup; motivated by a recent PR which
was using pre-C99 code as a base.

---

cli/undeploy: Port to C99 style

General background cleanup.

---

cli/unlock: Port to C99 style

General background cleanup.

---

