### PR TITLE
test-basic-c: Don't assert that extended attributes are available

### DIFF
--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -514,8 +514,15 @@ test_read_xattrs (void)
     g_assert_no_error (local_error);
   
     int r = fsetxattr (tmpd.fd, "user.ostreetesting", value, sizeof (value), 0);
-    g_assert_cmpint (r, ==, 0);
-  
+
+    if (r != 0)
+      {
+        g_autofree gchar *message = g_strdup_printf ("Unable to set extended attributes in /var/tmp: %s",
+                                                     g_strerror (errno));
+        g_test_skip (message);
+        return;
+      }
+
     g_autoptr(GVariant) new_xattrs = ostree_fs_get_all_xattrs (tmpd.fd, NULL, error);
     g_assert_no_error (local_error);
   


### PR DESCRIPTION
Not all filesystems support extended attributes. This test uses
/var/tmp to try to get an extended-attributes-capable filesystem,
but that might not succeed.

---

Some Debian autobuilders operate entirely from (very large) tmpfs filesystems, to avoid disk I/O and `fsync()` overhead. On those systems, not even `/var/tmp` has extended attributes available.