### PR TITLE
rust: Bump semver to 0.15 && bump cap-std 0.25

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_PROJECT_FEATURES: "v2021_5"
+  CARGO_PROJECT_FEATURES: "v2021_5,cap-std-apis"
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_5"
   # Minimum supported Rust version (MSRV)
@@ -49,6 +49,17 @@ jobs:
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
       - name: cargo build
         run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+  build-no-features:
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: Build
+        run: cargo test --no-run
+      - name: Run tests
+        run: cargo test --verbose
   build-git-libostree:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,8 +47,8 @@ jobs:
           default: true
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
-      - name: cargo build
-        run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+      - name: cargo check
+        run: cargo check --features=${{ env['CARGO_PROJECT_FEATURES'] }}
   build-no-features:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
-version = "0.14.0"
+version = "0.15.0"
 
 exclude = [
     "/*.am", "/apidoc", "/autogen.sh", "/bash", "/bsdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ members = [".", "rust-bindings/sys"]
 
 [dependencies]
 bitflags = "1.2.1"
-cap-std = { version = "0.24", optional = true}
-io-lifetimes = { version = "0.5", optional = true}
+cap-std = { version = "0.25", optional = true}
+io-lifetimes = { version = "0.7", optional = true}
 ffi = { package = "ostree-sys", path = "rust-bindings/sys", version = "0.10.0" }
 gio = "0.14"
 glib = "0.14.4"
@@ -53,7 +53,7 @@ thiserror = "1.0.20"
 maplit = "1.0.2"
 openat = "0.1.19"
 tempfile = "3"
-cap-tempfile = "0.24"
+cap-tempfile = "0.25"
 
 [features]
 cap-std-apis = ["cap-std", "io-lifetimes", "v2017_10"]

--- a/rust-bindings/src/repo.rs
+++ b/rust-bindings/src/repo.rs
@@ -154,13 +154,15 @@ impl Repo {
     /// Borrow the directory file descriptor for this repository.
     #[cfg(feature = "cap-std-apis")]
     pub fn dfd_borrow(&self) -> io_lifetimes::BorrowedFd {
-        unsafe { io_lifetimes::BorrowedFd::borrow_raw_fd(self.dfd()) }
+        unsafe { io_lifetimes::BorrowedFd::borrow_raw(self.dfd()) }
     }
 
     /// Return a new `cap-std` directory reference for this repository.
     #[cfg(feature = "cap-std-apis")]
     pub fn dfd_as_dir(&self) -> std::io::Result<cap_std::fs::Dir> {
-        cap_std::fs::Dir::reopen_dir(&self.dfd_borrow())
+        use io_lifetimes::AsFd;
+        let dfd = self.dfd_borrow();
+        cap_std::fs::Dir::reopen_dir(&dfd.as_fd())
     }
 
     /// Find all objects reachable from a commit.

--- a/rust-bindings/src/repo.rs
+++ b/rust-bindings/src/repo.rs
@@ -153,7 +153,7 @@ impl Repo {
 
     /// Borrow the directory file descriptor for this repository.
     #[cfg(feature = "cap-std-apis")]
-    pub fn dfd_borrow<'a>(&'a self) -> io_lifetimes::BorrowedFd<'a> {
+    pub fn dfd_borrow(&self) -> io_lifetimes::BorrowedFd {
         unsafe { io_lifetimes::BorrowedFd::borrow_raw_fd(self.dfd()) }
     }
 


### PR DESCRIPTION
ci/rust: Enable `cap-std-apis` in default build, add a no-feature build

Our CI was missing coverage of `cap-std-apis`.

---

ci/rust: Change MSRV to `cargo check`

No reason to codegen just to throw it away.  We could test here too,
but eh.

---

Fix clippy lint in cap-std bits

---

rust: Bump semver to 0.15

Prep for some breaking changes.

---

Bump to cap-std 0.25 and io-lifetimes 0.7

Prep for bumping ostree-rs-ext, which will help bump rpm-ostree,
which will get it out of having two copies of rustix.

---

