### PR TITLE
ci/rust: Enable `cap-std-apis` in default build && Change MSRV to `cargo check`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_PROJECT_FEATURES: "v2021_5"
+  CARGO_PROJECT_FEATURES: "v2021_5,cap-std-apis"
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_5"
   # Minimum supported Rust version (MSRV)
@@ -49,6 +49,17 @@ jobs:
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
       - name: cargo build
         run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+  build-no-features:
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: Build
+        run: cargo test --no-run
+      - name: Run tests
+        run: cargo test --verbose
   build-git-libostree:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,8 +47,8 @@ jobs:
           default: true
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
-      - name: cargo build
-        run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+      - name: cargo check
+        run: cargo check --features=${{ env['CARGO_PROJECT_FEATURES'] }}
   build-no-features:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel


### PR DESCRIPTION
ci/rust: Enable `cap-std-apis` in default build, add a no-feature build

Our CI was missing coverage of `cap-std-apis`.

---

ci/rust: Change MSRV to `cargo check`

No reason to codegen just to throw it away.  We could test here too,
but eh.

---

