### PR TITLE
lib/static-delta: document and check parameters format

### DIFF
--- a/rust-bindings/tests/repo/generate_static.rs
+++ b/rust-bindings/tests/repo/generate_static.rs
@@ -14,8 +14,10 @@ fn should_generate_static_delta_at() {
     let delta_path = delta_dir.path().join("static_delta.file");
     let path_var = delta_path
         .to_str()
+        .map(std::ffi::CString::new)
         .expect("no valid path")
-        .as_bytes()
+        .unwrap()
+        .as_bytes_with_nul()
         .to_variant();
 
     let test_repo = TestRepo::new();
@@ -38,5 +40,5 @@ fn should_generate_static_delta_at() {
         )
         .expect("static delta generate");
 
-    assert!(std::fs::File::open(&delta_path).is_err());
+    assert!(delta_path.try_exists().unwrap());
 }

--- a/rust-bindings/tests/repo/generate_static.rs
+++ b/rust-bindings/tests/repo/generate_static.rs
@@ -1,0 +1,42 @@
+use crate::util::*;
+use gio::NONE_CANCELLABLE;
+use ostree::glib::prelude::*;
+use ostree::glib::Variant;
+use ostree::*;
+
+use std::collections::HashMap;
+
+#[test]
+fn should_generate_static_delta_at() {
+    let mut options: HashMap<String, Variant> = HashMap::<String, Variant>::new();
+
+    let delta_dir = tempfile::tempdir().expect("static delta dir");
+    let delta_path = delta_dir.path().join("static_delta.file");
+    let path_var = delta_path
+        .to_str()
+        .expect("no valid path")
+        .as_bytes()
+        .to_variant();
+
+    let test_repo = TestRepo::new();
+    let from = test_repo.test_commit("commit1");
+    let to = test_repo.test_commit("commit2");
+
+    options.insert(String::from("filename"), path_var);
+
+    let varopts = &options.to_variant();
+
+    let _result = test_repo
+        .repo
+        .static_delta_generate(
+            ostree::StaticDeltaGenerateOpt::Major,
+            Some(&from),
+            &to,
+            None,
+            Some(varopts),
+            NONE_CANCELLABLE,
+        )
+        .expect("static delta generate");
+
+    assert!(std::fs::File::open(&delta_path).is_err());
+}

--- a/rust-bindings/tests/repo/mod.rs
+++ b/rust-bindings/tests/repo/mod.rs
@@ -5,6 +5,7 @@ use ostree::{ObjectName, ObjectType};
 
 #[cfg(feature = "v2016_8")]
 mod checkout_at;
+mod generate_static;
 
 #[test]
 fn should_commit_content_to_repo_and_list_refs_again() {

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1334,9 +1334,9 @@ get_fallback_headers (OstreeRepo               *self,
  *   - inline-parts: b: Put part data in header, to get a single file delta.  Default FALSE.
  *   - verbose: b: Print diagnostic messages.  Default FALSE.
  *   - endianness: b: Deltas use host byte order by default; this option allows choosing (G_BIG_ENDIAN or G_LITTLE_ENDIAN)
- *   - filename: ay: Save delta superblock to this filename, and parts in the same directory.  Default saves to repository.
- *   - sign-name: ay: Signature type to use.
- *   - sign-key-ids: as: Array of keys used to sign delta superblock.
+ *   - filename: ^ay: Save delta superblock to this filename (bytestring), and parts in the same directory.  Default saves to repository.
+ *   - sign-name: ^ay: Signature type to use (bytestring).
+ *   - sign-key-ids: ^as: NULL-terminated array of keys used to sign delta superblock.
  */
 gboolean
 ostree_repo_static_delta_generate (OstreeRepo                   *self,
@@ -1409,9 +1409,13 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
 
   if (!g_variant_lookup (params, "filename", "^&ay", &opt_filename))
     opt_filename = NULL;
+  else if (opt_filename[0] == '\0')
+    return glnx_throw (error, "Invalid 'filename' parameter");
 
   if (!g_variant_lookup (params, "sign-name", "^&ay", &opt_sign_name))
     opt_sign_name = NULL;
+  else if (opt_sign_name[0] == '\0')
+    return glnx_throw (error, "Invalid 'sign-name' parameter");
 
   if (!g_variant_lookup (params, "sign-key-ids", "^a&s", &opt_key_ids))
     opt_key_ids = NULL;


### PR DESCRIPTION
This enhances the logic handling GVariant parameters within
`ostree_repo_static_delta_generate()`.
Several of those entries are expected to be zero-terminated values,
and this implicit assumption has been observed to be an hidden trap
in languages where strings and arrays may not carry a terminator value
(e.g. Rust).
In order to improve the situation, this makes the documentation more
explicit and actively tries to catch invalid input parameters.

Closes: https://github.com/ostreedev/ostree/issues/2728

---
[Original PR text below here]

This commit adds a test for the rust interface.
It should test the static-delta generation into a specified file.
Unfortunately it does not work because the ostree-lib throws an error:

```
---- repo::generate_static::should_generate_static_delta_at stdout ----
thread 'repo::generate_static::should_generate_static_delta_at' panicked at
'static delta generate: Error { domain: g-io-error-quark, code: 1, message: "renameat(./tmp.ReHre1, ): No such file or directory" }', 
rust-bindings/tests/repo/generate_static.rs:39:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It seems, that there is something wrong with the GVariant of filename, because
[`if (!g_variant_lookup (params, "filename", "^&ay", &opt_filename))`](https://github.com/ostreedev/ostree/blob/e527cdc5826ffb7c06ebf39fb3ab70482699eb8e/src/libostree/ostree-repo-static-delta-compilation.c#L1411) returns "true", but `opt_filename` is empty (see the empty 2nd parameter of [`renameat()`](https://gitlab.gnome.org/GNOME/libglnx/-/blob/master/glnx-fdio.h#L365) in the error message).