### PR TITLE
ostree-repo: bls-append-except-default followup

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -224,6 +224,7 @@ struct OstreeRepo {
   gint fs_support_reflink; /* The underlying filesystem has support for ioctl (FICLONE..) */
   gchar **repo_finders;
   OstreeCfgSysrootBootloaderOpt bootloader; /* Configure which bootloader to use. */
+  GHashTable *bls_append_values; /* Parsed key-values from bls-append-except-default key in config. */
 
   OstreeRepo *parent_repo;
 };


### PR DESCRIPTION
This PR is followup from https://github.com/coreos/coreos-assembler/pull/2863
Summary of changes:
- Moved bls-append-except-default parsing logic to `reload_sysroot_config()`
- Made sure heap allocated memory is being free'd