### PR TITLE
lib: Stop using old `ostree_sysroot_get_repo()` API

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1807,7 +1807,6 @@ parse_os_release (const char *contents,
  */
 static gboolean
 install_deployment_kernel (OstreeSysroot   *sysroot,
-                           OstreeRepo      *repo,
                            int             new_bootversion,
                            OstreeDeployment   *deployment,
                            guint           n_deployments,
@@ -1854,6 +1853,8 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
 
   if (!glnx_shutil_mkdir_p_at (sysroot->boot_fd, bootconfdir, 0775, cancellable, error))
     return FALSE;
+
+  OstreeRepo *repo = ostree_sysroot_repo (sysroot);
 
   /* Install (hardlink/copy) the kernel into /boot/ostree/osname-${bootcsum} if
    * it doesn't exist already.
@@ -2378,13 +2379,6 @@ write_deployments_bootswap (OstreeSysroot     *self,
                                cancellable, error))
     return FALSE;
 
-  /* Need the repo to try and extract the versions for deployments.
-   * But this is a "nice-to-have" for the bootloader UI, so failure
-   * here is not fatal to the whole operation.  We just gracefully
-   * fall back to the deployment index. */
-  g_autoptr(OstreeRepo) repo = NULL;
-  (void) ostree_sysroot_get_repo (self, &repo, cancellable, NULL);
-
   /* Only show the osname in bootloader titles if there are multiple
    * osname's among the new deployments.  Check for that here. */
   gboolean show_osname = FALSE;
@@ -2402,7 +2396,7 @@ write_deployments_bootswap (OstreeSysroot     *self,
   for (guint i = 0; i < new_deployments->len; i++)
     {
       OstreeDeployment *deployment = new_deployments->pdata[i];
-      if (!install_deployment_kernel (self, repo, new_bootversion,
+      if (!install_deployment_kernel (self, new_bootversion,
                                       deployment, new_deployments->len,
                                       show_osname, cancellable, error))
         return FALSE;

--- a/src/libostree/ostree-sysroot-upgrader.c
+++ b/src/libostree/ostree-sysroot-upgrader.c
@@ -492,7 +492,6 @@ ostree_sysroot_upgrader_pull_one_dir (OstreeSysrootUpgrader  *self,
                                       GCancellable           *cancellable,
                                       GError                **error)
 {
-  g_autoptr(OstreeRepo) repo = NULL;
   char *refs_to_fetch[] = { NULL, NULL };
   const char *from_revision = NULL;
   g_autofree char *origin_refspec = NULL;
@@ -506,8 +505,7 @@ ostree_sysroot_upgrader_pull_one_dir (OstreeSysrootUpgrader  *self,
   else
     refs_to_fetch[0] = self->origin_ref;
 
-  if (!ostree_sysroot_get_repo (self->sysroot, &repo, cancellable, error))
-    return FALSE;
+  OstreeRepo *repo = ostree_sysroot_repo (self->sysroot);
 
   if (self->origin_remote)
     origin_refspec = g_strconcat (self->origin_remote, ":", self->origin_ref, NULL);


### PR DESCRIPTION
It's falliable, and in one place we were actually ignoring
the error and leaving a `NULL` repo object which is just a trap
for people coming along later since it's rarely nullable.

Quite a while ago we switched to loading the repo at the same time
as the sysroot; convert callers in the library to use this infallible
accessor.

Prep for another patch which will use the repo object.