### PR TITLE
Fix link to rust bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ write higher level manual bindings on top; this is more common
 for statically compiled languages.  Here's a list of such bindings:
 
  - [ostree-go](https://github.com/ostreedev/ostree-go/)
- - [ostree-rs](https://github.com/ostreedev/ostree-rs/)
+ - [ostree-rs](./rust-bindings)
 
 ## Building
 


### PR DESCRIPTION
ostree-rs was merged into ostree, so link to the rust bindings within this repository.
