### PR TITLE
sysroot: Have `ensure_writable` also always initialize

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -328,13 +328,12 @@ gboolean
 _ostree_sysroot_ensure_writable (OstreeSysroot      *self,
                                  GError            **error)
 {
+  if (!ostree_sysroot_initialize (self, error))
+    return FALSE;
+
   /* Do nothing if no mount namespace is in use */
   if (!self->mount_namespace_in_use)
     return TRUE;
-
-  /* If a mount namespace is in use, ensure we're initialized */
-  if (!ostree_sysroot_initialize (self, error))
-    return FALSE;
 
   /* If we aren't operating on a booted system, then we don't
    * do anything with mounts.


### PR DESCRIPTION
For historical reasons we have a fair bit of distinct sysroot
initialization going on.  A lot of code is calling *just* the new
`ensure_writable()` API, which does basically what you'd expect...
except if we're not using a mount namespace.

Which is the case in unit tests and legacy setups.
Change this API to also ensure the sysroot is fully initialized
even in those cases.  Specifically we'll have `self->sysroot_fd`.

For now, callers that need `/boot` also need to separately
call `_ensure_boot_fd()`.