### PR TITLE
RFC: Support `/etc/ostree/config.d/` and use it to support user-configured top-level symlinks

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -82,6 +82,7 @@ ostree_SOURCES += \
 	src/ostree/ot-admin-builtin-pin.c \
 	src/ostree/ot-admin-builtin-upgrade.c \
 	src/ostree/ot-admin-builtin-unlock.c \
+	src/ostree/ot-admin-builtin-create-toplevel-user-links.c \
 	src/ostree/ot-admin-builtins.h \
 	src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c \
 	src/ostree/ot-admin-instutil-builtin-set-kargs.c \

--- a/src/libostree/ostree-cmd-private.c
+++ b/src/libostree/ostree-cmd-private.c
@@ -52,6 +52,7 @@ ostree_cmd__private__ (void)
     _ostree_repo_verify_bindings,
     _ostree_sysroot_finalize_staged,
     _ostree_sysroot_boot_complete,
+    _ostree_sysroot_create_toplevel_user_links,
   };
 
   return &table;

--- a/src/libostree/ostree-cmd-private.h
+++ b/src/libostree/ostree-cmd-private.h
@@ -34,6 +34,7 @@ typedef struct {
   gboolean (* ostree_repo_verify_bindings) (const char *collection_id, const char *ref_name, GVariant *commit, GError **error);
   gboolean (* ostree_finalize_staged) (OstreeSysroot *sysroot, GCancellable *cancellable, GError **error);
   gboolean (* ostree_boot_complete) (OstreeSysroot *sysroot, GCancellable *cancellable, GError **error);
+  gboolean (* ostree_create_toplevel_user_links) (OstreeSysroot *sysroot, int deployment_dfd, GCancellable *cancellable, GError **error);
 } OstreeCmdPrivateVTable;
 
 /* Note this not really "public", we just export the symbol, but not the header */

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -211,6 +211,7 @@ struct OstreeRepo {
   guint test_error_flags; /* OstreeRepoTestErrorFlags */
 
   GKeyFile *config;
+  GKeyFile *user_config;
   GHashTable *remotes;
   GMutex remotes_lock;
   OstreeRepoMode mode;

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -187,4 +187,10 @@ gboolean _ostree_sysroot_cleanup_internal (OstreeSysroot *sysroot,
                                            GCancellable  *cancellable,
                                            GError       **error);
 
+gboolean
+_ostree_sysroot_create_toplevel_user_links (OstreeSysroot     *self,
+                                            int                deployment_dfd,
+                                            GCancellable      *cancellable,
+                                            GError           **error);
+
 G_END_DECLS

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -258,3 +258,25 @@ ot_keyfile_copy_group (GKeyFile   *source_keyfile,
  out:
   return ret;
 }
+
+void
+ot_keyfile_get_keys_in_hashtable (GKeyFile   *keyfile,
+                                  GHashTable *table,
+                                  const char *group_name)
+{
+  g_assert (keyfile != NULL);
+  g_assert (table != NULL);
+  g_assert (group_name != NULL);
+
+  gsize length;
+  g_auto(GStrv) keys = g_key_file_get_keys (keyfile, group_name, &length, NULL);
+  if (keys == NULL)
+    return;
+
+  for (gsize i = 0; i < length; i++)
+    {
+      const char *key = keys[i];
+      g_autofree char *val = g_key_file_get_value (keyfile, group_name, key, NULL);
+      g_hash_table_insert (table, g_strdup (key), g_strdup (val));
+    }
+}

--- a/src/libotutil/ot-keyfile-utils.h
+++ b/src/libotutil/ot-keyfile-utils.h
@@ -72,4 +72,9 @@ ot_keyfile_copy_group (GKeyFile   *source_keyfile,
                        GKeyFile   *target_keyfile,
                        const char *group_name);
 
+void
+ot_keyfile_get_keys_in_hashtable (GKeyFile   *keyfile,
+                                  GHashTable *table,
+                                  const char *group_name);
+
 G_END_DECLS

--- a/src/ostree/ot-admin-builtin-create-toplevel-user-links.c
+++ b/src/ostree/ot-admin-builtin-create-toplevel-user-links.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "ot-main.h"
+#include "ot-admin-builtins.h"
+#include "ostree-cmd-private.h"
+
+static GOptionEntry options[] = {
+  { NULL }
+};
+
+gboolean
+ot_admin_builtin_create_toplevel_user_links (int argc, char **argv,
+                                             OstreeCommandInvocation *invocation,
+                                             GCancellable *cancellable,
+                                             GError **error)
+{
+  g_autoptr(OstreeSysroot) sysroot = NULL;
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                          invocation, &sysroot, cancellable, error))
+    return glnx_prefix_error (error, "parsing options");
+
+  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment (sysroot);
+  g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
+
+  glnx_autofd int deployment_dfd = -1;
+  if (!glnx_opendirat (ostree_sysroot_get_fd (sysroot), deployment_path, TRUE, &deployment_dfd, error))
+    return glnx_prefix_error (error, "open(%s)", deployment_path);
+
+  if (!ostree_sysroot_deployment_set_mutable (sysroot, deployment, TRUE, cancellable, error))
+    return glnx_prefix_error (error, "setting deployment mutable");
+
+  if (!ostree_cmd__private__()->ostree_create_toplevel_user_links (sysroot, deployment_dfd, cancellable, error))
+    return glnx_prefix_error (error, "creating toplevel user links");
+
+  if (!ostree_sysroot_deployment_set_mutable (sysroot, deployment, FALSE, cancellable, error))
+    return glnx_prefix_error (error, "setting deployment immutable");
+
+  return TRUE;
+}

--- a/src/ostree/ot-admin-builtins.h
+++ b/src/ostree/ot-admin-builtins.h
@@ -47,6 +47,7 @@ BUILTINPROTO(diff);
 BUILTINPROTO(switch);
 BUILTINPROTO(upgrade);
 BUILTINPROTO(kargs);
+BUILTINPROTO(create_toplevel_user_links);
 
 #undef BUILTINPROTO
 

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -79,6 +79,9 @@ static OstreeCommand admin_subcommands[] = {
   { "kargs", OSTREE_BUILTIN_FLAG_NO_REPO,
     ot_admin_builtin_kargs,
     "Change kernel arguments" },
+  { "create-toplevel-user-links", OSTREE_BUILTIN_FLAG_NO_REPO | OSTREE_BUILTIN_FLAG_HIDDEN,
+    ot_admin_builtin_create_toplevel_user_links,
+    "Create user-configured top-level symlinks" },
   { NULL, 0, NULL, NULL }
 };
 


### PR DESCRIPTION
The first commit adds support for users to drop configs in `/etc/ostree/config.d`. The second commit makes use of it to support users configuring top-level symbolic links. See individual commit messages for details.

Example using Fedora CoreOS:

```
$ cat config-toplevel-symlinks.bu
variant: fcos
version: 1.4.0
storage:
  disks:
    - device: /dev/disk/by-id/coreos-boot-disk
      partitions:
        - start_mib: 8000
          label: foobar
  filesystems:
    - device: /dev/disk/by-partlabel/foobar
      format: xfs
      with_mount_unit: true
      path: /var/foobar
  files:
    - path: /etc/ostree/config.d/01-foobar.conf
      contents:
        inline: |
          [toplevel-links]
          foobar=/var/foobar

$ cosa run -B config-toplevel-symlinks.bu -x 'sudo touch /foobar/bazboo && ls -l /foobar /foobar/'
lrwxrwxrwx. 1 root root 11 Jul 29 22:37 /foobar -> /var/foobar

/foobar/:
total 0
-rw-r--r--. 1 root root 0 Jul 29 22:37 bazboo
```