### PR TITLE
s390x: Avoid bash dependency

### DIFF
--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # This script creates new initramdisk with LUKS config within
-set -euo pipefail
+set -eu
 
 old_initrd=$1
 new_initrd=$2


### PR DESCRIPTION
bash is GPLv3 licensed and there's nothing in this script which really
needs it.

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>