### PR TITLE
deny.toml: Add `Unicode-DFS-2016`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 [licenses]
 unlicensed = "deny"
 copyleft = "allow"
-allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unlicense", "CC0-1.0"]
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unlicense", "Unicode-DFS-2016"]
 private = { ignore = true }
 
 [bans]


### PR DESCRIPTION
This is used by the unicode crate now and is definitely a compatible
FOSS license.