### PR TITLE
Handle conflicts between newer glibc and kernel headers

### DIFF
--- a/src/libostree/ostree-linuxfsutil.c
+++ b/src/libostree/ostree-linuxfsutil.c
@@ -24,9 +24,11 @@
 
 #include <fcntl.h>
 #include <sys/ioctl.h>
+// This should be the only file including linux/fs.h; see
+// https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+// https://github.com/ostreedev/ostree/issues/2685
+#include <linux/fs.h>
 #include <ext2fs/ext2_fs.h>
-
-#include "otutil.h"
 
 /**
  * _ostree_linuxfs_fd_alter_immutable_flag:
@@ -87,4 +89,22 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
     }
 
   return TRUE;
+}
+
+/* Wrapper for FIFREEZE ioctl.
+ * This is split into a separate wrapped API for
+ * reasons around conflicts between glibc and linux/fs.h
+ * includes; see above.
+ */
+int
+_ostree_linuxfs_filesystem_freeze (int fd)
+{
+  return TEMP_FAILURE_RETRY (ioctl (fd, FIFREEZE, 0));
+}
+
+/* Wrapper for FITHAW ioctl.  See above. */
+int
+_ostree_linuxfs_filesystem_thaw (int fd)
+{
+  return TEMP_FAILURE_RETRY (ioctl (fd, FITHAW, 0));
 }

--- a/src/libostree/ostree-linuxfsutil.h
+++ b/src/libostree/ostree-linuxfsutil.h
@@ -29,4 +29,7 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
                                          GCancellable  *cancellable,
                                          GError       **error);
 
+int _ostree_linuxfs_filesystem_freeze (int fd);
+int _ostree_linuxfs_filesystem_thaw (int fd);
+
 G_END_DECLS

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -30,7 +30,6 @@
 #include <sys/xattr.h>
 #include <glib/gprintf.h>
 #include <sys/ioctl.h>
-#include <linux/fs.h>
 #include <ext2fs/ext2_fs.h>
 
 #include "otutil.h"

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <sys/statvfs.h>
 #include <sys/mount.h>
-#include <linux/fs.h>
 
 #include "ot-main.h"
 #include "ostree.h"


### PR DESCRIPTION
Remove unused `linux/fs.h` includes

Prep for fixing conflicts introduced by newer glibc.
cc https://github.com/ostreedev/ostree/issues/2685

---

Move FIFREEZE/FITHAW ioctl invocations into linuxfsutil.c

Should help avoid conflicts between glibc and linux headers.

Closes: https://github.com/ostreedev/ostree/issues/2685

---

