### PR TITLE
Update to `libtest-mimic` 0.5.0

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -21,7 +21,7 @@ sh-inline = "0.2.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
 ostree-ext = { version = "0.7.0" }
-libtest-mimic = "0.3.0"
+libtest-mimic = "0.5.0"
 twoway = "0.2.1"
 hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }
 hyper-staticfile = "0.6.0"

--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -18,7 +18,6 @@ use hyper_staticfile::Static;
 use tokio::runtime::Runtime;
 
 pub(crate) type TestFn = fn() -> Result<()>;
-pub(crate) type TestImpl = libtest_mimic::Test<TestFn>;
 
 /// Run command and assert that its stderr contains pat
 pub(crate) fn cmd_fails_with<C: BorrowMut<Command>>(mut c: C, pat: &str) -> Result<()> {


### PR DESCRIPTION
I just released [a new version of libtest-mimic](https://github.com/LukasKalbertodt/libtest-mimic/releases/tag/v0.5.0). This is one of the bigger projects using it, so as a sanity check whether the new version still works for real world users, I just did this update. It allowed to remove some of the code here as the API changed a bit.

Two things to note:
- `libtest-mimic` requires Rust 1.58. 
- I do not know about this project at all and did not test anything. Please review carefully and/or test.