### PR TITLE
lib/commit: Directly use FICLONE for payload link

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -881,11 +881,8 @@ _try_clone_from_payload_link (OstreeRepo   *self,
       else
         {
           /* This undoes all of the previous writes; we want to generate reflinked data.   */
-          if (ftruncate (tmpf->fd, 0) < 0)
-            return glnx_throw_errno_prefix (error, "ftruncate");
-
-          if (glnx_regfile_copy_bytes (fdf, tmpf->fd, -1) < 0)
-            return glnx_throw_errno_prefix (error, "regfile copy");
+          if (ioctl (tmpf->fd, FICLONE, fdf) < 0)
+            return glnx_throw_errno_prefix (error, "FICLONE");
 
           return TRUE;
         }

--- a/tests/kolainst/destructive/staged-deploy.sh
+++ b/tests/kolainst/destructive/staged-deploy.sh
@@ -100,8 +100,7 @@ EOF
     newcommit=$(ostree rev-parse staged-deploy)
     ostree admin upgrade --stage >out.txt
     test -f /run/ostree/staged-deployment
-    # Debating bouncing back out to Ansible for this
-    firstdeploycommit=$(rpm-ostree status |grep 'Commit:' |head -1|sed -e 's,^ *Commit: *,,')
+    firstdeploycommit=$(rpm-ostree status --json | jq -r .deployments[0].checksum)
     assert_streq "${firstdeploycommit}" "${newcommit}"
     # Cleanup
     rpm-ostree cleanup -rp


### PR DESCRIPTION
The idea of payload linking is to reflink between objects where
possible. Instead of relying on `glnx_regfile_copy_bytes` to hit the
`FICLONE` path, just call `FICLONE` directly. At that point in the code,
we've already established that the source and dest repos are on the same
filesystem and that it supports `FICLONE`.

Related: https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/41
Related: https://github.com/ostreedev/ostree/pull/2684#issuecomment-1204068437