### PR TITLE
lib/commit: Unref repo on success

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1745,7 +1745,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
     return FALSE;
 
   /* Success: do not abort the transaction when returning. */
-  txn->repo = NULL; (void) txn;
+  g_clear_object (&txn->repo); (void) txn;
 
   if (out_transaction_resume)
     *out_transaction_resume = ret_transaction_resume;


### PR DESCRIPTION
Commit 540e60c3 introduced _ostree_repo_auto_transaction_new(), a
private constructor to OstreeRepoAutoTransaction, by factoring out
some code from _ostree_repo_auto_transaction_start(). This factored
code increased the refcount of the 'repo' variable.

Subsequent commit 71304e854c made ostree_repo_prepare_transaction()
use ths newly introduced constructor. However, in this function, the
happy path assumed no ref was taken, and therefore did not unref it.
Commit 71304e854c didn't add the corresponding unref either.

This leaks a reference to OstreeRepo when calling
ostree_repo_prepare_transaction().

Plug this leak by using g_clear_object() to clear the repo field
of OstreeRepoAutoTransaction, instead of simply setting it to NULL.

Closes https://github.com/flatpak/flatpak/issues/4928