### PR TITLE
libostree: fix a typo in annotation

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3594,7 +3594,7 @@ ostree_sysroot_deployment_set_kargs (OstreeSysroot     *self,
  * ostree_sysroot_deployment_set_kargs_in_place:
  * @self: Sysroot
  * @deployment: A deployment
- * @kargs_str: (allow none): Replace @deployment's kernel arguments
+ * @kargs_str: (allow-none): Replace @deployment's kernel arguments
  * @cancellable: Cancellable
  * @error: Error
  *


### PR DESCRIPTION
This fixes a typo in the `allow-none` annotation on
`ostree_sysroot_deployment_set_kargs_in_place` argument.