### PR TITLE
Backport Secure Execution enablement from 2022.5

### DIFF
--- a/src/libostree/ostree-bootloader-zipl.c
+++ b/src/libostree/ostree-bootloader-zipl.c
@@ -28,7 +28,7 @@
 #define SECURE_EXECUTION_SYSFS_FLAG     "/sys/firmware/uv/prot_virt_guest"
 #define SECURE_EXECUTION_PARTITION      "/dev/disk/by-label/se"
 #define SECURE_EXECUTION_MOUNTPOINT     "/sysroot/se"
-#define SECURE_EXECUTION_BOOT_IMAGE     SECURE_EXECUTION_MOUNTPOINT "/sd-boot"
+#define SECURE_EXECUTION_BOOT_IMAGE     SECURE_EXECUTION_MOUNTPOINT "/sdboot"
 #define SECURE_EXECUTION_HOSTKEY_PATH   "/etc/se-hostkeys/"
 #define SECURE_EXECUTION_HOSTKEY_PREFIX "ibm-z-hostkey"
 #define SECURE_EXECUTION_LUKS_ROOT_KEY  "/etc/luks/root"

--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -4,19 +4,19 @@ set -euo pipefail
 
 old_initrd=$1
 new_initrd=$2
+currdir=$PWD
 
-# Unpacking existing initramdisk
+# Copying existing initramdisk
+cp ${old_initrd} ${new_initrd}
+
+# Appending LUKS root keys and crypttab config to the end of initrd
 workdir=$(mktemp -d -p /tmp se-initramfs-XXXXXX)
 cd ${workdir}
-gzip -cd ${old_initrd} | cpio -imd --quiet
-
-# Adding LUKS root key and crypttab config
 mkdir -p etc/luks
 cp -f /etc/luks/* etc/luks/
 cp -f /etc/crypttab etc/
-
-# Creating new initramdisk image
 find . -mindepth 1 | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
 
 # Cleanup
+cd ${currdir}
 rm -rf ${workdir}

--- a/src/libostree/s390x-se-luks-gencpio
+++ b/src/libostree/s390x-se-luks-gencpio
@@ -12,11 +12,11 @@ gzip -cd ${old_initrd} | cpio -imd --quiet
 
 # Adding LUKS root key and crypttab config
 mkdir -p etc/luks
-cp -f /etc/luks/root etc/luks/
+cp -f /etc/luks/* etc/luks/
 cp -f /etc/crypttab etc/
 
 # Creating new initramdisk image
-find . | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
+find . -mindepth 1 | cpio --quiet -H newc -o | gzip -9 -n >> ${new_initrd}
 
 # Cleanup
 rm -rf ${workdir}


### PR DESCRIPTION
```
commit 14a7c0c74bc080bbe8529c8645b895c118b83d9a
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Thu Jun 23 15:54:04 2022 +0200

    s390x: rename sd-boot to sdboot

    Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>

commit 972f00e4835053b5c000937be2847da658f005dd
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Fri May 27 09:13:18 2022 +0200

    s390x: do not unpack existing initrd, just append LUKS keys to its copy

    Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>

commit b03fa626f1c3242cbf5555a885f69ac03563c95f
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Tue May 24 19:30:35 2022 +0200

    s390x: fail on error during reading of SecureExecution sysfs flag

commit d0005698596ff3e434a3e4ddd4aea8d4c618079f
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Mon May 23 17:28:54 2022 +0200

    s390x: ensure SecureExecution is enabled before sd-boot generation

    Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>

commit 7a5c604ca3391e93c4723dd539157434c7fb558b
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Mon Apr 4 16:09:50 2022 +0200

    s390x: generate sd-boot at its own partition

    Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>
```