### PR TITLE
Fix `ostree admin kargs edit-in-place` assertion when deployments are pending

### DIFF
--- a/tests/kolainst/destructive/kargs-edit-in-place.sh
+++ b/tests/kolainst/destructive/kargs-edit-in-place.sh
@@ -6,7 +6,19 @@ set -xeuo pipefail
 
 . ${KOLA_EXT_DATA}/libinsttest.sh
 
-sudo ostree admin kargs edit-in-place --append-if-missing=testarg
-assert_file_has_content /boot/loader/entries/ostree-* testarg
-
-echo "ok test `kargs edit-in-place --append-if-missing`"
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+  sudo rpm-ostree kargs --append=somedummykarg=1
+  sudo ostree admin kargs edit-in-place --append-if-missing=testarg
+  assert_file_has_content /boot/loader/entries/ostree-* testarg
+  /tmp/autopkgtest-reboot "2"
+  ;;
+"2")
+  assert_file_has_content_literal /proc/cmdline somedummykarg=1
+  assert_file_has_content_literal /proc/cmdline testarg
+  echo "ok test with stage: kargs edit-in-place --append-if-missing"
+  ;;
+*)
+  fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}"
+  ;;
+esac


### PR DESCRIPTION
This is to support pending deployments instead of rasing assertion.
For example:
```
$ sudo rpm-ostree kargs --append=foo=bar
$ sudo ostree admin kargs edit-in-place --append-if-missing=rw
```
After reboot we get both `foo=bar rw`.

Fix https://github.com/ostreedev/ostree/issues/2679