### PR TITLE
ci: Also drop seccomp on debian testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,7 @@ jobs:
 
           - name: Debian Testing
             image: debian:testing-slim
+            container-options: --security-opt seccomp=unconfined
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git


### PR DESCRIPTION


I didn't deep dive into debugging this but I'm pretty sure it's
 https://gitlab.gnome.org/GNOME/glib/-/issues/2580
which is us having an older Docker in the middle here.

---

