### PR TITLE
buildutil/glibtests.m4: fix bashism

### DIFF
--- a/buildutil/glibtests.m4
+++ b/buildutil/glibtests.m4
@@ -25,7 +25,7 @@ AC_DEFUN([GLIB_TESTS],
                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-always-build-tests]) ;;
                  esac])
   AM_CONDITIONAL([ENABLE_ALWAYS_BUILD_TESTS], test "$ENABLE_ALWAYS_BUILD_TESTS" = "1")
-  if test "$ENABLE_INSTALLED_TESTS" == "1"; then
+  if test "$ENABLE_INSTALLED_TESTS" = "1"; then
     AC_SUBST(installed_test_metadir, [${datadir}/installed-tests/]AC_PACKAGE_NAME)
     AC_SUBST(installed_testdir, [${libexecdir}/installed-tests/]AC_PACKAGE_NAME)
   fi


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors
like this aren't spotted. Notably Debian defaults to /bin/sh provided
by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Fixes configure warnings/errors like:
```

checking whether to build static libraries... no
./configure: 14795: test: unexpected operator
```

Signed-off-by: Sam James <sam@gentoo.org>