### PR TITLE
ostree-fetcher-curl: check for HTTP2 support before trying to use it

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -882,8 +882,10 @@ initiate_next_curl_request (FetcherRequest *req,
   if (!(self->config_flags & OSTREE_FETCHER_FLAGS_DISABLE_HTTP2))
     {
 #if CURL_AT_LEAST_VERSION(7, 51, 0)
-     rc = curl_easy_setopt (req->easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
-     g_assert_cmpint (rc, ==, CURLM_OK);
+     if ((curl_version_info (CURLVERSION_NOW))->features & CURL_VERSION_HTTP2) {
+         rc = curl_easy_setopt (req->easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+         g_assert_cmpint (rc, ==, CURLM_OK);
+     }
 #endif
       /* https://github.com/curl/curl/blob/curl-7_53_0/docs/examples/http2-download.c */
 #if (CURLPIPE_MULTIPLEX > 0)


### PR DESCRIPTION
https://github.com/flatpak/flatpak/pull/5074