### PR TITLE
otutil: add error handling to variant builders

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1369,7 +1369,6 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
   g_autoptr(GPtrArray) builder_parts = g_ptr_array_new_with_free_func ((GDestroyNotify)ostree_static_delta_part_builder_unref);
   g_autoptr(GPtrArray) builder_fallback_objects = g_ptr_array_new_with_free_func ((GDestroyNotify)g_variant_unref);
   g_auto(GLnxTmpfile) descriptor_tmpf = { 0, };
-  g_autoptr(OtVariantBuilder) descriptor_builder = NULL;
   const char *opt_sign_name;
   const char **opt_key_ids;
 
@@ -1456,7 +1455,10 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
                                       &descriptor_tmpf, error))
     return FALSE;
 
-  descriptor_builder = ot_variant_builder_new (G_VARIANT_TYPE (OSTREE_STATIC_DELTA_SUPERBLOCK_FORMAT), descriptor_tmpf.fd);
+  g_autoptr(OtVariantBuilder) descriptor_builder =
+    ot_variant_builder_new (G_VARIANT_TYPE (OSTREE_STATIC_DELTA_SUPERBLOCK_FORMAT),
+                            descriptor_tmpf.fd);
+  g_assert (descriptor_builder != NULL);
 
   /* Open the metadata dict */
   if (!ot_variant_builder_open (descriptor_builder, G_VARIANT_TYPE ("a{sv}"), error))
@@ -1603,7 +1605,6 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
       const gchar *signature_key = NULL;
       g_autoptr(GVariantBuilder) signature_builder = NULL;
       g_auto(GLnxTmpfile) descriptor_sign_tmpf = { 0, };
-      g_autoptr(OtVariantBuilder) descriptor_sign_builder = NULL;
 
       lseek (descriptor_tmpf.fd, 0, SEEK_SET);
       tmpdata = glnx_fd_readall_bytes (descriptor_tmpf.fd, cancellable, error);
@@ -1640,8 +1641,10 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
                                           &descriptor_sign_tmpf, error))
         return FALSE;
 
-      descriptor_sign_builder = ot_variant_builder_new (G_VARIANT_TYPE (OSTREE_STATIC_DELTA_SIGNED_FORMAT),
-                                                        descriptor_sign_tmpf.fd);
+      g_autoptr(OtVariantBuilder) descriptor_sign_builder =
+        ot_variant_builder_new (G_VARIANT_TYPE (OSTREE_STATIC_DELTA_SIGNED_FORMAT),
+                                descriptor_sign_tmpf.fd);
+      g_assert (descriptor_sign_builder != NULL);
 
       if (!ot_variant_builder_add (descriptor_sign_builder, error, "t",
                                    GUINT64_TO_BE (OSTREE_STATIC_DELTA_SIGNED_MAGIC)))

--- a/src/libotutil/ot-variant-builder.c
+++ b/src/libotutil/ot-variant-builder.c
@@ -758,11 +758,9 @@ struct _OtVariantBuilder {
 static OtVariantBuilderInfo *
 ot_variant_builder_info_new (OtVariantBuilder *builder, const GVariantType *type)
 {
-  OtVariantBuilderInfo *info;
+  g_assert (g_variant_type_is_container (type));
 
-  g_return_val_if_fail (g_variant_type_is_container (type), NULL);
-
-  info = (OtVariantBuilderInfo *) g_slice_new0 (OtVariantBuilderInfo);
+  OtVariantBuilderInfo *info = (OtVariantBuilderInfo *) g_slice_new0 (OtVariantBuilderInfo);
 
   info->builder = builder;
   info->type = g_variant_type_copy (type);
@@ -843,11 +841,9 @@ OtVariantBuilder *
 ot_variant_builder_new (const GVariantType *type,
                         int fd)
 {
-  OtVariantBuilder *builder;
+  g_assert (g_variant_type_is_container (type));
 
-  g_return_val_if_fail (g_variant_type_is_container (type), NULL);
-
-  builder = (OtVariantBuilder *) g_slice_new0 (OtVariantBuilder);
+  OtVariantBuilder *builder = (OtVariantBuilder *) g_slice_new0 (OtVariantBuilder);
 
   builder->head = ot_variant_builder_info_new (builder, type);
   builder->ref_count = 1;
@@ -1083,7 +1079,6 @@ ot_variant_builder_open (OtVariantBuilder *builder,
                          GError **error)
 {
   OtVariantBuilderInfo *info = builder->head;
-  OtVariantBuilderInfo *new_info;
 
   g_assert (info->n_children < info->max_items);
   g_assert (!info->expected_type ||
@@ -1096,7 +1091,9 @@ ot_variant_builder_open (OtVariantBuilder *builder,
   if (!ot_variant_builder_pre_add (info, type, error))
     return FALSE;
 
-  new_info = ot_variant_builder_info_new (builder, type);
+  OtVariantBuilderInfo *new_info = ot_variant_builder_info_new (builder, type);
+  g_assert (new_info != NULL);
+
   new_info->parent = info;
 
   /* push the prev_item_type down into the subcontainer */


### PR DESCRIPTION
This enhances a bunch of helpers related to GVariant building, in
order to properly handle errors and avoid some potential cases of
unexpected NULL results.