### PR TITLE
lib/mtree: drop redundant name checks

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -303,8 +303,6 @@ ostree_mutable_tree_replace_file (OstreeMutableTree *self,
                                   const char        *checksum,
                                   GError           **error)
 {
-  g_return_val_if_fail (name != NULL, FALSE);
-
   if (!ot_util_filename_validate (name, error))
     return FALSE;
 
@@ -338,8 +336,6 @@ ostree_mutable_tree_remove (OstreeMutableTree *self,
                             gboolean           allow_noent,
                             GError           **error)
 {
-  g_return_val_if_fail (name != NULL, FALSE);
-
   if (!ot_util_filename_validate (name, error))
     return FALSE;
 
@@ -374,8 +370,6 @@ ostree_mutable_tree_ensure_dir (OstreeMutableTree *self,
                                 OstreeMutableTree **out_subdir,
                                 GError           **error)
 {
-  g_return_val_if_fail (name != NULL, FALSE);
-
   if (!ot_util_filename_validate (name, error))
     return FALSE;
 


### PR DESCRIPTION
This drops several NULL checks against filename input argument.
Those checks are both redundant (as filename validation already checks for that) and dangerous (as they return early without setting an error value).