### PR TITLE
Support overlayfs whiteouts on checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,8 +172,14 @@ jobs:
       # An empty string isn't valid, so a dummy --label option is always
       # added.
       options: --label ostree ${{ matrix.container-options }}
+      # make sure tests are performed on a non-overlayfs filesystem
+      volumes:
+        - tmp_dir:/test-tmp
+      env:
+        TEST_TMPDIR: /test-tmp
 
     steps:
+
       - name: Pre-checkout setup
         run: ${{ matrix.pre-checkout-setup }}
         if: ${{ matrix.pre-checkout-setup }}
@@ -187,7 +193,7 @@ jobs:
         run: ./ci/gh-install.sh ${{ matrix.extra-packages }}
 
       - name: Add non-root user
-        run: "useradd builder && chown -R -h builder: ."
+        run: "useradd builder && chown -R -h builder: . $TEST_TMPDIR"
 
       - name: Build and test
         run: runuser -u builder -- ./ci/gh-build.sh ${{ matrix.configure-options }}

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -107,6 +107,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-deploy-nomerge.sh \
 	tests/test-admin-deploy-none.sh \
 	tests/test-admin-deploy-bootid-gc.sh \
+	tests/test-admin-deploy-whiteouts.sh \
 	tests/test-osupdate-dtb.sh \
 	tests/test-admin-instutil-set-kargs.sh \
 	tests/test-admin-upgrade-not-backwards.sh \

--- a/bash/ostree
+++ b/bash/ostree
@@ -249,6 +249,7 @@ _ostree_checkout() {
         --union-identical
         --user-mode -U
         --whiteouts
+        --process-passthrough-whiteouts
     "
 
     local options_with_args="

--- a/man/ostree-checkout.xml
+++ b/man/ostree-checkout.xml
@@ -115,6 +115,17 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--process-passthrough-whiteouts</option></term>
+
+                <listitem><para>
+                   Enable overlayfs whiteout extraction into 0:0 character devices.
+                   Overlayfs whiteouts are encoded inside ostree as <literal>.ostree-wh.filename</literal>
+                   and extracted as 0:0 character devices. This is useful to carry
+                   container storage embedded into ostree.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--allow-noent</option></term>
 
                 <listitem><para>

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -989,8 +989,9 @@ typedef struct {
   gboolean force_copy; /* Since: 2017.6 */
   gboolean bareuseronly_dirs; /* Since: 2017.7 */
   gboolean force_copy_zerosized; /* Since: 2018.9 */
-  gboolean unused_bools[4];
-  /* 4 byte hole on 64 bit */
+  gboolean process_passthrough_whiteouts;
+  gboolean unused_bools[3];
+  /* 3 byte hole on 64 bit */
 
   const char *subpath;
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -641,7 +641,7 @@ checkout_deployment_tree (OstreeSysroot     *sysroot,
     return FALSE;
 
   /* Generate hardlink farm, then opendir it */
-  OstreeRepoCheckoutAtOptions checkout_opts = { 0, };
+  OstreeRepoCheckoutAtOptions checkout_opts = { .process_passthrough_whiteouts = TRUE };
   if (!ostree_repo_checkout_at (repo, &checkout_opts, osdeploy_dfd,
                                 checkout_target_name, csum,
                                 cancellable, error))

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -37,6 +37,7 @@ static gboolean opt_union;
 static gboolean opt_union_add;
 static gboolean opt_union_identical;
 static gboolean opt_whiteouts;
+static gboolean opt_process_passthrough_whiteouts;
 static gboolean opt_from_stdin;
 static char *opt_from_file;
 static gboolean opt_disable_fsync;
@@ -77,6 +78,7 @@ static GOptionEntry options[] = {
   { "union-add", 0, 0, G_OPTION_ARG_NONE, &opt_union_add, "Keep existing files/directories, only add new", NULL },
   { "union-identical", 0, 0, G_OPTION_ARG_NONE, &opt_union_identical, "When layering checkouts, error out if a file would be replaced with a different version, but add new files and directories", NULL },
   { "whiteouts", 0, 0, G_OPTION_ARG_NONE, &opt_whiteouts, "Process 'whiteout' (Docker style) entries", NULL },
+  { "process-passthrough-whiteouts", 0, 0, G_OPTION_ARG_NONE, &opt_process_passthrough_whiteouts, "Enable overlayfs whiteout extraction into char 0:0 devices", NULL },
   { "allow-noent", 0, 0, G_OPTION_ARG_NONE, &opt_allow_noent, "Do nothing if specified path does not exist", NULL },
   { "from-stdin", 0, 0, G_OPTION_ARG_NONE, &opt_from_stdin, "Process many checkouts from standard input", NULL },
   { "from-file", 0, 0, G_OPTION_ARG_STRING, &opt_from_file, "Process many checkouts from input file", "FILE" },
@@ -129,7 +131,8 @@ process_one_checkout (OstreeRepo           *repo,
   if (opt_disable_cache || opt_whiteouts || opt_require_hardlinks ||
       opt_union_add || opt_force_copy || opt_force_copy_zerosized ||
       opt_bareuseronly_dirs || opt_union_identical ||
-      opt_skiplist_file || opt_selinux_policy || opt_selinux_prefix)
+      opt_skiplist_file || opt_selinux_policy || opt_selinux_prefix ||
+      opt_process_passthrough_whiteouts)
     {
       OstreeRepoCheckoutAtOptions checkout_options = { 0, };
 
@@ -162,6 +165,8 @@ process_one_checkout (OstreeRepo           *repo,
         }
       if (opt_whiteouts)
         checkout_options.process_whiteouts = TRUE;
+      if (opt_process_passthrough_whiteouts)
+        checkout_options.process_passthrough_whiteouts = TRUE;
       if (subpath)
         checkout_options.subpath = subpath;
 

--- a/tests/archive-test.sh
+++ b/tests/archive-test.sh
@@ -71,6 +71,11 @@ mkdir -p test-overlays
 date > test-overlays/overlaid-file
 $OSTREE commit ${COMMIT_ARGS} -b test-base --base test2 --owner-uid 42 --owner-gid 42 test-overlays/
 $OSTREE ls -R test-base > ls.txt
-assert_streq "$(wc -l < ls.txt)" 14
+if can_create_whiteout_devices; then
+    assert_streq "$(wc -l < ls.txt)" 17
+else
+    assert_streq "$(wc -l < ls.txt)" 14
+fi
+
 assert_streq "$(grep '42.*42' ls.txt | wc -l)" 2
 echo "ok commit overlay base"

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((88 + ${extra_basic_tests:-0}))"
+echo "1..$((90 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -1202,4 +1202,31 @@ if test "$(id -u)" != "0"; then
     echo "ok unwritable repo was caught"
 else
     echo "ok # SKIP not run when root"
+fi
+
+if ! skip_one_without_whiteouts_devices; then
+    cd ${test_tmpdir}
+    rm checkout-test2 -rf
+    $OSTREE checkout test2 checkout-test2
+
+    assert_not_has_file checkout-test2/whiteouts/whiteout
+    assert_not_has_file checkout-test2/whiteouts/whiteout2
+    assert_has_file checkout-test2/whiteouts/.ostree-wh.whiteout
+    assert_has_file checkout-test2/whiteouts/.ostree-wh.whiteout2
+
+    echo "ok checkout: no whiteout passthrough by default"
+fi
+
+if ! skip_one_without_whiteouts_devices; then
+    cd ${test_tmpdir}
+    rm checkout-test2 -rf
+    $OSTREE checkout --process-passthrough-whiteouts test2 checkout-test2
+
+    assert_not_has_file checkout-test2/whiteouts/.ostree-wh.whiteout
+    assert_not_has_file checkout-test2/whiteouts/.ostree-wh.whiteout2
+
+    assert_is_whiteout_device checkout-test2/whiteouts/whiteout
+    assert_is_whiteout_device checkout-test2/whiteouts/whiteout2
+
+    echo "ok checkout: whiteout with overlayfs passthrough processing"
 fi

--- a/tests/kolainst/data-shared/libtest-core.sh
+++ b/tests/kolainst/data-shared/libtest-core.sh
@@ -163,6 +163,13 @@ assert_file_has_mode () {
     fi
 }
 
+assert_is_whiteout_device () {
+    device_details="$(stat -c '%F %t:%T' $1)"
+    if [ "$device_details" != "character special file 0:0" ]; then
+        fatal "File '$1' is not a whiteout character device 0:0"
+    fi
+}
+
 assert_symlink_has_content () {
     if ! test -L "$1"; then
         fatal "File '$1' is not a symbolic link"

--- a/tests/test-admin-deploy-whiteouts.sh
+++ b/tests/test-admin-deploy-whiteouts.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+set -euox pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_whiteouts_devices
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive" "syslinux"
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
+
+echo "1..3"
+${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=LABEL=foo --karg=testkarg=1 testos:testos/buildmain/x86_64-runtime
+origdeployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
+
+assert_is_whiteout_device "${origdeployment}"/usr/container/layers/abcd/whiteout
+echo "ok whiteout deployment"
+
+assert_not_has_file  "${origdeployment}"/usr/container/layers/abcd/.ostree-wh.whiteout
+echo "ok .ostree-wh.whiteout not created"
+
+assert_file_has_mode "${origdeployment}"/usr/container/layers/abcd/whiteout 400
+assert_file_has_mode "${origdeployment}"/usr/container/layers/abcd/whiteout2 777
+echo "ok whiteout permissions are preserved"


### PR DESCRIPTION
Introduces an intermediate format for overlayfs storage, where
.wh-ostree. prefixed files will be converted into char 0:0
whiteout devices used by overlayfs to mark deletions across layers.

Related-Issue: #2712
