### PR TITLE
Update test-demo-buildsystem.sh

### DIFF
--- a/tests/test-demo-buildsystem.sh
+++ b/tests/test-demo-buildsystem.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 skip_without_fuse
 skip_without_user_xattrs
 
+user=$(env | grep USER | cut -d "=" -f 2)
+if [ "$user" != "root" ]
+then
+	skip "user:$user does not support running the test case"
+fi
+
 echo "1..1"
 
 # Run "triggers" like ldconfig, gtk-update-icon-cache, etc.


### PR DESCRIPTION
1.A normal user executing this user's occasional use case fails；
2.The main reason is that the cmd: fusermount -u mnt failed, of course, fuse is not excluded as a defect;
3.It is recommended that ostree do a circumvention here: the  normal user skips this use case.