### PR TITLE
Update test-rofiles-fuse.sh

### DIFF
--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 skip_without_fuse
 skip_without_user_xattrs
 
+user=$(env | grep USER | cut -d "=" -f 2)
+if [ "$user" != "root" ]
+then
+	skip "user:$user does not support running the test case"
+fi
+
 setup_test_repository "bare"
 
 echo "1..12"


### PR DESCRIPTION
1.A normal user executing this user's occasional use case fails；
2.The main reason is that the cmd: fusermount -u mnt failed, of course, fuse is not excluded as a defect;
3.It is recommended that ostree do a circumvention here: the normal user skips this use case.