### PR TITLE
Release 2022.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2022])
 m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2022])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This release contains a collection of bugfixes and enhancements. Notable fixes concern `finalize-staged`, which should now better support automounted partitions and skip waiting for termination signal.

A file descriptor leak has been fixed in the commit logic. The codebase has also been fixed to avoid conflicting declarations when building with latest `glibc` (>=  2.36). Thanks @GeorgesStavracas for both fixes!

On the feature side, there is now basic support for handling overlayfs whiteouts on checkout through a new `--process-passthrough-whiteouts` flag. This is useful for users that need to carry container storage embedded into ostree commits. Thanks @mangelajo for that!

The `ostree rev-parse` command gained a new `--single` flag to better support repositories containing exactly one commit.
Overall, the s390x Secure Execution (SE) logic has been reworked to stop relying on glue scripts.

Thanks to all contributors!

---

```
Andrea Perotti (1):
      Fix recursive git archive reference

Colin Walters (12):
      configure: post-release version bump
      rust-bindings: Fix `cargo fmt`
      deny.toml: Add `Unicode-DFS-2016`
      Remove unused `linux/fs.h` includes
      Move FIFREEZE/FITHAW ioctl invocations into linuxfsutil.c
      cli/rev-parse: Port to new code style
      cli/rev-parse: Add `--single` option
      rust: Update to latest git
      ci: Also drop seccomp on debian testing
      rust: Bind `ostree_repo_list_commits_starting_with`
      finalize-staged: Don't listen to `SIGTERM`, just let kernel exit us
      README.md: Link otto

Dan Nicholson (3):
      main: Factor out sysroot loading
      finalize-staged: Ensure /boot automount doesn't expire
      lib/pull: Fix max-metadata-size documentation

Georges Basile Stavracas Neto (1):
      lib/commit: Unref repo on success

Huijing Hei (1):
      Fix `ostree admin kargs edit-in-place` assertion when deployments are pending

Jon Oster (1):
      docs: Add aktualizr and TorizonCore to related projects

Jonathan Lebon (3):
      lib/commit: Directly use FICLONE for payload link
      tests/kolainst/staged-deploy: parse `rpm-ostree status --json` instead
      docs: Add section about staged deployments

Luca BRUNO (7):
      libostree: fix a typo in annotation
      lib/bootloader: assert invariants
      lib/mtree: drop redundant name checks
      otutil: add error handling to variant builders
      lib/sign: convert invariant checks to assertions
      lib/repo: properly initialize boolean variable
      lib/sysroot-deploy: explicitly handle `g_variant_lookup` results

Lukas Kalbertodt (1):
      Update to `libtest-mimic` 0.5.0

Miguel Angel Ajo (1):
      Support overlayfs whiteouts on checkout

Nikita Dubrovskii (3):
      s390x: ensure both 'root' and 'boot' luks keys exist
      s390x: simplify 's390x-se-luks-gencpio' script
      s390x: use 'libarchive' to modify initrd in SE case

Sam James (1):
      buildutil/glibtests.m4: fix bashism

dependabot[bot] (1):
      build(deps): bump libglnx from `c59eb27` to `26375b5`

git-bruh (1):
      ostree-fetcher-curl: check for HTTP2 support before trying to use it
```