### PR TITLE
make-git-snapshot: Always run `git submodule init`

### DIFF
--- a/ci/make-git-snapshot.sh
+++ b/ci/make-git-snapshot.sh
@@ -11,9 +11,7 @@ PKG_VER="${name}-${version}"
 TARFILE=${PKG_VER}.tar
 TARFILE_TMP=${TARFILE}.tmp
 
-if ! test -f ${TOP}/libglnx/README.md || ! test -f ${TOP}/bsdiff/README.md; then
-    git submodule update --init
-fi
+git submodule update --init
 
 echo "Archiving ${PKG_VER} at ${GITREV} to ${TARFILE_TMP}"
 (cd ${TOP}; git archive --format=tar --prefix=${PKG_VER}/ ${GITREV}) > ${TARFILE_TMP}


### PR DESCRIPTION
It turns out COPR is buggy and does:

$ git clone --recursive
$ git switch `<branch>`

This results in the submodules not being initialized for the target branch.  Work around this by always re-initializing submodules.