### PR TITLE
lib/repo-checkout: fix typo in error message

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -684,7 +684,7 @@ _checkout_overlayfs_whiteout_at (OstreeRepo                     *repo,
 
             if (uid != dest_stbuf.st_uid)
               return glnx_throw(error, "existing destination file %s does not match uid %d",
-                                destination_name, gid);
+                                destination_name, uid);
 
             if ((file_mode & ALLPERMS) != (dest_stbuf.st_mode & ALLPERMS))
               return glnx_throw(error, "existing destination file %s does not match mode %o",


### PR DESCRIPTION
This fixes a typo in an error message, resulting in a GID vs UID mixup.
It was detected by RH internal static checks.