### PR TITLE
ci/rust: bump linting toolchain to latest stable (1.64)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.56.0
+  ACTION_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   build:

--- a/rust-bindings/src/repo_checkout_at_options/repo_checkout_filter.rs
+++ b/rust-bindings/src/repo_checkout_at_options/repo_checkout_filter.rs
@@ -18,6 +18,7 @@ use std::process::abort;
 ///
 /// # Return Value
 /// The return value determines whether the current file is checked out or skipped.
+#[allow(clippy::type_complexity)]
 pub struct RepoCheckoutFilter(Box<dyn Fn(&Repo, &Path, &libc::stat) -> RepoCheckoutFilterResult>);
 
 impl RepoCheckoutFilter {

--- a/rust-bindings/src/sysroot_deploy_tree_opts.rs
+++ b/rust-bindings/src/sysroot_deploy_tree_opts.rs
@@ -3,20 +3,12 @@ use glib::translate::*;
 use libc::c_char;
 
 /// Options for deploying an ostree commit.
+#[derive(Default)]
 pub struct SysrootDeployTreeOpts<'a> {
     /// Use these kernel arguments.
     pub override_kernel_argv: Option<&'a [&'a str]>,
     /// Paths to initramfs files to overlay.
     pub overlay_initrds: Option<&'a [&'a str]>,
-}
-
-impl<'a> Default for SysrootDeployTreeOpts<'a> {
-    fn default() -> Self {
-        SysrootDeployTreeOpts {
-            override_kernel_argv: None,
-            overlay_initrds: None,
-        }
-    }
 }
 
 type OptionStrSliceStorage<'a> =

--- a/rust-bindings/src/sysroot_write_deployments_opts.rs
+++ b/rust-bindings/src/sysroot_write_deployments_opts.rs
@@ -2,17 +2,10 @@ use ffi::OstreeSysrootWriteDeploymentsOpts;
 use glib::translate::*;
 
 /// Options for writing a deployment.
+#[derive(Default)]
 pub struct SysrootWriteDeploymentsOpts {
     /// Perform cleanup after writing the deployment.
     pub do_postclean: bool,
-}
-
-impl Default for SysrootWriteDeploymentsOpts {
-    fn default() -> Self {
-        SysrootWriteDeploymentsOpts {
-            do_postclean: false,
-        }
-    }
 }
 
 impl<'a> ToGlibPtr<'a, *const OstreeSysrootWriteDeploymentsOpts> for SysrootWriteDeploymentsOpts {


### PR DESCRIPTION
This bumps the Rust toolchain for clippy/rustfmt to 1.64.