### PR TITLE
ci/rust: test from git using latest feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_PROJECT_FEATURES: "v2021_5,cap-std-apis"
   # TODO: Automatically query this from the C side
-  LATEST_LIBOSTREE: "v2022_5"
+  LATEST_LIBOSTREE: "v2022_6"
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting


### PR DESCRIPTION
A late CI update with a followup for https://github.com/ostreedev/ostree/pull/2742.