### PR TITLE
Replace calls to g_memdup() with g_memdup2()

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -4858,7 +4858,7 @@ _ostree_repo_import_object (OstreeRepo           *self,
 static OstreeRepoTransactionStats *
 ostree_repo_transaction_stats_copy (OstreeRepoTransactionStats *stats)
 {
-  return g_memdup (stats, sizeof (OstreeRepoTransactionStats));
+  return g_memdup2 (stats, sizeof (OstreeRepoTransactionStats));
 }
 
 static void

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -430,7 +430,7 @@ gboolean ostree_sign_ed25519_add_pk (OstreeSign *self,
 
   if (g_list_find_custom (sign->public_keys, key, _compare_ed25519_keys) == NULL)
     {
-      gpointer newkey = g_memdup (key, n_elements);
+      gpointer newkey = g_memdup2 (key, n_elements);
       sign->public_keys = g_list_prepend (sign->public_keys, newkey);
     }
 
@@ -466,7 +466,7 @@ _ed25519_add_revoked (OstreeSign *self,
 
   if (g_list_find_custom (sign->revoked_keys, key, _compare_ed25519_keys) == NULL)
     {
-      gpointer newkey = g_memdup (key, n_elements);
+      gpointer newkey = g_memdup2 (key, n_elements);
       sign->revoked_keys = g_list_prepend (sign->revoked_keys, newkey);
     }
 

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -249,7 +249,7 @@ ot_gio_splice_get_checksum (GOutputStream  *out,
   guint8 digest[_OSTREE_SHA256_DIGEST_LEN];
   ot_checksum_get_digest (&checksum, digest, sizeof (digest));
   if (out_csum)
-    *out_csum = g_memdup (digest, sizeof (digest));
+    *out_csum = g_memdup2 (digest, sizeof (digest));
   return TRUE;
 }
 

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -43,7 +43,7 @@ GVariant *
 ot_gvariant_new_bytearray (const guchar   *data,
                            gsize           len)
 {
-  gpointer data_copy = g_memdup (data, len);
+  gpointer data_copy = g_memdup2 (data, len);
   GVariant *ret = g_variant_new_from_data (G_VARIANT_TYPE ("ay"), data_copy,
                                  len, FALSE, g_free, data_copy);
   return ret;

--- a/tests/test-commit-sign-sh-ext.c
+++ b/tests/test-commit-sign-sh-ext.c
@@ -41,7 +41,7 @@ corrupt (GBytes *input)
   const guint8 *buf = g_bytes_get_data (input, &len);
   g_assert_cmpint (len, >, 0);
   g_assert_cmpint (len, <, G_MAXINT);
-  g_autofree char *newbuf = g_memdup (buf, len);
+  g_autofree char *newbuf = g_memdup2 (buf, len);
   g_assert (newbuf != NULL);
   int o = g_random_int_range (0, len);
   newbuf[o] = (newbuf[0] + 1);


### PR DESCRIPTION
* Update submodule: libglnx
    
    - Backport g_memdup2 (see #2751)

* Replace calls to g_memdup() with g_memdup2()

    g_memdup() is subject to an integer overflow on 64-bit machines if the
    object being copied is larger than UINT_MAX bytes. I suspect none of
    these objects can actually be that large in practice, but it's easier
    to replace all the calls than it is to assess whether we need to
    replace them.

    A backport in libglnx is used on systems where GLib is older than 2.68.x.