### PR TITLE
copr: only use libostree tags

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,7 +4,7 @@ srpm:
 	git config --global --add safe.directory '*'
 	ci/make-git-snapshot.sh
 	curl -LO https://src.fedoraproject.org/rpms/ostree/raw/rawhide/f/ostree.spec
-	sed -ie "s,^Version:.*,Version: $$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,')," ostree.spec
+	sed -ie "s,^Version:.*,Version: $$(git describe --always --tags --match 'v2???.*' | sed -e 's,-,\.,g' -e 's,^v,,')," ostree.spec
 	sed -ie 's/^Patch/# Patch/g' ostree.spec  # we don't want any downstream patches
 	rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" ostree.spec
 	mv *.src.rpm $$outdir


### PR DESCRIPTION
This adds a tag filter to the logic which emits version labels for COPR build, so that it avoids mistakenly picking up tags belonging to the Rust bindings.