### PR TITLE
ci: Bump memory for ISO testing flow

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -41,8 +41,8 @@ stage("Build") {
 }
 
 // Build FCOS and run kola tests.
-// Both kola and kolaTestIso require 4G max. Add 1G for overhead.
-cosaPod(runAsUser: 0, memory: "5Gi", cpu: "4") {
+// There's some parallelization in testiso up to 8G, add 1G for overhead
+cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
   stage("Build FCOS") {
     checkout scm
     unstash 'build'


### PR DESCRIPTION
It seems likely that we're allocating more RAM here.  What we really need to do is for cosa to express the necessary RAM requirements declaratively, then we compute pod requirements from that.