### PR TITLE
ci: adjust git tags filtering

### DIFF
--- a/ci/Makefile.dist-packaging
+++ b/ci/Makefile.dist-packaging
@@ -2,7 +2,7 @@
 
 mypath = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 topsrcdir = $(shell git rev-parse --show-toplevel)
-GITREV = $(shell git describe --always --tags)
+GITREV = $(shell git describe --always --tags --match 'v2???.*')
 GITREV_FOR_PKG = $(shell echo "$(GITREV)" | sed -e 's,-,\.,g' -e 's,^v,,')
 
 PACKAGE ?= $(shell basename $(topsrcdir))

--- a/ci/make-git-snapshot.sh
+++ b/ci/make-git-snapshot.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 TOP=$(git rev-parse --show-toplevel)
 GITREV=$(git rev-parse HEAD)
-gitdescribe=$(git describe --always --tags $GITREV)
+gitdescribe=$(git describe --always --tags --match 'v2???.*' $GITREV)
 version=$(echo "$gitdescribe" | sed -e 's,-,\.,g' -e 's,^v,,')
 name=libostree
 PKG_VER="${name}-${version}"


### PR DESCRIPTION
Another attempt at fixing logic for version detection in COPR.

Followup to https://github.com/ostreedev/ostree/pull/2762.