### PR TITLE
ostree_kernel_args_contains for OstreeKernelArgs

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -171,9 +171,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-#if BUILDOPT_IS_DEVEL_BUILD
-#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-#endif
+if BUILDOPT_IS_DEVEL_BUILD
+symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -738,6 +738,7 @@ ostree_kernel_args_get_last_value
 ostree_kernel_args_from_string
 ostree_kernel_args_to_strv
 ostree_kernel_args_to_string
+ostree_kernel_args_contains
 </SECTION>
 
 <SECTION>

--- a/rust-bindings/sys/src/lib.rs
+++ b/rust-bindings/sys/src/lib.rs
@@ -1313,6 +1313,12 @@ extern "C" {
     #[cfg(any(feature = "v2022_5", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2022_5")))]
     pub fn ostree_kernel_args_append_if_missing(kargs: *mut OstreeKernelArgs, arg: *const c_char);
+    #[cfg(any(feature = "v2022_7", feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(feature = "v2022_7")))]
+    pub fn ostree_kernel_args_contains(
+        kargs: *mut OstreeKernelArgs,
+        arg: *const c_char,
+    ) -> gboolean;
     #[cfg(any(feature = "v2019_3", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2019_3")))]
     pub fn ostree_kernel_args_append_proc_cmdline(

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,6 +20,10 @@
    - uncomment the include in Makefile-libostree.am
 */
 
+LIBOSTREE_2022.7 {
+global:
+  ostree_kernel_args_contains;
+} LIBOSTREE_2022.5;
 
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste

--- a/src/libostree/ostree-kernel-args.c
+++ b/src/libostree/ostree-kernel-args.c
@@ -820,12 +820,31 @@ void
 ostree_kernel_args_append_if_missing (OstreeKernelArgs  *kargs,
                                       const char *arg)
 {
-  g_autofree char *key = g_strdup (arg);
-  split_keyeq (key);
- 
   // Don't insert a duplicate key.
-  if (g_hash_table_contains (kargs->table, key))
+  if (ostree_kernel_args_contains (kargs, arg))
     return;
  
   ostree_kernel_args_append (kargs, arg);
+}
+
+/**
+ * ostree_kernel_args_contains:
+ * @kargs: a OstreeKernelArgs instance
+ * @arg: key or key/value pair to check
+ *
+ * Search for @arg which is in the form of key=value pair at the hash table kargs->table
+ * and returns true if finds it.
+ *
+ *Returns: %TRUE if @arg is contained in @kargs, %FALSE otherwise.
+ *
+ * Since: 2022.7
+ **/
+gboolean
+ostree_kernel_args_contains (OstreeKernelArgs  *kargs,
+                             const char *arg)
+{
+  g_autofree char *key = g_strdup (arg);
+  split_keyeq (key);
+
+  return g_hash_table_contains (kargs->table, key);
 }

--- a/src/libostree/ostree-kernel-args.h
+++ b/src/libostree/ostree-kernel-args.h
@@ -134,4 +134,8 @@ _OSTREE_PUBLIC
 void ostree_kernel_args_append_if_missing (OstreeKernelArgs *kargs, 
                                            const char *arg);
 
+_OSTREE_PUBLIC
+gboolean ostree_kernel_args_contains (OstreeKernelArgs *kargs,
+                                      const char *arg);
+
 G_END_DECLS


### PR DESCRIPTION
Check if an argument is present in OstreeKernelArgs. This is a way to make easier idempotent append and delete operations.

Closes #2329

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>