### PR TITLE
cargo: bump minimum Rust version to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,6 @@ env:
   CARGO_PROJECT_FEATURES: "v2021_5,cap-std-apis"
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_6"
-  # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.64.0
 
@@ -38,6 +36,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Detect crate MSRV
+        shell: bash
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[0].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "ACTION_MSRV_TOOLCHAIN=$msrv" >> $GITHUB_ENV
       - name: Remove system Rust toolchain
         run: dnf remove -y rust cargo
       - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
+rust-version = "1.63.0"
 version = "0.16.0"
 
 exclude = [


### PR DESCRIPTION
This bumps MSRV to 1.63, in order to prepare for the next version of gtk-rs stack.

Refs:
 * https://gtk-rs.org/blog/2022/10/18/new-release.html
 * https://github.com/ostreedev/ostree/issues/2750