### PR TITLE
Idempotent delete operation for  OstreeKernelArgs

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -739,6 +739,7 @@ ostree_kernel_args_from_string
 ostree_kernel_args_to_strv
 ostree_kernel_args_to_string
 ostree_kernel_args_contains
+ostree_kernel_args_delete_if_present
 </SECTION>
 
 <SECTION>

--- a/rust-bindings/sys/src/lib.rs
+++ b/rust-bindings/sys/src/lib.rs
@@ -1319,6 +1319,13 @@ extern "C" {
         kargs: *mut OstreeKernelArgs,
         arg: *const c_char,
     ) -> gboolean;
+    #[cfg(any(feature = "v2022_7", feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(feature = "v2022_7")))]
+    pub fn ostree_kernel_args_delete_if_present(
+        kargs: *mut OstreeKernelArgs,
+        arg: *const c_char,
+        error: *mut *mut glib::GError,
+    ) -> gboolean;
     #[cfg(any(feature = "v2019_3", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2019_3")))]
     pub fn ostree_kernel_args_append_proc_cmdline(

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -23,6 +23,7 @@
 LIBOSTREE_2022.7 {
 global:
   ostree_kernel_args_contains;
+  ostree_kernel_args_delete_if_present;
 } LIBOSTREE_2022.5;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-kernel-args.c
+++ b/src/libostree/ostree-kernel-args.c
@@ -848,3 +848,25 @@ ostree_kernel_args_contains (OstreeKernelArgs  *kargs,
 
   return g_hash_table_contains (kargs->table, key);
 }
+
+/**
+ * ostree_kernel_args_delete_if_present:
+ * @kargs: a OstreeKernelArgs instance
+ * @arg: key or key/value pair to be deleted
+ * @error: an GError instance
+ *
+ * Deletes @arg which is in the form of key=value pair from the hash table kargs->table.
+ *
+ * Returns: %TRUE on success, %FALSE on failure
+ *
+ * Since: 2022.7
+ **/
+gboolean
+ostree_kernel_args_delete_if_present (OstreeKernelArgs  *kargs,
+                                      const char        *arg,
+                                      GError           **error)
+{
+  if (ostree_kernel_args_contains (kargs, arg))
+    return ostree_kernel_args_delete (kargs, arg, error);
+  return TRUE;
+}

--- a/src/libostree/ostree-kernel-args.h
+++ b/src/libostree/ostree-kernel-args.h
@@ -138,4 +138,8 @@ _OSTREE_PUBLIC
 gboolean ostree_kernel_args_contains (OstreeKernelArgs *kargs,
                                       const char *arg);
 
+_OSTREE_PUBLIC
+gboolean ostree_kernel_args_delete_if_present (OstreeKernelArgs *kargs,
+                                               const char       *arg,
+                                               GError          **error);
 G_END_DECLS


### PR DESCRIPTION
ostree_kernel_args_delete_if_present checks if an argument is present in OstreeKernelArgs and delete it.

#2329 

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>