### PR TITLE
sysroot: Add an API to initialize with mountns

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -548,6 +548,7 @@ OstreeSysroot
 ostree_sysroot_new
 ostree_sysroot_new_default
 ostree_sysroot_initialize
+ostree_sysroot_initialize_with_mount_namespace
 ostree_sysroot_get_path
 ostree_sysroot_load
 ostree_sysroot_load_if_changed

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -24,6 +24,7 @@ LIBOSTREE_2022.7 {
 global:
   ostree_kernel_args_contains;
   ostree_kernel_args_delete_if_present;
+  ostree_sysroot_initialize_with_mount_namespace;
 } LIBOSTREE_2022.5;
 
 /* Stub section for the stable release *after* this development one; don't

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -51,6 +51,9 @@ _OSTREE_PUBLIC
 void ostree_sysroot_set_mount_namespace_in_use (OstreeSysroot  *self);
 
 _OSTREE_PUBLIC
+gboolean ostree_sysroot_initialize_with_mount_namespace (OstreeSysroot *self, GCancellable *cancellable, GError **error);
+
+_OSTREE_PUBLIC
 GFile *ostree_sysroot_get_path (OstreeSysroot *self);
 
 _OSTREE_PUBLIC

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -586,23 +586,9 @@ ostree_admin_sysroot_load (OstreeSysroot            *sysroot,
 {
   if ((flags & OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED) == 0)
     {
-      /* If we're requested to lock the sysroot, first check if we're operating
-       * on a booted (not physical) sysroot.  Then find out if the /sysroot
-       * subdir is a read-only mount point, and if so, create a new mount
-       * namespace and tell the sysroot that we've done so. See the docs for
-       * ostree_sysroot_set_mount_namespace_in_use().
-       *
-       * This is a conservative approach; we could just always
-       * unshare() too.
-       */
-      if (ostree_sysroot_is_booted (sysroot))
-        {
-          gboolean setup_ns = FALSE;
-          if (!maybe_setup_mount_namespace (&setup_ns, error))
-            return FALSE;
-          if (setup_ns)
-            ostree_sysroot_set_mount_namespace_in_use (sysroot);
-        }
+      /* Set up the mount namespace, if applicable */
+      if (!ostree_sysroot_initialize_with_mount_namespace (sysroot, cancellable, error))
+        return FALSE;
 
       /* Released when sysroot is finalized, or on process exit */
       if (!ot_admin_sysroot_lock (sysroot, error))


### PR DESCRIPTION
This lowers down into the C library some logic we
have in the binary/app logic, in prep for having more Rust-native CLI code in https://github.com/ostreedev/ostree-rs-ext/pull/412

Basically we want to *ensure* a mount namespace by invoking `unshare()` if necessary, instead of requiring our callers to do this dance.

This also helps fix e.g.
Closes: https://github.com/ostreedev/ostree/issues/2769