### PR TITLE
Testinst updates

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 sh-inline = "0.2.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
-ostree-ext = { version = "0.7.0" }
+ostree-ext = { version = "0.9" }
 libtest-mimic = "0.5.0"
 twoway = "0.2.1"
 hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -29,12 +29,12 @@ futures = "0.3.4"
 http = "0.2.0"
 tokio = { version = "1.4.0", features = ["full"] }
 futures-util = "0.3.1"
+libc = "0.2.100"
 base64 = "0.12.0"
 procspawn = "0.8"
 rand = "0.8"
 strum = "0.18.0"
 strum_macros = "0.18.0"
-nix = "0.23.0"
 # See discussion in https://github.com/coreos/rpm-ostree/pull/2569#issuecomment-780569188
 rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", tag = "v2021.3" }
 

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -17,7 +17,7 @@ structopt = "0.3"
 serde = "1.0.111"
 serde_derive = "1.0.111"
 serde_json = "1.0"
-sh-inline = "0.2.0"
+sh-inline = "0.4.0"
 anyhow = "1.0"
 tempfile = "3.1.0"
 ostree-ext = { version = "0.9" }

--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -11,7 +11,7 @@ name = "ostree-test"
 path = "src/insttestmain.rs"
 
 [dependencies]
-cap-std-ext = "0.25"
+cap-std-ext = "1.0"
 clap = "2.32.0"
 structopt = "0.3"
 serde = "1.0.111"

--- a/tests/inst/src/sysroot.rs
+++ b/tests/inst/src/sysroot.rs
@@ -52,6 +52,6 @@ pub(crate) fn itest_tmpfiles() -> Result<()> {
         return Ok(());
     }
     let metadata = Path::new("/run/ostree").metadata()?;
-    assert_eq!(metadata.permissions().mode() & !nix::libc::S_IFMT, 0o755);
+    assert_eq!(metadata.permissions().mode() & !libc::S_IFMT, 0o755);
     Ok(())
 }

--- a/tests/inst/src/treegen.rs
+++ b/tests/inst/src/treegen.rs
@@ -75,7 +75,6 @@ pub(crate) fn mutate_one_executable_to(
 
 /// Find ELF files in the srcdir, write new copies to dest (only percentage)
 pub(crate) fn mutate_executables_to(src: &Dir, dest: &Dir, percentage: u32) -> Result<u32> {
-    use nix::sys::stat::Mode as NixMode;
     assert!(percentage > 0 && percentage <= 100);
     let mut mutated = 0;
     for entry in src.entries()? {
@@ -84,13 +83,13 @@ pub(crate) fn mutate_executables_to(src: &Dir, dest: &Dir, percentage: u32) -> R
             continue;
         }
         let meta = entry.metadata()?;
-        let mode = NixMode::from_bits_truncate(meta.mode());
+        let mode = meta.mode();
         // Must be executable
-        if !mode.intersects(NixMode::S_IXUSR | NixMode::S_IXGRP | NixMode::S_IXOTH) {
+        if mode & (libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH) == 0 {
             continue;
         }
         // Not suid
-        if mode.intersects(NixMode::S_ISUID | NixMode::S_ISGID) {
+        if mode & (libc::S_ISUID | libc::S_ISGID) == 0 {
             continue;
         }
         // Greater than 1k in size


### PR DESCRIPTION
tests/inst: Update to latest ostree-ext

---

tests/inst: Drop nix dependency

It has various semver bumps and we were literally just using
it to duplicate what's already in `libc`.

---

tests/inst: Update cap-std-ext to 1.0

---

tests/inst: Update sh-inline

---

