### PR TITLE
tests: Require OSTREE_TEST_SUDO to be set to use `sudo`

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -614,6 +614,12 @@ skip_without_user_xattrs () {
     fi
 }
 
+skip_without_sudo () {
+    if test -z "${OSTREE_TEST_SUDO:-}"; then
+        skip "this test needs sudo, skipping without OSTREE_TEST_SUDO being set"
+    fi
+}
+
 # Usage: if ! skip_one_without_whiteouts_devices; then ... more tests ...; fi
 skip_one_without_whiteouts_devices() {
     if ! can_create_whiteout_devices; then

--- a/tests/test-basic-bare-split-xattrs.sh
+++ b/tests/test-basic-bare-split-xattrs.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 mode="bare-split-xattrs"
 OSTREE="${CMD_PREFIX} ostree --repo=${test_tmpdir}/repo"
 
+skip_without_sudo
 SUDO="sudo --non-interactive"
+
 PRIVILEGED="false"
 if [ $(id -u) -eq 0 ]; then
   PRIVILEGED="true"

--- a/tests/test-repo-finder-mount-integration.sh
+++ b/tests/test-repo-finder-mount-integration.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_sudo
 SUDO="sudo --non-interactive"
 
 # Skip the test if a well-known USB stick is not available.


### PR DESCRIPTION
IMO, tools invoking `sudo` automatically is a huge anti-pattern. Require this to be opt-in.

In practice also...these tests really want to be *integration* and not unit tests because involving `sudo` alongside uninstalled binaries just creates a giant mess.

Closes: https://github.com/ostreedev/ostree/issues/2761