### PR TITLE
Release 2022.7

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -171,9 +171,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+# if BUILDOPT_IS_DEVEL_BUILD
+# symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+# endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2022])
-m4_define([release_version], [7])
+m4_define([release_version], [8])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2022])
 m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,13 +20,6 @@
    - uncomment the include in Makefile-libostree.am
 */
 
-LIBOSTREE_2022.7 {
-global:
-  ostree_kernel_args_contains;
-  ostree_kernel_args_delete_if_present;
-  ostree_sysroot_initialize_with_mount_namespace;
-} LIBOSTREE_2022.5;
-
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -689,6 +689,13 @@ global:
   ostree_sysroot_deployment_set_kargs_in_place;
 } LIBOSTREE_2022.4;
 
+LIBOSTREE_2022.7 {
+global:
+  ostree_kernel_args_contains;
+  ostree_kernel_args_delete_if_present;
+  ostree_sysroot_initialize_with_mount_namespace;
+} LIBOSTREE_2022.5;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-370e560e4044b17523d23b04e383539cd22eac7c3067b7324803129ceebd73f0  ${released_syms}
+d7b5a766b1607f7334e9b6f15385ad872879e336a160ae76336243e493f7ceab  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
Nothing critical, but a fair number of smaller fixes in the last month.

Closes: https://github.com/ostreedev/ostree/issues/2785