### PR TITLE
tests: Handle musl's ERANGE mapping

### DIFF
--- a/tests/test-commit-timestamp.sh
+++ b/tests/test-commit-timestamp.sh
@@ -40,6 +40,6 @@ fi
 ${CMD_PREFIX} ostree --repo=./testrepo show env > show-env.txt
 rm -rf testrepo testrepo-files
 assert_file_has_content_literal commit-invalid.txt 'Failed to convert SOURCE_DATE_EPOCH'
-assert_file_has_content_literal commit-overflowing.txt 'Parsing SOURCE_DATE_EPOCH: Numerical result out of range'
+assert_file_has_content commit-overflowing.txt 'Parsing SOURCE_DATE_EPOCH: \(Numerical result out of range\|Result not representable\)'
 assert_file_has_content_literal show-env.txt 'Date:  2009-02-13 23:31:30 +0000'
 echo "ok commit with env timestamp"


### PR DESCRIPTION
musl uses "Result not representable" for ERANGE, support this in addition to glibc's "Numerical result out of range".

Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>