### PR TITLE
Replace the radix64 crate with base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ path = "rust-bindings/tests/tests.rs"
 members = [".", "rust-bindings/sys"]
 
 [dependencies]
+base64 = "0.20.0"
 bitflags = "1.2.1"
 cap-std = { version = "1.0", optional = true}
 io-lifetimes = { version = "1.0", optional = true}
@@ -47,7 +48,6 @@ glib = "0.16"
 hex = "0.4.2"
 libc = "0.2"
 once_cell = "1.4.0"
-radix64 = "0.6.2"
 thiserror = "1.0.20"
 
 [dev-dependencies]


### PR DESCRIPTION
The [radix64](https://crates.io/crates/radix64) crate was last updated over 3 years ago.

On the other hand the [base64](https://crates.io/crates/base64) crate appears to be far more actively maintained, supports all the needed features and has a few orders of magnitude more users.