### PR TITLE
tests/inst: Update hyper-staticfile to 0.9.4

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -24,7 +24,7 @@ ostree-ext = { version = "0.9" }
 libtest-mimic = "0.5.0"
 twoway = "0.2.1"
 hyper = { version = "0.14", features = ["runtime", "http1", "http2", "tcp", "server"] }
-hyper-staticfile = "0.6.0"
+hyper-staticfile = "0.9.4"
 futures = "0.3.4"
 http = "0.2.0"
 tokio = { version = "1.4.0", features = ["full"] }


### PR DESCRIPTION
Due to some vulnerabilities[1][2], all versions prior to 0.9.4 have been yanked from crates.io. There have been some API changes since 0.6.0, but none of them affect the simple `hyper_staticfile::Static` usage here.

1. https://rustsec.org/advisories/RUSTSEC-2022-0069.html
2. https://rustsec.org/advisories/RUSTSEC-2022-0072.html