### PR TITLE
Various CLI improvements

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -68,6 +68,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-archivez.sh \
 	tests/test-remote-add.sh \
 	tests/test-remote-headers.sh \
+	tests/test-remote-refs.sh \
 	tests/test-commit-sign.sh \
 	tests/test-commit-timestamp.sh \
 	tests/test-export.sh \

--- a/bash/ostree
+++ b/bash/ostree
@@ -953,6 +953,7 @@ _ostree_pull() {
 _ostree_refs() {
     local boolean_options="
         $main_boolean_options
+        --revision -r
         --alias -A
         --collections -c
         --delete

--- a/bash/ostree
+++ b/bash/ostree
@@ -1275,6 +1275,7 @@ _ostree_remote_list_gpg_keys() {
 _ostree_remote_refs() {
     local boolean_options="
         $main_boolean_options
+        --revision -r
     "
 
     local options_with_args="

--- a/bash/ostree
+++ b/bash/ostree
@@ -900,7 +900,6 @@ _ostree_pull() {
     local boolean_options="
         $main_boolean_options
         --commit-metadata-only
-        --cache-dir
         --disable-fsync
         --disable-static-deltas
         --require-static-deltas
@@ -912,6 +911,7 @@ _ostree_pull() {
     "
 
     local options_with_args="
+        --cache-dir
         --depth
         --http-header
         --localcache-repo -L
@@ -925,7 +925,7 @@ _ostree_pull() {
     local options_with_args_glob=$( __ostree_to_extglob "$options_with_args" )
 
     case "$prev" in
-        --localcache-repo|-L|--repo|--subpath)
+        --cache-dir|--localcache-repo|-L|--repo|--subpath)
             __ostree_compreply_dirs_only
             return 0
             ;;
@@ -1274,17 +1274,17 @@ _ostree_remote_list_gpg_keys() {
 _ostree_remote_refs() {
     local boolean_options="
         $main_boolean_options
-        --cache-dir
     "
 
     local options_with_args="
+        --cache-dir
         --repo
     "
 
     local options_with_args_glob=$( __ostree_to_extglob "$options_with_args" )
 
     case "$prev" in
-        --repo)
+        --cache-dir|--repo)
             __ostree_compreply_dirs_only
             return 0
             ;;
@@ -1343,18 +1343,18 @@ _ostree_remote_show_url() {
 _ostree_remote_summary() {
     local boolean_options="
         $main_boolean_options
-        --cache-dir
         --raw
     "
 
     local options_with_args="
+        --cache-dir
         --repo
     "
 
     local options_with_args_glob=$( __ostree_to_extglob "$options_with_args" )
 
     case "$prev" in
-        --repo)
+        --cache-dir|--repo)
             __ostree_compreply_dirs_only
             return 0
             ;;

--- a/bash/ostree
+++ b/bash/ostree
@@ -1486,6 +1486,8 @@ _ostree_rev_parse() {
 _ostree_show() {
     local boolean_options="
         $main_boolean_options
+        --list-detached-metadata-keys
+        --list-metadata-keys
         --print-related
         --print-sizes
         --raw

--- a/bash/ostree
+++ b/bash/ostree
@@ -1345,11 +1345,13 @@ _ostree_remote_show_url() {
 _ostree_remote_summary() {
     local boolean_options="
         $main_boolean_options
+        --list-metadata-keys
         --raw
     "
 
     local options_with_args="
         --cache-dir
+        --print-metadata-key
         --repo
     "
 

--- a/bash/ostree
+++ b/bash/ostree
@@ -1816,6 +1816,7 @@ _ostree_static_delta() {
 _ostree_summary() {
     local boolean_options="
         $main_boolean_options
+        --list-metadata-keys
         --raw
         --update -u
         --view -v
@@ -1825,6 +1826,7 @@ _ostree_summary() {
         --add-metadata -m
         --gpg-homedir
         --gpg-sign
+        --print-metadata-key
         --repo
     "
 

--- a/man/ostree-find-remotes.xml
+++ b/man/ostree-find-remotes.xml
@@ -87,6 +87,14 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
         <variablelist>
             <varlistentry>
+                <term><option>--cache-dir</option>=DIR</term>
+
+                <listitem><para>
+                    Use an alternate cache directory in <literal>DIR</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--disable-fsync</option></term>
 
                 <listitem><para>

--- a/man/ostree-pull.xml
+++ b/man/ostree-pull.xml
@@ -66,6 +66,14 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--cache-dir</option>=DIR</term>
+
+                <listitem><para>
+                    Use an alternate cache directory in <literal>DIR</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--disable-fsync</option></term>
 
                 <listitem><para>

--- a/man/ostree-refs.xml
+++ b/man/ostree-refs.xml
@@ -99,6 +99,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--revision</option>, <option>-r</option></term>
+
+                <listitem><para>
+                    When listing refs, also print their revisions. The revisions
+                    will be separated by a tab character.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--alias</option>, <option>-A</option></term>
 
                 <listitem><para>

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -199,6 +199,17 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
         <variablelist>
             <varlistentry>
+                <term><option>--revision</option>, <option>-r</option></term>
+
+                <listitem><para>
+                    Also print the revisions for each ref. The revisions will
+                    be separated by a tab character.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+
+        <variablelist>
+            <varlistentry>
                 <term><option>--cache-dir</option>=DIR</term>
 
                 <listitem><para>

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -195,6 +195,20 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     </refsect1>
 
     <refsect1>
+        <title>'Refs' Options</title>
+
+        <variablelist>
+            <varlistentry>
+                <term><option>--cache-dir</option>=DIR</term>
+
+                <listitem><para>
+                    Use an alternate cache directory in <literal>DIR</literal>.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+
+    <refsect1>
         <title>'GPG-Import' Options</title>
 
         <variablelist>
@@ -226,6 +240,14 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <title>'Summary' Options</title>
 
         <variablelist>
+            <varlistentry>
+                <term><option>--cache-dir</option>=DIR</term>
+
+                <listitem><para>
+                    Use an alternate cache directory in <literal>DIR</literal>.
+                </para></listitem>
+            </varlistentry>
+
             <varlistentry>
                 <term><option>--raw</option></term>
 

--- a/man/ostree-show.xml
+++ b/man/ostree-show.xml
@@ -82,10 +82,26 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--list-metadata-keys</option></term>
+
+                <listitem><para>
+                    List the available metadata keys.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--print-metadata-key</option>="KEY"</term>
 
                 <listitem><para>
                     Print string value of metadata key.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--list-detached-metadata-keys</option></term>
+
+                <listitem><para>
+                    List the available detached metadata keys.
                 </para></listitem>
             </varlistentry>
 

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -27,6 +27,7 @@
 
 static gboolean opt_delete;
 static gboolean opt_list;
+static gboolean opt_revision;
 static gboolean opt_alias;
 static char *opt_create;
 static gboolean opt_collections;
@@ -40,6 +41,7 @@ static gboolean opt_force;
 static GOptionEntry options[] = {
   { "delete", 0, 0, G_OPTION_ARG_NONE, &opt_delete, "Delete refs which match PREFIX, rather than listing them", NULL },
   { "list", 0, 0, G_OPTION_ARG_NONE, &opt_list, "Do not remove the prefix from the refs", NULL },
+  { "revision", 'r', 0, G_OPTION_ARG_NONE, &opt_revision, "Show revisions in listing", NULL },
   { "alias", 'A', 0, G_OPTION_ARG_NONE, &opt_alias, "If used with --create, create an alias, otherwise just list aliases", NULL },
   { "create", 0, 0, G_OPTION_ARG_STRING, &opt_create, "Create a new ref for an existing commit", "NEWREF" },
   { "collections", 'c', 0, G_OPTION_ARG_NONE, &opt_collections, "Enable listing collection IDs for refs", NULL },
@@ -82,7 +84,16 @@ do_ref_with_collections (OstreeRepo    *repo,
       for (GList *iter = ordered_keys; iter != NULL; iter = iter->next)
         {
           OstreeCollectionRef *ref = iter->data;
-          g_print ("(%s, %s)\n", ref->collection_id, ref->ref_name);
+
+          if (opt_revision)
+            {
+              const char *rev = g_hash_table_lookup (refs, ref);
+              g_print ("(%s, %s)\t%s\n", ref->collection_id, ref->ref_name, rev);
+            }
+          else
+            {
+              g_print ("(%s, %s)\n", ref->collection_id, ref->ref_name);
+            }
         }
     }
   else if (opt_create)
@@ -202,6 +213,11 @@ static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellab
             {
               const char *alias = g_hash_table_lookup (refs, ref);
               g_print ("%s -> %s\n", ref, alias);
+            }
+          else if (opt_revision)
+            {
+              const char *rev = g_hash_table_lookup (refs, ref);
+              g_print ("%s\t%s\n", ref, rev);
             }
           else
             {

--- a/src/ostree/ot-dump.h
+++ b/src/ostree/ot-dump.h
@@ -41,5 +41,11 @@ void   ot_dump_object     (OstreeObjectType   objtype,
 void   ot_dump_summary_bytes  (GBytes          *summary_bytes,
                                OstreeDumpFlags  flags);
 
+void ot_dump_summary_metadata_keys (GBytes *summary_bytes);
+
+gboolean ot_dump_summary_metadata_key (GBytes      *summary_bytes,
+                                       const char  *key,
+                                       GError     **error);
+
 gboolean ot_dump_gpg_key  (GVariant  *key,
                            GError   **error);

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -24,6 +24,7 @@
 #include "ot-main.h"
 #include "ot-remote-builtins.h"
 
+static gboolean opt_revision;
 static char* opt_cache_dir;
 
 /* ATTENTION:
@@ -32,6 +33,7 @@ static char* opt_cache_dir;
  */
 
 static GOptionEntry option_entries[] = {
+  { "revision", 'r', 0, G_OPTION_ARG_NONE, &opt_revision, "Show revisions in listing", NULL },
   { "cache-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_cache_dir, "Use custom cache dir", NULL },
   { NULL }
 };
@@ -73,7 +75,17 @@ ot_remote_builtin_refs (int argc, char **argv, OstreeCommandInvocation *invocati
 
       for (iter = ordered_keys; iter; iter = iter->next)
         {
-          g_print ("%s:%s\n", remote_name, (const char *) iter->data);
+          const char *ref = iter->data;
+
+          if (opt_revision)
+            {
+              const char *rev = g_hash_table_lookup (refs, ref);
+              g_print ("%s:%s\t%s\n", remote_name, ref, rev);
+            }
+          else
+            {
+              g_print ("%s:%s\n", remote_name, ref);
+            }
         }
     }
 

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -25,8 +25,10 @@
 #include "ot-dump.h"
 #include "ot-remote-builtins.h"
 
+static gboolean opt_list_metadata_keys;
 static gboolean opt_raw;
 
+static char *opt_print_metadata_key;
 static char* opt_cache_dir;
 
 /* ATTENTION:
@@ -35,6 +37,8 @@ static char* opt_cache_dir;
  */
 
 static GOptionEntry option_entries[] = {
+  { "list-metadata-keys", 0, 0, G_OPTION_ARG_NONE, &opt_list_metadata_keys, "List the available metadata keys", NULL },
+  { "print-metadata-key", 0, 0, G_OPTION_ARG_STRING, &opt_print_metadata_key, "Print string value of metadata key", "KEY" },
   { "cache-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_cache_dir, "Use custom cache dir", NULL },
   { "raw", 0, 0, G_OPTION_ARG_NONE, &opt_raw, "Show raw variant data", NULL },
   { NULL }
@@ -90,42 +94,54 @@ ot_remote_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invoc
       goto out;
     }
 
-  ot_dump_summary_bytes (summary_bytes, flags);
+  if (opt_list_metadata_keys)
+    {
+      ot_dump_summary_metadata_keys (summary_bytes);
+    }
+  else if (opt_print_metadata_key)
+    {
+      if (!ot_dump_summary_metadata_key (summary_bytes, opt_print_metadata_key, error))
+        goto out;
+    }
+  else
+    {
+      ot_dump_summary_bytes (summary_bytes, flags);
 
 #ifndef OSTREE_DISABLE_GPGME
-  if (!ostree_repo_remote_get_gpg_verify_summary (repo, remote_name,
-                                                  &gpg_verify_summary,
-                                                  error))
-    goto out;
-
-  if (!gpg_verify_summary)
-    g_clear_pointer (&signature_bytes, g_bytes_unref);
-
-  /* XXX Note we don't show signatures for "--raw".  My intuition is
-   *     if someone needs to see or parse raw summary data, including
-   *     signatures in the output would probably just interfere.
-   *     If there's demand for it I suppose we could introduce a new
-   *     option for raw signature data like "--raw-signatures". */
-  if (signature_bytes != NULL && !opt_raw)
-    {
-      g_autoptr(OstreeGpgVerifyResult) result = NULL;
-
-      /* The actual signed summary verification happens above in
-       * ostree_repo_remote_fetch_summary().  Here we just parse
-       * the signatures again for the purpose of printing. */
-      result = ostree_repo_verify_summary (repo,
-                                           remote_name,
-                                           summary_bytes,
-                                           signature_bytes,
-                                           cancellable,
-                                           error);
-      if (result == NULL)
+      if (!ostree_repo_remote_get_gpg_verify_summary (repo, remote_name,
+                                                      &gpg_verify_summary,
+                                                      error))
         goto out;
 
-      g_print ("\n");
-      ostree_print_gpg_verify_result (result);
-    }
+      if (!gpg_verify_summary)
+        g_clear_pointer (&signature_bytes, g_bytes_unref);
+
+      /* XXX Note we don't show signatures for "--raw".  My intuition is
+       *     if someone needs to see or parse raw summary data, including
+       *     signatures in the output would probably just interfere.
+       *     If there's demand for it I suppose we could introduce a new
+       *     option for raw signature data like "--raw-signatures". */
+      if (signature_bytes != NULL && !opt_raw)
+        {
+          g_autoptr(OstreeGpgVerifyResult) result = NULL;
+
+          /* The actual signed summary verification happens above in
+           * ostree_repo_remote_fetch_summary().  Here we just parse
+           * the signatures again for the purpose of printing. */
+          result = ostree_repo_verify_summary (repo,
+                                               remote_name,
+                                               summary_bytes,
+                                               signature_bytes,
+                                               cancellable,
+                                               error);
+          if (result == NULL)
+            goto out;
+
+          g_print ("\n");
+          ostree_print_gpg_verify_result (result);
+        }
 #endif /* OSTREE_DISABLE_GPGME */
+    }
 
   ret = TRUE;
 out:

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -1006,6 +1006,13 @@ $OSTREE show -B --print-metadata-key=SOMENUM test2 > test2-meta
 assert_file_has_content test2-meta "uint64 42"
 $OSTREE show --print-detached-metadata-key=SIGNATURE test2 > test2-meta
 assert_file_has_content test2-meta "HANCOCK"
+
+$OSTREE show --list-metadata-keys test2 > test2-meta
+assert_file_has_content test2-meta "FOO"
+assert_file_has_content test2-meta "KITTENS"
+assert_file_has_content test2-meta "SOMENUM"
+$OSTREE show --list-detached-metadata-keys test2 > test2-meta
+assert_file_has_content test2-meta "SIGNATURE"
 echo "ok metadata commit with strings"
 
 $OSTREE commit ${COMMIT_ARGS} -b test2 --tree=ref=test2 \

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -157,6 +157,16 @@ assert_file_has_content summary.txt "Good signature from \"Ostree Tester <test@t
 grep static-deltas summary.txt > static-deltas.txt
 assert_file_has_content static-deltas.txt \
   $(${OSTREE} --repo=repo rev-parse origin:main)
+${OSTREE} --repo=repo remote summary origin --list-metadata-keys > metadata
+assert_file_has_content metadata "^ostree.static-deltas$"
+assert_file_has_content metadata "^ostree.summary.indexed-deltas$"
+assert_file_has_content metadata "^ostree.summary.last-modified$"
+assert_file_has_content metadata "^ostree.summary.mode$"
+assert_file_has_content metadata "^ostree.summary.tombstone-commits$"
+${OSTREE} --repo=repo remote summary origin --print-metadata-key=ostree.summary.indexed-deltas > metadata
+assert_file_has_content metadata "^true$"
+${OSTREE} --repo=repo remote summary origin --print-metadata-key=ostree.summary.mode > metadata
+assert_file_has_content metadata "^'archive-z2'$"
 
 ## Tests for handling of cached summaries while racing with remote summary updates
 

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -42,6 +42,10 @@ done
 ${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount
 assert_file_has_content refscount "^10$"
 
+${CMD_PREFIX} ostree --repo=repo refs > refs
+sort refs > refs-sorted
+assert_files_equal refs refs-sorted
+
 ${CMD_PREFIX} ostree --repo=repo refs foo > refs
 assert_not_file_has_content refs foo
 

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -55,6 +55,14 @@ assert_file_has_content refs foo
 ${CMD_PREFIX} ostree --repo=repo refs foo | wc -l > refscount.foo
 assert_file_has_content refscount.foo "^5$"
 
+rm -f expected-refs-revs
+for ref in foo/test-{1..5}; do
+    rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse $ref)
+    echo -e "${ref}\t${rev}" >> expected-refs-revs
+done
+${CMD_PREFIX} ostree --repo=repo refs --list --revision foo > refs-revs
+assert_files_equal refs-revs expected-refs-revs
+
 ${CMD_PREFIX} ostree --repo=repo refs --delete 2>/dev/null || true
 ${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount.delete1
 assert_file_has_content refscount.delete1 "^10$"

--- a/tests/test-remote-refs.sh
+++ b/tests/test-remote-refs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright © 2023 Endless OS Foundation LLC
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+#
+# Authors:
+#  - Dan Nicholson <dbn@endlessos.org>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..2"
+
+setup_fake_remote_repo2 "archive"
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/repo summary -u
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/repo refs > origin-refs
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/repo refs --revision > origin-refs-revs
+
+cd ${test_tmpdir}
+rm -rf repo
+ostree_repo_init repo --mode=archive
+${OSTREE} remote add --no-sign-verify origin $(cat httpd-address)/ostree/repo
+
+${OSTREE} remote refs origin > refs
+sed 's/^/origin:/' origin-refs > expected-refs
+assert_files_equal refs expected-refs
+
+echo "ok remote refs listing"
+
+${OSTREE} remote refs origin --revision > refs-revs
+sed 's/^/origin:/' origin-refs-revs > expected-refs-revs
+assert_files_equal refs-revs expected-refs-revs
+
+echo "ok remote refs revisions"

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -194,6 +194,16 @@ assert_file_has_content summary.txt "* yet-another"
 grep static-deltas summary.txt > static-deltas.txt
 assert_file_has_content static-deltas.txt \
     $(${OSTREE} --repo=repo rev-parse origin:main)
+${OSTREE} --repo=repo remote summary origin --list-metadata-keys > metadata
+assert_file_has_content metadata "^ostree.static-deltas$"
+assert_file_has_content metadata "^ostree.summary.indexed-deltas$"
+assert_file_has_content metadata "^ostree.summary.last-modified$"
+assert_file_has_content metadata "^ostree.summary.mode$"
+assert_file_has_content metadata "^ostree.summary.tombstone-commits$"
+${OSTREE} --repo=repo remote summary origin --print-metadata-key=ostree.summary.indexed-deltas > metadata
+assert_file_has_content metadata "^true$"
+${OSTREE} --repo=repo remote summary origin --print-metadata-key=ostree.summary.mode > metadata
+assert_file_has_content metadata "^'archive-z2'$"
 
 ## Tests for handling of cached summaries while racing with remote summary updates
 

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -59,6 +59,10 @@ ${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata=map='@a{sv} {}'
 # Check the additional metadata turns up in the output.
 ${CMD_PREFIX} ostree --repo=repo summary --view > summary
 assert_file_has_content summary "^map: {}$"
+${CMD_PREFIX} ostree --repo=repo summary --list-metadata-keys > metadata
+assert_file_has_content metadata "^map$"
+${CMD_PREFIX} ostree --repo=repo summary --print-metadata-key=map > metadata
+assert_file_has_content metadata "^@a{sv} {}$"
 
 echo "ok 1 update summary"
 


### PR DESCRIPTION
Often I want to quickly inspect local and remote repos to see what's currently in them. While it's often better to write something that uses the API to get the precise desired information, the CLI is very handy for quickly assessing the situation. This adds some options to various CLI builtins to expose or improve that information.