### PR TITLE
build: Do not include private headers in the introspection

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -266,10 +266,11 @@ if BUILDOPT_INTROSPECTION
 OSTree-1.0.gir: libostree-1.la Makefile
 OSTree_1_0_gir_EXPORT_PACKAGES = ostree-1
 OSTree_1_0_gir_INCLUDES = Gio-2.0
+OSTree_1_0_gir_C_INCLUDES = ostree.h
 OSTree_1_0_gir_CFLAGS = $(libostree_1_la_CFLAGS)
 OSTree_1_0_gir_LIBS = libostree-1.la
 OSTree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=Ostree --symbol-prefix=ostree $(GI_SCANNERFLAGS)
-OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %-private.h %/ostree-soup-uri.h,$(libostree_1_la_SOURCES))
+OSTree_1_0_gir_FILES = $(libostreeinclude_HEADERS) $(filter-out %.h,$(libostree_1_la_SOURCES))
 INTROSPECTION_GIRS += OSTree-1.0.gir
 gir_DATA += OSTree-1.0.gir
 typelib_DATA += OSTree-1.0.typelib

--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,7 @@ AS_IF([test x$with_curl != xno || test x$with_soup != xno],
 AS_IF([test x$with_curl = xyes], [fetcher_backend=curl], [test x$with_soup = xyes], [fetcher_backend=libsoup], [fetcher_backend=none])
 
 m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
-  GOBJECT_INTROSPECTION_CHECK([1.34.0])
+  GOBJECT_INTROSPECTION_CHECK([1.51.5])
 ])
 AM_CONDITIONAL(BUILDOPT_INTROSPECTION, test "x$found_introspection" = xyes)
 


### PR DESCRIPTION
This leads to private symbols being exported.

Also specify the single C header, this relies on the gir_C_INCLUDES make variable,
which was introduced in gobject-introspection 1.51.5.