### PR TITLE
tests: Ensure non-root users have access to libcap tools

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -32,6 +32,9 @@ else
 fi
 . ${test_srcdir}/libtest-core.sh
 
+# Make sure /sbin/capsh etc. are in our PATH even if non-root
+PATH="$PATH:/usr/sbin:/sbin"
+
 # Array of expressions to execute when exiting. Each expression should
 # be a single string (quoting if necessary) that will be eval'd. To add
 # a command to run on exit, append to the libtest_exit_cmds array like


### PR DESCRIPTION
On Debian systems, by default only root has /{usr/,}sbin in PATH.

---

Similar to containers/bubblewrap#228. This should give us test coverage for rofiles-fuse on Ubuntu's autopkgtest infrastructure; previously that wasn't tested.