### PR TITLE
ci: update for new kolaTestIso()

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -69,5 +69,5 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
     """)
   }
   kola(cosaDir: "${env.WORKSPACE}")
-  kolaTestIso(cosaDir: "${env.WORKSPACE}", skipMetal4k: true, skipMultipath: true)
+  kolaTestIso(cosaDir: "${env.WORKSPACE}", extraArgs: "--denylist-test *.4k.* --denylist-test *.mpath.*")
 }


### PR DESCRIPTION
The `skipMetal4k` and `skipMultipath` parameters no longer do anything. Instead use `--denylist-test` which is interpreted directly by the new `kola testiso` code.

This will run more tests than before. We'll likely cut down tests we consider redundant soon, but that should be transparent to this code.