### PR TITLE
docs: Use upstream theme & update to 0.4.1

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,7 +24,7 @@ exclude:
 # prep-docs.sh before jekyll to put it in place.
 include: [reference, man]
 
-remote_theme: coreos/just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.4.1
 plugins:
   - jekyll-remote-theme
 


### PR DESCRIPTION
Use a fixed tag for the theme so that we can directly pull it from upstream and skip vendoring the theme in the coreos org.