### PR TITLE
core: Ensure glib standard::size attribute is always set

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1739,6 +1739,8 @@ _ostree_stbuf_to_gfileinfo (const struct stat *stbuf)
 
   if (S_ISREG (mode))
     g_file_info_set_attribute_uint64 (ret, "standard::size", stbuf->st_size);
+  else
+    g_file_info_set_attribute_uint64 (ret, "standard::size", 0);
 
   return ret;
 }


### PR DESCRIPTION
A recent [change in glib](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3261) requires that the appropriate attribute be available when calling getters. ostree core only sets this attribute on regular files, and frequently triggers the critical warning. Solve this by setting standard::size to zero for non-regular files.

Fixes https://github.com/ostreedev/ostree/issues/2827