### PR TITLE
Cope with GLib 2.76 being more strict about GFileInfo standard::size

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -550,7 +550,9 @@ ostree_raw_file_to_content_stream (GInputStream       *input,
   g_autoptr(GBytes) file_header = _ostree_file_header_new (file_info, xattrs);
   *out_input = header_and_input_to_stream (file_header, input);
   if (out_length)
-    *out_length = g_bytes_get_size (file_header) + g_file_info_get_size (file_info);
+    *out_length = g_bytes_get_size (file_header);
+  if (out_length && g_file_info_has_attribute (file_info, "standard::size"))
+    *out_length += g_file_info_get_size (file_info);
   return TRUE;
 }
 

--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -355,7 +355,7 @@ GBytes *
 _ostree_zlib_file_header_new (GFileInfo         *file_info,
                               GVariant          *xattrs)
 {
-  guint64 size = g_file_info_get_size (file_info);
+  guint64 size = 0;
   guint32 uid = g_file_info_get_attribute_uint32 (file_info, "unix::uid");
   guint32 gid = g_file_info_get_attribute_uint32 (file_info, "unix::gid");
   guint32 mode = g_file_info_get_attribute_uint32 (file_info, "unix::mode");
@@ -365,6 +365,9 @@ _ostree_zlib_file_header_new (GFileInfo         *file_info,
     symlink_target = g_file_info_get_symlink_target (file_info);
   else
     symlink_target = "";
+
+  if (g_file_info_has_attribute (file_info, "standard::size"))
+    size = g_file_info_get_size (file_info);
 
   g_autoptr(GVariant) tmp_xattrs = NULL;
   if (xattrs == NULL)

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1211,7 +1211,8 @@ write_content_object (OstreeRepo         *self,
   /* Update statistics */
   g_mutex_lock (&self->txn_lock);
   self->txn.stats.content_objects_written++;
-  self->txn.stats.content_bytes_written += g_file_info_get_size (file_info);
+  if (g_file_info_has_attribute (file_info, "standard::size"))
+    self->txn.stats.content_bytes_written += g_file_info_get_size (file_info);
   self->txn.stats.content_objects_total++;
   g_mutex_unlock (&self->txn_lock);
 


### PR DESCRIPTION
* ostree_raw_file_to_content_stream: Make size default to 0
    
    Some existing code calls into ostree_raw_file_to_content_stream() with
    file objects that do not have the standard::size attribute. Since GLib
    2.76.0, attempting to access the size of such an object raises a
    critical warning. Handle this more gracefully by defaulting the size
    to 0, like earlier versions of GLib did.

* _ostree_zlib_file_header_new: Default size to 0
    
    Similar to the previous commit, but for
    ostree_raw_file_to_archive_z2_stream() and similar public APIs.

* write_content_object: Don't assume file info has standard::size
    
    The file info object for symlinks might validly not have this attribute.
    If not, behave as though it was 0, matching what happened with older
    versions of GLib.

---

The first commit avoids Flatpak test failures, and is an alternative to #2835 and flatpak/flatpak#5354 (although I think it might be best to address this both from the Flatpak side and the libostree side).