### PR TITLE
Use g_steal_fd() in preference to glnx_steal_fd()

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -687,7 +687,7 @@ ostree_content_file_parse_at (gboolean                compressed,
   if (!glnx_fstat (fd, &stbuf, error))
     return FALSE;
 
-  g_autoptr(GInputStream) file_input = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+  g_autoptr(GInputStream) file_input = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
 
   g_autoptr(GFileInfo) ret_file_info = NULL;
   g_autoptr(GVariant) ret_xattrs = NULL;
@@ -1038,7 +1038,7 @@ ostree_checksum_file_at (int               dfd,
       glnx_autofd int fd = -1;
       if (!glnx_openat_rdonly (dfd, path, FALSE, &fd, error))
         return FALSE;
-      in = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+      in = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
       if (canonicalize_perms)
         {
           g_file_info_set_attribute_uint32 (file_info, "unix::uid", 0);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1031,7 +1031,7 @@ content_fetch_on_complete (GObject        *object,
       if (!glnx_fstat (tmpf.fd, &stbuf, error))
         goto out;
       /* Non-mirroring path */
-      tmpf_input = g_unix_input_stream_new (glnx_steal_fd (&tmpf.fd), TRUE);
+      tmpf_input = g_unix_input_stream_new (g_steal_fd (&tmpf.fd), TRUE);
 
       /* If it appears corrupted, we'll delete it below */
       if (!ostree_content_stream_parse (TRUE, tmpf_input, stbuf.st_size, FALSE,
@@ -1338,7 +1338,7 @@ static_deltapart_fetch_on_complete (GObject           *object,
     goto out;
 
   /* Transfer ownership of the fd */
-  in = g_unix_input_stream_new (glnx_steal_fd (&tmpf.fd), TRUE);
+  in = g_unix_input_stream_new (g_steal_fd (&tmpf.fd), TRUE);
 
   /* TODO - make async */
   if (!_ostree_static_delta_part_open (in, NULL, 0, fetch_data->expected_checksum,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1446,7 +1446,7 @@ repo_open_at_take_fd (int *dfd,
                       GError **error)
 {
   g_autoptr(OstreeRepo) repo = g_object_new (OSTREE_TYPE_REPO, NULL);
-  repo->repo_dir_fd = glnx_steal_fd (dfd);
+  repo->repo_dir_fd = g_steal_fd (dfd);
 
   if (!ostree_repo_open (repo, cancellable, error))
     return NULL;
@@ -2809,7 +2809,7 @@ repo_create_at_internal (int             dfd,
           return FALSE;
 
         /* Note early return */
-        *out_dfd = glnx_steal_fd (&repo_dfd);
+        *out_dfd = g_steal_fd (&repo_dfd);
         return TRUE;
       }
   }
@@ -2872,7 +2872,7 @@ repo_create_at_internal (int             dfd,
         return FALSE;
   }
 
-  *out_dfd = glnx_steal_fd (&repo_dfd);
+  *out_dfd = g_steal_fd (&repo_dfd);
   return TRUE;
 }
 
@@ -2918,7 +2918,7 @@ ostree_repo_create (OstreeRepo     *self,
                                 &repo_dir_fd,
                                 cancellable, error))
     return FALSE;
-  self->repo_dir_fd = glnx_steal_fd (&repo_dir_fd);
+  self->repo_dir_fd = g_steal_fd (&repo_dir_fd);
   if (!ostree_repo_open (self, cancellable, error))
     return FALSE;
   return TRUE;
@@ -3743,7 +3743,7 @@ ostree_repo_set_cache_dir (OstreeRepo    *self,
     return FALSE;
 
   glnx_close_fd (&self->cache_dir_fd);
-  self->cache_dir_fd = glnx_steal_fd (&fd);
+  self->cache_dir_fd = g_steal_fd (&fd);
 
   return TRUE;
 }
@@ -4218,7 +4218,7 @@ repo_load_file_archive (OstreeRepo *self,
       if (!glnx_fstat (fd, &stbuf, error))
         return FALSE;
 
-      g_autoptr(GInputStream) tmp_stream = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+      g_autoptr(GInputStream) tmp_stream = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
       /* Note return here */
       return ostree_content_stream_parse (TRUE, tmp_stream, stbuf.st_size, TRUE,
                                           out_input, out_file_info, out_xattrs,
@@ -4416,7 +4416,7 @@ _ostree_repo_load_file_bare (OstreeRepo         *self,
     }
 
   if (out_fd)
-    *out_fd = glnx_steal_fd (&fd);
+    *out_fd = g_steal_fd (&fd);
   if (out_stbuf)
     *out_stbuf = stbuf;
   ot_transfer_out_value (out_symlink, &ret_symlink);
@@ -4467,7 +4467,7 @@ ostree_repo_load_file (OstreeRepo         *self,
       if (out_input)
         {
           if (fd != -1)
-            *out_input = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+            *out_input = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
           else
             *out_input = NULL;
         }
@@ -6835,7 +6835,7 @@ _ostree_repo_allocate_tmpdir (int tmpdir_dfd,
       g_debug ("Reusing tmpdir %s", dent->d_name);
       reusing_dir = TRUE;
       ret_tmpdir.src_dfd = tmpdir_dfd;
-      ret_tmpdir.fd = glnx_steal_fd (&target_dfd);
+      ret_tmpdir.fd = g_steal_fd (&target_dfd);
       ret_tmpdir.path = g_strdup (dent->d_name);
       ret_tmpdir.initialized = TRUE;
     }

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -273,7 +273,7 @@ checksum_dir_recurse (int          dfd,
             return FALSE;
           if (fd != -1)
             {
-              g_autoptr(GInputStream) in = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+              g_autoptr(GInputStream) in = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
               if (!ot_gio_splice_update_checksum (NULL, in, checksum, cancellable, error))
                 return FALSE;
             }
@@ -403,7 +403,7 @@ ensure_directory_from_template (int                 orig_etc_fd,
     return FALSE;
 
   if (out_dfd)
-    *out_dfd = glnx_steal_fd (&target_dfd);
+    *out_dfd = g_steal_fd (&target_dfd);
   return TRUE;
 }
 

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -82,7 +82,7 @@ ot_openat_read_stream (int             dfd,
   glnx_autofd int fd = -1;
   if (!glnx_openat_rdonly (dfd, path, follow, &fd, error))
     return FALSE;
-  *out_istream = g_unix_input_stream_new (glnx_steal_fd (&fd), TRUE);
+  *out_istream = g_unix_input_stream_new (g_steal_fd (&fd), TRUE);
   return TRUE;
 }
 

--- a/tests/test-repo-finder-mount.c
+++ b/tests/test-repo-finder-mount.c
@@ -166,7 +166,7 @@ assert_create_repos_dir (Fixture      *fixture,
     g_clear_error (&error);
   g_assert_no_error (error);
 
-  *out_repos_dfd = glnx_steal_fd (&repos_dfd);
+  *out_repos_dfd = g_steal_fd (&repos_dfd);
   g_autoptr(GFile) mount_root = g_file_get_child (fixture->working_dir, mount_root_name);
   *out_mount = G_MOUNT (ostree_mock_mount_new (mount_root_name, mount_root));
 


### PR DESCRIPTION
Based on #2822.

* Use g_steal_fd() in preference to glnx_steal_fd()
    
    g_steal_fd() exists in GLib since 2.70, and libglnx has a backport for
    older GLib versions, equivalent to the libglnx-specific glnx_steal_fd().