### PR TITLE
ostree-fetcher-curl: handle non 404 errors as G_IO_ERROR_TIMED_OUT

### DIFF
--- a/man/ostree-pull.xml
+++ b/man/ostree-pull.xml
@@ -145,6 +145,42 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--disable-retry-on-network-errors</option></term>
+
+                <listitem><para>
+                    Do not retry when network issues happen, instead fail automatically. (Currently only affects libcurl)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--low-speed-limit-bytes</option>=N</term>
+
+                <listitem><para>
+                    The average transfer speed per second of a transfer during the
+                    time set via 'low-speed-time-seconds' for libcurl to abort
+                    (default: 1000)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--low-speed-time-seconds</option>=N</term>
+
+                <listitem><para>
+                    The time in number seconds that the transfer speed should be
+                    below the 'low-speed-limit-bytes' setting for libcurl to abort
+                    (default: 30)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--max-outstanding-fetcher-requests</option>=N</term>
+
+                <listitem><para>
+                    The max amount of concurrent connections allowed. (default: 8)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--disable-verify-bindings</option></term>
 
                 <listitem><para>

--- a/src/libostree/ostree-fetcher-soup3.c
+++ b/src/libostree/ostree-fetcher-soup3.c
@@ -84,6 +84,7 @@ struct OstreeFetcher
   char *user_agent;
 
   guint64 bytes_transferred;
+  guint32 opt_max_outstanding_fetcher_requests;
 };
 
 enum
@@ -380,6 +381,31 @@ _ostree_fetcher_set_extra_user_agent (OstreeFetcher *self, const char *extra_use
     self->user_agent = g_strdup_printf ("%s %s", OSTREE_FETCHER_USERAGENT_STRING, extra_user_agent);
 }
 
+void
+_ostree_fetcher_set_low_speed_time (OstreeFetcher *self, guint32 opt_low_speed_time)
+{
+  // TODO
+}
+
+void
+_ostree_fetcher_set_low_speed_limit (OstreeFetcher *self, guint32 opt_low_speed_limit)
+{
+  // TODO
+}
+
+void
+_ostree_fetcher_set_retry_all (OstreeFetcher *self, gboolean opt_retry_all)
+{
+  // TODO
+}
+
+void
+_ostree_fetcher_set_max_outstanding_fetcher_requests (OstreeFetcher *self,
+                                                      guint32 opt_max_outstanding_fetcher_requests)
+{
+  self->opt_max_outstanding_fetcher_requests = opt_max_outstanding_fetcher_requests;
+}
+
 static gboolean
 finish_stream (FetcherRequest *request, GCancellable *cancellable, GError **error)
 {
@@ -667,7 +693,7 @@ create_soup_session (OstreeFetcher *self)
   const char *user_agent = self->user_agent ?: OSTREE_FETCHER_USERAGENT_STRING;
   SoupSession *session = soup_session_new_with_options (
       "user-agent", user_agent, "timeout", 60, "idle-timeout", 60, "max-conns-per-host",
-      _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS, NULL);
+      self->opt_max_outstanding_fetcher_requests, NULL);
 
   /* SoupContentDecoder is included in the session by default. Remove it
    * if gzip compression isn't in use.

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -99,6 +99,16 @@ void _ostree_fetcher_set_proxy (OstreeFetcher *fetcher, const char *proxy);
 void _ostree_fetcher_set_client_cert (OstreeFetcher *fetcher, const char *cert_path,
                                       const char *key_path);
 
+void _ostree_fetcher_set_low_speed_limit (OstreeFetcher *self, guint32 opt_low_speed_limit);
+
+void _ostree_fetcher_set_low_speed_time (OstreeFetcher *self, guint32 opt_low_speed_time);
+
+void _ostree_fetcher_set_retry_all (OstreeFetcher *self, gboolean opt_retry_all);
+
+void
+_ostree_fetcher_set_max_outstanding_fetcher_requests (OstreeFetcher *self,
+                                                      guint32 opt_max_outstanding_fetcher_requests);
+
 void _ostree_fetcher_set_tls_database (OstreeFetcher *self, const char *tlsdb_path);
 
 void _ostree_fetcher_set_extra_headers (OstreeFetcher *self, GVariant *extra_headers);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -33,7 +33,6 @@ G_BEGIN_DECLS
 #define _OSTREE_SUMMARY_CACHE_DIR "summaries"
 #define _OSTREE_CACHE_DIR "cache"
 
-#define _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS 8
 #define _OSTREE_MAX_OUTSTANDING_DELTAPART_REQUESTS 2
 
 /* We want some parallelism with disk writes, but we also

--- a/src/libostree/ostree-repo-pull-private.h
+++ b/src/libostree/ostree-repo-pull-private.h
@@ -54,6 +54,10 @@ typedef struct
 
   GVariant *extra_headers;
   char *append_user_agent;
+  guint32 low_speed_limit;
+  guint32 low_speed_time;
+  gboolean retry_all;
+  guint32 max_outstanding_fetcher_requests;
 
   gboolean dry_run;
   gboolean dry_run_emitted_progress;


### PR DESCRIPTION
This introduces the retry-all-network-errors option which
is enabled by default. This is a behavior change as now
ostree will retry on requests that fail except when
they fail with NOT_FOUND. It also introduces the options
low-speed-limit-bytes and low-speed-time-seconds these
map to CURL options only at the moment. Which have defaults
set following librepo:
https://github.com/rpm-software-management/librepo/blob/7c9af219abd49f8961542b7622fc82cfdaa572e3/librepo/handle.h#L90
https://github.com/rpm-software-management/librepo/blob/7c9af219abd49f8961542b7622fc82cfdaa572e3/librepo/handle.h#L96
Currently this changes only apply when using libcurl.

Closes: https://github.com/ostreedev/ostree/issues/2570