### PR TITLE
Add ostree=aboot for signed Android Boot Images

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -124,9 +124,13 @@ resolve_deploy_path (const char * root_mountpoint)
 {
   char destpath[PATH_MAX];
   struct stat stbuf;
-  char *ostree_target, *deploy_path;
+  char __attribute__ ((cleanup (free_char))) *ostree_target;
+  char *deploy_path;
 
   ostree_target = read_proc_cmdline_ostree ();
+  if (!strcmp (ostree_target, ABOOT_KARG))
+    ostree_target = bls_parser_get_ostree_option (root_mountpoint);
+
   if (!ostree_target)
     errx (EXIT_FAILURE, "No OSTree target; expected ostree=/ostree/boot.N/...");
 

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -62,7 +62,10 @@ main(int argc, char *argv[])
    * exit so that we don't error, but at the same time work where switchroot
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
-  char *ostree_cmdline = read_proc_cmdline_ostree ();
+  char __attribute__ ((cleanup (free_char))) *ostree_cmdline = read_proc_cmdline_ostree ();
+  if (!strcmp (ostree_cmdline, ABOOT_KARG))
+    ostree_cmdline = bls_parser_get_ostree_option ("/sysroot");
+
   if (!ostree_cmdline)
     exit (EXIT_SUCCESS);
 


### PR DESCRIPTION
Some kernel images are delivered in a signed kernel + cmdline +
initramfs + dtb blob. When this is added to the commit server side, only
after this do you know what the cmdline is, this creates a recursion
issue. To avoid this, in the case where we have ostree=aboot karg
set, do the bls parsing in the initramfs instead, so we can take
advantage of existing bls logic.