### PR TITLE
ci: two fixes

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -25,7 +25,7 @@ if test -x /usr/bin/clang; then
     if grep -q -e 'static inline.*_GLIB_AUTOPTR_LIST_FUNC_NAME' /usr/include/glib-2.0/glib/gmacros.h; then
         echo 'Skipping clang check, see https://bugzilla.gnome.org/show_bug.cgi?id=796346'
     else
-    export CFLAGS="-Wall -Werror ${CFLAGS:-}"
+    export CFLAGS="-Wall -Werror -Wno-error=deprecated-declarations ${CFLAGS:-}"
     git clean -dfx && git submodule foreach git clean -dfx
     export CC=clang
     build

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -30,6 +30,6 @@ esac
 
 # always fail on warnings; https://github.com/ostreedev/ostree/pull/971
 # NB: this disables the default set of flags from configure.ac
-export CFLAGS="-Wall -Werror ${CFLAGS:-}"
+export CFLAGS="-Wall -Werror -Wno-error=deprecated-declarations ${CFLAGS:-}"
 
 build --enable-gtk-doc ${CONFIGOPTS:-}

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -36,11 +36,6 @@ pkg_install_if_os() {
 pkg_install_buildroot() {
     case "${OS_ID}" in
         fedora)
-            # https://github.com/projectatomic/rpm-ostree/pull/1889/commits/9ff611758bea22b0ad4892cc16182dd1f7f47e89
-            # https://fedoraproject.org/wiki/Common_F30_bugs#Conflicts_between_fedora-release_packages_when_installing_package_groups
-            if rpm -q fedora-release-container; then
-                dnf -y swap fedora-release{-container,}
-            fi
             pkg_install dnf-plugins-core @buildsys-build;;
         *) fatal "pkg_install_buildroot(): Unhandled OS ${OS_ID}";;
     esac


### PR DESCRIPTION
ci: Turn off errors for deprecated-declarations

Having `-Werror` on in CI only by default has generally worked OK,
but I don't think it's worth trying to immediately scramble to port
when they deprecate APIs.

Motivated in this case by
```
 src/libostree/ostree-fetcher-curl.c: In function 'initiate_next_curl_request':
src/libostree/ostree-fetcher-curl.c:876:3: error: 'CURLOPT_PROTOCOLS' is deprecated: since 7.85.0. Use CURLOPT_PROTOCOLS_STR [-Werror=deprecated-declarations]
  876 |   rc = curl_easy_setopt (req->easy, CURLOPT_PROTOCOLS, (long)(CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FILE));
      |   ^~
```

---

ci: Drop workaround for fedora-release-container

I think this isn't necessary anymore, and is now actively broken
with f38.

---

