### PR TITLE
Add .clang-format file which defines coding style as GNU

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language: Cpp
+BasedOnStyle: GNU
+ColumnLimit: 99

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
 # Tests that validate structure of the source code;
 # can be run without building it.
-set -euo pipefail
+set -eo pipefail
+
+if command -v clang-format >/dev/null && [ -n "$GITHUB_ACTOR" ]; then
+    git remote add github_actor https:///github.com/$GITHUB_ACTOR/ostree.git
+    git remote add https_upstream https://github.com/ostreedev/ostree.git
+    git fetch --recurse-submodules=no github_actor &
+    git fetch --recurse-submodules=no https_upstream main &
+    LOG_LINE=$(git show -s --format=%B | grep Merge)
+    wait
+    THIS_COMMIT=$(echo $LOG_LINE | awk '{print $2}')
+    THAT_COMMIT=$(echo $LOG_LINE | awk '{print $4}')
+    git reset --hard $THIS_COMMIT
+    git rebase $THAT_COMMIT
+    
+    echo -n "Formatting with git clang-format... "
+    if ! git clang-format $THAT_COMMIT; then
+        echo "git clang-format $THAT_COMMIT failed; run: please commit the changes"
+        exit 1
+    fi
+    echo "ok"
+fi
 
 # Don't hard require Rust
 if command -v cargo >/dev/null; then

--- a/ci/gh-build.sh
+++ b/ci/gh-build.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 set -x
 
 # First, basic static analysis
-./ci/codestyle.sh
+./ci/codestyle.sh clang-format
 
 NOCONFIGURE=1 ./autogen.sh
 

--- a/ci/gh-install.sh
+++ b/ci/gh-install.sh
@@ -71,6 +71,7 @@ case "$ID" in
             build-essential
             bubblewrap
             ca-certificates
+            clang-format
             cpio
             debhelper
             dh-exec


### PR DESCRIPTION
This is particularly useful for those that work on multiple projects
with different styles so they can easily auto-format their code before
submission. Luckily libostree looks like it's pretty standard GNU style
so this file is quite small.