### PR TITLE
rust: Bump MSRV to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 version = "0.18.0"
 
 exclude = [


### PR DESCRIPTION
Since a dependency `winnow` bumped to this in a recent update.