### PR TITLE
tests/inst: Add xshell and use it in one place

### DIFF
--- a/tests/inst/Cargo.toml
+++ b/tests/inst/Cargo.toml
@@ -37,6 +37,7 @@ strum = "0.18.0"
 strum_macros = "0.18.0"
 # See discussion in https://github.com/coreos/rpm-ostree/pull/2569#issuecomment-780569188
 rpmostree-client = { git = "https://github.com/coreos/rpm-ostree", tag = "v2021.3" }
+xshell = "0.2.3"
 
 # This one I might publish to crates.io, not sure yet
 with-procspawn-tempdir = { git = "https://github.com/cgwalters/with-procspawn-tempdir" }


### PR DESCRIPTION
I've deprecated sh-inline; in the end I think it is better to minimize the amount of bash code we have.  xshell solves the core convenience problem of taking local variables and mapping them to command arguments.

A full port would be nontrivial; this just starts the ball rolling.