### PR TITLE
Release 2023.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2023])
 m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2023])
-m4_define([release_version], [3])
+m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Release 2023.3

NOTE: As usual, some of these commits are actually for the Rust bindings,
which are versioned and released separately.

```
Colin Walters (14):
      configure: post-release version bump
      treegen: Require at least one mutation
      ci: Turn off errors for deprecated-declarations
      ci: Drop workaround for fedora-release-container
      rust: Bump MSRV to 1.64
      build-sys: Squash automake conditional warning re `.PHONY`
      Add clang formatting infrastructure
      lib: clang-format `ostree.h`
      tree-wide: Fix various include ordering issues
      lib: Fix one include
      clang-format: Don't align backslashes
      tree-wide: Run clang-format
      ci: Validate clang-format
      tests/inst: Add xshell and use it in one place

Dan Nicholson (3):
      tests: Ensure real GIO backends aren't used
      ci: Add test configuration with soup3
      fetcher/soup3: Rewrite without threads

Daniel Kolesa (1):
      fetcher: add libsoup3 backend

Jonathan Lebon (10):
      lib/sysroot-cleanup: Convert bootdir listing to dfd-relative
      lib/sysroot-cleanup: Make some static utility functions global
      lib/sysroot-cleanup: Drop dead code
      lib/sysroot-cleanup: Factor out bootfs cleanup
      lib/sysroot-cleanup: Make bootfs cleanup function global
      libotutil: add utility functions for calculating directory size
      lib/sysroot-deploy: Nuke `finalize-failure.stamp` on successful finalization
      tests/kola: delete unused .gitignore
      tests/kolainst: Add `make localinstall`
      lib/sysroot-deploy: Add experimental support for automatic early prune

Joseph Marrero (2):
      Release 2023.3
      configure: post-release version bump

Philip Withnall (1):
      lib/fetcher: Add some debugging messages to the libsoup request path
```