### PR TITLE
Increase the metadata size limit to 128MB

### DIFF
--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -35,7 +35,7 @@ G_BEGIN_DECLS
  * objects). This is an arbitrary number intended to mitigate disk space
  * exhaustion attacks.
  */
-#define OSTREE_MAX_METADATA_SIZE (10 * 1024 * 1024)
+#define OSTREE_MAX_METADATA_SIZE (128 * 1024 * 1024)
 
 /**
  * OSTREE_MAX_METADATA_WARN_SIZE:

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -417,7 +417,7 @@ test_big_metadata (void)
   g_assert_no_error (error);
   g_assert (ret);
 
-  const size_t len = 20 * 1024 * 1024;
+  const size_t len = OSTREE_MAX_METADATA_SIZE + 1;
   g_assert_cmpint (len, >, OSTREE_MAX_METADATA_SIZE);
   g_autofree char *large_buf = g_malloc (len);
   memset (large_buf, 0x42, len);

--- a/tests/test-pull-large-metadata.sh
+++ b/tests/test-pull-large-metadata.sh
@@ -25,10 +25,11 @@ setup_fake_remote_repo1 "archive"
 
 echo '1..1'
 
-# Overwrite the commit object with 20 M of 
+# Overwrite the commit object with 121 M of zeroes. This is based on the
+# OSTREE_MAX_METADATA_SIZE constant in src/libostree/ostree-core.h
 cd ${test_tmpdir}
 rev=$(cd ostree-srv && ${CMD_PREFIX} ostree --repo=gnomerepo rev-parse main)
-dd if=/dev/zero bs=1M count=20 of=ostree-srv/gnomerepo/objects/$(echo $rev | cut -b 1-2)/$(echo $rev | cut -b 3-).commit
+dd if=/dev/zero bs=1M count=130 of=ostree-srv/gnomerepo/objects/$(echo $rev | cut -b 1-2)/$(echo $rev | cut -b 3-).commit
 
 cd ${test_tmpdir}
 mkdir repo


### PR DESCRIPTION
Flathub has hit the 10MB limit in 2022, and we had to drop some CPU architectures from the main summary to subsummaries, effectively cutting off users running too old Flatpak version. Despite that, the main summary containing only x86_64 is already at 7MB. As this is eventually going to happen to subsummaries as well, preemptively bump the limit 12 times.

It takes between 2 and 3 years for a change like this to roll out across Linux distibutions so the best time for this was yesterday.

fixes #2715