### PR TITLE
commit: fix ostree deployment on 64-bit inode fs

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1510,7 +1510,7 @@ scan_loose_devino (OstreeRepo *self, GHashTable *devino_cache, GCancellable *can
  * checksum. */
 static const char *
 devino_cache_lookup (OstreeRepo *self, OstreeRepoCommitModifier *modifier, guint32 device,
-                     guint32 inode)
+                     guint64 inode)
 {
   OstreeDevIno dev_ino_key;
   OstreeDevIno *dev_ino_val;


### PR DESCRIPTION
This commit addresses a bug that was causing ostree deployment to become corrupted on the large fs, when any package was installed using 'rpm-ostree install'.

In such instances, multiple files were assigned the same inode. For example, the '/home' directory and a regular file 'pkg-get' were assigned the same inode (2147484070), making the deployment unusable.

A root cause analysis was performed, running the process under gdb, which revealed a lossy conversion from guint64 to guint32, for example 6442451366 converted to 2147484070:

(gdb) p name
$10 = 0x7fe9224d2d70 "home"

(gdb) p inode
$73 = 6442451366

(gdb) s
    device=66311, modifier=0x7fe914791840) at
src/libostree/ostree-repo-commit.c:1590

The conversion resulted in entirely independent files potentially receiving the same inode.

The issue was discovered on PoC machine equipped with a large NVME (3.4TB), but the bug can be easily reproduced using `cosa run -m 4000 --qemu-size +3TB', followed by installation of any package using `rpm-ostree install`. The resulting deployment will be unusable due to many files being "corrupted" by the aforementioned issue.