### PR TITLE
fetcher: Always open tmpfiles in repo location

### DIFF
--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -35,14 +35,8 @@ static inline gboolean
 _ostree_fetcher_tmpf_from_flags (OstreeFetcherRequestFlags flags, int dfd, GLnxTmpfile *tmpf,
                                  GError **error)
 {
-  if ((flags & OSTREE_FETCHER_REQUEST_LINKABLE) > 0)
-    {
-      if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
-        return FALSE;
-    }
-  else if (!glnx_open_anonymous_tmpfile (O_RDWR | O_CLOEXEC, tmpf, error))
+  if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
     return FALSE;
-
   if (!glnx_fchmod (tmpf->fd, 0644, error))
     return FALSE;
   return TRUE;


### PR DESCRIPTION
In an installation environment (like a live ISO) we may not have significant space outside of the target installation repository.

There's no reason not to always open a linkable tempfile.  In the future we should fix the pull path to verify the checksum and then just directly link in the object instead of copying.

Closes: https://github.com/ostreedev/ostree/issues/2571