### PR TITLE
Add ostree=aboot for signed Android Boot Images

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -246,7 +246,7 @@ main (int argc, char *argv[])
     }
 
   OstreeComposefsMode composefs_mode = OSTREE_COMPOSEFS_MODE_MAYBE;
-  char *ot_composefs = read_proc_cmdline_key ("ot-composefs");
+  autofree char *ot_composefs = read_proc_cmdline_key ("ot-composefs");
   char *composefs_digest = NULL;
   if (ot_composefs)
     {

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -154,11 +154,8 @@ resolve_deploy_path (const char *root_mountpoint)
 {
   char destpath[PATH_MAX];
   struct stat stbuf;
-  char *ostree_target, *deploy_path;
-
-  ostree_target = read_proc_cmdline_key ("ostree");
-  if (!ostree_target)
-    errx (EXIT_FAILURE, "No OSTree target; expected ostree=/ostree/boot.N/...");
+  char *deploy_path;
+  autofree char *ostree_target = get_ostree_target ();
 
   if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_target) < 0)
     err (EXIT_FAILURE, "failed to assemble ostree target path");

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -63,9 +63,7 @@ main (int argc, char *argv[])
    * exit so that we don't error, but at the same time work where switchroot
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
-  char *ostree_cmdline = read_proc_cmdline_key ("ostree");
-  if (!ostree_cmdline)
-    exit (EXIT_SUCCESS);
+  autofree char *ostree_target = get_ostree_target ();
 
   /* See comments in ostree-prepare-root.c for this.
    *
@@ -77,7 +75,7 @@ main (int argc, char *argv[])
 
   {
     g_autoptr (GError) local_error = NULL;
-    if (!ostree_cmd__private__ ()->ostree_system_generator (ostree_cmdline, arg_dest, NULL,
+    if (!ostree_cmd__private__ ()->ostree_system_generator (ostree_target, arg_dest, NULL,
                                                             arg_dest_late, &local_error))
       errx (EXIT_FAILURE, "%s", local_error->message);
   }


### PR DESCRIPTION
Some kernel images are delivered in a signed kernel + cmdline + initramfs + dtb blob. When this is added to the commit server side, only after this do you know what the cmdline is, this creates a recursion issue. To avoid this, in the case where we have ostree=aboot karg set, create a symlink after deploy to the correct ostree target in the rootfs, as the cmdline can't be malleable and secured client-side at the same time.