### PR TITLE
test-concurrency: Don't lower timeout

### DIFF
--- a/tests/test-concurrency.py
+++ b/tests/test-concurrency.py
@@ -43,10 +43,6 @@ with open('repo/config', 'a') as f:
     # it's simpler, and we don't need xattr coverage for this
     f.write('disable-xattrs=true\n')
 
-    # Make any locking errors fail quickly instead of blocking the test
-    # for 30 seconds.
-    f.write('lock-timeout-secs=5\n')
-
 def commit(v):
     tdir='tree{}'.format(v)
     cmd = ['ostree', '--repo=repo', 'commit', '--fsync=0', '-b', tdir, '--tree=dir='+tdir]


### PR DESCRIPTION
I think there's never been a real race condition here.  Instead the problem is:

- We have a timeout on the lock, after which we error out (30s)
- This test actually *lowers* the timeout

Looking through the failures for test-concurrency what I see is
`error: Locking repo exclusive failed: Resource temporarily unavailable` which is us hitting the timeout.

Hardcoded timeouts are just going to be subject to race conditions. I understand not wanting to block forever in some cases, but any arbitrary timeout is just going to get hit in real world conditions too.

Anyways for now, stop shooting ourselves in the foot and at least keep the timeout at the default.

Closes: https://github.com/ostreedev/ostree/issues/2038