### PR TITLE
pull: Add error prefixing for corrupt checksums

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -734,11 +734,11 @@ scan_dirtree_object (OtPullData *pull_data, const char *checksum, const char *pa
 
       const guchar *tree_csum_bytes = ostree_checksum_bytes_peek_validate (tree_csum, error);
       if (tree_csum_bytes == NULL)
-        return FALSE;
+        return glnx_prefix_error (error, "Parsing dirtree %s tree child %s", checksum, dirname);
 
       const guchar *meta_csum_bytes = ostree_checksum_bytes_peek_validate (meta_csum, error);
       if (meta_csum_bytes == NULL)
-        return FALSE;
+        return glnx_prefix_error (error, "Parsing dirtree %s meta child %s", checksum, dirname);
 
       g_autofree char *subpath = g_strconcat (path, dirname, "/", NULL);
       queue_scan_one_metadata_object_c (pull_data, tree_csum_bytes, OSTREE_OBJECT_TYPE_DIR_TREE,


### PR DESCRIPTION
I got a bug report with the bare error
```
error: Invalid checksum of length 0 expected 32
```

And I'm pretty sure it's from here.  Add error prefixing so we know exactly which metadata object was corrupt.