### PR TITLE
ostree-fetcher-curl: explicitly use HTTP1.1 when HTTP2 is disabled

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -879,6 +879,12 @@ initiate_next_curl_request (FetcherRequest *req, GTask *task)
 #endif
     }
 
+  if (self->config_flags & OSTREE_FETCHER_FLAGS_DISABLE_HTTP2)
+    {
+      rc = curl_easy_setopt (req->easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+      g_assert_cmpint (rc, ==, CURLM_OK);
+    }
+
   rc = curl_easy_setopt (req->easy, CURLOPT_WRITEFUNCTION, write_cb);
   g_assert_cmpint (rc, ==, CURLM_OK);
   rc = curl_easy_setopt (req->easy, CURLOPT_HEADERFUNCTION, response_header_cb);


### PR DESCRIPTION
Currently, trying to disable HTTP2 with `ostree config get` doesn't work as HTTP2 is actually used anyway (see https://gitlab.apertis.org/infrastructure/apertis-issues/-/issues/349 for the context).

The current logic to select the HTTP version to be use relies on the fact that curl don't use by default HTTP2. This assumption seems wrong with recent versions of curl. To fix this option, this PR adds a specific check if HTTP2 is disabled and explicitely switch to HTTP1.1 in this case.