### PR TITLE
Add more error prefixing when parsing commit objects

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2152,18 +2152,18 @@ ostree_validate_structureof_commit (GVariant *commit, GError **error)
   if (n_elts > 0)
     {
       if (!ostree_validate_structureof_csum_v (parent_csum_v, error))
-        return FALSE;
+        return glnx_prefix_error (error, "Invalid commit parent");
     }
 
   g_autoptr (GVariant) content_csum_v = NULL;
   g_variant_get_child (commit, 6, "@ay", &content_csum_v);
   if (!ostree_validate_structureof_csum_v (content_csum_v, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Invalid commit tree content checksum");
 
   g_autoptr (GVariant) metadata_csum_v = NULL;
   g_variant_get_child (commit, 7, "@ay", &metadata_csum_v);
   if (!ostree_validate_structureof_csum_v (metadata_csum_v, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Invalid commit tree metadata checksum");
 
   return TRUE;
 }


### PR DESCRIPTION
I've got more debug information in the error case that motivated https://github.com/ostreedev/ostree/pull/2884/commits/bae4347abeaa2a66d213758f790058f42cb71fd1 "pull: Add error prefixing for corrupt checksums"
where the sole error is

`error: Invalid checksum of length 0 expected 32`

This must be coming from the pull code in the case where we've already fetched the commit object.

- Add some error prefixing here in the core commit validation code
- Ensure that we do the validation immediately after loading, including of the parent commit reference where I think this error must be coming from
- Then the pull code can just safely call `ostree_commit_get_parent` which already does the hex conversion etc.