### PR TITLE
composefs: Avoid double unref

### DIFF
--- a/src/libostree/ostree-repo-composefs.c
+++ b/src/libostree/ostree-repo-composefs.c
@@ -461,6 +461,9 @@ checkout_composefs_recurse (OstreeRepo *self, const char *dirtree_checksum,
                                          dname, cancellable, error))
           return FALSE;
       }
+    /* Freed by iter-loop */
+    subdirtree_csum_v = NULL;
+    subdirmeta_csum_v = NULL;
   }
 
   return TRUE;


### PR DESCRIPTION
The interaction of `iter_loop` and autofree is way too subtle; I happened to be reading this code and noticed we did the NULL reset in one path but not another.

The real fix is Rust...