### PR TITLE
ci: Add some composefs testing

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,4 +1,21 @@
-FROM registry.fedoraproject.org/fedora:30
+FROM registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
-RUN ./ci/build.sh
+RUN env CONFIGOPTS=--with-composefs ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
+# Uncomment this to fake a build to test the code below
+#RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
+
+FROM registry.ci.openshift.org/coreos/coreos-assembler:latest
+WORKDIR /srv
+USER root
+# Copy binaries from the build
+COPY --from=builder /cosa /cosa
+# Merge them to the real root since we're used at compose time
+RUN rsync -rlv /cosa/component-install/ /
+# Merge installed tests
+RUN rsync -rlv /cosa/component-tests/ /
+# Grab all of our ci scripts
+COPY --from=builder /src/ci/ /ci/
+RUN ln -sr /ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e
+USER builder

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Prow jobs don't support adding emptydir today
+export COSA_SKIP_OVERLAY=1
+# And suppress depcheck since we didn't install via RPM
+export COSA_SUPPRESS_DEPCHECK=1
+ostree --version
+cd $(mktemp -d)
+cosa init https://github.com/coreos/fedora-coreos-config/
+rsync -rlv /cosa/component-install/ overrides/rootfs/
+cosa fetch
+cosa build
+# For now, Prow just runs the composefs tests, since Jenkins covers the others
+cosa kola run 'ext.ostree.destructive-rs.composefs*'

--- a/tests/inst/src/composefs.rs
+++ b/tests/inst/src/composefs.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use xshell::cmd;
+
+pub(crate) fn itest_composefs() -> Result<()> {
+    let sh = xshell::Shell::new()?;
+    if !cmd!(sh, "ostree --version").read()?.contains("- composefs") {
+        println!("SKIP no composefs support");
+        return Ok(());
+    }
+    let mark = match crate::test::get_reboot_mark()? {
+        None => {
+            cmd!(
+                sh,
+                "ostree --repo=/ostree/repo config set ex-integrity.composefs true"
+            )
+            .run()?;
+            // A dummy change; TODO add an ostree command for this
+            cmd!(sh, "rpm-ostree kargs --append=foo=bar").run()?;
+            return Err(crate::test::reboot("1").into());
+        }
+        Some(v) => v,
+    };
+    if mark != "1" {
+        anyhow::bail!("Invalid reboot mark: {mark}")
+    }
+
+    let fstype = cmd!(sh, "findmnt -n -o FSTYPE /").read()?;
+    assert_eq!(fstype.as_str(), "overlay");
+
+    Ok(())
+}

--- a/tests/inst/src/insttestmain.rs
+++ b/tests/inst/src/insttestmain.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use libtest_mimic::Trial;
 use structopt::StructOpt;
 
+mod composefs;
 mod destructive;
 mod repobin;
 mod sysroot;
@@ -28,7 +29,10 @@ const TESTS: &[StaticTest] = &[
     test!(repobin::itest_extensions),
     test!(repobin::itest_pull_basicauth),
 ];
-const DESTRUCTIVE_TESTS: &[StaticTest] = &[test!(destructive::itest_transactionality)];
+const DESTRUCTIVE_TESTS: &[StaticTest] = &[
+    test!(destructive::itest_transactionality),
+    test!(composefs::itest_composefs),
+];
 
 #[derive(Debug, StructOpt)]
 #[structopt(rename_all = "kebab-case")]


### PR DESCRIPTION
tests: Add a sanity check for composefs

Prep for adding some coverage of this flow when booting with
composefs.

---

ci: Sync prow config with rpm-ostree, enable composefs there

I want to gain testing over the composefs path; but without
yet changing the main Jenkins build.  Because we have duplicate/overlapping
CI systems, we can take advantage of this by testing the composefs
flow via Prow.

Sync the Prow build scripts with what's in coreos/rpm-ostree
right now.

Then let's test the composefs flow a bit more e2e there.

---

