### PR TITLE
Revert "fetcher: Always open tmpfiles in repo location"

### DIFF
--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -35,8 +35,14 @@ static inline gboolean
 _ostree_fetcher_tmpf_from_flags (OstreeFetcherRequestFlags flags, int dfd, GLnxTmpfile *tmpf,
                                  GError **error)
 {
-  if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
+  if ((flags & OSTREE_FETCHER_REQUEST_LINKABLE) > 0)
+    {
+      if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
+        return FALSE;
+    }
+  else if (!glnx_open_anonymous_tmpfile (O_RDWR | O_CLOEXEC, tmpf, error))
     return FALSE;
+
   if (!glnx_fchmod (tmpf->fd, 0644, error))
     return FALSE;
   return TRUE;


### PR DESCRIPTION
This reverts commit f7f6f87c513c9f35bc24f35e909779c19cb49d3a.

This seems to have broken flatpak, so we'll revert and then investigate.

Closes: https://github.com/ostreedev/ostree/issues/2900