### PR TITLE
prepare-root: Adjust to composefs mount struct changes

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -326,7 +326,7 @@ main (int argc, char *argv[])
       if (composefs_mode == OSTREE_COMPOSEFS_MODE_DIGEST)
         {
           cfs_options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
-          cfs_options.expected_digest = composefs_digest;
+          cfs_options.expected_fsverity_digest = composefs_digest;
         }
 
 #ifdef USE_LIBSYSTEMD


### PR DESCRIPTION
This fixes a regression from the latest composefs submodule update in 1582edd1d4a6b26874d3897de8a5586f979a0715. In composefs commit 7560a4fd388481f479c0b3fc2e6d20c6321d9b74 the struct field was changed from the generic `expected_digest` with the thought that there may be other signatures or digests in the future.