### PR TITLE
ci/prow: Build tests before trying to install

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
 RUN env CONFIGOPTS=--with-composefs ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN make -C tests/kolainst
 RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 # Uncomment this to fake a build to test the code below
 #RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo


### PR DESCRIPTION
Our `install` target doesn't depend on `all` unlike the rpm-ostree version; not doing so is arguably better, so let's explicitly build before installing.