### PR TITLE
Separate prepare-root static path + link to glib

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -15,6 +15,12 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+ostree_prepare_root_SOURCES = \
+    src/switchroot/ostree-mount-util.h
+ostree_prepare_root_CFLAGS =
+ostree_prepare_root_CPPFLAGS = $(AM_CPPFLAGS)
+ostree_prepare_root_LDADD =
+
 if BUILDOPT_SYSTEMD
 ostree_boot_PROGRAMS += ostree-remount
 else
@@ -23,15 +29,9 @@ else
 check_PROGRAMS += ostree-remount
 endif
 
-ostree_prepare_root_SOURCES = \
-    src/switchroot/ostree-mount-util.h \
-    src/switchroot/ostree-prepare-root.c \
-    $(NULL)
-ostree_prepare_root_CFLAGS =
-ostree_prepare_root_CPPFLAGS = $(AM_CPPFLAGS)
-ostree_prepare_root_LDADD =
-
 if BUILDOPT_USE_STATIC_COMPILER
+ostree_prepare_root_SOURCES += src/switchroot/ostree-prepare-root-static.c
+
 # ostree-prepare-root can be used as init in a system without a populated /lib.
 # To support this use case we need to link statically as we will be unable to
 # locate libc.so at run time if it's not installed in /lib.
@@ -45,12 +45,15 @@ if BUILDOPT_USE_STATIC_COMPILER
 ostree_boot_SCRIPTS += ostree-prepare-root
 
 ostree-prepare-root : $(ostree_prepare_root_SOURCES)
-	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES) -DOSTREE_PREPARE_ROOT_STATIC=1
+	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root-static.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES) -DOSTREE_PREPARE_ROOT_STATIC=1
 CLEANFILES += ostree-prepare-root
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_prepare_root_CFLAGS += $(AM_CFLAGS) -Isrc/switchroot -I$(srcdir)/composefs
-endif
+else
+ostree_prepare_root_SOURCES += src/switchroot/ostree-prepare-root.c
+endif # BUILDOPT_USE_STATIC_COMPILER
+
 
 ostree_remount_SOURCES = \
     src/switchroot/ostree-mount-util.h \

--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -50,8 +50,9 @@ CLEANFILES += ostree-prepare-root
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_prepare_root_CFLAGS += $(AM_CFLAGS) -Isrc/switchroot -I$(srcdir)/composefs
-else
 ostree_prepare_root_SOURCES += src/switchroot/ostree-prepare-root.c
+ostree_prepare_root_CPPFLAGS += $(OT_INTERNAL_GIO_UNIX_CFLAGS) -I $(srcdir)/libglnx
+ostree_prepare_root_LDADD += $(AM_LDFLAGS) $(OT_INTERNAL_GIO_UNIX_LIBS) libglnx.la
 endif # BUILDOPT_USE_STATIC_COMPILER
 
 
@@ -68,7 +69,7 @@ endif
 
 if BUILDOPT_SYSTEMD
 ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD=1
-ostree_prepare_root_LDADD += $(AM_LDFLAGS) $(LIBSYSTEMD_LIBS)
+ostree_prepare_root_LDADD += $(LIBSYSTEMD_LIBS)
 endif
 
 # This is the "new mode" of using a generator for /var; see


### PR DESCRIPTION
Separate prepare-root static path

We should have done this a long time ago.  We don't have any test
coverage for the no-initramfs path, and I think it's not long
term supportable as we want to add more features like composefs.

Particularly now that there's good support for embedding an
initramfs in a kernel image, I see little value in a path for
having custom static linking for this prepare root flow.

That said, we will continue to make a best-effort "it compiles"
attempt to support it.

Fork the "pid 1" prepare root code into a new
`ostree-prepare-root-static.c` file, and drop the runtime conditionals.

We can drop the composefs logic from `-static.c` which ends up
keeping that file much smaller.

A further next step here will be to actually fold the
`prepare-root.c` logic into the main `ostree` binary which we
can then just include in the initramfs.

---

prepare-root: Link to glib

Since we've split off the "prepare root as init" code
into a separate file, we can now use glib to parse
the config file again, which is a lot less hacky.

This is particularly motivated by composefs, where
we want to do more in the initramfs.  Future patches
may also link to parts of libostree.

---

