### PR TITLE
tests: Source libtest before exiting

### DIFF
--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -17,12 +17,13 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '- composefs'; then
+. $(dirname $0)/libtest.sh
+
+if ! ${CMD_PREFIX} ostree --version | grep -q -e '- composefs'; then
     echo "1..0 #SKIP no composefs support compiled in"
     exit 0
 fi
 
-. $(dirname $0)/libtest.sh
 
 setup_test_repository "bare-user"
 


### PR DESCRIPTION
I am not sure why this is failing on older Debian systems, but I'm wildly guessing that something being done in `libtest.sh` is setting up automake in a way that we need.  This is done in other tests.