### PR TITLE
Fix return value of generator on non-ostree systems

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -153,7 +153,7 @@ get_ostree_target (void)
   autofree char *ostree_cmdline = read_proc_cmdline_key ("ostree");
 
   if (!ostree_cmdline)
-    errx (EXIT_FAILURE, "No ostree= cmdline");
+    return NULL;
 
   if (strcmp (ostree_cmdline, "aboot") == 0)
     return get_aboot_root_slot ();

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -157,6 +157,8 @@ resolve_deploy_path (const char *root_mountpoint)
   struct stat stbuf;
   char *deploy_path;
   autofree char *ostree_target = get_ostree_target ();
+  if (!ostree_target)
+    errx (EXIT_FAILURE, "No ostree= cmdline");
 
   if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_target) < 0)
     err (EXIT_FAILURE, "failed to assemble ostree target path");

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -64,6 +64,8 @@ main (int argc, char *argv[])
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
   autofree char *ostree_target = get_ostree_target ();
+  if (!ostree_target)
+    exit (EXIT_SUCCESS);
 
   /* See comments in ostree-prepare-root.c for this.
    *


### PR DESCRIPTION
Commit aa72caffb540114a0e8635ab2990b9c8b0b8f9db
regressed the `ostree-system-generator` on non-ostree systems. If there's no `ostree=` karg, we need to just exit 0.

Closes: https://github.com/ostreedev/ostree/issues/2909
Fixes: aa72caffb540114a0e8635ab2990b9c8b0b8f9db