### PR TITLE
tests/inst: A few small patches

### DIFF
--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -459,17 +459,14 @@ fn impl_transaction_test<M: AsRef<str>>(
         // Reset the target ref to booted, and perform a cleanup
         // to ensure we're re-downloading objects each time
         let testref = TESTREF;
-        bash!(
-            "
-            systemctl stop rpm-ostreed
-            systemctl stop ostree-finalize-staged
-            systemctl stop ostree-finalize-staged-hold
-            ostree reset testrepo:${testref} ${booted_commit}
-            rpm-ostree cleanup -pbrm
-            ",
-            testref,
-            booted_commit
-        )
+        (|| -> Result<()> {
+            cmd!(sh, "systemctl stop rpm-ostreed").run()?;
+            cmd!(sh, "systemctl stop ostree-finalize-staged").run()?;
+            cmd!(sh, "systemctl stop ostree-finalize-staged-hold").run()?;
+            cmd!(sh, "ostree reset testrepo:{testref} {booted_commit}").run()?;
+            cmd!(sh, "rpm-ostree cleanup -pbrm").run()?;
+            Ok(())
+        })()
         .with_context(|| {
             format!(
                 "Failed pre-upgrade cleanup (prev strategy: {})",

--- a/tests/inst/src/insttestmain.rs
+++ b/tests/inst/src/insttestmain.rs
@@ -26,6 +26,7 @@ const TESTS: &[StaticTest] = &[
     test!(sysroot::itest_tmpfiles),
     test!(repobin::itest_basic),
     test!(repobin::itest_nofifo),
+    test!(repobin::itest_mtime),
     test!(repobin::itest_extensions),
     test!(repobin::itest_pull_basicauth),
 ];

--- a/tests/inst/src/repobin.rs
+++ b/tests/inst/src/repobin.rs
@@ -42,6 +42,7 @@ pub(crate) fn itest_mtime() -> Result<()> {
 "
     )?;
     let ts = Path::new("repo").metadata()?.modified().unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1));
     bash!(r#"ostree --repo=repo commit -b test -s "bump mtime" --tree=dir=tmproot >/dev/null"#)?;
     assert_ne!(ts, Path::new("repo").metadata()?.modified().unwrap());
     Ok(())

--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -17,8 +17,6 @@ use hyper::{Body, Request, Response};
 use hyper_staticfile::Static;
 use tokio::runtime::Runtime;
 
-pub(crate) type TestFn = fn() -> Result<()>;
-
 /// Run command and assert that its stderr contains pat
 pub(crate) fn cmd_fails_with<C: BorrowMut<Command>>(mut c: C, pat: &str) -> Result<()> {
     let c = c.borrow_mut();


### PR DESCRIPTION
tests/transactionality: Port a bit to xshell

This will give us more useful error messages which should
help debug a flake.

---

tests: Drop unused alias

---

tests: Enable mtime test

I think this just accidentally was never enabled.

While looking at the code, add a sleep here to be resilient to
filesystems with only second mtime granularity.

---

