### PR TITLE
fetcher: Always open tmpfiles in repo (except on FUSE)

### DIFF
--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -32,17 +32,10 @@ G_BEGIN_DECLS
 #define OSTREE_FETCHER_USERAGENT_STRING (PACKAGE_NAME "/" PACKAGE_VERSION)
 
 static inline gboolean
-_ostree_fetcher_tmpf_from_flags (OstreeFetcherRequestFlags flags, int dfd, GLnxTmpfile *tmpf,
-                                 GError **error)
+_ostree_fetcher_tmpf (int dfd, GLnxTmpfile *tmpf, GError **error)
 {
-  if ((flags & OSTREE_FETCHER_REQUEST_LINKABLE) > 0)
-    {
-      if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
-        return FALSE;
-    }
-  else if (!glnx_open_anonymous_tmpfile (O_RDWR | O_CLOEXEC, tmpf, error))
+  if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_RDWR | O_CLOEXEC, tmpf, error))
     return FALSE;
-
   if (!glnx_fchmod (tmpf->fd, 0644, error))
     return FALSE;
   return TRUE;

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -88,6 +88,8 @@ GType _ostree_fetcher_get_type (void) G_GNUC_CONST;
 OstreeFetcher *_ostree_fetcher_new (int tmpdir_dfd, const char *remote_name,
                                     OstreeFetcherConfigFlags flags);
 
+void _ostree_fetcher_set_force_anonymous_tmpfiles (OstreeFetcher *fetcher);
+
 int _ostree_fetcher_get_dfd (OstreeFetcher *fetcher);
 
 void _ostree_fetcher_set_cookie_jar (OstreeFetcher *self, const char *jar_path);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -193,6 +193,7 @@ struct OstreeRepo
 
   gboolean inited;
   gboolean writable;
+  gboolean is_on_fuse; /* TRUE if the repository is on a FUSE filesystem */
   OstreeRepoSysrootKind sysroot_kind;
   GError *writable_error;
   gboolean in_transaction;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2966,6 +2966,8 @@ _ostree_repo_remote_new_fetcher (OstreeRepo *self, const char *remote_name, gboo
   }
 
   fetcher = _ostree_fetcher_new (self->tmp_dir_fd, remote_name, fetcher_flags);
+  if (self->is_on_fuse)
+    _ostree_fetcher_set_force_anonymous_tmpfiles (fetcher);
 
   {
     g_autofree char *tls_client_cert_path = NULL;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3426,6 +3426,17 @@ ostree_repo_open (OstreeRepo *self, GCancellable *cancellable, GError **error)
       /* Note - we don't return this error yet! */
     }
 
+  {
+    struct statfs fsstbuf;
+    if (fstatfs (self->repo_dir_fd, &fsstbuf) < 0)
+      return glnx_throw_errno_prefix (error, "fstatfs");
+#ifndef FUSE_SUPER_MAGIC
+#define FUSE_SUPER_MAGIC 0x65735546
+#endif
+    self->is_on_fuse = (fsstbuf.f_type == FUSE_SUPER_MAGIC);
+    g_debug ("using fuse: %d", self->is_on_fuse);
+  }
+
   if (!glnx_fstat (self->objects_dir_fd, &stbuf, error))
     return FALSE;
   self->owner_uid = stbuf.st_uid;


### PR DESCRIPTION
This reverts commit 4e61e6f7d0d6aebd6abcdc455ec53164afe39e8d and re-instates the fix for ensuring that we download temporary files into the repository location.

However in order to ensure we don't re-introduce
https://github.com/ostreedev/ostree/issues/2900
we detect the case where we're writing to a FUSE mount and keep the prior behavior.

I've verified that this works with flatpak.

Note a downside of this is the change needs to be triplicated across the 3 http backends.

This then again
Closes: https://github.com/ostreedev/ostree/issues/2571