### PR TITLE
Implement ed255519 using openssl too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,8 +193,10 @@ jobs:
             pre-checkout-setup: |
               apt-get update
               apt-get install -y git
+            extra-packages: >-
+              libssl-dev
             configure-options: >-
-              --with-composefs
+              --with-composefs --with-crypto=openssl
 
           # A build using libsoup3. After bookworm is released, this can
           # be switched to Debian Stable.

--- a/Makefile-otutil.am
+++ b/Makefile-otutil.am
@@ -52,5 +52,5 @@ libotutil_la_SOURCES += \
 	$(NULL)
 endif
 
-libotutil_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libotutil -DLOCALEDIR=\"$(datadir)/locale\" $(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(LIBSYSTEMD_CFLAGS)
-libotutil_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) $(LIBSYSTEMD_LIBS)
+libotutil_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libotutil -DLOCALEDIR=\"$(datadir)/locale\" $(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS)  $(OT_DEP_CRYPTO_LIBS) $(LIBSYSTEMD_CFLAGS)
+libotutil_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) $(LIBSYSTEMD_LIBS) $(OT_DEP_CRYPTO_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,6 @@ AS_IF([test x$with_ed25519_libsodium != xno], [
     AS_IF([ test x$have_libsodium = xno ], [
        AC_MSG_ERROR([Need LIBSODIUM version $LIBSODIUM_DEPENDENCY or later])
     ])
-    OSTREE_FEATURES="$OSTREE_FEATURES sign-ed25519"
 ], with_ed25519_libsodium=no )
 AM_CONDITIONAL(USE_LIBSODIUM, test "x$have_libsodium" = xyes)
 
@@ -449,6 +448,11 @@ AS_IF([ test x$with_openssl != xno ], [
 if test x$with_openssl != xno; then OSTREE_FEATURES="$OSTREE_FEATURES openssl"; fi
 AM_CONDITIONAL(USE_OPENSSL, test $with_openssl != no)
 dnl end openssl
+
+if test x$with_openssl != xno || test x$with_ed25519_libsodium != xno; then
+   AC_DEFINE([HAVE_ED25519], 1, [Define if ed25519 is supported ])
+   OSTREE_FEATURES="$OSTREE_FEATURES sign-ed25519"
+fi
 
 dnl begin gnutls; in contrast to openssl this one only
 dnl supports --with-crypto=gnutls
@@ -684,6 +688,7 @@ echo "
     systemd:                                      $with_libsystemd
     libmount:                                     $with_libmount
     libsodium (ed25519 signatures):               $with_ed25519_libsodium
+    openssl (ed25519 signatures):                 $with_openssl
     libarchive (parse tar files directly):        $with_libarchive
     static deltas:                                yes (always enabled now)
     O_TMPFILE:                                    $enable_otmpfile

--- a/src/libostree/ostree-sign.c
+++ b/src/libostree/ostree-sign.c
@@ -40,11 +40,9 @@
 #include "ostree-autocleanups.h"
 #include "ostree-core.h"
 #include "ostree-sign-dummy.h"
+#include "ostree-sign-ed25519.h"
 #include "ostree-sign-private.h"
 #include "ostree-sign.h"
-#ifdef HAVE_LIBSODIUM
-#include "ostree-sign-ed25519.h"
-#endif
 
 #include "ostree-autocleanups.h"
 #include "ostree-repo-private.h"
@@ -59,7 +57,7 @@ typedef struct
 } _sign_type;
 
 _sign_type sign_types[] = {
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   { OSTREE_SIGN_NAME_ED25519, 0 },
 #endif
   { "dummy", 0 }
@@ -67,7 +65,7 @@ _sign_type sign_types[] = {
 
 enum
 {
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   SIGN_ED25519,
 #endif
   SIGN_DUMMY
@@ -535,7 +533,7 @@ ostree_sign_get_by_name (const gchar *name, GError **error)
   OstreeSign *sign = NULL;
 
   /* Get types if not initialized yet */
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   if (sign_types[SIGN_ED25519].type == 0)
     sign_types[SIGN_ED25519].type = OSTREE_TYPE_SIGN_ED25519;
 #endif

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -48,7 +48,7 @@ static GOptionEntry options[]
         { "verify", 0, 0, G_OPTION_ARG_NONE, &opt_verify, "Verify signatures", NULL },
         { "sign-type", 's', 0, G_OPTION_ARG_STRING, &opt_sign_name,
           "Signature type to use (defaults to 'ed25519')", "NAME" },
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
         { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_filename, "Read key(s) from file", "NAME" },
         { "keys-dir", 0, 0, G_OPTION_ARG_STRING, &opt_keysdir,
           "Redefine system-wide directories with public and revoked keys for verification",

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -105,7 +105,7 @@ static GOptionEntry generate_options[] = {
   { "sign", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_key_ids, "Sign the delta with", "KEY_ID" },
   { "sign-type", 0, 0, G_OPTION_ARG_STRING, &opt_sign_name,
     "Signature type to use (defaults to 'ed25519')", "NAME" },
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_keysfilename, "Read key(s) from file", "NAME" },
 #endif
   { NULL }
@@ -114,7 +114,7 @@ static GOptionEntry generate_options[] = {
 static GOptionEntry apply_offline_options[] = {
   { "sign-type", 0, 0, G_OPTION_ARG_STRING, &opt_sign_name,
     "Signature type to use (defaults to 'ed25519')", "NAME" },
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_keysfilename, "Read key(s) from file", "NAME" },
   { "keys-dir", 0, 0, G_OPTION_ARG_STRING, &opt_keysdir,
     "Redefine system-wide directories with public and revoked keys for verification", "NAME" },
@@ -127,7 +127,7 @@ static GOptionEntry list_options[] = { { NULL } };
 static GOptionEntry verify_options[] = {
   { "sign-type", 0, 0, G_OPTION_ARG_STRING, &opt_sign_name,
     "Signature type to use (defaults to 'ed25519')", "NAME" },
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_keysfilename, "Read key(s) from file", "NAME" },
   { "keys-dir", 0, 0, G_OPTION_ARG_STRING, &opt_keysdir,
     "Redefine system-wide directories with public and revoked keys for verification", "NAME" },
@@ -513,7 +513,7 @@ ot_static_delta_builtin_apply_offline (int argc, char **argv, OstreeCommandInvoc
       return FALSE;
     }
 
-#if defined(HAVE_LIBSODIUM)
+#if defined(HAVE_ED25519)
   /* Initialize crypto system */
   opt_sign_name = opt_sign_name ?: OSTREE_SIGN_NAME_ED25519;
 #endif


### PR DESCRIPTION
This adds an openssl-based implementation to ostree-sign-ed25519.c which is used if libsodium was not manually configured.

The target usedcase for this is: https://github.com/ostreedev/ostree/pull/2921