### PR TITLE
prepare-root: A few cleanups

### DIFF
--- a/src/libostree/ostree-repo-composefs.c
+++ b/src/libostree/ostree-repo-composefs.c
@@ -593,7 +593,6 @@ ostree_repo_commit_add_composefs_metadata (OstreeRepo *self, guint format_versio
   /* For now */
   g_assert (format_version == 0);
 
-  /* Create a composefs image and put in deploy dir as .ostree.cfs */
   g_autoptr (OstreeComposefsTarget) target = ostree_composefs_target_new ();
 
   if (!ostree_repo_checkout_composefs (self, target, repo_root, cancellable, error))

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -46,7 +46,7 @@
 #include "ostree-sepolicy-private.h"
 #include "ostree-sysroot-private.h"
 #include "ostree.h"
-#include "otutil.h"
+#include "otcore.h"
 
 #ifdef HAVE_LIBSYSTEMD
 #define OSTREE_VARRELABEL_ID \
@@ -662,7 +662,7 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
       g_autoptr (GVariant) metadata_composefs = g_variant_lookup_value (
           metadata, OSTREE_COMPOSEFS_DIGEST_KEY_V0, G_VARIANT_TYPE_BYTESTRING);
 
-      /* Create a composefs image and put in deploy dir as .ostree.cfs */
+      /* Create a composefs image and put in deploy dir */
       g_autoptr (OstreeComposefsTarget) target = ostree_composefs_target_new ();
 
       g_autoptr (GFile) commit_root = NULL;
@@ -674,7 +674,7 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
         return FALSE;
 
       g_autofree char *composefs_cfs_path
-          = g_strdup_printf ("%s/.ostree.cfs", checkout_target_name);
+          = g_strdup_printf ("%s/" OSTREE_COMPOSEFS_NAME, checkout_target_name);
 
       if (!glnx_open_tmpfile_linkable_at (osdeploy_dfd, checkout_target_name, O_WRONLY | O_CLOEXEC,
                                           &tmpf, error))

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -42,3 +42,6 @@
 bool otcore_ed25519_init (void);
 gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes *signature,
                                             bool *out_valid, GError **error);
+
+// The name of the composefs metadata root
+#define OSTREE_COMPOSEFS_NAME ".ostree.cfs"

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -79,9 +79,6 @@
 #define FS_VERITY_FL 0x00100000 /* Verity protected inode */
 #define FS_IOC_GETFLAGS _IOR ('f', 1, long)
 
-// The name of the composefs metadata root
-#define OSTREE_COMPOSEFS_NAME ".ostree.cfs"
-
 #if defined(HAVE_LIBSYSTEMD) && !defined(OSTREE_PREPARE_ROOT_STATIC)
 #define USE_LIBSYSTEMD
 #endif

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -75,10 +75,6 @@
 
 #include "otcore.h"
 
-/* We can't include both linux/fs.h and sys/mount.h, so define these directly */
-#define FS_VERITY_FL 0x00100000 /* Verity protected inode */
-#define FS_IOC_GETFLAGS _IOR ('f', 1, long)
-
 #define OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG \
   SD_ID128_MAKE (71, 70, 33, 6a, 73, ba, 46, 01, ba, d3, 1a, f8, 88, aa, 0d, f7)
 


### PR DESCRIPTION
Add an internal constant for the composefs image name

Just a minor cleanup.

---

prepare-root: Use otutil and g_print

Now that we link to libotutil (and glib) we don't need separate
handling for conditionalizing on the presence of systemd.

Further, there's no value in `sd_journal_send(MESSAGE=)` over
just printing to stdout.

---

prepare-root: Drop unused verity flag querying

This logic got pushed down into libcomposefs.

---

