### PR TITLE
More prepare-root cleanups

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -60,8 +60,8 @@ ostree_remount_SOURCES = \
     src/switchroot/ostree-mount-util.h \
     src/switchroot/ostree-remount.c \
     $(NULL)
-ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -Isrc/switchroot -I$(srcdir)/libglnx
-ostree_remount_LDADD = $(AM_LDFLAGS) $(OT_INTERNAL_GIO_UNIX_LIBS) libglnx.la
+ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -Isrc/switchroot -I$(srcdir)/src/libotcore -I$(srcdir)/src/libotutil -I$(srcdir)/libglnx
+ostree_remount_LDADD = $(AM_LDFLAGS) $(OT_INTERNAL_GIO_UNIX_LIBS) libotcore.la libotutil.la libglnx.la
 
 if USE_COMPOSEFS
 ostree_prepare_root_LDADD += libcomposefs.la

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -54,3 +54,5 @@ gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes
 // This key if present contains the public key successfully used
 // to verify the signature.
 #define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_SIGNATURE "composefs.signed"
+// This key will be present if the sysroot-ro flag was found
+#define OTCORE_RUN_BOOTED_KEY_SYSROOT_RO "sysroot-ro"

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -45,3 +45,12 @@ gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes
 
 // The name of the composefs metadata root
 #define OSTREE_COMPOSEFS_NAME ".ostree.cfs"
+
+// The file written in the initramfs which contains an a{sv} of metadata
+// from ostree-prepare-root.
+#define OTCORE_RUN_BOOTED "/run/ostree-booted"
+// This key will be present if composefs was successfully used.
+#define OTCORE_RUN_BOOTED_KEY_COMPOSEFS "composefs"
+// This key if present contains the public key successfully used
+// to verify the signature.
+#define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_SIGNATURE "composefs.signed"

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -352,8 +352,8 @@ main (int argc, char *argv[])
                                        &local_error))
             errx (EXIT_FAILURE, "Error loading signatures from repo: %s", local_error->message);
 
-          g_autoptr (GVariant) signatures
-              = g_variant_lookup_value (commitmeta, "ostree.sign.ed25519", G_VARIANT_TYPE ("aay"));
+          g_autoptr (GVariant) signatures = g_variant_lookup_value (
+              commitmeta, OSTREE_SIGN_METADATA_ED25519_KEY, G_VARIANT_TYPE ("aay"));
           if (signatures == NULL)
             errx (EXIT_FAILURE, "Signature validation requested, but no signatures in commit");
 

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -441,12 +441,10 @@ main (int argc, char *argv[])
       if (!sysroot_currently_writable)
         errx (EXIT_FAILURE, "sysroot.readonly=true requires %s to be writable at this point",
               root_arg);
-      /* Pass on the fact that we discovered a readonly sysroot to ostree-remount.service */
-      int fd = open (_OSTREE_SYSROOT_READONLY_STAMP, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
-      if (fd < 0)
-        err (EXIT_FAILURE, "failed to create %s", _OSTREE_SYSROOT_READONLY_STAMP);
-      (void)close (fd);
     }
+  /* Pass on the state for use by ostree-prepare-root */
+  g_variant_builder_add (&metadata_builder, "{sv}", OTCORE_RUN_BOOTED_KEY_SYSROOT_RO,
+                         g_variant_new_boolean (sysroot_readonly));
 
   /* Prepare /boot.
    * If /boot is on the same partition, use a bind mount to make it visible

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -400,11 +400,6 @@ main (int argc, char *argv[])
 
       if (lcfs_mount_image (OSTREE_COMPOSEFS_NAME, TMP_SYSROOT, &cfs_options) == 0)
         {
-          int fd = open (_OSTREE_COMPOSEFS_ROOT_STAMP, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
-          if (fd < 0)
-            err (EXIT_FAILURE, "failed to create %s", _OSTREE_COMPOSEFS_ROOT_STAMP);
-          (void)close (fd);
-
           using_composefs = 1;
           g_variant_builder_add (&metadata_builder, "{sv}", OTCORE_RUN_BOOTED_KEY_COMPOSEFS,
                                  g_variant_new_boolean (true));

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -36,10 +36,8 @@
 #include <sys/statvfs.h>
 #include <unistd.h>
 
-#include <glib.h>
-
-#include "glnx-backport-autocleanups.h"
 #include "ostree-mount-util.h"
+#include "otcore.h"
 
 static void
 do_remount (const char *target, bool writable)
@@ -81,15 +79,36 @@ do_remount (const char *target, bool writable)
 int
 main (int argc, char *argv[])
 {
-  /* We really expect that nowadays that everything is done in the initramfs,
-   * but historically we created this file here, so we'll continue to do be
-   * sure here it exists.  This code should be removed at some point though.
-   */
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GVariant) ostree_run_metadata_v = NULL;
   {
-    int fd = open (OSTREE_PATH_BOOTED, O_EXCL | O_CREAT | O_WRONLY | O_NOCTTY | O_CLOEXEC, 0640);
-    if (fd != -1)
-      (void)close (fd);
+    glnx_autofd int fd = open (OTCORE_RUN_BOOTED, O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+      {
+        /* We really expect that nowadays that everything is done in the initramfs,
+         * but historically we created this file here, so we'll continue to do be
+         * sure here it exists.  This code should be removed at some point though.
+         */
+        if (errno == ENOENT)
+          {
+            int subfd = open (OTCORE_RUN_BOOTED, O_EXCL | O_CREAT | O_WRONLY | O_NOCTTY | O_CLOEXEC,
+                              0640);
+            if (subfd != -1)
+              (void)close (subfd);
+          }
+        else
+          {
+            err (EXIT_FAILURE, "failed to open %s", OTCORE_RUN_BOOTED);
+          }
+      }
+    else
+      {
+        if (!ot_variant_read_fd (fd, 0, G_VARIANT_TYPE_VARDICT, TRUE, &ostree_run_metadata_v,
+                                 &error))
+          errx (EXIT_FAILURE, "failed to read %s: %s", OTCORE_RUN_BOOTED, error->message);
+      }
   }
+  g_autoptr (GVariantDict) ostree_run_metadata = g_variant_dict_new (ostree_run_metadata_v);
 
   /* The /sysroot mount needs to be private to avoid having a mount for e.g. /var/cache
    * also propagate to /sysroot/ostree/deploy/$stateroot/var/cache
@@ -100,10 +119,9 @@ main (int argc, char *argv[])
   if (mount ("none", "/sysroot", NULL, MS_REC | MS_PRIVATE, NULL) < 0)
     perror ("warning: While remounting /sysroot MS_PRIVATE");
 
-  bool root_is_composefs = false;
-  struct stat stbuf;
-  if (fstatat (AT_FDCWD, _OSTREE_COMPOSEFS_ROOT_STAMP, &stbuf, 0) == 0)
-    root_is_composefs = true;
+  gboolean root_is_composefs = FALSE;
+  g_variant_dict_lookup (ostree_run_metadata, OTCORE_RUN_BOOTED_KEY_COMPOSEFS, "b",
+                         &root_is_composefs);
 
   if (path_is_on_readonly_fs ("/") && !root_is_composefs)
     {

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -134,7 +134,9 @@ main (int argc, char *argv[])
   /* Handle remounting /sysroot; if it's explicitly marked as read-only (opt in)
    * then ensure it's readonly, otherwise mount writable, the same as /
    */
-  bool sysroot_configured_readonly = unlink (_OSTREE_SYSROOT_READONLY_STAMP) == 0;
+  gboolean sysroot_configured_readonly = FALSE;
+  g_variant_dict_lookup (ostree_run_metadata, OTCORE_RUN_BOOTED_KEY_SYSROOT_RO, "b",
+                         &sysroot_configured_readonly);
   do_remount ("/sysroot", !sysroot_configured_readonly);
 
   /* And also make sure to make /etc rw again. We make this conditional on

--- a/src/switchroot/ostree-remount.c
+++ b/src/switchroot/ostree-remount.c
@@ -81,10 +81,15 @@ do_remount (const char *target, bool writable)
 int
 main (int argc, char *argv[])
 {
-  /* When systemd is in use this is normally created via the generator, but
-   * we ensure it's created here as well for redundancy.
+  /* We really expect that nowadays that everything is done in the initramfs,
+   * but historically we created this file here, so we'll continue to do be
+   * sure here it exists.  This code should be removed at some point though.
    */
-  touch_run_ostree ();
+  {
+    int fd = open (OSTREE_PATH_BOOTED, O_EXCL | O_CREAT | O_WRONLY | O_NOCTTY | O_CLOEXEC, 0640);
+    if (fd != -1)
+      (void)close (fd);
+  }
 
   /* The /sysroot mount needs to be private to avoid having a mount for e.g. /var/cache
    * also propagate to /sysroot/ostree/deploy/$stateroot/var/cache

--- a/tests/inst/src/composefs.rs
+++ b/tests/inst/src/composefs.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ostree_ext::glib;
 use xshell::cmd;
 
 pub(crate) fn itest_composefs() -> Result<()> {
@@ -26,6 +27,12 @@ pub(crate) fn itest_composefs() -> Result<()> {
 
     let fstype = cmd!(sh, "findmnt -n -o FSTYPE /").read()?;
     assert_eq!(fstype.as_str(), "overlay");
+
+    let metadata = std::fs::read("/run/ostree-booted")?;
+    let metadata = glib::Variant::from_bytes::<glib::VariantDict>(&glib::Bytes::from(&metadata));
+    let metadata = glib::VariantDict::new(Some(&metadata));
+
+    assert_eq!(metadata.lookup::<bool>("composefs").unwrap(), Some(true));
 
     Ok(())
 }


### PR DESCRIPTION
prepare-root: Use constant for ed25519 signature

Minor cleanup.

---

prepare-root: Add metadata for composefs to `/run/ostree-booted`

Particularly for the signature case, having this metadata
acts as a reliable "proof of execution" of the signature verification
code (as opposed to parsing a log file or so).

Besides that, this is also just a stronger check for "we're using
composefs" instead of checking for "overlayfs on /".

---

remount: Don't overwrite /run/ostree-booted

Since it should always be written in the initramfs.

---

remount: Use new metadata in `/run/ostree-booted` for composefs

Since we now have a generalized more structured way of serializing
state in the initramfs instead of "stamp files", use it for
passing the composefs state.

---

Use /run/ostree-booted metadata for sysroot-ro state passing

Just like we did with composefs, use the new metadata instead
of a "stamp file".

---

