### PR TITLE
prepare-root: Introduce ostree/prepare-root.conf && sysroot.readonly improvements

### DIFF
--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -101,6 +101,23 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     </refsect1>
 
     <refsect1>
+        <title>Configuration</title>
+
+        <para>
+            The <literal>/usr/lib/ostree/prepare-root.conf</literal> (or <literal>/etc/ostree/prepare-root.conf</literal>) config file is parsed by <literal>ostree-prepare-root</literal>.  This file must
+            be present in the initramfs.  The default dracut module will copy it from the real root if present.
+        </para>
+
+        <variablelist>
+            <varlistentry>
+                <term><varname>sysroot.readonly</varname></term>
+                <listitem><para>A boolean value; the default is false.  If this is set to <literal>true</literal>, then the <literal>/sysroot</literal> mount point is mounted read-only.</para></listitem>
+          </varlistentry>
+        </variablelist>
+    </refsect1>
+
+
+    <refsect1>
         <title>systemd</title>
 
         <para>

--- a/src/boot/dracut/module-setup.sh
+++ b/src/boot/dracut/module-setup.sh
@@ -33,6 +33,11 @@ depends() {
 
 install() {
     dracut_install /usr/lib/ostree/ostree-prepare-root
+    for r in /usr/lib /etc; do
+        if test -f "$r/ostree/prepare-root.conf"; then
+            inst_simple "$r/ostree/prepare-root.conf"
+        fi
+    done
     inst_simple "${systemdsystemunitdir}/ostree-prepare-root.service"
     mkdir -p "${initdir}${systemdsystemconfdir}/initrd-root-fs.target.wants"
     ln_r "${systemdsystemunitdir}/ostree-prepare-root.service" \

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -376,8 +376,10 @@ main (int argc, char *argv[])
   /* Fall back to querying the repository configuration in the target disk.
    * This is an operating system builder choice.  More info:
    * https://github.com/ostreedev/ostree/pull/1767
+   * However, we only do this if composefs is not enabled, because we don't
+   * want to parse the target root filesystem before verifying its integrity.
    */
-  if (!sysroot_readonly)
+  if (!sysroot_readonly && composefs_config->enabled != OT_TRISTATE_YES)
     {
       sysroot_readonly = sysroot_is_configured_ro (root_arg);
       // Encourage porting to the new config file


### PR DESCRIPTION
prepare-root: Introduce `ostree/prepare-root.conf`

Using the repository configuration for configuration of this
program was always a bit hacky.

But actually with composefs, we really must validate
the target root *before* we parse anything in it.

Let's add a config file for `ostree-prepare-root` that can live
in the initramfs, which will already have been verified.

In the future we'll also add configuration for composefs here.

We expect OS builders to drop this in `/usr/lib/ostree/prepare-root.conf`,
but system local configuration can live in `/etc`.

---

prepare-root: Default sysroot.readonly=true if composefs

Not because it's logically required or anything, but because
it's just a good idea.

---

prepare-root: Don't parse target root when composefs enabled

We shouldn't load anything from the target root filesystem *before*
verifying its integrity if composefs is enabled.

In effect, we want to force composefs users to migrate to
`/usr/lib/ostree/prepare-root.conf` which lives in the initramfs.
(But because we enable sysroot.readonly=true if composefs is enabled
 too, they don't actually need to)

---

