### PR TITLE
mount: Fix gcc -fanalyzer warning for parsing androidboot.slot_suffix

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -137,6 +137,9 @@ static inline char *
 get_aboot_root_slot (void)
 {
   autofree char *slot_suffix = read_proc_cmdline_key ("androidboot.slot_suffix");
+  if (!slot_suffix)
+    errx (EXIT_FAILURE, "Missing androidboot.slot_suffix");
+
   if (strcmp (slot_suffix, "_a") == 0)
     return strdup ("/ostree/root.a");
   else if (strcmp (slot_suffix, "_b") == 0)


### PR DESCRIPTION
If the karg wasn't present, we'd do a NULL deref which is undefined behavior.