### PR TITLE
build-sys: Enable composefs at *build time* by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,7 @@ jobs:
             extra-packages: >-
               libssl-dev
             configure-options: >-
-              --with-composefs --with-crypto=openssl
+              --with-crypto=openssl
 
           # A build using libsoup3. After bookworm is released, this can
           # be switched to Debian Stable.

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
-RUN env CONFIGOPTS=--with-composefs ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN env ./ci/build.sh && make install DESTDIR=/cosa/component-install
 RUN make -C tests/kolainst
 RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 # Uncomment this to fake a build to test the code below

--- a/configure.ac
+++ b/configure.ac
@@ -294,7 +294,7 @@ AC_COMPILE_IFELSE(
 
 AC_ARG_WITH(composefs,
 	    AS_HELP_STRING([--with-composefs], [Support composefs]),
-	    :, with_composefs=no)
+	    :, with_composefs=yes)
 
 if test x$with_composefs != xno; then OSTREE_FEATURES="$OSTREE_FEATURES composefs";
    AC_DEFINE([HAVE_COMPOSEFS], 1, [Define if we have libcomposefs])


### PR DESCRIPTION
There's no additional dependencies, and it's a small amount of new code.

The riskiest thing is the changes to ostree-prepare-root, but I believe that things are in a good state now there.

Again, this just enables it at *build time* - it's still off at runtime by default.