### PR TITLE
commit: Add `--sign-from-file`

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -311,10 +311,22 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 </para></listitem>
 
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--sign-from-file</option>="PATH"</term>
+                <listitem><para>
+                        This will read a key (corresponding to the provided <literal>--sign-type</literal> from the provided path.  The key should be base64 encoded.
+                </para></listitem>
+            </varlistentry>
+
             <varlistentry>
                 <term><option>--sign</option>="KEY-ID"</term>
                 <listitem><para>
-                        There <literal>KEY-ID</literal> is:
+                        In new code, avoid using this because passing private keys via command line arguments
+                        are prone to leakage in logs and process listings.
+                        </para>
+                        <para>
+                        The <literal>KEY-ID</literal> is:
                         <variablelist>
                             <varlistentry>
                                 <term><option>for ed25519:</option></term>

--- a/tests/test-signed-pull.sh
+++ b/tests/test-signed-pull.sh
@@ -157,8 +157,9 @@ gen_ed25519_keys
 PUBLIC=${ED25519PUBLIC}
 SEED=${ED25519SEED}
 SECRET=${ED25519SECRET}
-
-COMMIT_ARGS="--sign=${SECRET} --sign-type=ed25519"
+# Other tests verify --sign, we will verify --sign-from-file here
+echo ${ED25519SECRET} > key
+COMMIT_ARGS="--sign-from-file=key --sign-type=ed25519"
 
 repo_init --set=sign-verify=true
 ${CMD_PREFIX} ostree --repo=repo config set 'remote "origin"'.verification-ed25519-key "${PUBLIC}"


### PR DESCRIPTION
Passing the private key via a direct command line argument is just a bad idea because it's highly likely to get logged or appear in `ps`.
Spotted in review of work for composefs signatures.