### PR TITLE
autofree to g_autofree

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -23,6 +23,7 @@
 
 #include <err.h>
 #include <fcntl.h>
+#include <glib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -39,8 +40,6 @@
 #define INITRAMFS_MOUNT_VAR "/run/ostree/initramfs-mount-var"
 #define _OSTREE_SYSROOT_READONLY_STAMP "/run/ostree-sysroot-ro.stamp"
 #define _OSTREE_COMPOSEFS_ROOT_STAMP "/run/ostree-composefs-root.stamp"
-
-#define autofree __attribute__ ((cleanup (cleanup_free)))
 
 static inline int
 path_is_on_readonly_fs (const char *path)
@@ -79,13 +78,6 @@ out:
   if (f)
     fclose (f);
   return cmdline;
-}
-
-static inline void
-cleanup_free (void *p)
-{
-  void **pp = (void **)p;
-  free (*pp);
 }
 
 static inline char *
@@ -139,7 +131,7 @@ get_aboot_root_slot (const char *slot_suffix)
 static inline char *
 get_ostree_target (void)
 {
-  autofree char *slot_suffix = read_proc_cmdline_key ("androidboot.slot_suffix");
+  g_autofree char *slot_suffix = read_proc_cmdline_key ("androidboot.slot_suffix");
   if (slot_suffix)
     return get_aboot_root_slot (slot_suffix);
 

--- a/src/switchroot/ostree-prepare-root-static.c
+++ b/src/switchroot/ostree-prepare-root-static.c
@@ -116,7 +116,7 @@ resolve_deploy_path (const char *root_mountpoint)
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  autofree char *ostree_target = get_ostree_target ();
+  g_autofree char *ostree_target = get_ostree_target ();
 
   if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_target) < 0)
     err (EXIT_FAILURE, "failed to assemble ostree target path");

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -112,7 +112,7 @@ resolve_deploy_path (const char *root_mountpoint)
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  autofree char *ostree_target = get_ostree_target ();
+  g_autofree char *ostree_target = get_ostree_target ();
   if (!ostree_target)
     errx (EXIT_FAILURE, "No ostree= cmdline");
 
@@ -236,7 +236,7 @@ load_composefs_config (GError **error)
   ret->enabled = OT_TRISTATE_MAYBE;
 
   // TODO: Drop this kernel argument in favor of just the config file in the initramfs
-  autofree char *ot_composefs = read_proc_cmdline_key (OT_COMPOSEFS_KARG);
+  g_autofree char *ot_composefs = read_proc_cmdline_key (OT_COMPOSEFS_KARG);
   if (ot_composefs)
     {
       if (strcmp (ot_composefs, "off") == 0)

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -63,7 +63,7 @@ main (int argc, char *argv[])
    * exit so that we don't error, but at the same time work where switchroot
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
-  autofree char *ostree_target = get_ostree_target ();
+  g_autofree char *ostree_target = get_ostree_target ();
   if (!ostree_target)
     exit (EXIT_SUCCESS);
 


### PR DESCRIPTION
Now that we link in glib into ostree-prepare-root, etc. We don't need this reimplementation of g_autofree.