### PR TITLE
bootloader: fold all Android Bootloader specific logic into prepare-root

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -119,29 +119,6 @@ read_proc_cmdline_key (const char *key)
   return ret;
 }
 
-static inline char *
-get_aboot_root_slot (const char *slot_suffix)
-{
-  if (strcmp (slot_suffix, "_a") == 0)
-    return strdup ("/ostree/root.a");
-  else if (strcmp (slot_suffix, "_b") == 0)
-    return strdup ("/ostree/root.b");
-
-  errx (EXIT_FAILURE, "androidboot.slot_suffix invalid: %s", slot_suffix);
-
-  return NULL;
-}
-
-static inline char *
-get_ostree_target (void)
-{
-  autofree char *slot_suffix = read_proc_cmdline_key ("androidboot.slot_suffix");
-  if (slot_suffix)
-    return get_aboot_root_slot (slot_suffix);
-
-  return read_proc_cmdline_key ("ostree");
-}
-
 /* This is an API for other projects to determine whether or not the
  * currently running system is ostree-controlled.
  */

--- a/src/switchroot/ostree-prepare-root-static.c
+++ b/src/switchroot/ostree-prepare-root-static.c
@@ -116,9 +116,9 @@ resolve_deploy_path (const char *root_mountpoint)
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  autofree char *ostree_target = get_ostree_target ();
+  autofree char *ostree_cmdline = read_proc_cmdline_key ("ostree");
 
-  if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_target) < 0)
+  if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_cmdline) < 0)
     err (EXIT_FAILURE, "failed to assemble ostree target path");
   if (lstat (destpath, &stbuf) < 0)
     err (EXIT_FAILURE, "Couldn't find specified OSTree root '%s'", destpath);

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -63,8 +63,8 @@ main (int argc, char *argv[])
    * exit so that we don't error, but at the same time work where switchroot
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
-  autofree char *ostree_target = get_ostree_target ();
-  if (!ostree_target)
+  autofree char *ostree_cmdline = read_proc_cmdline_key ("ostree");
+  if (!ostree_cmdline)
     exit (EXIT_SUCCESS);
 
   /* See comments in ostree-prepare-root.c for this.
@@ -77,7 +77,7 @@ main (int argc, char *argv[])
 
   {
     g_autoptr (GError) local_error = NULL;
-    if (!ostree_cmd__private__ ()->ostree_system_generator (ostree_target, arg_dest, NULL,
+    if (!ostree_cmd__private__ ()->ostree_system_generator (ostree_cmdline, arg_dest, NULL,
                                                             arg_dest_late, &local_error))
       errx (EXIT_FAILURE, "%s", local_error->message);
   }


### PR DESCRIPTION
Now that we use androidboot.slot_suffix karg to determine whether we
boot into /ostree/root.a or /ostree/root.b, we can use ostree= karg
simply for parsing the stateroot, although we will still boot into
what's pointed to by /ostree/root.a or /ostree/root.b.
