### PR TITLE
prepare-root: Drop more dead code

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -32,10 +32,6 @@
 #include <sys/statvfs.h>
 #include <unistd.h>
 
-#ifdef HAVE_LINUX_FSVERITY_H
-#include <linux/fsverity.h>
-#endif
-
 #define INITRAMFS_MOUNT_VAR "/run/ostree/initramfs-mount-var"
 #define _OSTREE_SYSROOT_READONLY_STAMP "/run/ostree-sysroot-ro.stamp"
 #define _OSTREE_COMPOSEFS_ROOT_STAMP "/run/ostree-composefs-root.stamp"
@@ -159,82 +155,6 @@ touch_run_ostree (void)
   if (fd == -1)
     return;
   (void)close (fd);
-}
-
-static inline unsigned char *
-read_file (const char *path, size_t *out_len)
-{
-  int fd;
-
-  fd = open (path, O_RDONLY | O_CLOEXEC);
-  if (fd < 0)
-    {
-      if (errno == ENOENT)
-        return NULL;
-      err (EXIT_FAILURE, "failed to open %s", path);
-    }
-
-  struct stat stbuf;
-  if (fstat (fd, &stbuf))
-    err (EXIT_FAILURE, "fstat(%s) failed", path);
-
-  size_t file_size = stbuf.st_size;
-  unsigned char *buf = malloc (file_size);
-  if (buf == NULL)
-    err (EXIT_FAILURE, "Out of memory");
-
-  size_t file_read = 0;
-  while (file_read < file_size)
-    {
-      ssize_t bytes_read;
-      do
-        bytes_read = read (fd, buf + file_read, file_size - file_read);
-      while (bytes_read == -1 && errno == EINTR);
-      if (bytes_read == -1)
-        err (EXIT_FAILURE, "read_file(%s) failed", path);
-      if (bytes_read == 0)
-        break;
-
-      file_read += bytes_read;
-    }
-
-  close (fd);
-
-  *out_len = file_read;
-  return buf;
-}
-
-static inline void
-fsverity_sign (int fd, unsigned char *signature, size_t signature_len)
-{
-#ifdef HAVE_LINUX_FSVERITY_H
-  struct fsverity_enable_arg arg = {
-    0,
-  };
-  arg.version = 1;
-  arg.hash_algorithm = FS_VERITY_HASH_ALG_SHA256;
-  arg.block_size = 4096;
-  arg.sig_size = signature_len;
-  arg.sig_ptr = (uint64_t)signature;
-
-  if (ioctl (fd, FS_IOC_ENABLE_VERITY, &arg) < 0)
-    err (EXIT_FAILURE, "failed to fs-verity sign file");
-#endif
-}
-
-static inline void
-bin2hex (char *out_buf, const unsigned char *inbuf, size_t len)
-{
-  static const char hexchars[] = "0123456789abcdef";
-  unsigned int i, j;
-
-  for (i = 0, j = 0; i < len; i++, j += 2)
-    {
-      unsigned char byte = inbuf[i];
-      out_buf[j] = hexchars[byte >> 4];
-      out_buf[j + 1] = hexchars[byte & 0xF];
-    }
-  out_buf[j] = '\0';
 }
 
 #endif /* __OSTREE_MOUNT_UTIL_H_ */


### PR DESCRIPTION
Most of this was used for the old composefs signature model.  We now reuse the core signature code and link to glib, so we don't need reimplementations of hex strings and reading files.