### PR TITLE
[rhel8] Backport inode64 patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,10 @@ AM_COND_IF([BUILDOPT_TSAN],
 LT_PREREQ([2.2.4])
 LT_INIT([disable-static])
 
-OSTREE_FEATURES=""
+dnl We have an always-on feature now to signify the fix for 
+dnl https://github.com/ostreedev/ostree/pull/2874/commits/de6fddc6adee09a93901243dc7074090828a1912
+dnl "commit: fix ostree deployment on 64-bit inode fs"
+OSTREE_FEATURES="inode64"
 AC_SUBST([OSTREE_FEATURES])
 
 GLIB_TESTS

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1584,7 +1584,7 @@ static const char *
 devino_cache_lookup (OstreeRepo           *self,
                      OstreeRepoCommitModifier *modifier,
                      guint32               device,
-                     guint32               inode)
+                     guint64               inode)
 {
   OstreeDevIno dev_ino_key;
   OstreeDevIno *dev_ino_val;


### PR DESCRIPTION
commit: fix ostree deployment on 64-bit inode fs

This commit addresses a bug that was causing ostree deployment
to become corrupted on the large fs, when any package was installed using
'rpm-ostree install'.

In such instances, multiple files were assigned the same inode. For
example, the '/home' directory and a regular file 'pkg-get' were
assigned the same inode (2147484070), making the deployment unusable.

A root cause analysis was performed, running the process under gdb,
which revealed a lossy conversion from guint64 to guint32, for example
6442451366 converted to 2147484070:

(gdb) p name
$10 = 0x7fe9224d2d70 "home"

(gdb) p inode
$73 = 6442451366

(gdb) s
    device=66311, modifier=0x7fe914791840) at
src/libostree/ostree-repo-commit.c:1590

The conversion resulted in entirely independent files potentially
receiving the same inode.

The issue was discovered on PoC machine equipped with a large NVME
(3.4TB), but the bug can be easily reproduced using `cosa run -m 4000
--qemu-size +3TB', followed by installation of any package using
`rpm-ostree install`. The resulting deployment will be unusable due to
many files being "corrupted" by the aforementioned issue.

(cherry picked from commit de6fddc6adee09a93901243dc7074090828a1912)

---

Add an always-on `inode64` feature

As I (and others) will be backporting the fix in
https://github.com/ostreedev/ostree/pull/2874/commits/de6fddc6adee09a93901243dc7074090828a1912
pretty far, I want a way for sysadmins and OS builders to
be able to reliably see when their version of ostree has this fix
(Because comparing version numbers isn't portable).

---

