### PR TITLE
generator: Some cleanup

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -186,6 +186,7 @@ EXTRA_DIST += \
 	$(NULL)
 
 libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(srcdir)/composefs -I$(srcdir)/src/libotutil -I$(srcdir)/src/libotcore -I$(srcdir)/src/libostree -I$(builddir)/src/libostree \
+    -I$(srcdir)/src/switchroot \
 	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_CRYPTO_CFLAGS) \
 	-fvisibility=hidden '-D_OSTREE_PUBLIC=__attribute__((visibility("default"))) extern' \
 	-DPKGLIBEXECDIR=\"$(pkglibexecdir)\"

--- a/src/libostree/ostree-cmd-private.h
+++ b/src/libostree/ostree-cmd-private.h
@@ -23,14 +23,13 @@
 
 G_BEGIN_DECLS
 
-gboolean _ostree_impl_system_generator (const char *ostree_cmdline, const char *normal_dir,
-                                        const char *early_dir, const char *late_dir,
-                                        GError **error);
+gboolean _ostree_impl_system_generator (const char *normal_dir, const char *early_dir,
+                                        const char *late_dir, GError **error);
 
 typedef struct
 {
-  gboolean (*ostree_system_generator) (const char *ostree_cmdline, const char *normal_dir,
-                                       const char *early_dir, const char *late_dir, GError **error);
+  gboolean (*ostree_system_generator) (const char *normal_dir, const char *early_dir,
+                                       const char *late_dir, GError **error);
   gboolean (*ostree_generate_grub2_config) (OstreeSysroot *sysroot, int bootversion, int target_fd,
                                             GCancellable *cancellable, GError **error);
   gboolean (*ostree_static_delta_dump) (OstreeRepo *repo, const char *delta_id,

--- a/src/switchroot/ostree-system-generator.c
+++ b/src/switchroot/ostree-system-generator.c
@@ -67,14 +67,6 @@ main (int argc, char *argv[])
   if (!ostree_cmdline)
     exit (EXIT_SUCCESS);
 
-  /* See comments in ostree-prepare-root.c for this.
-   *
-   * It's a lot easier for various bits of userspace to check for
-   * a file versus parsing the kernel cmdline.  So let's ensure
-   * the stamp file is created here too.
-   */
-  touch_run_ostree ();
-
   {
     g_autoptr (GError) local_error = NULL;
     if (!ostree_cmd__private__ ()->ostree_system_generator (ostree_cmdline, arg_dest, NULL,


### PR DESCRIPTION
generator: Stop creating `/run/ostree-booted`

This must have always been dead code.  We're trying to iterate
towards a place where it's only `ostree-prepare-root.c` which
parses the `ostree=` kernel argument, and canonically sets up
`/run/ostree-booted`.

---

src/generator: Move all logic into libostree-1.so

This pushes down the code for parsing the `ostree=` cmdline
in the generator into code that's part of libostree-1.so.

This is prep for using logic shared in libotcore.la.

But in general it's just cleaner to also keep the binary
entrypoint to just be a trampoline into the C library.

---

