### PR TITLE
tree-wide: Consistently `(void)g_variant_lookup()`

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3548,8 +3548,9 @@ ostree_repo_pull_with_options (OstreeRepo *self, const char *remote_name_or_base
       opt_gpg_verify_set = g_variant_lookup (options, "gpg-verify", "b", &pull_data->gpg_verify);
       opt_gpg_verify_summary_set
           = g_variant_lookup (options, "gpg-verify-summary", "b", &pull_data->gpg_verify_summary);
-      g_variant_lookup (options, "disable-sign-verify", "b", &disable_sign_verify);
-      g_variant_lookup (options, "disable-sign-verify-summary", "b", &disable_sign_verify_summary);
+      (void)g_variant_lookup (options, "disable-sign-verify", "b", &disable_sign_verify);
+      (void)g_variant_lookup (options, "disable-sign-verify-summary", "b",
+                              &disable_sign_verify_summary);
       (void)g_variant_lookup (options, "depth", "i", &pull_data->maxdepth);
       (void)g_variant_lookup (options, "disable-static-deltas", "b",
                               &pull_data->disable_static_deltas);
@@ -4415,8 +4416,8 @@ ostree_repo_pull_with_options (OstreeRepo *self, const char *remote_name_or_base
           if (!collect_available_deltas_for_pull (pull_data, deltas, error))
             goto out;
 
-          g_variant_lookup (additional_metadata, OSTREE_SUMMARY_INDEXED_DELTAS, "b",
-                            &pull_data->has_indexed_deltas);
+          (void)g_variant_lookup (additional_metadata, OSTREE_SUMMARY_INDEXED_DELTAS, "b",
+                                  &pull_data->has_indexed_deltas);
         }
 
       if (pull_data->summary

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2637,7 +2637,7 @@ repo_create_at_internal (int dfd, const char *path, OstreeRepoMode mode, GVarian
 
       const char *collection_id = NULL;
       if (options)
-        g_variant_lookup (options, "collection-id", "&s", &collection_id);
+        (void)g_variant_lookup (options, "collection-id", "&s", &collection_id);
       if (collection_id != NULL)
         g_string_append_printf (config_data, "collection-id=%s\n", collection_id);
 
@@ -5806,10 +5806,10 @@ regenerate_metadata (OstreeRepo *self, gboolean do_metadata_commit, GVariant *ad
         return glnx_throw (error, "Invalid options doesn't match variant type '%s'",
                            (const char *)G_VARIANT_TYPE_VARDICT);
 
-      g_variant_lookup (options, "gpg-key-ids", "^a&s", &gpg_key_ids);
-      g_variant_lookup (options, "gpg-homedir", "&s", &gpg_homedir);
+      (void)g_variant_lookup (options, "gpg-key-ids", "^a&s", &gpg_key_ids);
+      (void)g_variant_lookup (options, "gpg-homedir", "&s", &gpg_homedir);
       sign_keys = g_variant_lookup_value (options, "sign-keys", G_VARIANT_TYPE_ARRAY);
-      g_variant_lookup (options, "sign-type", "&s", &sign_type);
+      (void)g_variant_lookup (options, "sign-type", "&s", &sign_type);
 
       if (sign_keys != NULL)
         {


### PR DESCRIPTION
Coverity warns when we're checking the return value in most-but-not-all instances.  The code is correct in these instances; we're initializing the values to defaults.  So add a `(void)` cast like we are doing in many other places.