### PR TITLE
docs: update boot loader spec link

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,7 +110,7 @@ the `/etc` issue above, it may be better to not stage deployments.
 While OSTree parallel installs deployments cleanly inside the
 `/ostree` directory, ultimately it has to control the system's `/boot`
 directory.  The way this works is via the
-[Boot Loader Specification](http://www.freedesktop.org/wiki/Specifications/BootLoaderSpec),
+[Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/),
 which is a standard for bootloader-independent drop-in configuration
 files.
 


### PR DESCRIPTION
Docs currently link to [this deprecated freedesktop wiki page](http://www.freedesktop.org/wiki/Specifications/BootLoaderSpec,) which directs users to [this deprecated systemd page](https://systemd.io/BOOT_LOADER_SPECIFICATION/), which directs users to [the UAPI Group spec](https://uapi-group.org/specifications/specs/boot_loader_specification/).