### PR TITLE
Harden gvariant get data

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2093,11 +2093,15 @@ _ostree_verify_metadata_object (OstreeObjectType objtype, const char *expected_c
 {
   g_assert (expected_checksum);
 
+  const guint8 *data = ot_variant_get_data (metadata, error);
+  if (!data)
+    return FALSE;
+
   g_auto (OtChecksum) hasher = {
     0,
   };
   ot_checksum_init (&hasher);
-  ot_checksum_update (&hasher, g_variant_get_data (metadata), g_variant_get_size (metadata));
+  ot_checksum_update (&hasher, data, g_variant_get_size (metadata));
 
   char actual_checksum[OSTREE_SHA256_STRING_LEN + 1];
   ot_checksum_get_hexdigest (&hasher, actual_checksum, sizeof (actual_checksum));

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -93,6 +93,7 @@ void
 ot_checksum_update (OtChecksum *checksum, const guint8 *buf, size_t len)
 {
   OtRealChecksum *real = (OtRealChecksum *)checksum;
+  g_assert (buf);
   g_return_if_fail (real->initialized);
   g_return_if_fail (!real->closed);
 #if defined(HAVE_OPENSSL)
@@ -108,6 +109,7 @@ static void
 ot_checksum_get_digest_internal (OtRealChecksum *real, guint8 *buf, size_t buflen)
 {
   g_return_if_fail (real->initialized);
+  g_assert (buf);
   g_assert_cmpint (buflen, ==, _OSTREE_SHA256_DIGEST_LEN);
 #if defined(HAVE_OPENSSL)
   guint digest_len = buflen;

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -146,3 +146,21 @@ ot_variant_bsearch_str (GVariant *array, const char *str, int *out_pos)
   *out_pos = imid;
   return FALSE;
 }
+
+/**
+ * ot_variant_get_data:
+ * @variant: A variant
+ * @error: An error
+ *
+ * `g_variant_get_data` says it can return `NULL`, which many callers are not prepared
+ * to handle.  Return an error in this case.
+ *
+ **/
+const guint8 *
+ot_variant_get_data (GVariant *variant, GError **error)
+{
+  const guint8 *data = g_variant_get_data (variant);
+  if (!data)
+    return glnx_null_throw (error, "Corrupted serialized variant");
+  return data;
+}

--- a/src/libotutil/ot-variant-utils.h
+++ b/src/libotutil/ot-variant-utils.h
@@ -38,4 +38,6 @@ GVariantBuilder *ot_util_variant_builder_from_variant (GVariant *variant, const 
 
 gboolean ot_variant_bsearch_str (GVariant *array, const char *str, int *out_pos);
 
+const guint8 *ot_variant_get_data (GVariant *variant, GError **error);
+
 G_END_DECLS

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -464,10 +464,12 @@ main (int argc, char *argv[])
               metadata, OSTREE_COMPOSEFS_DIGEST_KEY_V0, G_VARIANT_TYPE_BYTESTRING);
           if (cfs_digest_v == NULL || g_variant_get_size (cfs_digest_v) != OSTREE_SHA256_DIGEST_LEN)
             errx (EXIT_FAILURE, "Signature validation requested, but no valid digest in commit");
+          const guint8 *cfs_digest_buf = ot_variant_get_data (cfs_digest_v, &error);
+          if (!cfs_digest_buf)
+            errx (EXIT_FAILURE, "Failed to query digest: %s", error->message);
 
           expected_digest_owned = g_malloc (OSTREE_SHA256_STRING_LEN + 1);
-          ot_bin2hex (expected_digest_owned, g_variant_get_data (cfs_digest_v),
-                      g_variant_get_size (cfs_digest_v));
+          ot_bin2hex (expected_digest_owned, cfs_digest_buf, g_variant_get_size (cfs_digest_v));
           expected_digest = expected_digest_owned;
         }
 


### PR DESCRIPTION
core, switchroot: Harden a bit against `g_variant_get_data() == NULL`

I'm not totally sure this is the cause of
https://bugzilla.redhat.com/show_bug.cgi?id=2217401
but analyzing the code a bit it seems the most likely.

---

checksum-utils: Add an assertion that `buf != NULL`

Another hardening against https://bugzilla.redhat.com/show_bug.cgi?id=2217401

---

