### PR TITLE
deploy: Support an empty `/etc` and populated `/usr/etc`

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -114,6 +114,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-deploy-none.sh \
 	tests/test-admin-deploy-bootid-gc.sh \
 	tests/test-admin-deploy-whiteouts.sh \
+	tests/test-admin-deploy-emptyetc.sh \
 	tests/test-osupdate-dtb.sh \
 	tests/test-admin-instutil-set-kargs.sh \
 	tests/test-admin-upgrade-not-backwards.sh \

--- a/tests/test-admin-deploy-emptyetc.sh
+++ b/tests/test-admin-deploy-emptyetc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_os_repository "archive" "syslinux"
+
+echo "1..1"
+cd ${test_tmpdir}/osdata
+mkdir etc
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=42.etc" -b testos/buildmain/x86_64-runtime
+cd -
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
+origdeployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
+assert_file_has_content ${origdeployment}/etc/NetworkManager/nm.conf "a default daemon file"
+echo "ok empty etc"


### PR DESCRIPTION
In preparation for support for a transient `/etc`: https://github.com/ostreedev/ostree/issues/2868
particularly in combination with composefs.

Basically it's just much more elegant if we can directly mount an overlayfs on the *empty* `etc` directory, using `usr/etc` as the lower.

In the composefs case, we'd have to mount the composefs overlayfs itself writable (and call `mkdir`) *just* so we can make that empty `etc` directory which is ugly.