### PR TITLE
os-init: Create a mount namespace

### DIFF
--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -38,9 +38,8 @@ ot_admin_builtin_os_init (int argc, char **argv, OstreeCommandInvocation *invoca
 
   g_autoptr (OstreeSysroot) sysroot = NULL;
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER
-                                              | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
-                                          invocation, &sysroot, cancellable, error))
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER, invocation, &sysroot,
+                                          cancellable, error))
     return FALSE;
 
   if (!ostree_sysroot_ensure_initialized (sysroot, cancellable, error))

--- a/tests/inst/src/insttestmain.rs
+++ b/tests/inst/src/insttestmain.rs
@@ -24,6 +24,7 @@ const TESTS: &[StaticTest] = &[
     test!(sysroot::itest_sysroot_ro),
     test!(sysroot::itest_immutable_bit),
     test!(sysroot::itest_tmpfiles),
+    test!(sysroot::itest_osinit_unshare),
     test!(repobin::itest_basic),
     test!(repobin::itest_nofifo),
     test!(repobin::itest_mtime),

--- a/tests/inst/src/sysroot.rs
+++ b/tests/inst/src/sysroot.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 use ostree_ext::prelude::*;
 use ostree_ext::{gio, ostree};
+use xshell::cmd;
 
 use crate::test::*;
 
@@ -51,6 +52,17 @@ pub(crate) fn itest_tmpfiles() -> Result<()> {
     if skip_non_ostree_host() {
         return Ok(());
     }
+    let metadata = Path::new("/run/ostree").metadata()?;
+    assert_eq!(metadata.permissions().mode() & !libc::S_IFMT, 0o755);
+    Ok(())
+}
+
+pub(crate) fn itest_osinit_unshare() -> Result<()> {
+    if skip_non_ostree_host() {
+        return Ok(());
+    }
+    let sh = xshell::Shell::new()?;
+    cmd!(sh, "ostree admin os-init ostreetestsuite").run()?;
     let metadata = Path::new("/run/ostree").metadata()?;
     assert_eq!(metadata.permissions().mode() & !libc::S_IFMT, 0o755);
     Ok(())


### PR DESCRIPTION
Today on anything using readonly sysroot `os-init` fails, because we don't create a mount namespace if the `UNLOCKED` flag is specified because we assume it's a readonly operation.

Since technically this is a mutation, let's just lock the sysroot and use the tested path.