### PR TITLE
deploy: Fix mutex locking for global sync timeout

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1606,11 +1606,10 @@ static void *
 sync_in_thread (void *ptr)
 {
   SyncData *syncdata = ptr;
-  // Ensure that the caller is blocked waiting
-  g_mutex_lock (&syncdata->mutex);
   ot_journal_print (LOG_INFO, "Starting global sync()");
   sync ();
   ot_journal_print (LOG_INFO, "Completed global sync()");
+  g_mutex_lock (&syncdata->mutex);
   // Signal success
   syncdata->success = true;
   g_cond_broadcast (&syncdata->cond);


### PR DESCRIPTION
The locking here was always too long - by holding the mutex during the `sync()` call, it means `g_cond_wait_until()` can never wake up (because its API requires the mutex to be locked).

Confusingly though of course we do still print the "timed out" message, and I think that tricked us when we were doing testing here.

We only need to lock the mutex when we're manipulating shared state, which basically boils down to the `gboolean success`.