### PR TITLE
Read composefs configuration from initrd instead of commandline

### DIFF
--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -32,7 +32,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <surname>Walters</surname>
                 <email>walters@verbum.org</email>
             </author>
-        </authorgroup>g
+        </authorgroup>
     </refentryinfo>
 
     <refmeta>
@@ -111,8 +111,25 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <variablelist>
             <varlistentry>
                 <term><varname>sysroot.readonly</varname></term>
-                <listitem><para>A boolean value; the default is false.  If this is set to <literal>true</literal>, then the <literal>/sysroot</literal> mount point is mounted read-only.</para></listitem>
-          </varlistentry>
+                <listitem><para>A boolean value; the default is <literal>false</literal>.  If this is set to <literal>true</literal>, then the <literal>/sysroot</literal> mount point is mounted read-only.</para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><varname>composefs.enabled</varname></term>
+                <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>. <literal>maybe</literal> or
+                <literal>signed</literal>. The default is <literal>maybe</literal>.  If set to <literal>yes</literal> or
+                <literal>signed</literal>, then composefs is always used, and the boot fails if it is not
+                available. Additionally if set to <literal>signed</literal>, boot will fail if the image cannot be
+                validated by a public key. If set to <literal>maybe</literal>, then composefs is used if supported.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><varname>composefs.keypath</varname></term>
+                <listitem><para>Path to a file with Ed25519 public keys in the initramfs, used if
+                <literal>composefs.enabled</literal> is set to <literal>signed</literal>. The default value for this is
+                <literal>/etc/ostree/initramfs-root-binding.key</literal>. For a valid signed boot the target OSTree
+                commit must be signed by at least one public key in this file, and the commitfs digest listed in the
+                commit must match the target composefs image.</para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/src/boot/dracut/module-setup.sh
+++ b/src/boot/dracut/module-setup.sh
@@ -38,6 +38,9 @@ install() {
             inst_simple "$r/ostree/prepare-root.conf"
         fi
     done
+    if test -f "/etc/ostree/initramfs-root-binding.key"; then
+        inst_simple "/etc/ostree/initramfs-root-binding.key"
+    fi
     inst_simple "${systemdsystemunitdir}/ostree-prepare-root.service"
     mkdir -p "${initdir}${systemdsystemconfdir}/initrd-root-fs.target.wants"
     ln_r "${systemdsystemunitdir}/ostree-prepare-root.service" \


### PR DESCRIPTION
This drops the `ot-composefs` kernel commandline in favour of a `[composefs]` section in the `prepare-rootfs.conf` file.

You can set `composefs.enabled` to `yes`, `no` or `maybe`, with `maybe` being the default.

You can also set `composefs.keyfile` to point to an ed25519 key, which the commit must be signed with, or boot fails.

NOTE: This drop the option to define a digest in the commandline. However, that was currently unused (i.e. ComposefsConfig.expected_digest was never read).

Additionally it very hard to actually store the composefs digest in the initrd, as the initrd is typically part of the commit and thus the composefs. It may be possible to handle this, but lets add it back when we know exactly how that will work.