### PR TITLE
prepare-root: On a non-A/B androidboot system, boot system slot a

### DIFF
--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -87,29 +87,26 @@ cleanup_free (void *p)
 static inline char *
 find_proc_cmdline_key (const char *cmdline, const char *key)
 {
-  char *ret = NULL;
-  size_t key_len = strlen (key);
-
-  const char *iter = cmdline;
-  while (iter != NULL)
+  const size_t key_len = strlen (key);
+  for (const char *iter = cmdline; iter;)
     {
       const char *next = strchr (iter, ' ');
-      const char *next_nonspc = next;
-      while (next_nonspc && *next_nonspc == ' ')
-        next_nonspc += 1;
       if (strncmp (iter, key, key_len) == 0 && iter[key_len] == '=')
         {
           const char *start = iter + key_len + 1;
           if (next)
-            ret = strndup (start, next - start);
-          else
-            ret = strdup (start);
-          break;
+            return strndup (start, next - start);
+
+          return strdup (start);
         }
-      iter = next_nonspc;
+
+      if (next)
+        next += strspn (next, " ");
+
+      iter = next;
     }
 
-  return ret;
+  return NULL;
 }
 
 /* This is an API for other projects to determine whether or not the

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -163,12 +163,36 @@ get_aboot_root_slot (const char *slot_suffix)
   return NULL;
 }
 
+static bool
+proc_cmdline_has_key_starting_with (const char *cmdline, const char *key)
+{
+  for (const char *iter = cmdline; iter;)
+    {
+      if (g_str_has_prefix (iter, key))
+        return true;
+
+      iter = strchr (iter, ' ');
+      if (iter == NULL)
+        return false;
+
+      iter += strspn (iter, " ");
+    }
+
+  return false;
+}
+
 static inline char *
 get_ostree_target (const char *cmdline)
 {
   autofree char *slot_suffix = find_proc_cmdline_key (cmdline, "androidboot.slot_suffix");
   if (slot_suffix)
     return get_aboot_root_slot (slot_suffix);
+
+  /* Non-A/B androidboot:
+   * https://source.android.com/docs/core/ota/nonab
+   */
+  if (proc_cmdline_has_key_starting_with (cmdline, "androidboot."))
+    return strdup ("/ostree/root.a");
 
   return find_proc_cmdline_key (cmdline, "ostree");
 }


### PR DESCRIPTION
Sometimes android bootloaders boot in a nonab way:

  https://source.android.com/docs/core/ota/nonab

In this case, "androidboot." kargs are present but not "androidboot.slot_suffix" specifically.

In this case, rather than getting stuck in a partially booted environment, boot system slot a.