### PR TITLE
README.md: Drop dead mailing list, link to GH discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,8 @@ make install DESTDIR=/path/to/dest
 
 ## Contact and discussion forums
 
-OSTree has a [mailing list](https://mail.gnome.org/archives/ostree-list/) and
-there is also an `#ostree` channel on [Libera.Chat](ircs://irc.libera.chat/ostree).  However, asynchronous+logged
-communication is preferred for nontrivial questions.
+There is also an `#ostree` channel on [Libera.Chat](ircs://irc.libera.chat/ostree) as
+well as [enabled Github discussions](https://github.com/ostreedev/ostree/discussions/).
 
 ## Contributing
 


### PR DESCRIPTION
While I resisted taking the next step in binding ourselves more to GH with discussions...it's way, way better than answering questions out of band in private (also proprietary) chats.

We haven't been successful in using the GNOME discussion forums.