### PR TITLE
Prepare root minor

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -332,13 +332,13 @@ load_composefs_config (GKeyFile *config, GError **error)
           for (char **iter = lines; *iter; iter++)
             {
               const char *line = *iter;
-              if (strlen (line) > 0)
-                {
-                  gsize pubkey_size;
-                  g_autofree guchar *pubkey = g_base64_decode (line, &pubkey_size);
-                  ret->pubkeys = g_list_append (
-                      ret->pubkeys, g_bytes_new_take (g_steal_pointer (&pubkey), pubkey_size));
-                }
+              if (!*line)
+                continue;
+
+              gsize pubkey_size;
+              g_autofree guchar *pubkey = g_base64_decode (line, &pubkey_size);
+              ret->pubkeys = g_list_append (
+                  ret->pubkeys, g_bytes_new_take (g_steal_pointer (&pubkey), pubkey_size));
             }
         }
 


### PR DESCRIPTION
prepare-root: Use declare-and-initialize

This is our default style.

---

prepare-root: Check for empty string, not strlen > 0

No point in doing a full strlen, we can just check the first byte.
Also, invert the conditional using `continue` to avoid another
level of indentation.

---

prepare-root: Use ptrarray, not linked list

Linked lists are a data structure with only very obscure
use cases, and this is a classic one where since we're appending
it's O(N^2) behavior.

Also we were leaking the memory.

It's more ergonomic, clearer and efficient to use a ptrarray.

---

