### PR TITLE
switchroot,generator: Only read /proc/cmdline once

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -251,12 +251,16 @@ _ostree_impl_system_generator (const char *normal_dir, const char *early_dir, co
   if (unlinkat (AT_FDCWD, INITRAMFS_MOUNT_VAR, 0) == 0)
     return TRUE;
 
+  g_autofree char *cmdline = read_proc_cmdline ();
+  if (!cmdline)
+    return glnx_throw (error, "Failed to read /proc/cmdline");
+
   /* If we're installed on a system which isn't using OSTree for boot (e.g.
    * package installed as a dependency for flatpak or whatever), silently
    * exit so that we don't error, but at the same time work where switchroot
    * is PID 1 (and so hasn't created /run/ostree-booted).
    */
-  autofree char *ostree_cmdline = read_proc_cmdline_key ("ostree");
+  g_autofree char *ostree_cmdline = find_proc_cmdline_key (cmdline, "ostree");
   if (!ostree_cmdline)
     return TRUE;
 

--- a/src/switchroot/ostree-mount-util.h
+++ b/src/switchroot/ostree-mount-util.h
@@ -85,18 +85,12 @@ cleanup_free (void *p)
 }
 
 static inline char *
-read_proc_cmdline_key (const char *key)
+find_proc_cmdline_key (const char *cmdline, const char *key)
 {
-  char *cmdline = NULL;
-  const char *iter;
   char *ret = NULL;
   size_t key_len = strlen (key);
 
-  cmdline = read_proc_cmdline ();
-  if (!cmdline)
-    err (EXIT_FAILURE, "failed to read /proc/cmdline");
-
-  iter = cmdline;
+  const char *iter = cmdline;
   while (iter != NULL)
     {
       const char *next = strchr (iter, ' ');
@@ -115,7 +109,6 @@ read_proc_cmdline_key (const char *key)
       iter = next_nonspc;
     }
 
-  free (cmdline);
   return ret;
 }
 

--- a/src/switchroot/ostree-prepare-root-static.c
+++ b/src/switchroot/ostree-prepare-root-static.c
@@ -116,7 +116,10 @@ resolve_deploy_path (const char *root_mountpoint)
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  autofree char *ostree_cmdline = read_proc_cmdline_key ("ostree");
+  autofree char *kernel_cmdline = read_proc_cmdline ();
+  if (!kernel_cmdline)
+    errx (EXIT_FAILURE, "Failed to read kernel cmdline");
+  autofree char *ostree_cmdline = find_proc_cmdline_key (kernel_cmdline, "ostree");
 
   if (snprintf (destpath, sizeof (destpath), "%s/%s", root_mountpoint, ostree_cmdline) < 0)
     err (EXIT_FAILURE, "failed to assemble ostree target path");

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -160,13 +160,13 @@ get_aboot_root_slot (const char *slot_suffix)
 }
 
 static inline char *
-get_ostree_target (void)
+get_ostree_target (const char *cmdline)
 {
-  autofree char *slot_suffix = read_proc_cmdline_key ("androidboot.slot_suffix");
+  autofree char *slot_suffix = find_proc_cmdline_key (cmdline, "androidboot.slot_suffix");
   if (slot_suffix)
     return get_aboot_root_slot (slot_suffix);
 
-  return read_proc_cmdline_key ("ostree");
+  return find_proc_cmdline_key (cmdline, "ostree");
 }
 
 static char *
@@ -175,7 +175,11 @@ resolve_deploy_path (const char *root_mountpoint)
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  autofree char *ostree_target = get_ostree_target ();
+  g_autofree char *kernel_cmdline = read_proc_cmdline ();
+  if (!kernel_cmdline)
+    errx (EXIT_FAILURE, "Failed to read kernel cmdline");
+
+  g_autofree char *ostree_target = get_ostree_target (kernel_cmdline);
   if (!ostree_target)
     errx (EXIT_FAILURE, "No ostree target");
 


### PR DESCRIPTION
Change the helper function to parse an existing cmdline instead of potentially reading `/proc/cmdline` multiple times.