### PR TITLE
Two s/osname/stateroot/ patches

### DIFF
--- a/Makefile-man.am
+++ b/Makefile-man.am
@@ -26,7 +26,7 @@ if ENABLE_MAN
 # ostree.xml.
 man1_files = ostree.1 ostree-admin-cleanup.1				\
 ostree-admin-config-diff.1 ostree-admin-deploy.1			\
-ostree-admin-init-fs.1 ostree-admin-instutil.1 ostree-admin-os-init.1	\
+ostree-admin-init-fs.1 ostree-admin-instutil.1 ostree-admin-stateroot-init.1 ostree-admin-os-init.1	\
 ostree-admin-status.1 ostree-admin-set-origin.1 ostree-admin-switch.1	\
 ostree-admin-undeploy.1 ostree-admin-upgrade.1 ostree-admin-unlock.1	\
 ostree-admin-pin.1 ostree-admin-set-default.1 \

--- a/man/ostree-admin-deploy.xml
+++ b/man/ostree-admin-deploy.xml
@@ -66,10 +66,18 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
         <variablelist>
             <varlistentry>
+                <term><option>--stateroot</option>="STATEROOT"</term>
+
+                <listitem><para>
+                    Use a different operating system stateroot than the current one.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--os</option>="STATEROOT"</term>
 
                 <listitem><para>
-                    Use a different operating system root than the current one.
+                    Alias for <literal>--stateroot</literal>.
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree-admin-stateroot-init.xml
+++ b/man/ostree-admin-stateroot-init.xml
@@ -24,7 +24,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 <refentry id="ostree">
 
     <refentryinfo>
-        <title>ostree admin os-init</title>
+        <title>ostree admin stateroot-init</title>
         <productname>OSTree</productname>
 
         <authorgroup>
@@ -38,18 +38,18 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     </refentryinfo>
 
     <refmeta>
-        <refentrytitle>ostree admin os-init</refentrytitle>
+        <refentrytitle>ostree admin stateroot-init</refentrytitle>
         <manvolnum>1</manvolnum>
     </refmeta>
 
     <refnamediv>
-        <refname>ostree-admin-os-init</refname>
-        <refpurpose>Soft-deprecated alias for stateroot-init</refpurpose>
+        <refname>ostree-admin-stateroot-init</refname>
+        <refpurpose>Initialize empty state for a given operating system</refpurpose>
     </refnamediv>
 
     <refsynopsisdiv>
             <cmdsynopsis>
-                <command>ostree admin os-init</command> <arg choice="req">STATEROOT</arg>
+                <command>ostree admin stateroot-init</command> <arg choice="req">STATEROOT</arg>
             </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -57,7 +57,19 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <title>Description</title>
 
         <para>
-            This is a soft-deprecated alias for stateroot-init.  Please see the documentation for that.
+            Initializes an new stateroot (AKA "osname") for an operating system.
+            Ensures that the core subdirectories of /var (/tmp, /lib, /run, and
+            /lock) exist and initialize the given STATEROOT as OSTree stateroot.
+            Each deployment location is comprised of a single shared
+            <filename>var</filename> and a set of deployments (chroots).
         </para>
+    </refsect1>
+
+    <refsect1>
+        <title>Example</title>
+        <para><command>$ ostree admin stateroot-init exampleos</command></para>
+    <programlisting>
+        ostree/deploy/exampleos initialized as OSTree stateroot
+    </programlisting>
     </refsect1>
 </refentry>

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -51,6 +51,8 @@ static char **opt_overlay_initrds;
 static GOptionEntry options[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname,
     "Use a different operating system root than the current one", "OSNAME" },
+  { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Target the provided stateroot",
+    "STATEROOT" },
   { "origin-file", 0, 0, G_OPTION_ARG_FILENAME, &opt_origin_path, "Specify origin file",
     "FILENAME" },
   { "no-prune", 0, 0, G_OPTION_ARG_NONE, &opt_no_prune, "Don't prune the repo when done", NULL },

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -34,7 +34,7 @@ gboolean
 ot_admin_builtin_os_init (int argc, char **argv, OstreeCommandInvocation *invocation,
                           GCancellable *cancellable, GError **error)
 {
-  g_autoptr (GOptionContext) context = g_option_context_new ("OSNAME");
+  g_autoptr (GOptionContext) context = g_option_context_new ("STATEROOT");
 
   g_autoptr (OstreeSysroot) sysroot = NULL;
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
@@ -47,7 +47,7 @@ ot_admin_builtin_os_init (int argc, char **argv, OstreeCommandInvocation *invoca
 
   if (argc < 2)
     {
-      ot_util_usage_error (context, "OSNAME must be specified", error);
+      ot_util_usage_error (context, "STATEROOT must be specified", error);
       return FALSE;
     }
 
@@ -56,7 +56,7 @@ ot_admin_builtin_os_init (int argc, char **argv, OstreeCommandInvocation *invoca
   if (!ostree_sysroot_init_osname (sysroot, osname, cancellable, error))
     return FALSE;
 
-  g_print ("ostree/deploy/%s initialized as OSTree root\n", osname);
+  g_print ("ostree/deploy/%s initialized as OSTree stateroot\n", osname);
 
   return TRUE;
 }

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -47,6 +47,8 @@ static OstreeCommand admin_subcommands[] = {
     "Deprecated commands intended for installer programs" },
   { "os-init", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_os_init,
     "Initialize empty state for given operating system" },
+  { "stateroot-init", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_os_init,
+    "Initialize empty state for given operating system" },
   { "pin", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_pin,
     "Change the \"pinning\" state of a deployment" },
   { "set-origin", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_set_origin,

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -97,7 +97,7 @@ assert_file_has_content_literal err.txt "Cannot stage deployment: Not currently 
 echo "ok staging does not work when not booted"
 
 orig_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
-${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --stateroot=testos testos:testos/buildmain/x86_64-runtime
 new_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 assert_not_streq "${orig_mtime}" "${new_mtime}"
 # Need a new bootversion, sine we now have two deployments

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -494,7 +494,7 @@ EOF
     if test -n "${OSTREE_NO_XATTRS:-}"; then
         echo -e 'disable-xattrs=true\n' >> sysroot/ostree/repo/config
     fi
-    ${CMD_PREFIX} ostree admin os-init testos
+    ${CMD_PREFIX} ostree admin stateroot-init testos
 
     case $bootmode in
         "syslinux")


### PR DESCRIPTION
Add `ostree admin stateroot-init` as alias for `os-init`

To further help deprecate the confusing "osname" terminology.

---

admin-deploy: Add `--stateroot` as alias for `--os`

To further help deprecate the confusing "osname" terminology.

---

