### PR TITLE
Refactor composefs warnings

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -493,7 +493,6 @@ main (int argc, char *argv[])
           // Or stated in reverse: if signature verification is enabled, then digest verification
           // must also be.
           g_assert (!composefs_config->is_signed);
-          g_print ("composefs: Mounting with no digest or signature check\n");
         }
 
       if (lcfs_mount_image (OSTREE_COMPOSEFS_NAME, TMP_SYSROOT, &cfs_options) == 0)

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -479,20 +479,10 @@ main (int argc, char *argv[])
 
           expected_digest = g_malloc (OSTREE_SHA256_STRING_LEN + 1);
           ot_bin2hex (expected_digest, cfs_digest_buf, g_variant_get_size (cfs_digest_v));
-        }
 
-      if (expected_digest != NULL)
-        {
           cfs_options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
           g_print ("composefs: Verifying digest: %s\n", expected_digest);
           cfs_options.expected_fsverity_digest = expected_digest;
-        }
-      else
-        {
-          // If we're not verifying a digest, then we *must* also have signatures disabled.
-          // Or stated in reverse: if signature verification is enabled, then digest verification
-          // must also be.
-          g_assert (!composefs_config->is_signed);
         }
 
       if (lcfs_mount_image (OSTREE_COMPOSEFS_NAME, TMP_SYSROOT, &cfs_options) == 0)

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -264,6 +264,24 @@ validate_signature (GBytes *data, GVariant *signatures, GPtrArray *pubkeys)
 
   return FALSE;
 }
+
+// Output a friendly message based on an errno for common cases
+static const char *
+composefs_error_message (int errsv)
+{
+  switch (errsv)
+    {
+    case ENOVERITY:
+      return "fsverity not enabled on composefs image";
+    case EWRONGVERITY:
+      return "Wrong fsverity digest in composefs image";
+    case ENOSIGNATURE:
+      return "Missing signature for fsverity in composefs image";
+    default:
+      return strerror (errsv);
+    }
+}
+
 #endif
 
 typedef struct
@@ -495,29 +513,14 @@ main (int argc, char *argv[])
       else
         {
           int errsv = errno;
-          const char *errmsg;
-          switch (errsv)
+          g_assert (composefs_config->enabled != OT_TRISTATE_NO);
+          if (composefs_config->enabled == OT_TRISTATE_MAYBE && errsv == ENOENT)
             {
-            case ENOVERITY:
-              errmsg = "fsverity not enabled on composefs image";
-              break;
-            case EWRONGVERITY:
-              errmsg = "Wrong fsverity digest in composefs image";
-              break;
-            case ENOSIGNATURE:
-              errmsg = "Missing signature for fsverity in composefs image";
-              break;
-            default:
-              errmsg = strerror (errno);
-              break;
-            }
-          if (composefs_config->enabled == OT_TRISTATE_MAYBE)
-            {
-              g_print ("composefs: optional support failed: %s\n", errmsg);
+              g_print ("composefs: No image present\n");
             }
           else
             {
-              g_assert (composefs_config->enabled == OT_TRISTATE_YES);
+              const char *errmsg = composefs_error_message (errsv);
               errx (EXIT_FAILURE, "composefs: failed to mount: %s", errmsg);
             }
         }

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -436,6 +436,11 @@ main (int argc, char *argv[])
         1,
       };
 
+      cfs_options.flags = LCFS_MOUNT_FLAGS_READONLY;
+      cfs_options.image_mountdir = OSTREE_COMPOSEFS_LOWERMNT;
+      if (mkdirat (AT_FDCWD, OSTREE_COMPOSEFS_LOWERMNT, 0700) < 0)
+        err (EXIT_FAILURE, "Failed to create %s", OSTREE_COMPOSEFS_LOWERMNT);
+
       g_autofree char *expected_digest = NULL;
 
       if (composefs_config->is_signed)
@@ -475,11 +480,6 @@ main (int argc, char *argv[])
           expected_digest = g_malloc (OSTREE_SHA256_STRING_LEN + 1);
           ot_bin2hex (expected_digest, cfs_digest_buf, g_variant_get_size (cfs_digest_v));
         }
-
-      cfs_options.flags = LCFS_MOUNT_FLAGS_READONLY;
-      cfs_options.image_mountdir = OSTREE_COMPOSEFS_LOWERMNT;
-      if (mkdirat (AT_FDCWD, OSTREE_COMPOSEFS_LOWERMNT, 0700) < 0)
-        err (EXIT_FAILURE, "Failed to create %s", OSTREE_COMPOSEFS_LOWERMNT);
 
       if (expected_digest != NULL)
         {


### PR DESCRIPTION
prepare-root: Drop redundant print about signature/digest

We print if we're doing a signature+digest verification; its absence is
sufficient in the other case.  The goal here is to avoid polluting
the logs when signatures are not enabled.

---

prepare-root: Init composefs options earlier

Prep for a later patch.

---

prepare-root: Fold together composefs signature cases

Now that we don't support digest-but-not-signature verification
for composefs, the logic here was unnecessarily complicated.
With a prior prep patch that moved the composefs option
initialization up, we can just have everything related to signature
verification in a single conditonal.

---

composefs: Hard error except on ENOENT even in "optional" case

Since we enabled composefs at build time, the default (non-composefs)
case now always prints
`composefs: Optional support failed: No such file or directory`
But that's normal and expected.

Rework things here so that in the very special case where
we are in "maybe/optional" mode and we get ENOENT, then we
output a much more normal-looking message that doesn't include
the string "failed".

Now on the flip side - if I have explicitly enabled signature
checking, I think we *do* want to make that fatal even if
composefs is in "maybe" mode.

(This part is more debatable; perhaps we should just disallow
 the case of "maybe" + signatures at all; but I think this is
 an improvement in that direction)

---

