### PR TITLE
Release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2023])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2023])
 m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
# signing: ed25519 can now be backed by openssl

If ostree is compiled with OpenSSL support (as it is on e.g. Fedora derivatives), this also enables an OpenSSL-backed implementation of the ed25519 signature support.  Previously, this required libsodium - which can still be used if desired instead of openssl.

# composefs changes

## Now enabled at build time (but disabled at runtime) by default

On systems with sufficiently new glibc and fsverity, ostree enables support for composefs at build time.  It continues to be disabled by default at runtime.

## composefs now supports signature verification

There is support for an "initramfs root binding key" that can be injected into the initramfs, and used to verify the ostree commit (including its embedded composefs checksum).  One suggested model is to follow how e.g. Fedora signs kernel modules with a transient throwaway key.  For more, please see the ostree/composefs doc.

Note that composefs continues to be classified as experimental.

## Configuration format has changed

The old `ot-composefs` kernel argument is no longer honored in favor of a configuration file that should be present in the initramfs.

# ostree-prepare-root other changes

- A new configuration file in the initramfs is honored: `/etc/ostree/prepare-root.conf`
- This configuration file can also specify the readonly-sysroot default, which is now recommended
- Improved Android Boot support
- The `sysroot.readonly` flag can now also be configured from here, and this is recommended
- `/run/ostree-booted` is now non-empty, and contains serialized state (this is an implementation detail)
- Several preparatory code cleanups for other changes
- `ostree-prepare-root` has a new man page which documents the previous state, along with the above

# ostree admin set-default

A long-overdue CLI verb to change the default deployment for the next boot.

# sysroot other bugfixes and changes

- It is now supported to have `/usr/etc` with an empty `/etc`.  This is preparatory for supporting a transient `/etc`.
- Finally fixed the global `sync` timeout at shutdown
- Increased verbosity of changes
- `ostree admin deploy` now honors `--stateroot` as we prefer that term over `--os`

# trivial-httpd

The remnants of the deprecated `ostree trivial-httpd` CLI are now completely gone.


```
Alexander Larsson (8):
      tests: Fix composefs test
      sign-ed25519: Drop some uses of libsodium
      sign-ed25519: Implement sign and verify using openssl
      CI: Enable --with-crypto=openssl on debian testing to test openssl signatures
      libotutil: Link to crypto libs
      ostree-prepare-root: Validate ed25519 signatures when requested
      Read composefs configuration from initrd instead of commandline
      prepare-root: Only support base64 formated public key files

Colin Walters (84):
      tests/transactionality: Port a bit to xshell
      tests: Drop unused alias
      tests: Enable mtime test
      docs: Update user and group section
      Separate prepare-root static path
      prepare-root: Link to glib
      configure: post-release version bump
      Drop "ostree trivial-httpd" CLI, move to tests directory
      fetcher: Always open tmpfiles in repo (except on FUSE)
      show: Add --print-hex
      build-sys: Add libsodium to OT_DEP_CRYPTO
      Factor out a libotcore
      build: Drop `make syntax-check`
      Add an internal constant for the composefs image name
      prepare-root: Use otutil and g_print
      prepare-root: Drop unused verity flag querying
      sysroot: Add some error prefixing for bootversion
      prepare-root: Use constant for ed25519 signature
      prepare-root: Add metadata for composefs to `/run/ostree-booted`
      remount: Don't overwrite /run/ostree-booted
      remount: Use new metadata in `/run/ostree-booted` for composefs
      prepare-root: Drop dead `pivot_root` code
      Use /run/ostree-booted metadata for sysroot-ro state passing
      man: Add ostree-prepare-root
      mount: Fix gcc -fanalyzer warning for parsing androidboot.slot_suffix
      build-sys: Enable composefs at *build time* by default
      prepare-root: Refactor composefs config handling
      commit: Add `--sign-from-file`
      tests: Remove dead references to "SEED"
      sign-ed25519: More verbose errors for invalid length
      sign-ed25519: Add some comments for data structure
      sign-ed25519: Don't set sk unless we've validated it
      generator: Deduplicate ostree= karg parsing
      prepare-root: Drop code mounting `/proc`
      prepare-root: Drop more dead code
      Add an always-on `inode64` feature
      composefs: Use lowerdir in /run
      generator: Stop creating `/run/ostree-booted`
      src/generator: Move all logic into libostree-1.so
      kernel-args: Move private functions out of public header
      sysroot: Add a bit more error prefixing
      repo: Clarify when we fail to parse a remote
      prepare-root: Introduce `ostree/prepare-root.conf`
      prepare-root: Default sysroot.readonly=true if composefs
      prepare-root: Don't parse target root when composefs enabled
      tree-wide: Consistently `(void)g_variant_lookup()`
      core, switchroot: Harden a bit against `g_variant_get_data() == NULL`
      checksum-utils: Add an assertion that `buf != NULL`
      deploy: Be way more verbose about what we're doing
      tests/destructive: Turn off global sync()
      deploy: Support an empty `/etc` and populated `/usr/etc`
      composefs: Only call `_get_symlink_target()` on symlinks
      os-init: Create a mount namespace
      Add `admin set-default`
      More fully drop `trivial-httpd` entrypoint
      deploy: Fix mutex locking for global sync timeout
      README.md: Drop dead mailing list, link to GH discussions
      prepare-root: Use declare-and-initialize
      prepare-root: Check for empty string, not strlen > 0
      prepare-root: Use ptrarray, not linked list
      switchroot,generator: Only read /proc/cmdline once
      deploy: Add some error prefixing
      prepare-root: Minor clarifications
      repo: Bump lock timeout to 5 minutes
      Add `ostree admin stateroot-init` as alias for `os-init`
      admin-deploy: Add `--stateroot` as alias for `--os`
      admin: Port to c99 style
      remote-add: Port to c99 style
      lzma: Port to C99 style
      checkout: Port to C99 style
      cli/set-origin: Port to C99 style
      tests/destructive: Port more to xshell
      build-sys: Disable composefs on too-old Linux headers
      tests: Add otcore unit tests
      tests/inst: Update to latest ostree-ext
      cmd/init: Port to C99 style
      cmd/grub2-generate: Port to C99 style
      Move prepare-root karg helpers into otcore, add unit tests
      deploy: Add bootloader-naming-2 opt-init
      ci: Add c9s build
      build-sys: Look for both linux/mount.h and sys/mount.h
      build-sys: Really fix composefs check
      Release 2023.6
      configure: post-release version bump

Eric Curtin (6):
      android-boot: Remove dependency on ostree= karg, use androidboot.slot_suffix=
      Remove steal_pointer and steal_pointer_impl as we link in glib now
      bootloader: fold all Android Bootloader specific logic into prepare-root
      prepare-root: On a non-A/B androidboot system, boot system slot a
      prepare-root: Changes made to find_proc_cmdline_key
      prepare-root: If composefs is configured as "maybe" don't fail

dependabot[bot] (5):
      build(deps): bump composefs from `412cb5e` to `ac729b5`
      build(deps): bump composefs from `ac729b5` to `1704f82`
      build(deps): bump libglnx from `07e3e49` to `c02eb59`
      build(deps): bump composefs from `1704f82` to `a6e827d`
      build(deps): bump composefs from `a6e827d` to `1aed878`

samcday (1):
      docs: update boot loader spec link
```