### PR TITLE
Misc c99 style 5

### DIFF
--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -65,37 +65,23 @@ gboolean
 ostree_builtin_export (int argc, char **argv, OstreeCommandInvocation *invocation,
                        GCancellable *cancellable, GError **error)
 {
-  g_autoptr (GOptionContext) context = NULL;
+  g_autoptr (GOptionContext) context = g_option_context_new ("COMMIT");
+
   g_autoptr (OstreeRepo) repo = NULL;
-  gboolean ret = FALSE;
-  g_autoptr (GFile) root = NULL;
-  g_autoptr (GFile) subtree = NULL;
-  g_autofree char *commit = NULL;
-  g_autoptr (GVariant) commit_data = NULL;
-#ifdef HAVE_LIBARCHIVE
-  const char *rev;
-  g_autoptr (OtAutoArchiveWrite) a = NULL;
-  OstreeRepoExportArchiveOptions opts = {
-    0,
-  };
-#endif
-
-  context = g_option_context_new ("COMMIT");
-
   if (!ostree_option_context_parse (context, options, &argc, &argv, invocation, &repo, cancellable,
                                     error))
-    goto out;
+    return FALSE;
 
 #ifdef HAVE_LIBARCHIVE
 
   if (argc <= 1)
     {
       ot_util_usage_error (context, "A COMMIT argument is required", error);
-      goto out;
+      return FALSE;
     }
-  rev = argv[1];
+  const char *rev = argv[1];
 
-  a = archive_write_new ();
+  g_autoptr (OtAutoArchiveWrite) a = archive_write_new ();
   /* Yes, this is hardcoded for now.  There is
    * archive_write_set_format_filter_by_ext() but it's fairly magic.
    * Many programs have support now for GNU tar, so should be a good
@@ -105,19 +91,19 @@ ostree_builtin_export (int argc, char **argv, OstreeCommandInvocation *invocatio
   if (archive_write_set_format_gnutar (a) != ARCHIVE_OK)
     {
       propagate_libarchive_error (error, a);
-      goto out;
+      return FALSE;
     }
   if (archive_write_add_filter_none (a) != ARCHIVE_OK)
     {
       propagate_libarchive_error (error, a);
-      goto out;
+      return FALSE;
     }
   if (opt_output_path)
     {
       if (archive_write_open_filename (a, opt_output_path) != ARCHIVE_OK)
         {
           propagate_libarchive_error (error, a);
-          goto out;
+          return FALSE;
         }
     }
   else
@@ -125,21 +111,28 @@ ostree_builtin_export (int argc, char **argv, OstreeCommandInvocation *invocatio
       if (archive_write_open_FILE (a, stdout) != ARCHIVE_OK)
         {
           propagate_libarchive_error (error, a);
-          goto out;
+          return FALSE;
         }
     }
 
+  OstreeRepoExportArchiveOptions opts = {
+    0,
+  };
   if (opt_no_xattrs)
     opts.disable_xattrs = TRUE;
 
+  g_autofree char *commit = NULL;
+  g_autoptr (GFile) root = NULL;
   if (!ostree_repo_read_commit (repo, rev, &root, &commit, cancellable, error))
-    goto out;
+    return FALSE;
 
+  g_autoptr (GVariant) commit_data = NULL;
   if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, commit, &commit_data, error))
-    goto out;
+    return FALSE;
 
   opts.timestamp_secs = ostree_commit_get_timestamp (commit_data);
 
+  g_autoptr (GFile) subtree = NULL;
   if (opt_subpath)
     subtree = g_file_resolve_relative_path (root, opt_subpath);
   else
@@ -149,21 +142,18 @@ ostree_builtin_export (int argc, char **argv, OstreeCommandInvocation *invocatio
 
   if (!ostree_repo_export_tree_to_archive (repo, &opts, (OstreeRepoFile *)subtree, a, cancellable,
                                            error))
-    goto out;
+    return FALSE;
 
   if (archive_write_close (a) != ARCHIVE_OK)
     {
       propagate_libarchive_error (error, a);
-      goto out;
+      return FALSE;
     }
 
+  return TRUE;
 #else
   g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
                "This version of ostree is not compiled with libarchive support");
-  goto out;
+  return FALSE;
 #endif
-
-  ret = TRUE;
-out:
-  return ret;
 }

--- a/src/ostree/ot-remote-builtin-show-url.c
+++ b/src/ostree/ot-remote-builtin-show-url.c
@@ -35,32 +35,24 @@ gboolean
 ot_remote_builtin_show_url (int argc, char **argv, OstreeCommandInvocation *invocation,
                             GCancellable *cancellable, GError **error)
 {
-  g_autoptr (GOptionContext) context = NULL;
+  g_autoptr (GOptionContext) context = g_option_context_new ("NAME");
   g_autoptr (OstreeRepo) repo = NULL;
-  const char *remote_name;
-  g_autofree char *remote_url = NULL;
-  gboolean ret = FALSE;
-
-  context = g_option_context_new ("NAME");
-
   if (!ostree_option_context_parse (context, option_entries, &argc, &argv, invocation, &repo,
                                     cancellable, error))
-    goto out;
+    return FALSE;
 
   if (argc < 2)
     {
       ot_util_usage_error (context, "NAME must be specified", error);
-      goto out;
+      return FALSE;
     }
 
-  remote_name = argv[1];
+  const char *remote_name = argv[1];
 
-  if (ostree_repo_remote_get_url (repo, remote_name, &remote_url, error))
-    {
-      g_print ("%s\n", remote_url);
-      ret = TRUE;
-    }
+  g_autofree char *remote_url = NULL;
+  if (!ostree_repo_remote_get_url (repo, remote_name, &remote_url, error))
+    return FALSE;
 
-out:
-  return ret;
+  g_print ("%s\n", remote_url);
+  return TRUE;
 }


### PR DESCRIPTION
cmd/export: Port to C99 style

Just keeping up momentum.

---

cmd/export: Fold libarchive error handling

The helper function here doesn't quite carry its weight; this
brings us inline with having single line (no braces) error
return paths.

---

cmd/log: Port to C99 style

Just keeping up momentum.

---

cmd/show-remote-url: Port to C99 style

Just keeping up momentum.

---

