### PR TITLE
deploy: Add bootloader-naming-2 opt-in

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1912,8 +1912,15 @@ install_deployment_kernel (OstreeSysroot *sysroot, int new_bootversion,
   const char *bootcsum = ostree_deployment_get_bootcsum (deployment);
   g_autofree char *bootcsumdir = g_strdup_printf ("ostree/%s-%s", osname, bootcsum);
   g_autofree char *bootconfdir = g_strdup_printf ("loader.%d/entries", new_bootversion);
-  g_autofree char *bootconf_name = g_strdup_printf (
-      "ostree-%d-%s.conf", n_deployments - ostree_deployment_get_index (deployment), osname);
+  g_autofree char *bootconf_name = NULL;
+  guint index = n_deployments - ostree_deployment_get_index (deployment);
+  // Allow opt-in to dropping the stateroot, because grub2 parses the *filename* and ignores
+  // the version field.  xref https://github.com/ostreedev/ostree/issues/2961
+  bool use_new_naming = (sysroot->opt_flags & OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_2) > 0;
+  if (use_new_naming)
+    bootconf_name = g_strdup_printf ("ostree-%d.conf", index);
+  else
+    bootconf_name = g_strdup_printf ("ostree-%d-%s.conf", index, osname);
   if (!glnx_shutil_mkdir_p_at (sysroot->boot_fd, bootcsumdir, 0775, cancellable, error))
     return FALSE;
 

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -45,6 +45,7 @@ typedef enum
   OSTREE_SYSROOT_GLOBAL_OPT_SKIP_SYNC = 1 << 0,
   /* See https://github.com/ostreedev/ostree/pull/2847 */
   OSTREE_SYSROOT_GLOBAL_OPT_EARLY_PRUNE = 1 << 1,
+  OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_2 = 1 << 2,
 } OstreeSysrootGlobalOptFlags;
 
 typedef enum

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -180,6 +180,7 @@ ostree_sysroot_init (OstreeSysroot *self)
   const GDebugKey globalopt_keys[] = {
     { "skip-sync", OSTREE_SYSROOT_GLOBAL_OPT_SKIP_SYNC },
     { "early-prune", OSTREE_SYSROOT_GLOBAL_OPT_EARLY_PRUNE },
+    { "bootloader-naming-2", OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_2 },
   };
   const GDebugKey keys[] = {
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },

--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -560,9 +560,10 @@ fn impl_transaction_test<M: AsRef<str>>(
 fn suppress_ostree_global_sync(sh: &xshell::Shell) -> Result<()> {
     let dropindir = "/etc/systemd/system/ostree-finalize-staged.service.d";
     std::fs::create_dir_all(dropindir)?;
+    // Aslo opt-in to the new bootloader naming
     std::fs::write(
-        Path::new(dropindir).join("50-suppress-sync.conf"),
-        "[Service]\nEnvironment=OSTREE_SYSROOT_OPTS=skip-sync\n",
+        Path::new(dropindir).join("50-test-options.conf"),
+        "[Service]\nEnvironment=OSTREE_SYSROOT_OPTS=skip-sync,bootloader-naming-2\n",
     )?;
     cmd!(sh, "systemctl daemon-reload").run()?;
     Ok(())


### PR DESCRIPTION
I've verified that this fixes compatibility with GRUB, which parses the filename:
https://github.com/ostreedev/ostree/issues/2961

However, out of a large degree of conservatism I've made this an opt-in behavior for now.

My plan is to test it out in the FCOS development streams first.