### PR TITLE
C9s CI && composefs build detection fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,30 @@ jobs:
         with:
           name: inst.tar.zst
           path: inst.tar.zst
+  build-c9s:
+    name: "Build (C9S)"
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    steps:
+      - name: Install bootstrap dependencies
+        run: dnf -y install git-core dnf-utils zstd
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Install build dependencies
+        run:  dnf config-manager --enable crb && dnf builddep -y ostree
+      - name: Build
+        run: |
+          env NOCONFIGURE=1 ./autogen.sh &&
+          ./configure --with-curl --with-selinux --with-dracut=yesbutnoconf &&
+          make -j 4 && make install DESTDIR=$(pwd)/install && tar -c -C install --zstd -f inst.tar.zst .
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: inst-c9s.tar.zst
+          path: inst.tar.zst
   privtest:
     name: "Privileged testing"
     needs: [build-c, build-integration]

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,7 @@ dnl composefs won't work at all without this
 AC_MSG_CHECKING([for MOUNT_ATTR_IDMAP])
 AC_COMPILE_IFELSE(
 	[AC_LANG_SOURCE([[
+			#include <linux/mount.h>
 			#include <sys/mount.h>
       int foo = MOUNT_ATTR_IDMAP;
 	]])],


### PR DESCRIPTION
ci: Add c9s build

Since it's an active target of this project.

---

build-sys: Look for both linux/mount.h and sys/mount.h

Since that's what composefs uses.

---

