### PR TITLE
build-sys: Really fix composefs check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,11 +277,11 @@ AM_CONDITIONAL(USE_GPGME, test "x$have_gpgme" = xyes)
 dnl composefs won't work at all without this
 AC_MSG_CHECKING([for MOUNT_ATTR_IDMAP])
 AC_COMPILE_IFELSE(
-	[AC_LANG_SOURCE([[
-			#include <linux/mount.h>
+	[AC_LANG_PROGRAM([
 			#include <sys/mount.h>
-      int foo = MOUNT_ATTR_IDMAP;
-	]])],
+			#include <linux/mount.h>
+  ],[int foo = MOUNT_ATTR_IDMAP;]
+	)],
 	[AC_MSG_RESULT(yes)
 	 have_mount_attr_idmap=yes],
 	[AC_MSG_RESULT(no)])


### PR DESCRIPTION
The ordering of the includes apparently matters...and I didn't actually check that the previous change enables composefs on c9s. But I did now.  For reals.

While we have the patient open, I switched to `AC_LANG_PROGRAM` because I originally thought the bug had something to do with that. As far as I understand, more cleanly separating the includes from the injected body text is a useful thing in `AC_LANG_PROGRAM`.