### PR TITLE
2023.6 coverity minor fixes

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -366,7 +366,7 @@ tests_test_bsdiff_CFLAGS = $(TESTS_CFLAGS)
 tests_test_bsdiff_LDADD = libbsdiff.la $(TESTS_LDADD)
 
 tests_test_otcore_CFLAGS = $(AM_CFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -I$(srcdir)/src/libotutil -I$(srcdir)/src/libotcore -I$(srcdir)/libglnx
-tests_test_otcore_LDADD = $(OT_INTERNAL_GIO_UNIX_LIBS) libotcore.la libglnx.la
+tests_test_otcore_LDADD = $(OT_INTERNAL_GIO_UNIX_LIBS) libotcore.la libglnx.la libotutil.la
 
 tests_test_checksum_SOURCES = \
 	src/libostree/ostree-core.c \

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2850,14 +2850,6 @@ ostree_repo_write_content_finish (OstreeRepo *self, GAsyncResult *result, guchar
   return TRUE;
 }
 
-static GVariant *
-create_empty_gvariant_dict (void)
-{
-  GVariantBuilder builder;
-  g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
-  return g_variant_builder_end (&builder);
-}
-
 /**
  * ostree_repo_write_commit:
  * @self: Repo
@@ -2951,7 +2943,7 @@ ostree_repo_write_commit_with_time (OstreeRepo *self, const char *parent, const 
     return FALSE;
 
   g_autoptr (GVariant) commit = g_variant_new (
-      "(@a{sv}@ay@a(say)sst@ay@ay)", new_metadata ? new_metadata : create_empty_gvariant_dict (),
+      "(@a{sv}@ay@a(say)sst@ay@ay)", new_metadata,
       parent ? ostree_checksum_to_bytes_v (parent) : ot_gvariant_new_bytearray (NULL, 0),
       g_variant_new_array (G_VARIANT_TYPE ("(say)"), NULL, 0), subject ? subject : "",
       body ? body : "", GUINT64_TO_BE (time),

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -415,17 +415,18 @@ ostree_sign_ed25519_add_pk (OstreeSign *self, GVariant *public_key, GError **err
   if (!_ostree_sign_ed25519_is_initialized (sign, error))
     return FALSE;
 
-  gpointer key = NULL;
+  g_autofree guint8 *key_owned = NULL;
+  const guint8 *key = NULL;
   gsize n_elements = 0;
 
   if (g_variant_is_of_type (public_key, G_VARIANT_TYPE_STRING))
     {
       const gchar *pk_ascii = g_variant_get_string (public_key, NULL);
-      key = g_base64_decode (pk_ascii, &n_elements);
+      key = key_owned = g_base64_decode (pk_ascii, &n_elements);
     }
   else if (g_variant_is_of_type (public_key, G_VARIANT_TYPE_BYTESTRING))
     {
-      key = (gpointer)g_variant_get_fixed_array (public_key, &n_elements, sizeof (guchar));
+      key = g_variant_get_fixed_array (public_key, &n_elements, sizeof (guchar));
     }
   else
     {
@@ -461,7 +462,7 @@ _ed25519_add_revoked (OstreeSign *self, GVariant *revoked_key, GError **error)
 
   const gchar *rk_ascii = g_variant_get_string (revoked_key, NULL);
   gsize n_elements = 0;
-  gpointer key = g_base64_decode (rk_ascii, &n_elements);
+  g_autofree guint8 *key = g_base64_decode (rk_ascii, &n_elements);
 
   if (!validate_length (n_elements, OSTREE_SIGN_ED25519_PUBKEY_SIZE, error))
     return glnx_prefix_error (error, "Incorrect ed25519 revoked key");

--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -82,12 +82,12 @@ otcore_get_ostree_target (const char *cmdline, char **out_target, GError **error
     {
       if (strcmp (slot_suffix, "_a") == 0)
         {
-          *out_target = strdup (slot_a);
+          *out_target = g_strdup (slot_a);
           return TRUE;
         }
       else if (strcmp (slot_suffix, "_b") == 0)
         {
-          *out_target = strdup (slot_b);
+          *out_target = g_strdup (slot_b);
           return TRUE;
         }
       return glnx_throw (error, "androidboot.slot_suffix invalid: %s", slot_suffix);
@@ -98,7 +98,7 @@ otcore_get_ostree_target (const char *cmdline, char **out_target, GError **error
    */
   if (proc_cmdline_has_key_starting_with (cmdline, "androidboot."))
     {
-      *out_target = strdup (slot_a);
+      *out_target = g_strdup (slot_a);
       return TRUE;
     }
 

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -46,6 +46,8 @@ gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes
 char *otcore_find_proc_cmdline_key (const char *cmdline, const char *key);
 gboolean otcore_get_ostree_target (const char *cmdline, char **out_target, GError **error);
 
+GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
+
 // Our directory with transient state (eventually /run/ostree-booted should be a link to
 // /run/ostree/booted)
 #define OTCORE_RUN_OSTREE "/run/ostree"

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -247,8 +247,8 @@ static void
 free_composefs_config (ComposefsConfig *config)
 {
   g_ptr_array_unref (config->pubkeys);
-  free (config->signature_pubkey);
-  free (config);
+  g_free (config->signature_pubkey);
+  g_free (config);
 }
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (ComposefsConfig, free_composefs_config)


### PR DESCRIPTION
switchroot: Lower config parser to otcore, add unit tests

Part of the continuation of unit testing coverage.

---

commit: Drop dead code

Coverity points out that since we're now *always* initializing
metadata, the `create_empty_gvariant_dict()` is unreachable.

---

sign/ed25519: Fix two memory leaks

Spotted by coverity.

---

switchroot: Use g_new/g_free consistently

Coverity complains about this, even though they're the same thing.

---

