### PR TITLE
More analyzer fixes 2

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1052,6 +1052,7 @@ write_content_object (OstreeRepo *self, const char *expected_checksum, GInputStr
                                                 actual_checksum, error))
             return FALSE;
         }
+      (void)actual_checksum_owned; // Just used to autofree
 
       if (checksum_payload_input)
         actual_payload_checksum = ot_checksum_instream_get_string (checksum_payload_input);

--- a/src/libostree/ostree-repo-finder-mount.c
+++ b/src/libostree/ostree-repo-finder-mount.c
@@ -438,7 +438,6 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder *finder,
         {
           const OstreeCollectionRef *ref = refs[i];
           g_autofree gchar *resolved_repo_uri = NULL;
-          g_autoptr (UriAndKeyring) resolved_repo = NULL;
 
           for (gsize j = 0; j < repos_refs->len; j++)
             {
@@ -484,7 +483,8 @@ ostree_repo_finder_mount_resolve_async (OstreeRepoFinder *finder,
                        ref->collection_id, ref->ref_name, mount_name, resolved_repo_uri,
                        keyring_remote->keyring, keyring_remote->name);
 
-              resolved_repo = uri_and_keyring_new (resolved_repo_uri, keyring_remote);
+              g_autoptr (UriAndKeyring) resolved_repo
+                  = uri_and_keyring_new (resolved_repo_uri, keyring_remote);
 
               supported_ref_to_checksum = g_hash_table_lookup (repo_to_refs, resolved_repo);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -784,7 +784,7 @@ fetch_ref_contents (OtPullData *pull_data, const char *main_collection_id,
                                                   filename, pull_data->n_network_retries,
                                                   &ret_contents, cancellable, error))
         return FALSE;
-
+      g_assert (ret_contents);
       g_strchomp (ret_contents);
     }
 
@@ -1951,6 +1951,7 @@ load_remote_repo_config (OtPullData *pull_data, GKeyFile **out_keyfile, GCancell
                                               "config", pull_data->n_network_retries, &contents,
                                               cancellable, error))
     return FALSE;
+  g_assert (contents);
 
   g_autoptr (GKeyFile) ret_keyfile = g_key_file_new ();
   if (!g_key_file_load_from_data (ret_keyfile, contents, strlen (contents), 0, error))

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -6340,6 +6340,7 @@ ostree_repo_remote_fetch_summary_with_options (OstreeRepo *self, const char *nam
     return FALSE;
 
   mainctx = _ostree_main_context_new_default ();
+  (void)mainctx; // Used for autocleanup
 
   fetcher = _ostree_repo_remote_new_fetcher (self, name, TRUE, extra_headers, append_user_agent,
                                              NULL, error);


### PR DESCRIPTION
lib/repo-finder: Squash memory leak

We want to free this value on each iteration; it's moved below
if the value is used.

---

pull: Add assertions to quiet clang-analyzer

It's warning the value can be NULL, but I don't think that's true.
I believe we're just hitting analysis limit (the path length is 119).

---

commit: Quiet clang-analyzer warning

This is just another instance of the "conditionally owned"
pattern.

---

pull: Quiet clang-analyzer warning

Just used for side-effects.

---

