### PR TITLE
More analyzer fixes 3

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -909,6 +909,8 @@ write_content_object (OstreeRepo *self, const char *expected_checksum, GInputStr
   else
     file_input = input;
 
+  (void)file_input_owned; // Conditionally owned
+
   gboolean phys_object_is_symlink = FALSE;
   switch (object_file_type)
     {

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -454,6 +454,7 @@ throw_min_free_space_error (OstreeRepo *self, guint64 bytes_required, GError **e
     }
   else
     err_msg = "would be exceeded";
+  (void)err_msg_owned; // Conditional ownership
 
   if (self->min_free_space_mb > 0)
     return glnx_throw (error, "min-free-space-size %" G_GUINT64_FORMAT "MB %s",

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1267,7 +1267,6 @@ ostree_repo_static_delta_generate (OstreeRepo *self, OstreeStaticDeltaGenerateOp
   guint64 total_compressed_size = 0;
   guint64 total_uncompressed_size = 0;
   g_autoptr (GVariantBuilder) part_headers = NULL;
-  g_autoptr (GPtrArray) part_temp_paths = NULL;
   g_autoptr (GVariant) to_commit = NULL;
   const char *opt_filename;
   g_autofree char *descriptor_name = NULL;
@@ -1422,7 +1421,6 @@ ostree_repo_static_delta_generate (OstreeRepo *self, OstreeStaticDeltaGenerateOp
   }
 
   part_headers = g_variant_builder_new (G_VARIANT_TYPE ("a" OSTREE_STATIC_DELTA_META_ENTRY_FORMAT));
-  part_temp_paths = g_ptr_array_new_with_free_func ((GDestroyNotify)glnx_tmpfile_clear);
   for (i = 0; i < builder.parts->len; i++)
     {
       OstreeStaticDeltaPartBuilder *part_builder = builder.parts->pdata[i];

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2877,6 +2877,9 @@ get_remotes_d_dir (OstreeRepo *self, GFile *sysroot)
           break;
         }
     }
+
+  (void)sysroot_owned; // Conditionally owned
+
   /* For backwards compat, also fall back to the sysroot-path variable, which we
    * don't set anymore internally, and I hope no one else uses.
    */

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -473,6 +473,7 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
                                   cancellable, error))
         goto out;
     }
+  (void)mode_overrides; // This takes care of cleanup
 
   if (opt_skiplist_file)
     {


### PR DESCRIPTION
lib/delta: Remove dead code

Found by clang-analyzer.

---

lib/commit: Quiet clang-analyzer warning

Another conditional ownership.

---

commit: Quiet clang-analyzer warning

Another conditional ownership.

---

commit: Quiet clang-analyzer warning

Another conditional ownership.

---

repo: Quiet clang-analyzer warning

Another conditional ownership.

---

