### PR TITLE
mutable-tree: Quiet clang-analyzer warning

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -505,8 +505,9 @@ ostree_mutable_tree_fill_empty_from_dirtree (OstreeMutableTree *self, OstreeRepo
         if (g_strcmp0 (empty_tree_csum, contents_checksum) == 0)
           {
             /* Adding an empty tree to a full one - stick with the old contents */
-            contents_checksum = self->contents_checksum;
-            break;
+            g_set_object (&self->repo, repo);
+            ostree_mutable_tree_set_metadata_checksum (self, metadata_checksum);
+            return TRUE;
           }
         else
           return FALSE;


### PR DESCRIPTION
The warning here was about a use-after-free which is serious, but I don't think it was reachable in practice, because we'd only enter the second conditional if `contents_checksum != self->contents_checksum`, yet we made them the same thing here.

Nevertheless, refactor the code to do a direct return in this case because that's basically what happened before, and doing so is a lot clearer.