### PR TITLE
mutable-tree: Change some `g_return_if_fail` to `g_assert()`

### DIFF
--- a/src/libostree/ostree-mutable-tree.c
+++ b/src/libostree/ostree-mutable-tree.c
@@ -490,9 +490,9 @@ ostree_mutable_tree_fill_empty_from_dirtree (OstreeMutableTree *self, OstreeRepo
                                              const char *contents_checksum,
                                              const char *metadata_checksum)
 {
-  g_return_val_if_fail (repo, FALSE);
-  g_return_val_if_fail (contents_checksum, FALSE);
-  g_return_val_if_fail (metadata_checksum, FALSE);
+  g_assert (repo);
+  g_assert (contents_checksum);
+  g_assert (metadata_checksum);
 
   switch (self->state)
     {
@@ -546,7 +546,7 @@ gboolean
 ostree_mutable_tree_walk (OstreeMutableTree *self, GPtrArray *split_path, guint start,
                           OstreeMutableTree **out_subdir, GError **error)
 {
-  g_return_val_if_fail (start < split_path->len, FALSE);
+  g_assert_cmpuint (start, <, split_path->len);
 
   if (start == split_path->len - 1)
     {


### PR DESCRIPTION
We did this in some prior patches because it's better for static analyzers; code is either reachable or not, and we don't want the default desktop-style behavior of "try to stumble on without crashing".  It's just likely to lead to a crash somewhere else.