### PR TITLE
Clang analyzer fixes 5

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -941,6 +941,8 @@ write_content_object (OstreeRepo *self, const char *expected_checksum, GInputStr
   else
     size = 0;
 
+  (void)file_input_owned; // Conditionally owned
+
   /* Free space check; only applies during transactions */
   if ((self->min_free_space_percent > 0 || self->min_free_space_mb > 0) && self->in_transaction)
     {

--- a/src/libotutil/ot-keyfile-utils.c
+++ b/src/libotutil/ot-keyfile-utils.c
@@ -174,10 +174,11 @@ ot_keyfile_get_string_list_with_separator_choice (GKeyFile *keyfile, const char 
                                                   const char *key, const char *separators,
                                                   char ***out_value, GError **error)
 {
-  g_return_val_if_fail (keyfile != NULL, FALSE);
-  g_return_val_if_fail (section != NULL, FALSE);
-  g_return_val_if_fail (key != NULL, FALSE);
-  g_return_val_if_fail (separators != NULL, FALSE);
+  g_assert (keyfile != NULL);
+  g_assert (section != NULL);
+  g_assert (key != NULL);
+  g_assert (separators != NULL);
+  g_assert (out_value != NULL);
 
   g_autofree char *value_str = NULL;
   if (!ot_keyfile_get_value_with_default (keyfile, section, key, NULL, &value_str, error))
@@ -215,7 +216,7 @@ ot_keyfile_get_string_list_with_separator_choice (GKeyFile *keyfile, const char 
         }
     }
 
-  ot_transfer_out_value (out_value, &value_list);
+  *out_value = g_steal_pointer (&value_list);
   return TRUE;
 }
 


### PR DESCRIPTION
keyfile-utils: Quiet a clang-analyzer warning

It complains that we could leak memory if the return value
pointer isn't set.  That's actually a nonsensical case, there's
no reason to call this and ignore the return value.

So change things to require it be set, and also change the
`g_return_val_if_fail` to be hard assertions per our new policy.

---

commit: Quiet clang-analyzer warning

Another conditional ownership.

---

