### PR TITLE
Drop cap-std from our public APIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_PROJECT_FEATURES: "v2021_5,cap-std-apis"
+  CARGO_PROJECT_FEATURES: "v2022_6"
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_6"
   # Pinned toolchain for linting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,6 @@ env:
   CARGO_PROJECT_FEATURES: "v2022_6"
   # TODO: Automatically query this from the C side
   LATEST_LIBOSTREE: "v2022_6"
-  # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   build:
@@ -25,10 +23,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: cargo fmt (check)
+        run: cargo fmt -p ostree -- --check -l
       - name: Build
         run: cargo build --verbose --features=${{ env['CARGO_PROJECT_FEATURES'] }}
       - name: Run tests
         run: cargo test --verbose --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+      - name: cargo clippy (non-gating)
+        run: cargo clippy -p ostree --features=${{ env['CARGO_PROJECT_FEATURES'] }}
   build-minimum-toolchain:
     name: "Build, minimum supported toolchain (MSRV)"
     runs-on: ubuntu-latest
@@ -83,25 +85,6 @@ jobs:
         run: cargo test --no-run --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
       - name: Run tests
         run: cargo test --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
-  linting:
-    name: "Lints, pinned toolchain"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          default: true
-          components: rustfmt, clippy
-      - name: cargo fmt (check)
-        run: cargo fmt -p ostree -- --check -l
-      - name: cargo clippy (warnings)
-        run: cargo clippy -p ostree --features=${{ env['CARGO_PROJECT_FEATURES'] }} -- -D warnings
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 version = "0.18.0"
 
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ members = [".", "rust-bindings/sys"]
 [dependencies]
 base64 = "0.20.0"
 bitflags = "1.2.1"
-cap-std = { version = "1.0", optional = true}
-io-lifetimes = { version = "1.0", optional = true}
 ffi = { package = "ostree-sys", path = "rust-bindings/sys", version = "0.13.0" }
 gio = "0.16"
 glib = "0.16"
@@ -53,10 +51,10 @@ thiserror = "1.0.20"
 [dev-dependencies]
 maplit = "1.0.2"
 tempfile = "3"
-cap-tempfile = "1.0"
+io-lifetimes = "1"
+cap-tempfile = "2"
 
 [features]
-cap-std-apis = ["cap-std", "io-lifetimes", "v2017_10"]
 dox = ["ffi/dox"]
 v2014_9 = ["ffi/v2014_9"]
 v2015_7 = ["v2014_9", "ffi/v2015_7"]

--- a/rust-bindings/src/lib.rs
+++ b/rust-bindings/src/lib.rs
@@ -12,8 +12,6 @@
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
 // them needing to update matching versions.
-#[cfg(feature = "cap-std-apis")]
-pub use cap_std;
 pub use ffi;
 pub use gio;
 pub use glib;

--- a/rust-bindings/tests/util/mod.rs
+++ b/rust-bindings/tests/util/mod.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "v2017_10")]
+use cap_tempfile::cap_std;
 use glib::prelude::*;
 use glib::GString;
+#[cfg(feature = "v2017_10")]
+use std::os::fd::AsFd;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -28,13 +32,13 @@ impl TestRepo {
 }
 
 #[derive(Debug)]
-#[cfg(feature = "cap-std-apis")]
+#[cfg(feature = "v2017_10")]
 pub struct CapTestRepo {
     pub dir: cap_tempfile::TempDir,
     pub repo: ostree::Repo,
 }
 
-#[cfg(feature = "cap-std-apis")]
+#[cfg(feature = "v2017_10")]
 impl CapTestRepo {
     pub fn new() -> Self {
         Self::new_with_mode(ostree::RepoMode::Archive)
@@ -42,7 +46,8 @@ impl CapTestRepo {
 
     pub fn new_with_mode(repo_mode: ostree::RepoMode) -> Self {
         let dir = cap_tempfile::tempdir(cap_std::ambient_authority()).unwrap();
-        let repo = ostree::Repo::create_at_dir(&dir, ".", repo_mode, None).expect("repo create");
+        let repo =
+            ostree::Repo::create_at_dir(dir.as_fd(), ".", repo_mode, None).expect("repo create");
         Self { dir, repo }
     }
 }


### PR DESCRIPTION
Since it bumped semver (when I didn't expect it to; xref https://github.com/bytecodealliance/cap-std/commit/963eebf3ab52b04a2e8b9ba88ce6308bbed5cbd0#r121651362

It's not load-bearing enough here to matter versus just passing an untyped file descriptor.

This mainly means that it will be the `glib` ecosystem which forces transitive semver bumps for us, not both.