### PR TITLE
rust: Drop composefs from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "ostree"
 readme = "rust-bindings/README.md"
 repository = "https://github.com/ostreedev/ostree"
 rust-version = "1.70.0"
-version = "0.19.0"
+version = "0.19.1"
 
 exclude = [
     "/*.am", "/apidoc", "/autogen.sh", "/bash", "/bsdiff",
@@ -18,6 +18,7 @@ exclude = [
     "/*.yml", "/*.doap", "/src", "/tests",
     "/.github", "/.cci.jenkinsfile", "/.dir-locals.el", "/.editorconfig",
     "/.vimrc", "/.copr", "/.packit.yaml", "/GNUmakefile", "TODO",
+    "composefs",
     "/rust-bindings/conf/**",
     "/rust-bindings/gir-files/**",
     "/rust-bindings/sys/**",


### PR DESCRIPTION
This greatly reduces the size.  TODO: switch to using `include`.