### PR TITLE
rust: Switch to using `include`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,12 @@ repository = "https://github.com/ostreedev/ostree"
 rust-version = "1.70.0"
 version = "0.19.1"
 
-exclude = [
-    "/*.am", "/apidoc", "/autogen.sh", "/bash", "/bsdiff",
-    "/build-aux", "/buildutil", "/*.mk", "/ci", "/coccinelle",
-    "/*.ac", "/docs", "/libglnx", "/man", "/manual-tests",
-    "/*.yml", "/*.doap", "/src", "/tests",
-    "/.github", "/.cci.jenkinsfile", "/.dir-locals.el", "/.editorconfig",
-    "/.vimrc", "/.copr", "/.packit.yaml", "/GNUmakefile", "TODO",
-    "composefs",
-    "/rust-bindings/conf/**",
-    "/rust-bindings/gir-files/**",
-    "/rust-bindings/sys/**",
+include = [
+    "/COPYING",
+    "/rust-bindings/**",
+    "!/rust-bindings/conf/**",
+    "!/rust-bindings/gir-files/**",
+    "!/rust-bindings/sys/**",
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This way we don't randomly pick up bits from the C library unintentionally as things change on that side.

I think the support for `!` in `include` may be relatively new and that's why the original author here chose to do things via `exclude`.  But using `include` with a few specific exclusions is just way better.