### PR TITLE
Revert "ci: Run cosa unprivileged"

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -47,7 +47,6 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
     checkout scm
     unstash 'build'
     shwrap("""
-      chown -R -h builder: .
       # Move the bits into the cosa pod (but only if major versions match)
       buildroot_id=\$(cat installed/buildroot-id)
       osver=\$(. /usr/lib/os-release && echo \$VERSION_ID)
@@ -55,15 +54,17 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
         rsync -rlv installed/rootfs/ /
       fi
       rsync -rlv installed/tests/ /
-      runuser -u builder -- coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+      coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+      mkdir -p overrides/rootfs
       # And override the on-host bits
       mv installed/rootfs/* overrides/rootfs/
       rm installed -rf
-      runuser -u builder -- coreos-assembler fetch
-      runuser -u builder -- coreos-assembler build
-      runuser -u builder -- coreos-assembler buildextend-metal
-      runuser -u builder -- coreos-assembler buildextend-metal4k
-      runuser -u builder -- coreos-assembler buildextend-live --fast
+      coreos-assembler fetch
+      coreos-assembler build
+      coreos-assembler buildextend-metal
+      coreos-assembler buildextend-metal4k
+      coreos-assembler buildextend-live --fast
+
     """)
   }
   kola(cosaDir: "${env.WORKSPACE}")


### PR DESCRIPTION
This reverts commit 2fe88f80fae83e206f811003a072c73ceebcea59.

This shouldn't be necessary now with the workaround built in cosa:

https://github.com/coreos/coreos-assembler/pull/3625