### PR TITLE
gitmodules: Use github GNOME mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libglnx"]
 	path = libglnx
-	url = https://gitlab.gnome.org/GNOME/libglnx.git
+	url = https://github.com/GNOME/libglnx
 [submodule "bsdiff"]
 	path = bsdiff
 	url = https://github.com/mendsley/bsdiff


### PR DESCRIPTION
gitlab.gnome.org is down right now, but it's been somewhat flaky in the past.  Our CI uptime becomes an *intersection* of all systems it depends on, and by cutting out gitlab.gnome.org we increase its reliability.