### PR TITLE
boot/dracut: Add erofs and overlayfs kernel modules

### DIFF
--- a/src/boot/dracut/module-setup.sh
+++ b/src/boot/dracut/module-setup.sh
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+installkernel() {
+    instmods erofs overlay
+}
+
 check() {
     if [[ -x $systemdutildir/systemd ]] && [[ -x /usr/lib/ostree/ostree-prepare-root ]]; then
        return 255


### PR DESCRIPTION
These kernel modules are required for composefs usage in the initramfs.

The composefs use-case as of today uses an overlayfs on top of a erofs.