### PR TITLE
repo: Default bootloader to zipl on s390x

### DIFF
--- a/src/libostree/ostree-bootloader-zipl.c
+++ b/src/libostree/ostree-bootloader-zipl.c
@@ -63,10 +63,11 @@ static gboolean
 _ostree_bootloader_zipl_query (OstreeBootloader *bootloader, gboolean *out_is_active,
                                GCancellable *cancellable, GError **error)
 {
-  /* We don't auto-detect this one; should be explicitly chosen right now.
-   * see also https://github.com/coreos/coreos-assembler/pull/849
-   */
+#if defined(__s390x__)
+  *out_is_active = TRUE;
+#else
   *out_is_active = FALSE;
+#endif
   return TRUE;
 }
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -143,6 +143,13 @@ typedef enum
   /* Non-exhaustive */
 } OstreeCfgSysrootBootloaderOpt;
 
+#if !defined(__s390x__)
+#define CFG_SYSROOT_BOOTLOADER_DEFAULT_STR "auto"
+#else
+// There's nothing else on s390x.
+#define CFG_SYSROOT_BOOTLOADER_DEFAULT_STR "zipl"
+#endif
+
 static const char *const CFG_SYSROOT_BOOTLOADER_OPTS_STR[] = {
   /* This must be kept in the same order as the enum */
   "auto", "none", "grub2", "syslinux", "uboot", "zipl", "aboot", NULL,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3300,7 +3300,8 @@ reload_sysroot_config (OstreeRepo *self, GCancellable *cancellable, GError **err
   g_autofree char *bootloader = NULL;
 
   if (!ot_keyfile_get_value_with_default_group_optional (self->config, "sysroot", "bootloader",
-                                                         "auto", &bootloader, error))
+                                                         CFG_SYSROOT_BOOTLOADER_DEFAULT_STR,
+                                                         &bootloader, error))
     return FALSE;
 
   /* TODO: possibly later add support for specifying a generic bootloader


### PR DESCRIPTION
This will allow us to drop code like
https://github.com/coreos/coreos-assembler/blob/87fc693c115eae1e7ff0e1621ce26c9167af6e84/src/create_disk.sh#L503 which is really just unnecessary since there aren't any other bootloaders we care about on this architecture.