### PR TITLE
When exporting, use hardlinks for duplicated files

### DIFF
--- a/tests/archive-test.sh
+++ b/tests/archive-test.sh
@@ -72,9 +72,9 @@ date > test-overlays/overlaid-file
 $OSTREE commit ${COMMIT_ARGS} -b test-base --base test2 --owner-uid 42 --owner-gid 42 test-overlays/
 $OSTREE ls -R test-base > ls.txt
 if can_create_whiteout_devices; then
-    assert_streq "$(wc -l < ls.txt)" 17
+    assert_streq "$(wc -l < ls.txt)" 22
 else
-    assert_streq "$(wc -l < ls.txt)" 14
+    assert_streq "$(wc -l < ls.txt)" 19
 fi
 
 assert_streq "$(grep '42.*42' ls.txt | wc -l)" 2

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -249,6 +249,13 @@ setup_test_repository () {
     mkdir baz/another/
     echo x > baz/another/y
 
+    mkdir baz/sub1
+    echo SAME_CONTENT > baz/sub1/duplicate_a
+    echo SAME_CONTENT > baz/sub1/duplicate_b
+
+    mkdir baz/sub2
+    echo SAME_CONTENT > baz/sub2/duplicate_c
+
     # if we are running inside a container we cannot test
     # the overlayfs whiteout marker passthrough
     if ! test -n "${OSTREE_NO_WHITEOUTS:-}"; then

--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -38,7 +38,7 @@ orig_composefs_digest=$($OSTREE show --print-hex --print-metadata-key ostree.com
 $OSTREE commit ${COMMIT_ARGS} -b test-composefs2 --generate-composefs-metadata test2-co
 new_composefs_digest=$($OSTREE show --print-hex --print-metadata-key ostree.composefs.digest.v0 test-composefs2)
 assert_streq "${orig_composefs_digest}" "${new_composefs_digest}"
-assert_streq "${new_composefs_digest}" "7a53698f5aa7af7e8034a10bd2fcc195e9df46781efd967a3fc83d32a1d3eda1"
+assert_streq "${new_composefs_digest}" "be956966c70970ea23b1a8043bca58cfb0d011d490a35a7817b36d04c0210954"
 tap_ok "composefs metadata"
 
 tap_end

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -28,7 +28,7 @@ fi
 
 setup_test_repository "archive"
 
-echo '1..5'
+echo '1..6'
 
 $OSTREE checkout test2 test2-co
 $OSTREE commit --no-xattrs -b test2-noxattrs -s "test2 without xattrs" --tree=dir=test2-co
@@ -81,3 +81,11 @@ assert_file_empty diff.txt
 rm test2.tar diff.txt t -rf
 
 echo 'ok export import'
+
+cd ${test_tmpdir}
+${OSTREE} 'export' test2 -o test2.tar
+tar tvf test2.tar > test2.manifest
+assert_file_has_content test2.manifest 'baz/sub1/duplicate_b link to baz/sub1/duplicate_a'
+assert_file_has_content test2.manifest 'baz/sub2/duplicate_c link to baz/sub1/duplicate_a'
+
+echo 'ok export hard links'


### PR DESCRIPTION
For ostree_repo_export_tree_to_archive(), and 'ostree export', when the exported tree contains multiple files with the same checksum, write an archive with hard links.

Without this, importing a tree, then exporting it again breaks hardlinks.

As an example of savings: this reduces the (compressed) size of the Fedora Flatpak Runtime image from 1345MiB to 712MiB.

Resolves: #2925

As noted in #2925, if this is considered insufficiently compatible, it could be put behind an option. If someone is untarring an 'ostree export'  tarball and then using it read-write, then hardlinking coincidentally the same files (like all empty files) could be quite surprising. For typical usage of ostree, however, using hardlinks in the exported tar is less surprising.

There's a fair bit of memory usage during export from keeping all the OstreeRepoFile objects. Making the hash table be 'checksum => path string' might save some of that, though it would depend on the paths. I'm not sure which way is better.
