### PR TITLE
Support transient /etc

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -63,6 +63,11 @@ ostree_remount_SOURCES = \
 ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -Isrc/switchroot -I$(srcdir)/src/libotcore -I$(srcdir)/src/libotutil -I$(srcdir)/libglnx
 ostree_remount_LDADD = $(AM_LDFLAGS) $(OT_INTERNAL_GIO_UNIX_LIBS) libotcore.la libotutil.la libglnx.la
 
+if USE_SELINUX
+ostree_remount_CPPFLAGS += $(OT_DEP_SELINUX_CFLAGS)
+ostree_remount_LDADD += $(OT_DEP_SELINUX_LIBS)
+endif
+
 if USE_COMPOSEFS
 ostree_prepare_root_LDADD += libcomposefs.la
 endif

--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -114,6 +114,10 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <listitem><para>A boolean value; the default is <literal>false</literal>.  If this is set to <literal>true</literal>, then the <literal>/sysroot</literal> mount point is mounted read-only.</para></listitem>
             </varlistentry>
             <varlistentry>
+                <term><varname>etc.transient</varname></term>
+                <listitem><para>A boolean value; the default is <literal>false</literal>.  If this is set to <literal>true</literal>, then the <literal>/etc</literal> mount point is mounted transiently i.e. a non-persistent location.</para></listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><varname>composefs.enabled</varname></term>
                 <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>. <literal>maybe</literal> or
                 <literal>signed</literal>. The default is <literal>maybe</literal>.  If set to <literal>yes</literal> or

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -72,3 +72,5 @@ GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
 #define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_SIGNATURE "composefs.signed"
 // This key will be present if the sysroot-ro flag was found
 #define OTCORE_RUN_BOOTED_KEY_SYSROOT_RO "sysroot-ro"
+
+#define OTCORE_RUN_BOOTED_KEY_TRANSIENT_ETC "transient-etc"


### PR DESCRIPTION
This is a new version of https://github.com/ostreedev/ostree/pull/2972
There was a lot of complexities, so this is essentially a clean restart. So, rather than reusing that PR I created a new one.

This PR does multiple things:

 *  Adds a `etc.transient=true` option to `prepare-root.conf`, which causes /etc to be and overlayfs mount with a tmpfs-based upper.
 * Relabels /usr/etc as if it was /etc in the generated composefs image, allowing the use of usr/etc as the lower for the above /etc overlayfs mount.
 * Since we're changing the composefs image format anyway (due to the relabeling), we're copying the mkcomposefs change that inlines files at 64 bytes or smaller to avoid overhead.

The actual transient etc overlay mount details are quite complex due to selinux interactions between tmpfs, selinux policy loading, and overlayfs. See https://github.com/ostreedev/ostree/pull/2972#issuecomment-1674558770 for some details. In the end, after a discussion with @rhatdan I ended up with a new ostree selinux module that will be needed for transient mode to work.
