### PR TITLE
repo: Add an option to label /usr/etc as /etc

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -185,6 +185,14 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--selinux-labeling-epoch</option>0 | 1</term>
+
+                <listitem><para>
+                    When SELinux labeling is enabled, epoch <literal>1</literal> ensures that <literal>/usr/etc</literal> is labeled as if it was <literal>/etc</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--bootable</option></term>
                 <listitem><para>
                     Inject standard metadata for a bootable Linux filesystem tree.

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -517,6 +517,8 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo *repo
  * 2017.13
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL: If a devino cache hit is found, skip
  * modifier filters (non-directories only); Since: 2017.14
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SELINUX_LABEL_V1: For SELinux and other systems, label
+ * /usr/etc as if it was /etc.
  *
  * Flags modifying commit behavior. In bare-user-only mode,
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS and
@@ -532,6 +534,7 @@ typedef enum
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED = (1 << 3),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME = (1 << 4),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL = (1 << 5),
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SELINUX_LABEL_V1 = (1 << 6),
 } OstreeRepoCommitModifierFlags;
 
 /**

--- a/tests/kolainst/destructive/itest-label-selinux.sh
+++ b/tests/kolainst/destructive/itest-label-selinux.sh
@@ -32,6 +32,21 @@ ostree refs --delete testbranch
 rm co -rf
 echo "ok commit with sepolicy"
 
+ostree ls -X ${host_refspec} /usr/etc/sysctl.conf > ls.txt
+if grep -qF ':etc_t:' ls.txt; then
+  ostree checkout -H ${host_refspec} co
+  ostree commit -b testbranch --link-checkout-speedup \
+       --selinux-policy co --tree=dir=co --selinux-labeling-epoch=1
+  ostree ls -X testbranch /usr/etc/sysctl.conf > ls.txt
+  assert_file_has_content ls.txt ':system_conf_t:'
+  rm co ls.txt -rf
+  ostree refs --delete testbranch
+else
+  echo 'Already using --selinux-labeling-epoch > 0 on host, hopefully!'
+fi
+
+echo "ok --selinux-labeling-epoch=1"
+
 # Now let's check that selinux policy labels can be applied on checkout
 
 rm rootfs -rf


### PR DESCRIPTION
This will be very useful for enabling a "transient /etc" option because we won't have to do hacks relabling in the initramfs, or forcing it on just for composefs.