### PR TITLE
pull: Lower max concurrent HTTP requests to 2

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -33,7 +33,7 @@ G_BEGIN_DECLS
 #define _OSTREE_SUMMARY_CACHE_DIR "summaries"
 #define _OSTREE_CACHE_DIR "cache"
 
-#define _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS 8
+#define _OSTREE_MAX_OUTSTANDING_FETCHER_REQUESTS 2
 #define _OSTREE_MAX_OUTSTANDING_DELTAPART_REQUESTS 2
 
 /* We want some parallelism with disk writes, but we also


### PR DESCRIPTION
I believe this may help re-enabling the libcurl low-speed limit checks in the case where we have a full 8 HTTP requests outstanding with the remote server, but it's actually throttling us.

In practice, we really don't need more than two.  Experimenting with this using the builtin Go HTTP server, this actually seems to increase performance; but I get pretty wild timing variations overall.