### PR TITLE
tests: Fix whiteout test

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -1126,7 +1126,7 @@ echo "ok test error pre commit/bootid"
 
 # Whiteouts
 cd ${test_tmpdir}
-mkdir -p overlay/baz/
+mkdir -p overlay/baz/another/
 if touch overlay/baz/.wh.cow && touch overlay/.wh.deeper && touch overlay/baz/another/.wh..wh..opq; then
     touch overlay/anewfile
     mkdir overlay/anewdir/


### PR DESCRIPTION
This test was always skipped, because the check:

 if touch overlay/baz/.wh.cow &&
    touch overlay/.wh.deeper &&
    touch overlay/baz/another/.wh..wh..opq; then

always fails due to the missing overlay/baz/another directory. Fix by creating the directory.