### PR TITLE
deploy: Remove lock when re-staging

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3676,6 +3676,9 @@ ostree_sysroot_stage_tree_with_options (OstreeSysroot *self, const char *osname,
     {
       if (!_ostree_sysroot_rmrf_deployment (self, self->staged_deployment, cancellable, error))
         return FALSE;
+      // Also remove the lock; xref https://github.com/ostreedev/ostree/issues/3025
+      if (!ot_ensure_unlinked_at (AT_FDCWD, _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED, error))
+        return FALSE;
     }
 
   /* Bump mtime so external processes know something changed, and then reload. */

--- a/tests/kolainst/destructive/staged-deploy.sh
+++ b/tests/kolainst/destructive/staged-deploy.sh
@@ -91,6 +91,14 @@ EOF
     test ! -f /run/ostree/staged-deployment-locked
     echo "ok cleanup staged"
 
+    # And verify that re-staging cleans the previous lock
+    test '!' -f /run/ostree/staged-deployment
+    ostree admin deploy --stage staged-deploy
+    test -f /run/ostree/staged-deployment
+    test '!' -f /run/ostree/staged-deployment-locked
+    ostree admin undeploy 0
+    echo "ok restage unlocked"
+
     # Upgrade with staging
     ostree admin deploy --stage staged-deploy
     origcommit=$(ostree rev-parse staged-deploy)


### PR DESCRIPTION
This closes the biggest foot-gun when doing e.g.
`rpm-ostree rebase` when zincati is running on a FCOS system.

Previously if zincati happened to have staged + locked a deployment, we'd keep around the lock which is definitely not what is desired.