### PR TITLE
undeploy: Parse integer more properly

### DIFF
--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -50,7 +50,14 @@ ot_admin_builtin_undeploy (int argc, char **argv, OstreeCommandInvocation *invoc
   g_autoptr (GPtrArray) current_deployments = ostree_sysroot_get_deployments (sysroot);
 
   const char *deploy_index_str = argv[1];
-  int deploy_index = atoi (deploy_index_str);
+  guint deploy_index;
+  {
+    char *endptr = NULL;
+    errno = 0;
+    deploy_index = (guint)g_ascii_strtoull (deploy_index_str, &endptr, 10);
+    if (*endptr != '\0')
+      return glnx_throw (error, "Invalid index: %s", deploy_index_str);
+  }
 
   g_autoptr (OstreeDeployment) target_deployment
       = ot_admin_get_indexed_deployment (sysroot, deploy_index, error);

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((30 + ${extra_admin_tests:-0}))"
+echo "1..$((31 + ${extra_admin_tests:-0}))"
 
 mkdir sysrootmin
 ${CMD_PREFIX} ostree admin init-fs --modern sysrootmin
@@ -186,6 +186,12 @@ assert_not_has_file sysroot/ostree/deploy/testos/deploy/${rev}.4/etc/aconfigfile
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 echo "ok deploy with modified /etc"
+
+if ${CMD_PREFIX} ostree admin undeploy blah 2>err.txt; then
+    fatal "undeploy parsed string"
+fi
+assert_file_has_content_literal err.txt 'error: Invalid index: blah'
+echo "ok undeploy error invalid int"
 
 # we now have 5 deployments, let's bring that back down to 1
 for i in $(seq 4); do


### PR DESCRIPTION
`atoi` doesn't offer any error checking.

Closes: https://github.com/ostreedev/ostree/issues/3088