### PR TITLE
rust: Add a `stateroot()` alias in the Rust bindings

### DIFF
--- a/rust-bindings/src/deployment.rs
+++ b/rust-bindings/src/deployment.rs
@@ -1,0 +1,10 @@
+use glib::GString;
+
+use crate::Deployment;
+
+impl Deployment {
+    /// Access the name of the deployment stateroot.
+    pub fn stateroot(&self) -> GString {
+        self.osname()
+    }
+}

--- a/rust-bindings/src/lib.rs
+++ b/rust-bindings/src/lib.rs
@@ -56,6 +56,7 @@ mod object_name;
 pub use crate::object_name::*;
 mod object_details;
 pub use crate::object_details::*;
+mod deployment;
 mod repo;
 pub use crate::repo::*;
 #[cfg(any(feature = "v2016_8", feature = "dox"))]


### PR DESCRIPTION
Easy to do here, super annoying in C.