### PR TITLE
Symbol cleanups

### DIFF
--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -29,8 +29,8 @@ global:
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION
  * with whatever the next version with new symbols will be.
-LIBOSTREE_2021.$NEWVERSION {
+LIBOSTREE_$YEAR.$NEWVERSION {
 global:
   someostree_symbol_deleteme;
-} LIBOSTREE_2021.$LASTSTABLE;
+} LIBOSTREE_$YEAR.$LASTSTABLE;
 */

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,6 +20,11 @@
    - uncomment the include in Makefile-libostree.am
 */
 
+LIBOSTREE_2023.8 {
+global:
+  ostree_sysroot_update_post_copy;
+} LIBOSTREE_2023.4;
+
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION
@@ -29,8 +34,3 @@ global:
   someostree_symbol_deleteme;
 } LIBOSTREE_2021.$LASTSTABLE;
 */
-
-LIBOSTREE_2023.11 {
-global:
-  ostree_sysroot_update_post_copy;
-} LIBOSTREE_2023.4;


### PR DESCRIPTION
devel: Fix symbol versioning number

The .11 was wrong.

---

lib: Don't hardcode year in sample symver section

The 2021 was misleading.

---

