### PR TITLE
main: Drop some redundant includes of `ot-main.h`

### DIFF
--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -25,7 +25,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <err.h>

--- a/src/ostree/ot-admin-builtin-boot-complete.c
+++ b/src/ostree/ot-admin-builtin-boot-complete.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include "ostree-cmd-private.h"

--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 
 #include <glib/gi18n.h>
 

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -26,7 +26,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 
 #include <glib/gi18n.h>
 

--- a/src/ostree/ot-admin-builtin-finalize-staged.c
+++ b/src/ostree/ot-admin-builtin-finalize-staged.c
@@ -28,7 +28,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include "ostree-cmd-private.h"

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -23,7 +23,6 @@
 
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -24,7 +24,6 @@
 #include "ot-admin-functions.h"
 #include "ot-admin-instutil-builtins.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 
 #include <glib/gi18n.h>
 

--- a/src/ostree/ot-admin-builtin-kargs.c
+++ b/src/ostree/ot-admin-builtin-kargs.c
@@ -23,7 +23,6 @@
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
 #include "ot-admin-kargs-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-lock-finalization.c
+++ b/src/ostree/ot-admin-builtin-lock-finalization.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -23,7 +23,6 @@
 
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-pin.c
+++ b/src/ostree/ot-admin-builtin-pin.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_unpin;

--- a/src/ostree/ot-admin-builtin-post-copy.c
+++ b/src/ostree/ot-admin-builtin-post-copy.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-set-default.c
+++ b/src/ostree/ot-admin-builtin-set-default.c
@@ -22,7 +22,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static GOptionEntry options[] = { { NULL } };

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -22,7 +22,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -25,7 +25,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 
 #include <glib/gi18n.h>
 

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -22,7 +22,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static GOptionEntry options[] = { { NULL } };

--- a/src/ostree/ot-admin-builtin-unlock.c
+++ b/src/ostree/ot-admin-builtin-unlock.c
@@ -22,7 +22,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <err.h>

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <glib/gi18n.h>

--- a/src/ostree/ot-admin-functions.h
+++ b/src/ostree/ot-admin-functions.h
@@ -21,8 +21,7 @@
 
 #pragma once
 
-#include <gio/gio.h>
-#include <ostree.h>
+#include "ot-main.h"
 
 G_BEGIN_DECLS
 

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -22,7 +22,6 @@
 
 #include "ostree-cmd-private.h"
 #include "ot-admin-instutil-builtins.h"
-#include "ot-main.h"
 
 #include "otutil.h"
 

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -21,7 +21,6 @@
 #include <string.h>
 
 #include "ot-admin-instutil-builtins.h"
-#include "ot-main.h"
 
 #include "otutil.h"
 

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -21,7 +21,6 @@
 #include <string.h>
 
 #include "ot-admin-instutil-builtins.h"
-#include "ot-main.h"
 
 #include "ostree.h"
 #include "otutil.h"

--- a/src/ostree/ot-admin-kargs-builtin-edit-in-place.c
+++ b/src/ostree/ot-admin-kargs-builtin-edit-in-place.c
@@ -19,9 +19,6 @@
 #include "config.h"
 
 #include "ot-admin-kargs-builtins.h"
-#include "ot-main.h"
-
-#include "ostree.h"
 #include "otutil.h"
 
 static char **opt_kargs_edit_in_place_append;

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -26,7 +26,6 @@
 #include "ot-admin-builtins.h"
 #include "ot-admin-functions.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 
 #include <glib/gi18n.h>
 

--- a/src/ostree/ot-builtin-cat.c
+++ b/src/ostree/ot-builtin-cat.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include <gio/gunixoutputstream.h>

--- a/src/ostree/ot-builtin-checkout.c
+++ b/src/ostree/ot-builtin-checkout.c
@@ -26,7 +26,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_user_mode;

--- a/src/ostree/ot-builtin-checksum.c
+++ b/src/ostree/ot-builtin-checksum.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 
 #include <string.h>
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -27,7 +27,6 @@
 #include "ostree.h"
 #include "ot-builtins.h"
 #include "ot-editor.h"
-#include "ot-main.h"
 #include "otutil.h"
 #include "parse-datetime.h"
 

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static char *opt_group;

--- a/src/ostree/ot-builtin-create-usb.c
+++ b/src/ostree/ot-builtin-create-usb.c
@@ -24,7 +24,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include "ostree-remote-private.h"

--- a/src/ostree/ot-builtin-diff.c
+++ b/src/ostree/ot-builtin-diff.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_stats;

--- a/src/ostree/ot-builtin-export.c
+++ b/src/ostree/ot-builtin-export.c
@@ -23,7 +23,6 @@
 #include "ostree-repo-file.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #ifdef HAVE_LIBARCHIVE

--- a/src/ostree/ot-builtin-find-remotes.c
+++ b/src/ostree/ot-builtin-find-remotes.c
@@ -24,7 +24,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 #include "ostree-remote-private.h"

--- a/src/ostree/ot-builtin-fsck.c
+++ b/src/ostree/ot-builtin-fsck.c
@@ -25,7 +25,6 @@
 #include "ostree-cmd-private.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_quiet;

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -24,7 +24,6 @@
 #include "ostree-core-private.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_delete;

--- a/src/ostree/ot-builtin-init.c
+++ b/src/ostree/ot-builtin-init.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 
 static char *opt_mode = "bare";
 static char *opt_collection_id = NULL;

--- a/src/ostree/ot-builtin-log.c
+++ b/src/ostree/ot-builtin-log.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-builtins.h"
 #include "ot-dump.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_raw;

--- a/src/ostree/ot-builtin-ls.c
+++ b/src/ostree/ot-builtin-ls.c
@@ -24,7 +24,6 @@
 #include "ostree-repo-file.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_dironly;

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -24,7 +24,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 #include "parse-datetime.h"
 

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -26,7 +26,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static char *opt_remote;

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_disable_fsync;

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 
 static gboolean opt_delete;
 static gboolean opt_list;

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -22,7 +22,6 @@
 #include "config.h"
 
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static OstreeCommand remote_subcommands[] = {

--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 /* ATTENTION:

--- a/src/ostree/ot-builtin-rev-parse.c
+++ b/src/ostree/ot-builtin-rev-parse.c
@@ -23,7 +23,6 @@
 
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 #include <stdbool.h>
 

--- a/src/ostree/ot-builtin-show.c
+++ b/src/ostree/ot-builtin-show.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-builtins.h"
 #include "ot-dump.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_print_related;

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -28,7 +28,6 @@
 #include "ostree-sign.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_delete;

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -22,7 +22,6 @@
 #include "ostree-cmd-private.h"
 #include "ostree.h"
 #include "ot-builtins.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static char *opt_from_rev;

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -24,7 +24,6 @@
 #include "ostree.h"
 #include "ot-builtins.h"
 #include "ot-dump.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static gboolean opt_update, opt_view, opt_raw;

--- a/src/ostree/ot-builtins.h
+++ b/src/ostree/ot-builtins.h
@@ -23,7 +23,6 @@
 
 #include "config.h"
 
-#include "ostree.h"
 #include "ot-main.h"
 
 G_BEGIN_DECLS

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -31,7 +31,6 @@
 
 #include "ostree.h"
 #include "ot-admin-functions.h"
-#include "ot-main.h"
 #include "otutil.h"
 
 static char *opt_repo;

--- a/src/ostree/ot-remote-builtin-add-cookie.c
+++ b/src/ostree/ot-remote-builtin-add-cookie.c
@@ -23,7 +23,6 @@
 #include "otutil.h"
 
 #include "ostree-repo-private.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 #include "ot-remote-cookie-util.h"
 

--- a/src/ostree/ot-remote-builtin-add.c
+++ b/src/ostree/ot-remote-builtin-add.c
@@ -21,7 +21,6 @@
 
 #include "otutil.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static char **opt_set;

--- a/src/ostree/ot-remote-builtin-delete-cookie.c
+++ b/src/ostree/ot-remote-builtin-delete-cookie.c
@@ -24,7 +24,6 @@
 #include <sys/stat.h>
 
 #include "ostree-repo-private.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 #include "ot-remote-cookie-util.h"
 

--- a/src/ostree/ot-remote-builtin-delete.c
+++ b/src/ostree/ot-remote-builtin-delete.c
@@ -21,7 +21,6 @@
 
 #include "otutil.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static gboolean opt_if_exists = FALSE;

--- a/src/ostree/ot-remote-builtin-gpg-import.c
+++ b/src/ostree/ot-remote-builtin-gpg-import.c
@@ -24,7 +24,6 @@
 
 #include "otutil.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 /* XXX This belongs in libotutil. */

--- a/src/ostree/ot-remote-builtin-gpg-list-keys.c
+++ b/src/ostree/ot-remote-builtin-gpg-list-keys.c
@@ -22,7 +22,6 @@
 #include "otutil.h"
 
 #include "ot-dump.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 /* ATTENTION:

--- a/src/ostree/ot-remote-builtin-list-cookies.c
+++ b/src/ostree/ot-remote-builtin-list-cookies.c
@@ -23,7 +23,6 @@
 #include "otutil.h"
 
 #include "ostree-repo-private.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 #include "ot-remote-cookie-util.h"
 

--- a/src/ostree/ot-remote-builtin-list.c
+++ b/src/ostree/ot-remote-builtin-list.c
@@ -19,7 +19,6 @@
 
 #include "config.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static gboolean opt_show_urls;

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -21,7 +21,6 @@
 
 #include "otutil.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static gboolean opt_revision;

--- a/src/ostree/ot-remote-builtin-show-url.c
+++ b/src/ostree/ot-remote-builtin-show-url.c
@@ -21,7 +21,6 @@
 
 #include "otutil.h"
 
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 /* ATTENTION:

--- a/src/ostree/ot-remote-builtin-summary.c
+++ b/src/ostree/ot-remote-builtin-summary.c
@@ -22,7 +22,6 @@
 #include "otutil.h"
 
 #include "ot-dump.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 
 static gboolean opt_list_metadata_keys;

--- a/src/ostree/ot-remote-builtins.h
+++ b/src/ostree/ot-remote-builtins.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <ostree.h>
+#include "ot-main.h"
 
 G_BEGIN_DECLS
 

--- a/src/ostree/ot-remote-cookie-util.c
+++ b/src/ostree/ot-remote-cookie-util.c
@@ -23,7 +23,6 @@
 #include "ot-remote-cookie-util.h"
 
 #include "ostree-repo-private.h"
-#include "ot-main.h"
 #include "ot-remote-builtins.h"
 #include "otutil.h"
 


### PR DESCRIPTION
When backporting a patch recently we hit a non-obvious dependency on another fix for `ot-main.h` includes.  Clean this up a bit by dropping the redundant includes.