### PR TITLE
tmpfiles: Copy `/usr/share/factory/var` to `/var`

### DIFF
--- a/src/boot/ostree-tmpfiles.conf
+++ b/src/boot/ostree-tmpfiles.conf
@@ -17,3 +17,7 @@
 d /run/ostree 0755 root root -
 # https://github.com/ostreedev/ostree/issues/393
 R! /var/tmp/ostree-unlock-ovl.*
+# Automatically propagate all /var content from /usr/share/factory/var;
+# the ostree-container stack is being changed to do this, and we want to
+# encourage ostree use cases in general to follow this pattern.
+C+! /var - - - - -

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3039,10 +3039,10 @@ lint_deployment_fs (OstreeSysroot *self, OstreeDeployment *deployment, int deplo
       if (dent == NULL)
         break;
 
-      fprintf (
-          stderr,
-          "note: Deploying commit %s which contains content in /var/%s that will be ignored.\n",
-          ostree_deployment_get_csum (deployment), dent->d_name);
+      fprintf (stderr,
+               "note: Deploying commit %s which contains content in /var/%s that should be in "
+               "/usr/share/factory/var\n",
+               ostree_deployment_get_csum (deployment), dent->d_name);
     }
 
   return TRUE;

--- a/tests/kolainst/destructive/var-tmpfiles.sh
+++ b/tests/kolainst/destructive/var-tmpfiles.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libinsttest.sh
+
+require_writable_sysroot
+prepare_tmpdir
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    factory_var=rootfs/usr/share/factory/var
+    mkdir -p ${factory_var}
+    cd "${factory_var}"
+    mkdir -p home/someuser
+    echo bashrc > home/someuser/.bashrc
+    chown -R 1000:1000 home/someuser
+    mkdir -m 01777 -p tmp
+    cd -
+    ostree commit -b testlint --no-bindings --selinux-policy-from-base --tree=ref="${host_refspec}" --consume --tree=dir=rootfs
+    ostree admin deploy testlint 2>err.txt
+    assert_not_file_has_content err.txt 'contains content in /var'
+
+    /tmp/autopkgtest-reboot "2"
+    ;;
+  2)
+    assert_file_has_content /home/someuser/.bashrc bashrc
+    ;;
+  *) fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}" ;;
+esac


### PR DESCRIPTION
This is a pattern we want to encourage.  It's honestly just way simpler than what rpm-ostree is doing today in auto-synthesizing individual tmpfiles.d snippets.