### PR TITLE
bootloader/zipl: Run in target deployment as container if needed

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3164,9 +3164,9 @@ child_setup_fchdir (gpointer data)
 /*
  * Derived from rpm-ostree's rust/src/bwrap.rs
  */
-static gboolean
-run_in_deployment (int deployment_dfd, const gchar *const *child_argv, gint *exit_status,
-                   gchar **stdout, GError **error)
+gboolean
+_ostree_sysroot_run_in_deployment (int deployment_dfd, const gchar *const *child_argv,
+                                   gint *exit_status, gchar **stdout, GError **error)
 {
   static const gchar *const COMMON_ARGV[] = { "/usr/bin/bwrap",
                                               "--dev",
@@ -3264,7 +3264,8 @@ sysroot_finalize_selinux_policy (int deployment_dfd, GError **error)
    * flag is not supported by semodule.
    */
   static const gchar *const SEMODULE_HELP_ARGV[] = { "semodule", "--help", NULL };
-  if (!run_in_deployment (deployment_dfd, SEMODULE_HELP_ARGV, &exit_status, &stdout, error))
+  if (!_ostree_sysroot_run_in_deployment (deployment_dfd, SEMODULE_HELP_ARGV, &exit_status, &stdout,
+                                          error))
     return FALSE;
   if (!g_spawn_check_exit_status (exit_status, error))
     return glnx_prefix_error (error, "failed to run semodule");
@@ -3278,7 +3279,8 @@ sysroot_finalize_selinux_policy (int deployment_dfd, GError **error)
 
   ot_journal_print (LOG_INFO, "Refreshing SELinux policy");
   guint64 start_msec = g_get_monotonic_time () / 1000;
-  if (!run_in_deployment (deployment_dfd, SEMODULE_REBUILD_ARGV, &exit_status, NULL, error))
+  if (!_ostree_sysroot_run_in_deployment (deployment_dfd, SEMODULE_REBUILD_ARGV, &exit_status, NULL,
+                                          error))
     return FALSE;
   guint64 end_msec = g_get_monotonic_time () / 1000;
   ot_journal_print (LOG_INFO, "Refreshed SELinux policy in %" G_GUINT64_FORMAT " ms",

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -3151,7 +3151,6 @@ get_var_dfd (OstreeSysroot *self, int osdeploy_dfd, OstreeDeployment *deployment
   return glnx_opendirat (base_dfd, base_path, TRUE, ret_fd, error);
 }
 
-#ifdef HAVE_SELINUX
 static void
 child_setup_fchdir (gpointer data)
 {
@@ -3245,6 +3244,7 @@ _ostree_sysroot_run_in_deployment (int deployment_dfd, const char *const *bwrap_
                        (gpointer)(uintptr_t)deployment_dfd, stdout, NULL, exit_status, error);
 }
 
+#ifdef HAVE_SELINUX
 /*
  * Run semodule to check if the module content changed after merging /etc
  * and rebuild the policy if needed.

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -150,6 +150,9 @@ gboolean _ostree_sysroot_rmrf_deployment (OstreeSysroot *sysroot, OstreeDeployme
 
 char *_ostree_sysroot_get_runstate_path (OstreeDeployment *deployment, const char *key);
 
+gboolean _ostree_sysroot_run_in_deployment (int deployment_dfd, const gchar *const *child_argv,
+                                            gint *exit_status, gchar **stdout, GError **error);
+
 char *_ostree_sysroot_join_lines (GPtrArray *lines);
 
 gboolean _ostree_sysroot_ensure_boot_fd (OstreeSysroot *self, GError **error);

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -150,8 +150,9 @@ gboolean _ostree_sysroot_rmrf_deployment (OstreeSysroot *sysroot, OstreeDeployme
 
 char *_ostree_sysroot_get_runstate_path (OstreeDeployment *deployment, const char *key);
 
-gboolean _ostree_sysroot_run_in_deployment (int deployment_dfd, const gchar *const *child_argv,
-                                            gint *exit_status, gchar **stdout, GError **error);
+gboolean _ostree_sysroot_run_in_deployment (int deployment_dfd, const char *const *bwrap_argv,
+                                            const gchar *const *child_argv, gint *exit_status,
+                                            gchar **stdout, GError **error);
 
 char *_ostree_sysroot_join_lines (GPtrArray *lines);
 


### PR DESCRIPTION
sysroot: Expose deployment container executor internally

Prep for using this for zipl.

---

bootloader/zipl: Run in target deployment as container if needed

xref https://issues.redhat.com/browse/MGMT-16303

Basically the OCP Assisted installer has now grown code
to try to do OS updates offline post-install, and this means
we need to handle the case of running zipl from the target
root.

---

