### PR TITLE
sysroot: Add a method to borrow sysroot fd

### DIFF
--- a/rust-bindings/src/sysroot.rs
+++ b/rust-bindings/src/sysroot.rs
@@ -1,5 +1,7 @@
 use crate::gio;
 use crate::Sysroot;
+#[cfg(any(feature = "v2017_10", feature = "dox"))]
+use std::os::fd::BorrowedFd;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default)]
@@ -59,6 +61,14 @@ impl SysrootBuilder {
         }
 
         sysroot
+    }
+}
+
+impl Sysroot {
+    /// Borrow the directory file descriptor for this sysroot.
+    #[cfg(feature = "v2017_10")]
+    pub fn dfd_borrow(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd()) }
     }
 }
 


### PR DESCRIPTION
For the same reason we have this method on `Repo`.