### PR TITLE
Update Torizon information

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ their host system as well as Flatpak.
 [Liri OS](https://liri.io/download/silverblue/) has the option to install
 their distribution using ostree.
 
-[TorizonCore](https://developer.toradex.com/torizon/working-with-torizon/torizoncore-technical-overview/) is a Linux distribution for embedded systems that updates via OSTree images delivered via [Uptane](https://uptane.github.io/) and [aktualizr](https://github.com/uptane/aktualizr/).
+[Torizon OS](https://developer.toradex.com/torizon/torizoncore/torizoncore-technical-overview/) is a Linux distribution for embedded systems that updates via OSTree images delivered via [Uptane](https://uptane.github.io/) and [aktualizr](https://github.com/uptane/aktualizr/).
 
 ## Distribution build tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,9 +66,9 @@ system for GNOME.
 [Liri OS](https://liri.io/download/silverblue/) has the option to install
 their distribution using ostree.
 
-[TorizonCore](https://developer.toradex.com/knowledge-base/torizoncore-overview)
+[Torizon OS](https://developer.toradex.com/torizon/torizoncore/)
 uses libostree and Aktualizr as the base for OTA updates from compatible
-platforms, including [Torizon OTA](https://developer.toradex.com/knowledge-base/torizon-update-system).
+platforms, including [Torizon Cloud](https://developer.toradex.com/torizon/torizon-platform/torizon-platform-services-overview).
 
 ## Distribution build tools
 

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -370,23 +370,23 @@ Linux software. It is designed to be used out-of-the-box on devices requiring
 high reliability, allowing you to focus on your application and not on building
 and maintaining the operating system.
 
-### TorizonCore
+### Torizon OS
 
-The platform OS - [TorizonCore](https://developer.toradex.com/knowledge-base/torizoncore-overview) -
+The platform OS - [Torizon OS](https://www.toradex.com/operating-systems/torizon) -
 is a minimal OS with a Docker runtime and libostree + Aktualizr. The main goal
 of this system is to allow application developers to use containers, while the
-maintainers of TorizonCore focus on the base system updates.
+maintainers of Torizon OS focus on the base system updates.
 
 ### TorizonCore Builder
 
-Since the TorizonCore OS is meant as a binary distribution, OS customization is
-made easier with [TorizonCore Builder](https://developer.toradex.com/knowledge-base/torizoncore-builder-tool),
+Since the Torizon OS is meant as a binary distribution, OS customization is
+made easier with [TorizonCore Builder](https://developer.toradex.com/torizon/os-customization/torizoncore-builder-tool-customizing-torizoncore-images/),
 as the tool abstracts the handling of OSTree concepts from the final users.
 
-### Torizon OTA
+### Torizon Cloud
 
-[Torizon OTA](https://developer.toradex.com/knowledge-base/torizon-update-system)
-is a hosted OTA update system that provides OS updates to TorizonCore using
+[Torizon Cloud](https://developer.toradex.com/torizon/torizon-platform/torizon-platform-services-overview/)
+is a hosted OTA update system that provides OS updates to Torizon OS using
 OSTree and Aktualizr.
 
 ###### Licensing for this document:


### PR DESCRIPTION
TorizonCore became Torizon OS and Torizon OTA is now Torizon Cloud.