### PR TITLE
Link to gardenlinux/ostree-image-builder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ the build tool used to generate Fedora CoreOS derivatives.
 [debos](https://github.com/go-debos/debos) is a tool-chain for simplifying the
 process of building a Debian-based OS image.
 
+[gardenlinux/ostree-image-builder](https://github.com/gardenlinux/ostree-image-builder)
+is a sample for building Debian-based OS images.
+It is not production ready but it might be useful to get started.
+
 ## Projects linking to libostree
 
 [rpm-ostree](https://github.com/projectatomic/rpm-ostree) is used by the


### PR DESCRIPTION
This repo is the outcome of a PoC on how an existing debian-based distro could be adapted to be used with OSTree.