### PR TITLE
switchroot: use shared constant for unlock --hotfix

### DIFF
--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -60,6 +60,9 @@ GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
 // The directory holding the root overlayfs
 #define OSTREE_DEPLOYMENT_ROOT_TRANSIENT_DIR "root-transient"
 
+// Written by ostree admin unlock --hotfix, read by ostree-prepare-root
+#define OTCORE_HOTFIX_USR_OVL_WORK ".usr-ovl-work"
+
 // The name of the composefs metadata root
 #define OSTREE_COMPOSEFS_NAME ".ostree.cfs"
 // The temporary directory used for the EROFS mount; it's in the .private directory

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -632,12 +632,17 @@ main (int argc, char *argv[])
     }
 
   /* Prepare /usr.
-   * It may be either just a read-only bind-mount, or a persistent overlayfs. */
-  if (lstat (".usr-ovl-work", &stbuf) == 0)
+   * It may be either just a read-only bind-mount, or a persistent overlayfs if set up
+   * with ostree admin unlock --hotfix.
+   * Note however that root.transient as handled above is effectively a generalization of unlock
+   * --hotfix.
+   */
+  if (lstat (OTCORE_HOTFIX_USR_OVL_WORK, &stbuf) == 0)
     {
       /* Do we have a persistent overlayfs for /usr?  If so, mount it now. */
       const char usr_ovl_options[]
-          = "lowerdir=" TMP_SYSROOT "/usr,upperdir=.usr-ovl-upper,workdir=.usr-ovl-work";
+          = "lowerdir=" TMP_SYSROOT
+            "/usr,upperdir=.usr-ovl-upper,workdir=" OTCORE_HOTFIX_USR_OVL_WORK;
 
       /* Except overlayfs barfs if we try to mount it on a read-only
        * filesystem.  For this use case I think admins are going to be


### PR DESCRIPTION
So it's easier to link the two bits of code.