### PR TITLE
prepare-root: Fix composefs + ostree admin unlock --hotfix compat

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -639,18 +639,11 @@ main (int argc, char *argv[])
       const char usr_ovl_options[]
           = "lowerdir=" TMP_SYSROOT "/usr,upperdir=.usr-ovl-upper,workdir=.usr-ovl-work";
 
-      /* Except overlayfs barfs if we try to mount it on a read-only
-       * filesystem.  For this use case I think admins are going to be
-       * okay if we remount the rootfs here, rather than waiting until
-       * later boot and `systemd-remount-fs.service`.
-       */
-      if (path_is_on_readonly_fs (TMP_SYSROOT))
-        {
-          if (mount (TMP_SYSROOT, TMP_SYSROOT, NULL, MS_REMOUNT | MS_SILENT, NULL) < 0)
-            err (EXIT_FAILURE, "failed to remount rootfs writable (for overlayfs)");
-        }
-
-      if (mount ("overlay", TMP_SYSROOT "/usr", "overlay", MS_SILENT, usr_ovl_options) < 0)
+      unsigned long mflags = MS_SILENT;
+      // Propagate readonly state
+      if (!sysroot_currently_writable)
+        mflags |= MS_RDONLY;
+      if (mount ("overlay", TMP_SYSROOT "/usr", "overlay", mflags, usr_ovl_options) < 0)
         err (EXIT_FAILURE, "failed to mount /usr overlayfs");
     }
   else if (!using_composefs)


### PR DESCRIPTION
There's a test case for `ostree admin unlock --hotfix` that runs in FCOS, not here; it breaks when enabling composefs.

The reason is because the composefs is mounted readonly, and we tried to remount it writable.  Instead of trying to remount the rootfs writable at this point forcibly, honor the *real* sysroot readonly state flag from the underlying FS before we mounted the composefs.

Note that in FCOS derivatives we always have the root mounted writable via `rw` on the kernel cmdline and this is the default general expectation now with ostree usage.