### PR TITLE
status: Fix build without GPGME

### DIFF
--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -152,6 +152,8 @@ deployment_print_status (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploym
 
       g_print ("%s", output_buffer->str);
     }
+#else
+  g_autofree char *remote = NULL;
 #endif /* OSTREE_DISABLE_GPGME */
   if (opt_verify)
     {


### PR DESCRIPTION
If OSTREE_DISABLE_GPGME is not built in set remote to NULL.

The ostree_repo_signature_verify_commit_data path is irrelevant in the
no gpg case anyway. Having this set as NULL ensures an error gets
thrown early.
