### PR TITLE
systemd/ostree-boot-complete: Start earlier

### DIFF
--- a/src/boot/ostree-boot-complete.service
+++ b/src/boot/ostree-boot-complete.service
@@ -21,6 +21,9 @@ ConditionKernelCommandLine=ostree
 # marked as a triggering condition in case in the future we want
 # to do something else.
 ConditionPathExists=|/boot/ostree/finalize-failure.stamp
+# We start early
+DefaultDependencies=no
+After=sysinit.target
 RequiresMountsFor=/boot
 # Ensure that we propagate the failure into the current boot before
 # any further finalization attempts.

--- a/src/boot/ostree-boot-complete.service
+++ b/src/boot/ostree-boot-complete.service
@@ -16,6 +16,7 @@
 [Unit]
 Description=OSTree Complete Boot
 Documentation=man:ostree(1)
+ConditionKernelCommandLine=ostree
 # For now, this is the only condition on which we start, but it's
 # marked as a triggering condition in case in the future we want
 # to do something else.


### PR DESCRIPTION
systemd/ostree-boot-complete: Add `ConditionKernelCommandLine=ostree`

In practice we don't enable this unit except via our generator,
but let's do this on general principle.

---

systemd/ostree-boot-complete: Start earlier

Prep for changing this service to perform state computations
such as "is this boot the default, or did we get rolled back"
that can be used by higher level tools.

---

