### PR TITLE
status: Introduce tool to quickly check if we are booted as default

### DIFF
--- a/man/ostree-admin-status.xml
+++ b/man/ostree-admin-status.xml
@@ -62,6 +62,65 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     </refsect1>
 
     <refsect1>
+        <title>Options</title>
+
+        <variablelist>
+            <varlistentry>
+                <term><option>--sysroot</option>="PATH"</term>
+
+                <listitem><para>
+                    Create a new OSTree sysroot at PATH
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-V, --verify</option></term>
+
+                <listitem><para>
+                    Print the commit verification status
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-S, --skip-signatures</option></term>
+
+                <listitem><para>
+                    Skip signatures in output
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-Q, --query-booted</option></term>
+
+                <listitem><para>
+                    Output the string <literal>default</literal> if the default deployment
+                    is the booted one, <literal>not-default</literal> if we are booted in
+                    a non-default deployment (e.g. the user interactively chose a
+                    different entry in the bootloader menu, or the bootloader rolled back
+                    automatically, etc.). If we are not in a booted OSTree system, an
+                    error is returned.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-v, --verbose</option></term>
+
+                <listitem><para>
+                    Print debug information during command processing
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--version</option>--version</term>
+
+                <listitem><para>
+                    Print version information and exit
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+
+    <refsect1>
         <title>Example</title>
         <para><command>$ ostree admin status</command></para>
 <programlisting>

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -35,8 +35,8 @@ static gboolean opt_query_booted;
 static GOptionEntry options[] = {
   { "verify", 'V', 0, G_OPTION_ARG_NONE, &opt_verify, "Print the commit verification status",
     NULL },
-  { "skip-signatures", 'S', 0, G_OPTION_ARG_NONE, &opt_skip_signatures,
-    "Print the commit verification status", NULL },
+  { "skip-signatures", 'S', 0, G_OPTION_ARG_NONE, &opt_skip_signatures, "Skip signatures in output",
+    NULL },
   { "query-booted", 'Q', 0, G_OPTION_ARG_NONE, &opt_query_booted,
     "Output the string \"default\" if the default deployment is the booted one, \"not-default\" if "
     "we are booted in a non-default deployment (e.g. the user interactively chose a different "


### PR DESCRIPTION
Generally in ostree based systems you would expect to boot into deployment 0, in rollback conditions triggered by greenboot-related rollbacks this might not be the case. This is a tool to detect this.