### PR TITLE
Release 2024.1 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2024])
-m4_define([release_version], [1])
+m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
-m4_define([year_version], [2023])
-m4_define([release_version], [9])
+m4_define([year_version], [2024])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
# New features

There are two major new APIs around configuring mutability and persistence of the root filesystem.

First, OSTree gained support for a new `root.transient` flag that makes `/` an `overlayfs` that is persistent across reboots but *not* across upgrades.  This makes the system behave a bit more similarly to e.g. Docker and following tools such as podman and Kubernetes.  

* prepare-root: Add support for root.transient by @cgwalters in https://github.com/ostreedev/ostree/pull/3114
* Doc root transient by @cgwalters in https://github.com/ostreedev/ostree/pull/3117

There is a different approach in the (still classified as experimental) `ostree-state-overlay@.service` unit:

* Add concept of state overlays by @jlebon in https://github.com/ostreedev/ostree/pull/3120

This approach instead allows operating systems or downstream builders to choose to apply persistent merge semantics to specific targeted directories (e.g. `/opt`). 

# Notable bugfixes

* prepare-root: Fix composefs + ostree admin unlock --hotfix compat by @cgwalters in https://github.com/ostreedev/ostree/pull/3129
* lib/deploy: Round to block size in early prune space check by @jlebon in https://github.com/ostreedev/ostree/pull/3130
* * status: Pass correct remote name when verifying by @cgwalters in https://github.com/ostreedev/ostree/pull/3131

# Other misc changes

* Release 2023.8 by @cgwalters in https://github.com/ostreedev/ostree/pull/3111
* Update Torizon information by @leonheldattoradex in https://github.com/ostreedev/ostree/pull/3112

* doc: Add section about ostree and bootloaders by @jmarrero in https://github.com/ostreedev/ostree/pull/3116
* Link to gardenlinux/ostree-image-builder in README by @fwilhe in https://github.com/ostreedev/ostree/pull/3121
* deploy: Log calculated needed space by @cgwalters in https://github.com/ostreedev/ostree/pull/3123
* rust: Add missing feature versions by @cgwalters in https://github.com/ostreedev/ostree/pull/3124
* switchroot: Be explicit about what could cause /sysroot to be ro by @ericcurtin in https://github.com/ostreedev/ostree/pull/3125
* zipl: A few fixes by @cgwalters in https://github.com/ostreedev/ostree/pull/3119
* docs/composefs: Add note about toplevel dirs by @cgwalters in https://github.com/ostreedev/ostree/pull/3127
* switchroot: use shared constant for unlock --hotfix by @cgwalters in https://github.com/ostreedev/ostree/pull/3128
* status: Fix build without GPGME by @ericcurtin in https://github.com/ostreedev/ostree/pull/3132
* systemd/ostree-boot-complete: Start earlier by @cgwalters in https://github.com/ostreedev/ostree/pull/3133
* status: Introduce tool to quickly check if we are booted as default by @ericcurtin in https://github.com/ostreedev/ostree/pull/3134
* status: Rename query-booted to is-default by @ericcurtin in https://github.com/ostreedev/ostree/pull/3136
* doc: Add section about ostree and aboot by @ericcurtin in https://github.com/ostreedev/ostree/pull/3135

## New Contributors
* @leonheldattoradex made their first contribution in https://github.com/ostreedev/ostree/pull/3112
* @fwilhe made their first contribution in https://github.com/ostreedev/ostree/pull/3121

**Full Changelog**: https://github.com/ostreedev/ostree/compare/v2023.8...v2024.1