### PR TITLE
tests: Skip composefs test if /var/tmp does not support user xattrs

### DIFF
--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -24,6 +24,7 @@ if ! ${CMD_PREFIX} ostree --version | grep -q -e '- composefs'; then
     exit 0
 fi
 
+skip_without_user_xattrs
 
 setup_test_repository "bare-user"
 


### PR DESCRIPTION
Otherwise, this test fails on Debian 12 (Linux 6.1) kernels if /var/tmp is a tmpfs. Some autobuilders put the entire build chroot on a tmpfs, to speed up builds.