### PR TITLE
admin/pin: Add commands to pin booted, pending and rollbacks deployments

### DIFF
--- a/man/ostree-admin-pin.xml
+++ b/man/ostree-admin-pin.xml
@@ -58,8 +58,10 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
         <para>
           Ensures the deployment at <literal>INDEX</literal>, will not be garbage
-          collected by default. This is termed "pinning".   If the
+          collected by default. This is termed "pinning". If the
           <literal>-u</literal> option is provided, undoes a pinning operation.
+          <literal>INDEX</literal> can be >= 0 or one of booted, pending or
+          rollback strings.
         </para>
     </refsect1>
 

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -53,7 +53,8 @@ static OstreeCommand admin_subcommands[] = {
   { "stateroot-init", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_os_init,
     "Initialize empty state for given operating system" },
   { "pin", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_pin,
-    "Change the \"pinning\" state of a deployment" },
+    "Change the \"pinning\" state of a deployment, INDEX can be >= 0 or one of booted, pending or "
+    "rollback strings" },
   { "post-copy", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_post_copy,
     "Update the repo and deployments as needed after a copy" },
   { "set-origin", OSTREE_BUILTIN_FLAG_NO_REPO, ot_admin_builtin_set_origin,


### PR DESCRIPTION
Add new commands to pin the current, staged and previous deployment for
use in automation and scripting. Right now, it's difficult to pin the
current deployment without needing to look into the output of some other
tooling (like rpm-ostree) to get the index of each deployment. This
index also is not consistent - the current deployment could be 0 when
you first boot the system then 1 shortly after. This change makes it
easy to pin the current or future deployment.

Co-authored-by: Robert Sturla <robertsturla@outlook.com>
Signed-off-by: Eric Curtin <ecurtin@redhat.com>
