### PR TITLE
composefs: Bump composefs max version to 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,8 @@ AS_IF([test x$have_gpgme = xyes],
 AM_CONDITIONAL(USE_GPGME, test "x$have_gpgme" = xyes)
 
 dnl composefs won't work at all without this
+AC_CHECK_HEADERS([endian.h sys/endian.h machine/endian.h])
+AC_CHECK_FUNCS([reallocarray])
 AC_MSG_CHECKING([for MOUNT_ATTR_IDMAP])
 AC_COMPILE_IFELSE(
 	[AC_LANG_PROGRAM([

--- a/src/libostree/ostree-repo-composefs.c
+++ b/src/libostree/ostree-repo-composefs.c
@@ -235,6 +235,9 @@ ostree_composefs_target_write (OstreeComposefsTarget *target, int fd, guchar **o
       options.file_write_cb = _composefs_write_cb;
     }
 
+  options.version = 0;
+  options.max_version = 1; /* Support new whiteout xattr if required */
+
   if (lcfs_write_to (root, &options) != 0)
     return glnx_throw_errno_prefix (error, "lcfs_write_to");
 


### PR DESCRIPTION
This generates the new format for whiteout markers which was added in  6.8 (and which will be backported to 6.7). Without this whiteouts  will not work anymore.
    
This is a slight format change, but will only affect ostree commits that already were broken (i.e that had whiteouts), and since the composefs code is still marked experimental I think it is fine to do this without introducing another format version on the ostree side.
