### PR TITLE
grub2-15_ostree: Graceful exit if /etc/default/grub doesn't exist

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -1,5 +1,5 @@
 #!/bin/sh
-# 
+#
 # Copyright (C) 2014 Colin Walters <walters@verbum.org>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -24,6 +24,12 @@ if ! test -d /ostree/repo; then
     exit 0
 fi
 
+# Gracefully exit if we can not find the grub2 'default' configuration as it is
+# the case on new installations with bootupd where it is not needed.
+if ! test -f /etc/default/grub; then
+    exit 0
+fi
+
 # Gracefully exit if the grub2 configuration has BLS enabled,
 # and the installed version has support for the blscfg module.
 # Since there is no need to create menu entries for that case.


### PR DESCRIPTION
grub2-15_ostree: Graceful exit if /etc/default/grub doesn't exist

With the new bootupd installation path in Anaconda, the
`/etc/default/grub` config file is not written anymore as we are only
using BLS configs with new enough bootloaders.

We thus don't need to generate (duplicated) legacy boot entries.

We still need to keep this logic in place in Atomic Desktops
(Silverblue, etc.) until we've actually landed bootupd there and forced
a bootloader update for everybody.

See: https://github.com/fedora-silverblue/issue-tracker/issues/530
See: https://github.com/fedora-silverblue/issue-tracker/issues/120
See: https://fedoraproject.org/wiki/Changes/FedoraSilverblueBootupd

---

grub2-15_ostree: Fix whitespace