### PR TITLE
libostree: write selinux xattr when on non-selinux systems

### DIFF
--- a/.github/workflows/bootc.yaml
+++ b/.github/workflows/bootc.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: bootc install
         run: |
           set -xeuo pipefail
-          sudo podman run --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \
+          sudo podman run --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \
             -v /var/lib/containers:/var/lib/containers \
             localhost/test:latest bootc install to-filesystem --skip-fetch-check \
-            --disable-selinux --replace=alongside /target
+             --replace=alongside /target
+          # Verify labeling for /etc
+          sudo ls -dZ /ostree/deploy/default/deploy/*.0/etc |grep :etc_t:

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -195,7 +195,7 @@ create_file_copy_from_input_at (OstreeRepo *repo, OstreeRepoCheckoutAtOptions *o
   g_autoptr (GVariant) modified_xattrs = NULL;
 
   /* If we're doing SELinux labeling, prepare it */
-  if (sepolicy_enabled)
+  if (sepolicy_enabled && ostree_sepolicy_host_enabled (options->sepolicy))
     {
       /* If doing sepolicy path-based labeling, we don't want to set the
        * security.selinux attr via the generic xattr paths in either the symlink
@@ -1045,7 +1045,7 @@ checkout_tree_at_recurse (OstreeRepo *self, OstreeRepoCheckoutAtOptions *options
     };
 
     /* If we're doing SELinux labeling, prepare it */
-    if (sepolicy_enabled)
+    if (sepolicy_enabled && ostree_sepolicy_host_enabled (options->sepolicy))
       {
         /* We'll set the xattr via setfscreatecon(), so don't do it via generic xattrs below. */
         modified_xattrs = _ostree_filter_selinux_xattr (xattrs);

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -753,3 +753,19 @@ _ostree_filter_selinux_xattr (GVariant *xattrs)
     return NULL;
   return g_variant_ref_sink (g_variant_builder_end (&builder));
 }
+
+/**
+ * ostree_sepolicy_host_enabled:
+ * @self: Policy
+ *
+ * Return if the host has selinux enabled
+ */
+gboolean
+ostree_sepolicy_host_enabled (OstreeSePolicy *self)
+{
+#ifdef HAVE_SELINUX
+  return cached_is_selinux_enabled ();
+#else
+  return FALSE;
+#endif
+}

--- a/src/libostree/ostree-sepolicy.h
+++ b/src/libostree/ostree-sepolicy.h
@@ -77,4 +77,7 @@ void ostree_sepolicy_fscreatecon_cleanup (void **unused);
 #define ostree_cleanup_sepolicy_fscreatecon \
   __attribute__ ((cleanup (ostree_sepolicy_fscreatecon_cleanup)))
 
+_OSTREE_PUBLIC
+gboolean ostree_sepolicy_host_enabled (OstreeSePolicy *self);
+
 G_END_DECLS


### PR DESCRIPTION
Currently when writing data for selinux systems on a non-selinux system there will be no labels. This is because
`ostree_sepolicy_setfscreatecon()` just returns TRUE on non-selinux systems and xattr writing for `security.seliux` is filtered out.

This patches uses the suggestion of Colin Walters (thanks!) from https://github.com/ostreedev/ostree/issues/2804 and detects if the host has selinux enabled and if not just skips filtering the xattrs for selinux.


[draft as this will need a test (and validation of the basic approach by someone experienced) and I will need a hint how to best test this]