### PR TITLE
ci: Add a bootc/c9s workflow

### DIFF
--- a/.github/workflows/bootc.yaml
+++ b/.github/workflows/bootc.yaml
@@ -1,0 +1,41 @@
+name: ci-bootc
+
+permissions:
+  actions: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  c9s-bootc-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      # We use docker to build because it updates to the latest, whereas right now ubuntu-latest
+      # has podman and buildah from ~2021 (insane!)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v3
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/Containerfile.c9s
+          load: true
+          tags: localhost/test:latest
+      - name: Copy to podman
+        run: sudo skopeo copy docker-daemon:localhost/test:latest containers-storage:localhost/test:latest
+      - name: bootc install
+        run: |
+          set -xeuo pipefail
+          sudo podman run --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \
+            -v /var/lib/containers:/var/lib/containers \
+            localhost/test:latest bootc install to-filesystem --skip-fetch-check \
+            --disable-selinux --replace=alongside /target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,30 +80,6 @@ jobs:
         with:
           name: inst.tar.zst
           path: inst.tar.zst
-  build-c9s:
-    name: "Build (C9S)"
-    runs-on: ubuntu-latest
-    container: quay.io/centos/centos:stream9
-    steps:
-      - name: Install bootstrap dependencies
-        run: dnf -y install git-core dnf-utils zstd
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      # https://github.com/actions/checkout/issues/760
-      - name: Mark git checkout as safe
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Install build dependencies
-        run:  dnf config-manager --enable crb && dnf builddep -y ostree
-      - name: Build
-        run: |
-          env NOCONFIGURE=1 ./autogen.sh &&
-          ./configure --with-curl --with-selinux --with-dracut=yesbutnoconf &&
-          make -j 4 && make install DESTDIR=$(pwd)/install && tar -c -C install --zstd -f inst.tar.zst .
-      - name: Upload binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: inst-c9s.tar.zst
-          path: inst.tar.zst
   privtest:
     name: "Privileged testing"
     needs: [build-c, build-integration]

--- a/ci/Containerfile.c9s
+++ b/ci/Containerfile.c9s
@@ -1,0 +1,11 @@
+FROM quay.io/centos/centos:stream9 as build
+RUN dnf -y install dnf-utils zstd && dnf config-manager --enable crb && dnf builddep -y ostree
+COPY . /build
+WORKDIR /build
+RUN env NOCONFIGURE=1 ./autogen.sh && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc --with-curl --with-selinux --with-dracut=yesbutnoconf && \
+    make -j 8 && \
+    make install DESTDIR=$(pwd)/target/inst
+
+FROM quay.io/centos-bootc/centos-bootc-dev:stream9
+COPY --from=build /build/target/inst/ /

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -38,6 +38,9 @@ pkg_install_buildroot() {
     case "${OS_ID}" in
         fedora)
             pkg_install dnf-plugins-core @buildsys-build;;
+        centos)
+            # Sadly this stuff is actually hardcoded in *Python code* in mock...
+            dnf -y install make gcc;;
         *) fatal "pkg_install_buildroot(): Unhandled OS ${OS_ID}";;
     esac
 }


### PR DESCRIPTION
This obsoletes the "just build" on c9s flow, and actually runs though a bootc install, which exercises more of things.