### PR TITLE
admin/state-overlay: Require root and don't lock sysroot

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -260,9 +260,14 @@ _ostree_impl_system_generator (const char *normal_dir, const char *early_dir, co
   g_autofree char *cmdline = read_proc_cmdline ();
   if (!cmdline)
     return glnx_throw (error, "Failed to read /proc/cmdline");
+
   g_autofree char *ostree_cmdline = otcore_find_proc_cmdline_key (cmdline, "ostree");
-  // SAFETY: If we have /run/ostree, then we must have the ostree= karg
-  g_assert (ostree_cmdline);
+
+  /* This could happen in CoreOS live environments, where we hackily mock
+   * the `ostree=` karg for `ostree-prepare-root.service` specifically, but
+   * otherwise that karg doesn't exist on the real command-line. */
+  if (!ostree_cmdline)
+    return TRUE;
 
   if (!require_internal_units (normal_dir, early_dir, late_dir, error))
     return FALSE;

--- a/src/ostree/ot-admin-builtin-state-overlay.c
+++ b/src/ostree/ot-admin-builtin-state-overlay.c
@@ -243,8 +243,9 @@ ot_admin_builtin_state_overlay (int argc, char **argv, OstreeCommandInvocation *
   /* First parse the args without loading the sysroot to see what options are
    * set. */
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE, invocation, &sysroot,
-                                          cancellable, error))
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER
+                                              | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
+                                          invocation, &sysroot, cancellable, error))
     return FALSE;
 
   if (argc < 3)


### PR DESCRIPTION
Not required for anything in particular, but it's good to use the right flags here anyway.