### PR TITLE
Revert "Enable `sysroot.bootprefix` by default"

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3346,7 +3346,7 @@ reload_sysroot_config (OstreeRepo *self, GCancellable *cancellable, GError **err
       g_hash_table_replace (self->bls_append_values, key, value);
     }
 
-  if (!ot_keyfile_get_boolean_with_default (self->config, "sysroot", "bootprefix", TRUE,
+  if (!ot_keyfile_get_boolean_with_default (self->config, "sysroot", "bootprefix", FALSE,
                                             &self->enable_bootprefix, error))
     return FALSE;
 

--- a/tests/test-admin-deploy-bootprefix.sh
+++ b/tests/test-admin-deploy-bootprefix.sh
@@ -25,19 +25,11 @@ set -euo pipefail
 setup_os_repository "archive" "syslinux"
 
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
-# sysroot.bootprefix is on by default now
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set sysroot.bootprefix 'true'
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=root --os=testos testos:testos/buildmain/x86_64-runtime
 assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'linux /boot/ostree/testos-'
 assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'initrd /boot/ostree/testos-'
 
-tap_ok "bootprefix on"
-
-${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set sysroot.bootprefix 'false'
-${CMD_PREFIX} ostree admin undeploy 0
-${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=root --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'linux /ostree/testos-'
-assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'initrd /ostree/testos-'
-
-tap_ok "bootprefix off"
+tap_ok "bootprefix"
 
 tap_end


### PR DESCRIPTION
This reverts commit 8627c8afa15fa0b2dc2dc261a217dd043a991a7d.

See discussion in https://github.com/ostreedev/ostree/pull/3156 ; we think this breaks s390x in some cases at least, and that warrants further investigation.