### PR TITLE
ostree-grub-generator: allow adding custom scripts to grub.cfg

### DIFF
--- a/src/boot/grub2/ostree-grub-generator
+++ b/src/boot/grub2/ostree-grub-generator
@@ -25,6 +25,7 @@ script=$(basename ${0})
 # Atomically safe location where to generete grub.cfg when executing system upgrade.
 new_grub2_cfg=${2}
 entries_path=$(dirname $new_grub2_cfg)/entries
+custom_scripts="/etc/ostree.d"
 
 read_config()
 {
@@ -105,10 +106,22 @@ timeout=10
 EOF
 }
 
+populate_custom_section()
+{
+if [ -d "$custom_scripts" ]; then
+    for script in $(ls -v $custom_scripts/*); do
+        echo -e "\n### BEGIN ${script} ###" >> ${new_grub2_cfg} 
+        cat ${script} >> ${new_grub2_cfg}
+        echo -e "\n### END ${script} ###\n" >> ${new_grub2_cfg}
+    done
+fi
+}
+
 generate_grub2_cfg()
 {
     populate_warning
     populate_header
+    populate_custom_section
     populate_menu
 }
 


### PR DESCRIPTION
Hello!
I would like to propose this change here, since this may help someone else.

First the motivation for this change: rollback
We wanted to be able to perform a rollback if our update was unsuccessful in some way. And for that we needed to add some logic to `grub.cfg` script to get it done.

With that in mind, I tried to do this without changing too much or just manually editing `grub.cfg`. I took some inspiration on what `grub-mkconfig` does: check `/etc/grub.d` for custom scripts, and add those to the final `grub.cfg` script, parsing the files in their alphabetical order.

So with this change, whatever files found under `/etc/ostree.d` (just went with whatever name at the time) are added (in alphabetical order) between the cfg header and its menuentries, allowing to add custom logic to the bootloader in a non intrusive way.

NOTE: we're using this on Yocto, so there's also a minor change to be done in ostree recipe, to create the `/etc` folder being used.