### PR TITLE
Fix booted deploy detection with transient /etc

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -74,8 +74,8 @@ struct OstreeSysroot
   /* The device/inode for / and /etc, used to detect booted deployment */
   dev_t root_device;
   ino_t root_inode;
-  dev_t etc_device;
-  ino_t etc_inode;
+  dev_t deploydir_device;
+  ino_t deploydir_inode;
 
   gboolean is_physical; /* TRUE if we're pointed at physical storage root and not a deployment */
   GPtrArray *deployments;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -808,17 +808,7 @@ parse_deployment (OstreeSysroot *self, const char *boot_link, OstreeDeployment *
   if (looking_for_booted_deployment)
     {
       struct stat stbuf;
-      struct stat etc_stbuf = {};
       if (!glnx_fstat (deployment_dfd, &stbuf, error))
-        return FALSE;
-
-      /* We look for either the root or the etc subdir of the
-       * deployment. We need to do this, because when using composefs,
-       * the root is not a bind mount of the deploy dir, but the etc
-       * dir is.
-       */
-
-      if (!glnx_fstatat_allow_noent (deployment_dfd, "etc", &etc_stbuf, 0, error))
         return FALSE;
 
       /* A bit ugly, we're assigning to a sysroot-owned variable from deep in
@@ -827,7 +817,7 @@ parse_deployment (OstreeSysroot *self, const char *boot_link, OstreeDeployment *
        */
       is_booted_deployment
           = (stbuf.st_dev == self->root_device && stbuf.st_ino == self->root_inode)
-            || (etc_stbuf.st_dev == self->etc_device && etc_stbuf.st_ino == self->etc_inode);
+            || (stbuf.st_dev == self->deploydir_device && stbuf.st_ino == self->deploydir_inode);
     }
 
   g_autoptr (OstreeDeployment) ret_deployment
@@ -1029,13 +1019,13 @@ ostree_sysroot_initialize (OstreeSysroot *self, GError **error)
       }
 
       {
-        struct stat etc_stbuf;
-        if (!glnx_fstatat_allow_noent (AT_FDCWD, "/etc", &etc_stbuf, 0, error))
+        struct stat deploydir_stbuf;
+        if (!glnx_fstatat_allow_noent (AT_FDCWD, OTCORE_RUN_DEPLOYDIR, &deploydir_stbuf, 0, error))
           return FALSE;
         if (errno != ENOENT)
           {
-            self->etc_device = etc_stbuf.st_dev;
-            self->etc_inode = etc_stbuf.st_ino;
+            self->deploydir_device = deploydir_stbuf.st_dev;
+            self->deploydir_inode = deploydir_stbuf.st_ino;
           }
       }
 

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -55,6 +55,8 @@ GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
 // we make it with mode 0 (which requires CAP_DAC_OVERRIDE to pass through).
 #define OTCORE_RUN_OSTREE_PRIVATE "/run/ostree/.private"
 
+#define OTCORE_RUN_DEPLOYDIR OTCORE_RUN_OSTREE "/deploy"
+
 // The directory holding extra/backing data for a deployment, such as overlayfs workdirs
 #define OSTREE_DEPLOYMENT_BACKING_DIR "backing"
 // The directory holding the root overlayfs

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -392,6 +392,16 @@ main (int argc, char *argv[])
     err (EXIT_FAILURE, "Failed to create %s", OTCORE_RUN_OSTREE);
   if (mkdirat (AT_FDCWD, OTCORE_RUN_OSTREE_PRIVATE, 0) < 0)
     err (EXIT_FAILURE, "Failed to create %s", OTCORE_RUN_OSTREE_PRIVATE);
+  if (mkdirat (AT_FDCWD, OTCORE_RUN_DEPLOYDIR, 0) < 0)
+    err (EXIT_FAILURE, "Failed to create %s", OTCORE_RUN_DEPLOYDIR);
+
+  /* Bind mount deploy dir (readonly) so we can later find the active deployment */
+  if (mount (deploy_path, OTCORE_RUN_DEPLOYDIR, NULL, MS_BIND | MS_SILENT, NULL) < 0)
+    err (EXIT_FAILURE, "failed to bind-mount deploy dir %s", deploy_path);
+  if (mount (OTCORE_RUN_DEPLOYDIR, OTCORE_RUN_DEPLOYDIR, NULL,
+             MS_BIND | MS_REMOUNT | MS_RDONLY | MS_SILENT, NULL)
+      < 0)
+    err (EXIT_FAILURE, "failed to bind mount (class:readonly) deploy dir");
 
   /* Fall back to querying the repository configuration in the target disk.
    * This is an operating system builder choice.  More info:


### PR DESCRIPTION
When /etc is transient, and composefs is root, there is currently no bind-mount of the deploy directory so the checks for finding if a deploy is booted are failing.

We fix this by bind-mounting the deploy dir as /run/ostree/deploy and use that to look for the booted deploy directory.

This fixes: https://github.com/ostreedev/ostree/issues/316