### PR TITLE
Track deployment root/inode from prepare root

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -74,8 +74,9 @@ struct OstreeSysroot
   /* The device/inode for / and /etc, used to detect booted deployment */
   dev_t root_device;
   ino_t root_inode;
-  dev_t etc_device;
-  ino_t etc_inode;
+
+  // The parsed data from /run/ostree
+  GVariantDict *run_ostree_metadata;
 
   gboolean is_physical; /* TRUE if we're pointed at physical storage root and not a deployment */
   GPtrArray *deployments;

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -82,5 +82,7 @@ GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
 #define OTCORE_RUN_BOOTED_KEY_ROOT_TRANSIENT "root.transient"
 // This key will be present if the sysroot-ro flag was found
 #define OTCORE_RUN_BOOTED_KEY_SYSROOT_RO "sysroot-ro"
+// Always holds the (device, inode) pair of the booted deployment
+#define OTCORE_RUN_BOOTED_KEY_BACKING_ROOTDEVINO "backing-root-device-inode"
 
 #define OTCORE_RUN_BOOTED_KEY_TRANSIENT_ETC "transient-etc"

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -430,6 +430,15 @@ main (int argc, char *argv[])
   GVariantBuilder metadata_builder;
   g_variant_builder_init (&metadata_builder, G_VARIANT_TYPE ("a{sv}"));
 
+  /* Record the underlying plain deployment directory (device,inode) pair
+   * so that it can be later checked by the sysroot code to figure out
+   * which deployment was booted.
+   */
+  if (lstat (".", &stbuf) < 0)
+    err (EXIT_FAILURE, "lstat deploy_root");
+  g_variant_builder_add (&metadata_builder, "{sv}", OTCORE_RUN_BOOTED_KEY_BACKING_ROOTDEVINO,
+                         g_variant_new ("(tt)", (guint64)stbuf.st_dev, (guint64)stbuf.st_ino));
+
   // Tracks if we did successfully enable it at runtime
   bool using_composefs = false;
 


### PR DESCRIPTION


When we added composefs, it broke the logic for detecting the booted
deployment which was previously a direct (device, inode) comparison.
So the code there started looking at `etc`.  However, that in
turns breaks with `etc.transient = true` enabled.

Fix all of this by tracking the real deployment directory's
(device,inode) that we found in `ostree-prepare-root`, and inject
it into the extensible metadata we have in `/run/ostree-booted`
which is designed exactly to pass state between the initramfs
and the real root.

---

