### PR TITLE
tests: Use long key IDs

### DIFF
--- a/tests/test-admin-gpg.sh
+++ b/tests/test-admin-gpg.sh
@@ -34,7 +34,7 @@ setup_os_repository_signed () {
     bootdir=${1:-usr/lib/modules/3.6.0}
 
     oldpwd=`pwd`
-    keyid="472CDAFA"
+    keyid="7FCA23D8472CDAFA"
 
     cd ${test_tmpdir}
     mkdir testos-repo

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -33,7 +33,7 @@ fi
 
 echo "1..7"
 
-keyid="472CDAFA"
+keyid="7FCA23D8472CDAFA"
 oldpwd=`pwd`
 mkdir ostree-srv
 cd ostree-srv


### PR DESCRIPTION
Short key IDs are not secure, and may be rejected by OpenPGP implementations.  See https://evil32.com/