### PR TITLE
docs: Add webrick dependancy for building site locally

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -8,6 +8,7 @@ source "https://rubygems.org"
 group :jekyll_plugins do
   gem "github-pages"
   gem "jekyll-remote-theme"
+  gem "webrick"
 end
 
 # Prefer the GitHub flavored markdown version of kramdown.


### PR DESCRIPTION
This mimics the GitHub Pages environment so that you can build and serve the site locally for testing. It requires webrick these days.