### PR TITLE
test-admin-deploy-var: Don't rely on OSTREE_FEATURES

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -696,18 +696,20 @@ skip_without_fuse () {
     [ -e /etc/mtab ] || skip "no /etc/mtab"
 }
 
-has_gpgme () {
-    local ret
+has_ostree_feature () {
+    local ret=0
+    # Note that this needs to write to a file and then grep the file, to
+    # avoid ostree --version being killed with SIGPIPE and exiting with a
+    # nonzero status under `set -o pipefail`.
     ${CMD_PREFIX} ostree --version > version.txt
-    grep -q -e '- gpgme' version.txt
-    ret=$?
+    grep -q -e "- $1\$" version.txt || ret=$?
     rm -f version.txt
     return ${ret}
 }
 
-skip_without_gpgme() {
-    if ! has_gpgme; then
-        skip "no gpg support compiled in"
+skip_without_ostree_feature () {
+    if ! has_ostree_feature "$1"; then
+        skip "no $1 support compiled in"
     fi
 }
 
@@ -749,21 +751,6 @@ libtest_cleanup_gpg () {
     gpg-connect-agent --homedir "${gpg_homedir}" killagent /bye || true
 }
 libtest_exit_cmds+=(libtest_cleanup_gpg)
-
-has_sign_ed25519 () {
-    local ret
-    ${CMD_PREFIX} ostree --version > version.txt
-    grep -q -e '- sign-ed25519' version.txt
-    ret=$?
-    rm -f version.txt
-    return ${ret}
-}
-
-skip_without_sign_ed25519() {
-    if ! has_sign_ed25519; then
-        skip "no ed25519 support compiled in"
-    fi
-}
 
 # Keys for ed25519 signing tests
 ED25519PUBLIC=

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -54,7 +54,7 @@ function verify_initial_contents() {
 
 n_base_tests=35
 gpg_tests=3
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     echo "1..$(($n_base_tests+$gpg_tests))"
 else
     echo "1..$((n_base_tests))"
@@ -633,7 +633,7 @@ fi
 assert_file_has_content err.txt "404"
 echo "ok pull repo 404"
 
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     cd ${test_tmpdir}
     repo_init --set=gpg-verify=true
     if ${CMD_PREFIX} ostree --repo=repo --depth=0 pull origin main 2>err.txt; then
@@ -653,7 +653,7 @@ assert_file_has_content err.txt "404"
 find ostree-srv/gnomerepo/objects -name '*.dirtree.orig' | while read f; do mv ${f} $(dirname $f)/$(basename ${f} .orig); done
 echo "ok pull repo 404 on dirtree object"
 
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     cd ${test_tmpdir}
     repo_init --set=gpg-verify=true
     ${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo commit ${COMMIT_ARGS} \

--- a/tests/test-admin-deploy-var.sh
+++ b/tests/test-admin-deploy-var.sh
@@ -21,7 +21,7 @@ set -euox pipefail
 
 . $(dirname $0)/libtest.sh
 
-if ! echo "$OSTREE_FEATURES" | grep --quiet --no-messages "initial-var"; then
+if ! has_ostree_feature initial-var; then
     fatal missing initial-var
 fi
 

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -21,10 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-if ! has_gpgme; then
-    echo "1..0 #SKIP no gpg support compiled in"
-    exit 0
-fi
+skip_without_ostree_feature gpgme
 
 if test -z "${OSTREE_HTTPD}"; then
     echo "1..0 #SKIP no ostree-trivial-httpd"

--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -19,11 +19,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '- composefs'; then
-    echo "1..0 #SKIP no composefs support compiled in"
-    exit 0
-fi
-
+skip_without_ostree_feature composefs
 skip_without_user_xattrs
 
 setup_test_repository "bare-user"

--- a/tests/test-create-usb.sh
+++ b/tests/test-create-usb.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-skip_without_gpgme
+skip_without_ostree_feature gpgme
 
 echo "1..5"
 

--- a/tests/test-delta-ed25519.sh
+++ b/tests/test-delta-ed25519.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_user_xattrs
 
-skip_without_sign_ed25519
+skip_without_ostree_feature sign-ed25519
 
 bindatafiles="bash true ostree"
 

--- a/tests/test-export.sh
+++ b/tests/test-export.sh
@@ -19,13 +19,9 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '- libarchive'; then
-    echo "1..0 #SKIP no libarchive support compiled in"
-    exit 0
-fi
-
 . $(dirname $0)/libtest.sh
 
+skip_without_ostree_feature libarchive
 setup_test_repository "archive"
 
 echo '1..6'

--- a/tests/test-find-remotes.sh
+++ b/tests/test-find-remotes.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-skip_without_gpgme
+skip_without_ostree_feature gpgme
 
 echo '1..1'
 

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -22,10 +22,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-if ! has_gpgme; then
-    echo "1..0 #SKIP no gpgme support compiled in"
-    exit 0
-fi
+skip_without_ostree_feature gpgme
 
 num_tests=1
 

--- a/tests/test-libarchive.sh
+++ b/tests/test-libarchive.sh
@@ -19,12 +19,9 @@
 
 set -euo pipefail
 
-if ! ostree --version | grep -q -e '- libarchive'; then
-    echo "1..0 #SKIP no libarchive support compiled in"
-    exit 0
-fi
-
 . $(dirname $0)/libtest.sh
+
+skip_without_ostree_feature libarchive
 
 echo "1..18"
 

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -61,7 +61,7 @@ cmp checkout1.files checkout2.files
 cmp checkout1.files checkout3.files
 echo "ok checkouts same"
 
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     # These tests are needed GPG support
     mkdir repo4
     ostree_repo_init repo4 --mode="archive"

--- a/tests/test-parent.sh
+++ b/tests/test-parent.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_user_xattrs
 
-skip_without_gpgme
+skip_without_ostree_feature gpgme
 
 echo '1..2'
 

--- a/tests/test-pre-signed-pull.sh
+++ b/tests/test-pre-signed-pull.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 echo "1..1"
 
-if ! has_sign_ed25519; then
+if ! has_ostree_feature sign-ed25519; then
     echo "ok pre-signed pull # SKIP due ed25519 unavailability"
     exit 0
 fi

--- a/tests/test-pull-collections.sh
+++ b/tests/test-pull-collections.sh
@@ -33,7 +33,7 @@ do_commit() {
     mkdir -p files
     pushd files
     local GPG_ARGS=""
-    if has_gpgme; then
+    if has_ostree_feature gpgme; then
         GPG_ARGS="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
     fi
     ${CMD_PREFIX} ostree --repo="../${repo}" commit -s "Test ${repo} commit for branch ${branch}" -b "${branch}" ${GPG_ARGS} "$@" > "../${branch}-checksum"
@@ -45,7 +45,7 @@ do_summary() {
     shift 1
 
     local GPG_ARGS=""
-    if has_gpgme; then
+    if has_ostree_feature gpgme; then
         GPG_ARGS="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
     fi
     ${CMD_PREFIX} ostree "--repo=${repo}" summary --update ${GPG_ARGS}
@@ -103,7 +103,7 @@ do_remote_add() {
     shift 2
 
     local GPG_ARGS=""
-    if has_gpgme; then
+    if has_ostree_feature gpgme; then
         GPG_ARGS="--gpg-import=${test_tmpdir}/gpghome/key1.asc"
     fi
     ${CMD_PREFIX} ostree "--repo=${repo}" remote add "${remote_repo}-remote" "file://$(pwd)/${remote_repo}" "$@" ${GPG_ARGS}

--- a/tests/test-pull-contenturl.sh
+++ b/tests/test-pull-contenturl.sh
@@ -29,7 +29,7 @@ fi
 echo "1..2"
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
   COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 fi
 
@@ -47,7 +47,7 @@ cp -a ${test_tmpdir}/ostree-srv ostree
 
 # delete all the meta stuff from here
 rm ostree/gnomerepo/summary
-if has_gpgme; then
+if has_ostree_feature gpgme; then
   rm ostree/gnomerepo/summary.sig
   find ostree/gnomerepo/objects -name '*.commitmeta' | xargs rm
 fi
@@ -63,7 +63,7 @@ echo "http://127.0.0.1:${content_port}" > ${test_tmpdir}/httpd-content-address
 cd ${test_tmpdir}
 mkdir repo
 ostree_repo_init repo
-if has_gpgme; then VERIFY=true; else VERIFY=false; fi
+if has_ostree_feature gpgme; then VERIFY=true; else VERIFY=false; fi
 ${CMD_PREFIX} ostree --repo=repo remote add origin \
   --set=gpg-verify=$VERIFY --set=gpg-verify-summary=$VERIFY \
   --contenturl=$(cat httpd-content-address)/ostree/gnomerepo \
@@ -72,7 +72,7 @@ ${CMD_PREFIX} ostree --repo=repo pull origin:main
 
 echo "ok pull objects from contenturl"
 
-if ! has_gpgme; then
+if ! has_ostree_feature gpgme; then
   echo "ok don't pull sigs from contenturl # SKIP not compiled with gpgme"
 else
   echo "ok don't pull sigs from contenturl"

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
     echo "1..5"
 else
@@ -67,7 +67,7 @@ find repo/objects -name '*.filez' | while read name; do
 done
 echo "ok pull mirror summary"
 
-if ! has_gpgme; then
+if ! has_ostree_feature gpgme; then
     exit 0;
 fi
 

--- a/tests/test-pull-repeated.sh
+++ b/tests/test-pull-repeated.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 fi
 

--- a/tests/test-pull-summary-caching.sh
+++ b/tests/test-pull-summary-caching.sh
@@ -24,10 +24,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-if ! has_gpgme; then
-    echo "1..0 #SKIP no gpg support compiled in"
-    exit 0
-fi
+skip_without_ostree_feature gpgme
 
 # Ensure repo caching is in use.
 unset OSTREE_SKIP_CACHE

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 unset OSTREE_SKIP_CACHE
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
     echo "1..10"
 else
@@ -63,7 +63,7 @@ assert_file_has_content yet-another-copy/yet-another-hello-world "hello world ye
 ${CMD_PREFIX} ostree --repo=repo fsck
 echo "ok pull mirror summary"
 
-if ! has_gpgme; then
+if ! has_ostree_feature gpgme; then
     exit 0;
 fi
 

--- a/tests/test-signed-commit.sh
+++ b/tests/test-signed-commit.sh
@@ -61,7 +61,7 @@ assert_file_has_content_literal err.txt ' No valid signatures found'
 echo "ok dummy sig requires env"
 
 # tests below require libsodium support
-if ! has_sign_ed25519; then
+if ! has_ostree_feature sign-ed25519; then
     echo "ok Detached ed25519 signature # SKIP due libsodium unavailability"
     echo "ok ed25519 signature verified # SKIP due libsodium unavailability"
     echo "ok multiple signing # SKIP due libsodium unavailability"

--- a/tests/test-signed-pull-summary.sh
+++ b/tests/test-signed-pull-summary.sh
@@ -52,7 +52,7 @@ do
             PUBLIC_KEY="dummysign"
             ;;
         ed25519)
-            if ! has_sign_ed25519; then
+            if ! has_ostree_feature sign-ed25519; then
                 echo "ok ${engine} pull mirror summary # SKIP due libsodium unavailability"
                 echo "ok ${engine} pull with signed summary # SKIP due libsodium unavailability"
                 echo "ok ${engine} prune summary cache # SKIP due libsodium unavailability"
@@ -174,7 +174,7 @@ do
 
 done
 
-if ! has_sign_ed25519; then
+if ! has_ostree_feature sign-ed25519; then
     echo "ok ${engine} pull with signed summary remote old summary # SKIP due libsodium unavailability"
     echo "ok ${engine} pull with signed summary broken cache # SKIP due libsodium unavailability"
     exit 0

--- a/tests/test-signed-pull.sh
+++ b/tests/test-signed-pull.sh
@@ -140,7 +140,7 @@ fi
 assert_file_has_content err.txt 'Invalid key reference'
 echo "ok remote add errs"
 
-if ! has_sign_ed25519; then
+if ! has_ostree_feature sign-ed25519; then
     echo "ok ed25519-key pull signed commit # SKIP due libsodium unavailability"
     echo "ok ed25519-key re-pull signature for stored commit # SKIP due libsodium unavailability"
     echo "ok ed25519-key+file pull signed commit # SKIP due libsodium unavailability"

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 echo "1..2"
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 fi
 

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 echo "1..2"
 
 COMMIT_SIGN=""
-if has_gpgme; then
+if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
 fi
 


### PR DESCRIPTION
* tests: Generalize has_gpgme, has_sign_ed25519 into has_ostree_feature

* tests: Use skip_without_ostree_feature to detect libarchive, composefs
    
    This avoids false negatives from `ostree --version | grep -q ...` exiting with failure under `set -o pipefail` because `grep -q` can exit as soon as it sees the desired string, leaving `ostree --version` to be terminated by `SIGPIPE` next time it writes to stdout.

* test-admin-deploy-var: Don't rely on OSTREE_FEATURES
    
    This is set during build-time testing, but unset during "as-installed" tests.
    
    Resolves: https://github.com/ostreedev/ostree/issues/3183