### PR TITLE
deploy: Don't fail if loading composefs configuration fails due to mi…

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -683,8 +683,10 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
     return glnx_prefix_error (error, "Parsing prepare-root config");
   // We always parse the composefs config, because we want to detect and error
   // out if it's enabled, but not supported at compile time.
+  // However, we don't load the keys here, because they may not exist, such
+  // as in the initial deploy
   g_autoptr (ComposefsConfig) composefs_config
-      = otcore_load_composefs_config (prepare_root_config, error);
+      = otcore_load_composefs_config (prepare_root_config, FALSE, error);
   if (!composefs_config)
     return glnx_prefix_error (error, "Reading composefs config");
 

--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -154,7 +154,7 @@ otcore_free_composefs_config (ComposefsConfig *config)
 
 // Parse the [composefs] section of the prepare-root.conf.
 ComposefsConfig *
-otcore_load_composefs_config (GKeyFile *config, GError **error)
+otcore_load_composefs_config (GKeyFile *config, gboolean load_keys, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Loading composefs config", error);
 
@@ -178,7 +178,7 @@ otcore_load_composefs_config (GKeyFile *config, GError **error)
                                           &ret->signature_pubkey, error))
     return NULL;
 
-  if (ret->is_signed)
+  if (ret->is_signed && load_keys)
     {
       ret->pubkeys = g_ptr_array_new_with_free_func ((GDestroyNotify)g_bytes_unref);
 

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -58,7 +58,8 @@ typedef struct
 void otcore_free_composefs_config (ComposefsConfig *config);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (ComposefsConfig, otcore_free_composefs_config)
 
-ComposefsConfig *otcore_load_composefs_config (GKeyFile *config, GError **error);
+ComposefsConfig *otcore_load_composefs_config (GKeyFile *config, gboolean load_keys,
+                                               GError **error);
 
 // Our directory with transient state (eventually /run/ostree-booted should be a link to
 // /run/ostree/booted)

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -277,7 +277,8 @@ main (int argc, char *argv[])
 
   // We always parse the composefs config, because we want to detect and error
   // out if it's enabled, but not supported at compile time.
-  g_autoptr (ComposefsConfig) composefs_config = otcore_load_composefs_config (config, &error);
+  g_autoptr (ComposefsConfig) composefs_config
+      = otcore_load_composefs_config (config, TRUE, &error);
   if (!composefs_config)
     errx (EXIT_FAILURE, "%s", error->message);
 


### PR DESCRIPTION
…ssing keys

When we load the configuration during deploy we don't need to actually use the keys, so avoid loading them. This fixes an issue we had where this broke the initial deploy becasue of a failure to load the key. In our case it fails because the code looks for the config file in the deploy dir, but then for the binding key in the real root.

However, even if it were to look for the key in the deploy dir I don't think it necessarily has to be in the rootfs, it could be only in the initrd.

This fixes https://github.com/ostreedev/ostree/issues/3188