### PR TITLE
Remove ostree= as a hard dependancy from the systemd perspective

### DIFF
--- a/src/boot/ostree-boot-complete.service
+++ b/src/boot/ostree-boot-complete.service
@@ -16,7 +16,6 @@
 [Unit]
 Description=OSTree Complete Boot
 Documentation=man:ostree(1)
-ConditionKernelCommandLine=ostree
 # For now, this is the only condition on which we start, but it's
 # marked as a triggering condition in case in the future we want
 # to do something else.

--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -17,7 +17,6 @@
 Description=OSTree Prepare OS/
 Documentation=man:ostree(1)
 DefaultDependencies=no
-ConditionKernelCommandLine=ostree
 ConditionPathExists=/etc/initrd-release
 OnFailure=emergency.target
 After=sysroot.mount

--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -17,7 +17,6 @@
 Description=OSTree Remount OS/ Bind Mounts
 Documentation=man:ostree(1)
 DefaultDependencies=no
-ConditionKernelCommandLine=ostree
 OnFailure=emergency.target
 Conflicts=umount.target
 # Run after core mounts

--- a/src/boot/ostree-state-overlay@.service
+++ b/src/boot/ostree-state-overlay@.service
@@ -17,7 +17,6 @@
 Description=OSTree State Overlay On /%I
 Documentation=man:ostree(1)
 DefaultDependencies=no
-ConditionKernelCommandLine=ostree
 # run after /var is setup since that's where the upperdir is stored
 # and after boot.mount so we can load the sysroot
 After=var.mount boot.mount


### PR DESCRIPTION
We've been working on re-enabling our Android Boot builds since composefs integration. This problem reared it's head again. The Android Boot images don't use the "ostree=" karg at all (they alternatively use the androidboot.slot_suffix= karg to determine what OSTree to boot into). We've been working around this by faking an ostree= argument of sorts in hacky ways. Ideally we could do a ostree= or androidboot.slot_suffix= karg check but systemd doesn't support that. Checks for ostree= or androidboot.slot_suffix= are already contained in binaries such as ostree-prepare-root, etc. So there are still checks, the systemd check is too limited.