### PR TITLE
prepare-root: Disallow hotfixes if using signed composefs images

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -572,8 +572,10 @@ main (int argc, char *argv[])
    * with ostree admin unlock --hotfix.
    * Note however that root.transient as handled above is effectively a generalization of unlock
    * --hotfix.
+   * Also, hotfixes are incompatible with signed composefs use for security reasons.
    */
-  if (lstat (OTCORE_HOTFIX_USR_OVL_WORK, &stbuf) == 0)
+  if (lstat (OTCORE_HOTFIX_USR_OVL_WORK, &stbuf) == 0
+      && !(using_composefs && composefs_config->is_signed))
     {
       /* Do we have a persistent overlayfs for /usr?  If so, mount it now. */
       const char usr_ovl_options[]


### PR DESCRIPTION
As mentioned in https://github.com/ostreedev/ostree/issues/3187, we can't allow a hotfix overlay of /usr when using signed composefs images as that would allow an attacker to persist something used across boots.