### PR TITLE
sysroot: Reword comment and use gboolean over bool, error handling

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include <stdbool.h>
-
 #include "libglnx.h"
 #include "ostree-bootloader.h"
 #include "ostree.h"
@@ -179,9 +177,8 @@ gboolean _ostree_sysroot_parse_bootdir_name (const char *name, char **out_osname
 gboolean _ostree_sysroot_list_all_boot_directories (OstreeSysroot *self, char ***out_bootdirs,
                                                     GCancellable *cancellable, GError **error);
 
-gboolean _ostree_sysroot_parse_bootlink (const char *bootlink, const bool is_aboot,
-                                         int *out_entry_bootversion, char **out_osname,
-                                         char **out_bootcsum, int *out_treebootserial,
-                                         GError **error);
+gboolean _ostree_sysroot_parse_bootlink (const char *bootlink, int *out_entry_bootversion,
+                                         char **out_osname, char **out_bootcsum,
+                                         int *out_treebootserial, GError **error);
 
 G_END_DECLS

--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -75,7 +75,8 @@ otcore_find_proc_cmdline_key (const char *cmdline, const char *key)
 //
 // If invalid data is found, @error will be set.
 gboolean
-otcore_get_ostree_target (const char *cmdline, bool *is_aboot, char **out_target, GError **error)
+otcore_get_ostree_target (const char *cmdline, gboolean *is_aboot, char **out_target,
+                          GError **error)
 {
   g_assert (cmdline);
   g_assert (out_target && *out_target == NULL);
@@ -84,10 +85,14 @@ otcore_get_ostree_target (const char *cmdline, bool *is_aboot, char **out_target
 
   // First, handle the Android boot case
   g_autofree char *slot_suffix = otcore_find_proc_cmdline_key (cmdline, "androidboot.slot_suffix");
-  *is_aboot = false;
+  if (is_aboot)
+    *is_aboot = false;
+
   if (slot_suffix)
     {
-      *is_aboot = true;
+      if (is_aboot)
+        *is_aboot = true;
+
       if (strcmp (slot_suffix, "_a") == 0)
         {
           *out_target = g_strdup (slot_a);

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -44,7 +44,7 @@ gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes
                                             bool *out_valid, GError **error);
 
 char *otcore_find_proc_cmdline_key (const char *cmdline, const char *key);
-gboolean otcore_get_ostree_target (const char *cmdline, bool *is_aboot, char **out_target,
+gboolean otcore_get_ostree_target (const char *cmdline, gboolean *is_aboot, char **out_target,
                                    GError **error);
 
 GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -124,8 +124,7 @@ resolve_deploy_path (const char *root_mountpoint)
 
   g_autoptr (GError) error = NULL;
   g_autofree char *ostree_target = NULL;
-  bool is_aboot = false;
-  if (!otcore_get_ostree_target (kernel_cmdline, &is_aboot, &ostree_target, &error))
+  if (!otcore_get_ostree_target (kernel_cmdline, NULL, &ostree_target, &error))
     errx (EXIT_FAILURE, "Failed to determine ostree target: %s", error->message);
   if (!ostree_target)
     errx (EXIT_FAILURE, "No ostree target found");

--- a/tests/test-otcore.c
+++ b/tests/test-otcore.c
@@ -36,47 +36,45 @@ test_prepare_root_cmdline (void)
 {
   g_autoptr (GError) error = NULL;
   g_autofree char *target = NULL;
-  bool is_aboot = false;
-
   static const char *notfound_cases[]
       = { "", "foo", "foo=bar baz  sometest", "xostree foo", "xostree=blah bar", NULL };
   for (const char **iter = notfound_cases; iter && *iter; iter++)
     {
       const char *tcase = *iter;
-      g_assert (otcore_get_ostree_target (tcase, &is_aboot, &target, &error));
+      g_assert (otcore_get_ostree_target (tcase, NULL, &target, &error));
       g_assert_no_error (error);
       g_assert (target == NULL);
     }
 
   // Test the default ostree=
-  g_assert (otcore_get_ostree_target ("blah baz=blah ostree=/foo/bar somearg", &is_aboot, &target,
-                                      &error));
+  g_assert (
+      otcore_get_ostree_target ("blah baz=blah ostree=/foo/bar somearg", NULL, &target, &error));
   g_assert_no_error (error);
   g_assert_cmpstr (target, ==, "/foo/bar");
   free (g_steal_pointer (&target));
 
   // Test android boot
-  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_b somearg", &is_aboot,
+  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_b somearg", NULL,
                                       &target, &error));
   g_assert_no_error (error);
   g_assert_cmpstr (target, ==, "/ostree/root.b");
   free (g_steal_pointer (&target));
 
-  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_a somearg", &is_aboot,
+  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_a somearg", NULL,
                                       &target, &error));
   g_assert_no_error (error);
   g_assert_cmpstr (target, ==, "/ostree/root.a");
   free (g_steal_pointer (&target));
 
   // And an expected failure to parse a "c" suffix
-  g_assert (!otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_c somearg",
-                                       &is_aboot, &target, &error));
+  g_assert (!otcore_get_ostree_target ("blah baz=blah androidboot.slot_suffix=_c somearg", NULL,
+                                       &target, &error));
   g_assert (error);
   g_assert (target == NULL);
   g_clear_error (&error);
 
   // And non-A/B androidboot
-  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.somethingelse somearg", &is_aboot,
+  g_assert (otcore_get_ostree_target ("blah baz=blah androidboot.somethingelse somearg", NULL,
                                       &target, &error));
   g_assert_no_error (error);
   g_assert_cmpstr (target, ==, "/ostree/root.a");


### PR DESCRIPTION
Be more explicit in the comment, and use gboolean over bool. Less header
inclusions when we use gboolean. Although bool is used in some places.
Write a separate _ostree_sysroot_parse_bootlink_aboot function for
aboot. Make is_aboot optional. Handle invalid androidboot karg and no
ostree and androidboot kargs differently.

Co-authored-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Eric Curtin <ecurtin@redhat.com>
