### PR TITLE
sepolicy: Fix publicity mismatch for ostree_sepolicy_host_enabled

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -195,7 +195,7 @@ create_file_copy_from_input_at (OstreeRepo *repo, OstreeRepoCheckoutAtOptions *o
   g_autoptr (GVariant) modified_xattrs = NULL;
 
   /* If we're doing SELinux labeling, prepare it */
-  if (sepolicy_enabled && ostree_sepolicy_host_enabled (options->sepolicy))
+  if (sepolicy_enabled && _ostree_sepolicy_host_enabled (options->sepolicy))
     {
       /* If doing sepolicy path-based labeling, we don't want to set the
        * security.selinux attr via the generic xattr paths in either the symlink
@@ -1045,7 +1045,7 @@ checkout_tree_at_recurse (OstreeRepo *self, OstreeRepoCheckoutAtOptions *options
     };
 
     /* If we're doing SELinux labeling, prepare it */
-    if (sepolicy_enabled && ostree_sepolicy_host_enabled (options->sepolicy))
+    if (sepolicy_enabled && _ostree_sepolicy_host_enabled (options->sepolicy))
       {
         /* We'll set the xattr via setfscreatecon(), so don't do it via generic xattrs below. */
         modified_xattrs = _ostree_filter_selinux_xattr (xattrs);

--- a/src/libostree/ostree-sepolicy-private.h
+++ b/src/libostree/ostree-sepolicy-private.h
@@ -36,4 +36,6 @@ gboolean _ostree_sepolicy_preparefscreatecon (OstreeSepolicyFsCreatecon *con, Os
 
 GVariant *_ostree_filter_selinux_xattr (GVariant *xattrs);
 
+gboolean _ostree_sepolicy_host_enabled (OstreeSePolicy *self);
+
 G_END_DECLS

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -755,13 +755,13 @@ _ostree_filter_selinux_xattr (GVariant *xattrs)
 }
 
 /**
- * ostree_sepolicy_host_enabled:
+ * _ostree_sepolicy_host_enabled:
  * @self: Policy
  *
  * Return if the host has selinux enabled
  */
 gboolean
-ostree_sepolicy_host_enabled (OstreeSePolicy *self)
+_ostree_sepolicy_host_enabled (OstreeSePolicy *self)
 {
 #ifdef HAVE_SELINUX
   return cached_is_selinux_enabled ();

--- a/src/libostree/ostree-sepolicy.h
+++ b/src/libostree/ostree-sepolicy.h
@@ -77,7 +77,4 @@ void ostree_sepolicy_fscreatecon_cleanup (void **unused);
 #define ostree_cleanup_sepolicy_fscreatecon \
   __attribute__ ((cleanup (ostree_sepolicy_fscreatecon_cleanup)))
 
-_OSTREE_PUBLIC
-gboolean ostree_sepolicy_host_enabled (OstreeSePolicy *self);
-
 G_END_DECLS


### PR DESCRIPTION
As this is only used by internal code, just drop the `_OSTREE_PUBLIC` marker for now.  If we have a reason to export it we can do that later.

Closes: https://github.com/ostreedev/ostree/issues/3182