### PR TITLE
docs: Move SPDX identifiers under first title

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 190
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Contributing
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Submitting patches
 

--- a/docs/README-historical.md
+++ b/docs/README-historical.md
@@ -1,15 +1,14 @@
 ---
 nav_order: 990
-title: Historical OSTree README
 ---
+
+# Historical OSTree README
+
 <!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 **This file is outdated, but some of the text here is still useful for
 historical context.  I'm preserving it (explicitly still in the tree)
 for posterity.**
-
-OSTree
-======
 
 Problem statement
 -----------------

--- a/docs/adapting-existing.md
+++ b/docs/adapting-existing.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 70
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Adapting existing mainstream distributions
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## System layout
 

--- a/docs/atomic-rollbacks.md
+++ b/docs/atomic-rollbacks.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 60
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Atomic Rollbacks
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Automatic rollbacks
 

--- a/docs/atomic-upgrades.md
+++ b/docs/atomic-upgrades.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 50
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Atomic Upgrades
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## You can turn off the power anytime you want...
 

--- a/docs/authenticated-repos.md
+++ b/docs/authenticated-repos.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 100
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Handling access to authenticated remote repositories
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 There is no default concept of an "ostree server"; ostree expects to talk to a generic webserver, so any tool and technique applicable for generic HTTP can also apply to fetching content via OSTree's builtin HTTP client.
 

--- a/docs/bootloaders.md
+++ b/docs/bootloaders.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 120
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Bootloaders
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## OSTree and bootloaders
 

--- a/docs/buildsystem-and-repos.md
+++ b/docs/buildsystem-and-repos.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 90
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Writing a buildsystem and managing repositories
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 OSTree is not a package system.  It does not directly support building
 source code.  Rather, it is a tool for transporting and managing

--- a/docs/composefs.md
+++ b/docs/composefs.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 110
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Using composefs with OSTree
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## composefs
 

--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -1,7 +1,6 @@
 ---
 nav_order: 200
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # OSTree Contributing Tutorial
 {: .no_toc }
@@ -10,6 +9,8 @@ The following guide is about OSTree forking, building, adding a command, testing
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Getting Started
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 40
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Deployments
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Overview
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 80
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # OSTree data formats
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## On the topic of "smart servers"
 

--- a/docs/ima.md
+++ b/docs/ima.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 110
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Using Linux IMA with OSTree
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Linux IMA
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 10
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # libostree
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 This project is now known as "libostree", though it is still appropriate to use
 the previous name: "OSTree" (or "ostree"). The focus is on projects which use

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 20
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # OSTree Overview
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Introduction
 

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 110
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Related Projects
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 OSTree is in many ways very evolutionary.  It builds on concepts and
 ideas introduced from many different projects such as

--- a/docs/repo.md
+++ b/docs/repo.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 30
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Anatomy of an OSTree repository
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Core object types and data model
 

--- a/docs/repository-management.md
+++ b/docs/repository-management.md
@@ -1,13 +1,14 @@
 ---
 nav_order: 100
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # Managing content in OSTree repositories
 {: .no_toc }
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 Once you have a build system going, if you actually want client
 systems to retrieve the content, you will quickly feel a need for

--- a/docs/var.md
+++ b/docs/var.md
@@ -1,7 +1,6 @@
 ---
 nav_order: 70
 ---
-<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 # OSTree and /var handling
 
@@ -9,6 +8,8 @@ nav_order: 70
 
 1. TOC
 {:toc}
+
+<!-- SPDX-License-Identifier: (CC-BY-SA-3.0 OR GFDL-1.3-or-later) -->
 
 ## Default commit/image /var handling
 


### PR DESCRIPTION
docs: Move SPDX identifiers under first title

Having a comment right before the first title apparently confuses
Jekyll.

Fixes: https://github.com/ostreedev/ostree/pull/3185

---

docs: Cleanup title for historical OSTree README