### PR TITLE
otcore: Drop config load print

### DIFF
--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -139,8 +139,6 @@ otcore_load_config (int rootfs_fd, const char *filename, GError **error)
       if (fd == -1)
         continue;
 
-      g_print ("Loading %s\n", path);
-
       g_autofree char *buf = glnx_fd_readall_utf8 (fd, NULL, NULL, error);
       if (!buf)
         return NULL;


### PR DESCRIPTION
Now that we're using `otcore_load_config` from the deploy path we end up printing to stdout even for API callers (e.g. our own CLI tools, and rpm-ostree/bootc/etc) which is wrong.

We don't need this print, so just drop it.