### PR TITLE
sysroot: Turn on bootloader-naming-2 by default

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -45,7 +45,7 @@ typedef enum
   OSTREE_SYSROOT_GLOBAL_OPT_SKIP_SYNC = 1 << 0,
   /* See https://github.com/ostreedev/ostree/pull/2847 */
   OSTREE_SYSROOT_GLOBAL_OPT_NO_EARLY_PRUNE = 1 << 1,
-  OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_2 = 1 << 2,
+  OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_1 = 1 << 2,
 } OstreeSysrootGlobalOptFlags;
 
 typedef enum

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -181,7 +181,7 @@ ostree_sysroot_init (OstreeSysroot *self)
   const GDebugKey globalopt_keys[] = {
     { "skip-sync", OSTREE_SYSROOT_GLOBAL_OPT_SKIP_SYNC },
     { "no-early-prune", OSTREE_SYSROOT_GLOBAL_OPT_NO_EARLY_PRUNE },
-    { "bootloader-naming-2", OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_2 },
+    { "bootloader-naming-1", OSTREE_SYSROOT_GLOBAL_OPT_BOOTLOADER_NAMING_1 },
   };
   const GDebugKey keys[] = {
     { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -92,9 +92,9 @@ echo "ok nice error for deploy with no stateroot"
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
 assert_has_dir sysroot/ostree/boot.1.1
-assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* quiet'
+assert_has_file sysroot/boot/loader/entries/ostree-1.conf
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* quiet'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/boot.1/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
@@ -120,7 +120,7 @@ assert_not_has_dir sysroot/ostree/boot.0.0
 assert_not_has_dir sysroot/ostree/boot.1.0
 assert_not_has_dir sysroot/ostree/boot.1.1
 # Ensure we propagated kernel arguments from previous deployment
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/boot.0/testos/${bootcsum}/0/etc/os-release 'NAME=TestOS'
 assert_ostree_deployment_refs 0/1/{0,1}
@@ -147,8 +147,8 @@ ${CMD_PREFIX} ostree admin os-init otheros
 ${CMD_PREFIX} ostree admin deploy --os=otheros testos/buildmain/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
-assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2.conf
+assert_has_file sysroot/boot/loader/entries/ostree-3.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.1/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/deploy/otheros/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
 assert_ostree_deployment_refs 1/1/{0,1,2}
@@ -160,9 +160,9 @@ echo "ok independent deploy"
 ${CMD_PREFIX} ostree admin deploy --retain --os=testos testos:testos/buildmain/x86_64-runtime
 assert_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-4-testos.conf
+assert_has_file sysroot/boot/loader/entries/ostree-4.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.2/etc/os-release 'NAME=TestOS'
-assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2.conf
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.3/etc/os-release 'NAME=TestOS'
 ${CMD_PREFIX} ostree admin status
 assert_ostree_deployment_refs 0/1/{0,1,2,3}
@@ -202,14 +202,14 @@ echo "ok undeploy error invalid int"
 for i in $(seq 4); do
   ${CMD_PREFIX} ostree admin undeploy 0
 done
-assert_has_file sysroot/boot/loader/entries/ostree-1-testos.conf
-assert_not_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
-assert_not_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1.conf
+assert_not_has_file sysroot/boot/loader/entries/ostree-2.conf
+assert_not_has_file sysroot/boot/loader/entries/ostree-3.conf
 ${CMD_PREFIX} ostree admin deploy --not-as-default --os=otheros testos:testos/buildmain/x86_64-runtime
 assert_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
-assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1.conf
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -218,9 +218,9 @@ echo "ok deploy --not-as-default"
 ${CMD_PREFIX} ostree admin deploy --retain-rollback --os=otheros testos:testos/buildmain/x86_64-runtime
 assert_not_has_dir sysroot/boot/loader.0
 assert_has_dir sysroot/boot/loader.1
-assert_has_file sysroot/boot/loader/entries/ostree-3-otheros.conf
-assert_has_file sysroot/boot/loader/entries/ostree-2-testos.conf
-assert_has_file sysroot/boot/loader/entries/ostree-1-otheros.conf
+assert_has_file sysroot/boot/loader/entries/ostree-3.conf
+assert_has_file sysroot/boot/loader/entries/ostree-2.conf
+assert_has_file sysroot/boot/loader/entries/ostree-1.conf
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
 
@@ -228,11 +228,11 @@ echo "ok deploy --retain-rollback"
 
 
 ${CMD_PREFIX} ostree admin status
-assert_file_has_content sysroot/boot/loader/entries/ostree-3-otheros.conf "^title.*TestOS 42 1.0.10"
+assert_file_has_content sysroot/boot/loader/entries/ostree-3.conf "^title.*TestOS 42 1.0.10"
 ${CMD_PREFIX} ostree admin set-default 1
-assert_file_has_content sysroot/boot/loader/entries/ostree-3-testos.conf "^title.*TestOS 42 1.0.10"
+assert_file_has_content sysroot/boot/loader/entries/ostree-3.conf "^title.*TestOS 42 1.0.10"
 ${CMD_PREFIX} ostree admin set-default 1
-assert_file_has_content sysroot/boot/loader/entries/ostree-3-otheros.conf "^title.*TestOS 42 1.0.10"
+assert_file_has_content sysroot/boot/loader/entries/ostree-3.conf "^title.*TestOS 42 1.0.10"
 
 echo "ok set-default"
 
@@ -305,7 +305,7 @@ echo "ok deploy with unknown OS"
 
 ${CMD_PREFIX} ostree admin deploy --os=testos --karg-append=console=/dev/foo --karg-append=console=/dev/bar testos:testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf 'console=/dev/foo.*console=/dev/bar'
+assert_file_has_content sysroot/boot/loader/entries/ostree-4.conf 'console=/dev/foo.*console=/dev/bar'
 validate_bootloader
 
 echo "ok deploy with multiple kernel args"
@@ -315,17 +315,17 @@ os_repository_new_commit 0 "test upgrade multiple kernel args"
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 newrev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
 assert_not_streq ${origrev} ${newrev}
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf 'console=/dev/foo.*console=/dev/bar'
+assert_file_has_content sysroot/boot/loader/entries/ostree-4.conf 'console=/dev/foo.*console=/dev/bar'
 validate_bootloader
 
 echo "ok upgrade with multiple kernel args"
 
 os_repository_new_commit
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 ${version} (ostree:testos:0)$"
+assert_file_has_content sysroot/boot/loader/entries/ostree-4.conf "^title TestOS 42 ${version} (ostree:testos:0)$"
 os_repository_new_commit 0 0 testos/buildmain/x86_64-runtime 42
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-4-testos.conf "^title TestOS 42 (ostree:testos:0)$"
+assert_file_has_content sysroot/boot/loader/entries/ostree-4.conf "^title TestOS 42 (ostree:testos:0)$"
 
 echo "ok no duplicate version strings in title"
 

--- a/tests/inst/src/destructive.rs
+++ b/tests/inst/src/destructive.rs
@@ -563,7 +563,7 @@ fn suppress_ostree_global_sync(sh: &xshell::Shell) -> Result<()> {
     // Aslo opt-in to the new bootloader naming
     std::fs::write(
         Path::new(dropindir).join("50-test-options.conf"),
-        "[Service]\nEnvironment=OSTREE_SYSROOT_OPTS=skip-sync,bootloader-naming-2\n",
+        "[Service]\nEnvironment=OSTREE_SYSROOT_OPTS=skip-sync\n",
     )?;
     cmd!(sh, "systemctl daemon-reload").run()?;
     Ok(())

--- a/tests/test-admin-deploy-2.sh
+++ b/tests/test-admin-deploy-2.sh
@@ -69,9 +69,9 @@ oldversion=${version}
 # another commit with *same* bootcsum but *new* content
 os_repository_new_commit "1" "2"
 newversion=${version}
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf ${oldversion}
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf ${oldversion}
 ${CMD_PREFIX} ostree admin upgrade --os=testos
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf ${newversion}
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf ${newversion}
 
 echo "ok new version same bootcsum"
 

--- a/tests/test-admin-deploy-bootprefix.sh
+++ b/tests/test-admin-deploy-bootprefix.sh
@@ -27,8 +27,8 @@ setup_os_repository "archive" "syslinux"
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set sysroot.bootprefix 'true'
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=root --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'linux /boot/ostree/testos-'
-assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1-testos.conf 'initrd /boot/ostree/testos-'
+assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1.conf 'linux /boot/ostree/testos-'
+assert_file_has_content_literal sysroot/boot/loader/entries/ostree-1.conf 'initrd /boot/ostree/testos-'
 
 tap_ok "bootprefix"
 

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -33,12 +33,12 @@ export rev
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=FOO=BAR --os=testos testos:testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=TESTARG=TESTVALUE --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*TESTARG=TESTVALUE'
 ${CMD_PREFIX} ostree admin deploy --karg=ANOTHERARG=ANOTHERVALUE --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*ANOTHERARG=ANOTHERVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*ANOTHERARG=ANOTHERVALUE'
 
 echo "ok deploy with --karg, but same config"
 
@@ -49,7 +49,7 @@ for arg in $(cat /proc/cmdline); do
 	  ;;
 	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
 	   ;;
-	*) assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf "options.*$arg"
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf "options.*$arg"
 	   ;;
     esac
 done
@@ -60,20 +60,20 @@ ${CMD_PREFIX} ostree admin status
 ${CMD_PREFIX} ostree admin undeploy 0
 
 ${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=APPENDARG=VALAPPEND --karg-append=APPENDARG=2NDAPPEND testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*TESTARG=TESTVALUE'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 
 # Check correct ordering of different-valued args of the same key.
 ${CMD_PREFIX} ostree admin deploy  --os=testos --karg-append=FOO=TESTORDERED --karg-append=APPENDARG=3RDAPPEND testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND .*FOO=TESTORDERED .*APPENDARG=3RDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND .*FOO=TESTORDERED .*APPENDARG=3RDAPPEND'
 
 echo "ok deploy --karg-append"
 
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*quiet .*TESTARG=TESTVALUE .*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*quiet .*TESTARG=TESTVALUE .*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 ${CMD_PREFIX} ostree admin deploy  --os=testos --karg-delete=TESTARG=TESTVALUE --karg-delete=quiet --karg-delete=APPENDARG=VALAPPEND testos:testos/buildmain/x86_64-runtime
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*TESTARG=TESTVALUE'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*quiet'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'options.*APPENDARG=VALAPPEND'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*TESTARG=TESTVALUE'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*quiet'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'options.*APPENDARG=VALAPPEND'
 
 echo "ok deploy --karg-delete"

--- a/tests/test-admin-deploy-nomerge.sh
+++ b/tests/test-admin-deploy-nomerge.sh
@@ -30,11 +30,11 @@ ${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=LABEL=foo --karg=testk
 origdeployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
 testconfig=etc/modified-config-file-that-will-be-removed
 touch "${origdeployment}"/"${testconfig}"
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options.*root=LABEL=foo.*testkarg"
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf "^options.*root=LABEL=foo.*testkarg"
 ${CMD_PREFIX} ostree admin deploy --os=testos --no-merge --karg=root=LABEL=bar testos:testos/buildmain/x86_64-runtime
 deployment=$(${CMD_PREFIX} ostree admin --sysroot=sysroot --print-current-dir)
 assert_not_streq "${origdeployment}" "${deployment}"
 assert_not_has_file "${deployment}/${testconfig}"
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options root=LABEL=bar"
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "^options .*testkarg"
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf "^options root=LABEL=bar"
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf "^options .*testkarg"
 echo "ok no merge deployment"

--- a/tests/test-admin-deploy-none.sh
+++ b/tests/test-admin-deploy-none.sh
@@ -39,7 +39,7 @@ mkdir -p sysroot/boot/grub2
 touch sysroot/boot/grub2/grub.cfg
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os testos testos/buildmain/x86_64-runtime > out.txt
 assert_file_has_content out.txt "Bootloader updated.*"
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/.vmlinuz-3.6.0.hmac  'an hmac file'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -36,8 +36,8 @@ for test_bootdir in "boot" "usr/lib/ostree-boot"; do
     ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
     rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
     ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmain/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
-    assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* quiet'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* root=LABEL=MOO'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* quiet'
     assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
     assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
     # kernel/initrams should also be in the tree's /boot with the checksum
@@ -62,7 +62,7 @@ cd ${test_tmpdir}
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.* root=LABEL=MOO'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.* root=LABEL=MOO'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/vmlinuz-3.6.0 'a kernel'
 assert_file_has_content sysroot/boot/ostree/testos-${bootcsum}/initramfs-3.6.0.img 'an initramfs'
 # Note this bootcsum shouldn't be the modules one

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -32,25 +32,25 @@ ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-run
 
 ${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAR
 ${CMD_PREFIX} ostree admin instutil set-kargs FOO=BAZ FOO=BIF TESTARG=TESTVALUE KEYWORD EMPTYLIST=
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=BAZ .*FOO=BIF'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs (basic)"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge FOO=BAR
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAZ .*FOO=BIF .*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=BAZ .*FOO=BIF .*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs --merge"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --replace=FOO=XXX
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=XXX'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=XXX'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*TESTARG=TESTVALUE KEYWORD EMPTYLIST='
 echo "ok instutil set-kargs --replace"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --merge --append=FOO=BAR --append=APPENDARG=VALAPPEND --append=APPENDARG=2NDAPPEND testos:testos/buildmain/x86_64-runtime
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*FOO=XXX.*FOO=BAR'
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*FOO=XXX.*FOO=BAR'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*APPENDARG=VALAPPEND .*APPENDARG=2NDAPPEND'
 echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
@@ -60,7 +60,7 @@ for arg in $(cat /proc/cmdline); do
 	   ;;
 	initrd=*|BOOT_IMAGE=*) # Skip options set by bootloader that gets filtered out
 	   ;;
-	*) assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf "options.*$arg"
+	*) assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf "options.*$arg"
 	   ;;
     esac
 done

--- a/tests/test-admin-kargs.sh
+++ b/tests/test-admin-kargs.sh
@@ -31,14 +31,14 @@ ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testo
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree admin kargs edit-in-place --append-if-missing=TESTARG=TESTVALUE --append-if-missing=ARGWITHOUTKEY testos:testos/buildmain/x86_64-runtime
 
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'options.*TESTARG=TESTVALUE .*ARGWITHOUTKEY'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'options.*TESTARG=TESTVALUE .*ARGWITHOUTKEY'
 
 echo "ok kargs edit-in-place (basic)"
 
 ${CMD_PREFIX} ostree admin kargs edit-in-place --append-if-missing=quiet testos:testos/buildmain/x86_64-runtime
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'quiet$'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'quiet$'
 
 ${CMD_PREFIX} ostree admin kargs edit-in-place --append-if-missing=TESTARG=TESTVALUE testos:testos/buildmain/x86_64-runtime
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'TESTARG=TESTVALUE$'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'TESTARG=TESTVALUE$'
 
 echo "ok kargs edit-in-place (duplicate)"

--- a/tests/test-admin-pull-deploy-split.sh
+++ b/tests/test-admin-pull-deploy-split.sh
@@ -44,13 +44,13 @@ ${CMD_PREFIX} ostree admin upgrade --os=testos --pull-only --os=testos > out.txt
 assert_not_file_has_content out.txt 'No update available'
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${parent_rev}.0
 assert_not_has_dir sysroot/ostree/deploy/testos/deploy/${rev}.0
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'TestOS 42 1\.0\.9'
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'TestOS 42 1\.0\.9'
 assert_streq "${rev}" $(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
 # Now, generate new content upstream; we shouldn't pull it
 os_repository_new_commit
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only --os=testos > out.txt
 assert_not_file_has_content out.txt 'No update available'
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'TestOS 42 1\.0\.10'
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'TestOS 42 1\.0\.10'
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${parent_rev}.0
 assert_has_dir sysroot/ostree/deploy/testos/deploy/${rev}.0
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only --os=testos > out.txt

--- a/tests/test-admin-upgrade-endoflife.sh
+++ b/tests/test-admin-upgrade-endoflife.sh
@@ -63,7 +63,7 @@ ${CMD_PREFIX} ostree admin upgrade --os=testos --pull-only
 ${CMD_PREFIX} ostree admin upgrade --os=testos --deploy-only
 
 # Check we got redirected to the new branch
-assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf "${bootcsum}"
+assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf "${bootcsum}"
 rev=$(${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo rev-parse testos/buildmain/newbranch)
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/usr/bin/content-iteration "1"
 

--- a/tests/test-no-initramfs.sh
+++ b/tests/test-no-initramfs.sh
@@ -12,8 +12,8 @@ ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=fals
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmain/x86_64-runtime
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=rootfs --os=testos testos:testos/buildmain/x86_64-runtime
 
-assert_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'root=LABEL=rootfs'
-assert_not_file_has_content sysroot/boot/loader/entries/ostree-1-testos.conf 'init='
+assert_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'root=LABEL=rootfs'
+assert_not_file_has_content sysroot/boot/loader/entries/ostree-1.conf 'init='
 
 echo "ok deployment with initramfs"
 
@@ -63,28 +63,28 @@ for layout in /usr/lib/modules /usr/lib/ostree-boot /boot;
 do
     pull_test_tree "the kernel only"
     ${CMD_PREFIX} ostree admin deploy --os=testos --karg=root=/dev/sda2 --karg=rootwait testos:testos/buildmain/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'rootwait'
-    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'rootwait'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'init='
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'initrd'
 
     echo "ok switching to bootdir with no initramfs layout=$layout"
 
     pull_test_tree "the kernel" "initramfs to assist the kernel"
     ${CMD_PREFIX} ostree admin deploy --os=testos --karg-none --karg=root=LABEL=rootfs testos:testos/buildmain/x86_64-runtime
-    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
-    assert_file_has_content sysroot/boot/$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2-testos.conf "initrd") "initramfs to assist the kernel"
-    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'root=LABEL=rootfs'
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'rootwait'
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'initrd'
+    assert_file_has_content sysroot/boot/$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2.conf "initrd") "initramfs to assist the kernel"
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'root=LABEL=rootfs'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'rootwait'
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'init='
 
     echo "ok switching from no initramfs to initramfs enabled sysroot layout=$layout"
 
     pull_test_tree "the kernel" "" "my .dtb file"
     ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
 
-    assert_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'init='
-    assert_file_has_content sysroot/boot/"$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2-testos.conf 'devicetree')" "my \.dtb file"
-    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2-testos.conf 'initrd'
+    assert_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'init='
+    assert_file_has_content sysroot/boot/"$(get_key_from_bootloader_conf sysroot/boot/loader/entries/ostree-2.conf 'devicetree')" "my \.dtb file"
+    assert_not_file_has_content sysroot/boot/loader/entries/ostree-2.conf 'initrd'
 
     echo "ok switching from initramfs to no initramfs sysroot with devicetree layout=$layout"
 done


### PR DESCRIPTION
I think it's about time we flipped this on by default; like the bootprefix I was a bit too chicken.  We still have a `bootloader-naming-1` that can be flipped on in case of some regression.

Closes: https://github.com/ostreedev/ostree/issues/2961