### PR TITLE
curl: Also map HTTP errors for retries

### DIFF
--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1094,7 +1094,7 @@ on_request_sent (GObject *object, GAsyncResult *result, gpointer user_data)
 #endif
                   break;
                 default:
-                  code = _ostree_fetcher_http_status_code_to_io_error (msg->status_code);
+                  code = _ostree_fetcher_http_status_code_to_io_error (msg->status_code, FALSE);
                   break;
                 }
 

--- a/src/libostree/ostree-fetcher-soup3.c
+++ b/src/libostree/ostree-fetcher-soup3.c
@@ -621,7 +621,7 @@ on_request_sent (GObject *object, GAsyncResult *result, gpointer user_data)
             {
               g_autofree char *uristring
                   = g_uri_to_string (soup_message_get_uri (request->message));
-              GIOErrorEnum code = _ostree_fetcher_http_status_code_to_io_error (status);
+              GIOErrorEnum code = _ostree_fetcher_http_status_code_to_io_error (status, FALSE);
               {
                 g_autofree char *errmsg = g_strdup_printf ("Server returned status %u: %s", status,
                                                            soup_status_get_phrase (status));

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -224,7 +224,7 @@ _ostree_fetcher_should_retry_request (const GError *error, guint n_retries_remai
  * a #GIOErrorEnum. This will return %G_IO_ERROR_FAILED if the status code is
  * unknown or otherwise unhandled. */
 GIOErrorEnum
-_ostree_fetcher_http_status_code_to_io_error (guint status_code)
+_ostree_fetcher_http_status_code_to_io_error (guint status_code, gboolean should_retry)
 {
   switch (status_code)
     {
@@ -235,8 +235,9 @@ _ostree_fetcher_http_status_code_to_io_error (guint status_code)
     case 408: /* SOUP_STATUS_REQUEST_TIMEOUT */
       return G_IO_ERROR_TIMED_OUT;
     case 500: /* SOUP_STATUS_INTERNAL_SERVER_ERROR */
-      return G_IO_ERROR_BUSY;
+      /* retries are always mapped to timeouts, see similar logic in the curl error handling */
+      return should_retry ? G_IO_ERROR_TIMED_OUT : G_IO_ERROR_BUSY;
     default:
-      return G_IO_ERROR_FAILED;
+      return should_retry ? G_IO_ERROR_TIMED_OUT : G_IO_ERROR_FAILED;
     }
 }

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -57,7 +57,7 @@ void _ostree_fetcher_journal_failure (const char *remote_name, const char *url, 
 
 gboolean _ostree_fetcher_should_retry_request (const GError *error, guint n_retries_remaining);
 
-GIOErrorEnum _ostree_fetcher_http_status_code_to_io_error (guint status_code);
+GIOErrorEnum _ostree_fetcher_http_status_code_to_io_error (guint status_code, gboolean retry_all);
 
 G_END_DECLS
 


### PR DESCRIPTION
When we added the retry logic, the intention here was definitely to do it not just for network errors but also e.g. HTTP 500s and the like.

xref https://pagure.io/releng/issue/11439
where we rather painfully debugged that this was missing.