### PR TITLE
sepolicy: Add missing `(nullable)`

### DIFF
--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -497,7 +497,7 @@ ostree_sepolicy_get_path (OstreeSePolicy *self)
  * ostree_sepolicy_get_name:
  * @self:
  *
- * Returns: (transfer none): Type of current policy
+ * Returns: (transfer none) (nullable): Type of current policy
  */
 const char *
 ostree_sepolicy_get_name (OstreeSePolicy *self)


### PR DESCRIPTION
This can return NULL if there's no real policy.

Now obviously we need to update the Rust bindings too but... I am having trouble doing that, we're pretty out of date with upstream.