### PR TITLE
ostree-prepare-root.service: add OnFailureJobMode=isolate

### DIFF
--- a/src/boot/ostree-prepare-root.service
+++ b/src/boot/ostree-prepare-root.service
@@ -19,10 +19,12 @@ Documentation=man:ostree(1)
 DefaultDependencies=no
 ConditionKernelCommandLine=ostree
 ConditionPathExists=/etc/initrd-release
-OnFailure=emergency.target
 After=sysroot.mount
 Requires=sysroot.mount
 Before=initrd-root-fs.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is stronger than the default (`replace`) because it tells systemd to *stop everything* and go to `emergency.target`. In other codebases, this has definitely helped me with the problem of "systemd keeps going even after a failure".

Likely addresses #3219.

See also e.g. https://github.com/coreos/ignition-dracut/commit/3d2e165f97f30c1e62577357f27f32e60e6add18.