### PR TITLE
init-fs: Add --epoch=2

### DIFF
--- a/man/ostree-admin-init-fs.xml
+++ b/man/ostree-admin-init-fs.xml
@@ -87,7 +87,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                     should only be mounted in the final deployment root.  The main exception
                     is <literal>/boot</literal>, which may need to be mounted in some setups
                     before the target root.
-                </para></listitem>
+                </para>
+                <para>
+                    Epoch 2 is the same as 1, except that the toplevel <literal>ostree</literal>
+                    directory is mode 0700, denying access from unprivileged code.  This
+                    is a new recommended best practice as it avoids access to old configuration
+                    files in <literal>/etc</literal> in previous deployments, as well as
+                    potentially old setuid binaries in <literal>/ostree/repo</literal>.
+                </para>
+                </listitem>
             </varlistentry>
         </variablelist>
     </refsect1>          

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -99,6 +99,14 @@ ot_admin_builtin_init_fs (int argc, char **argv, OstreeCommandInvocation *invoca
           return FALSE;
         }
     }
+  else if (opt_epoch == 2)
+    {
+      /* In epoch 2, ostree is 0700 - no access from unprivileged code.  See
+       * https://github.com/ostreedev/ostree/issues/3211
+       */
+      if (!glnx_shutil_mkdir_p_at (root_dfd, "ostree", 0700, cancellable, error))
+        return FALSE;
+    }
 
   g_autoptr (GFile) dir = g_file_new_for_path (sysroot_path);
   g_autoptr (OstreeSysroot) sysroot = ostree_sysroot_new (dir);

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -29,6 +29,10 @@ for flag in --modern --epoch=1; do
     assert_not_has_dir sysrootmin/home
     rm sysrootmin -rf
 done
+mkdir sysrootmin
+${CMD_PREFIX} ostree admin init-fs --epoch=2 sysrootmin
+assert_streq "$(stat -c '%f' sysrootmin/ostree)" 41c0
+assert_not_has_dir sysrootmin/home
 echo "ok init-fs"
 
 function validate_bootloader() {


### PR DESCRIPTION
We want to start switching things so that the toplevel `/ostree` repository is mode 0700, to close off unprivileged code from being able to access it.  Previous deployment roots may have setuid binaries, etc.  The `/var/lib/containers/storage` directory is mode 0700 for this reason I believe.

Closes: https://github.com/ostreedev/ostree/issues/3211