### PR TITLE
prepare-root: Handle non-AB aboot properly

### DIFF
--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -111,6 +111,8 @@ otcore_get_ostree_target (const char *cmdline, gboolean *is_aboot, char **out_ta
    */
   if (proc_cmdline_has_key_starting_with (cmdline, "androidboot."))
     {
+      if (is_aboot)
+        *is_aboot = true;
       *out_target = g_strdup (slot_a);
       return TRUE;
     }


### PR DESCRIPTION
otcore_get_ostree_target() should set is_aboot for android boot systems, but currently it only does this on A/B boot systems, not single-boot-partition systems. Fix this by setting it in the second case.