### PR TITLE
docs: More accurate diagram in bootloaders documentation for aboot

### DIFF
--- a/docs/bootloaders.md
+++ b/docs/bootloaders.md
@@ -30,9 +30,9 @@ For historical reasons, OSTree defaults to detecting the bootloader; if some GRU
 
 ## OSTree and aboot
 
-The Android bootloader is another bootloader than may be used with ostree. It still uses the files in `/boot/loader/entries` as metadata, but the boootloader does not read these files. Android bootloaders package their kernel+initramfs+cmdline+dtb in a signed binary blob called an [Android Boot Image](https://source.android.com/docs/core/architecture/bootloader/boot-image-header). This binary blob then is written to either partition boot_a or boot_b depending on which slot is suitable.
+The Android bootloader is another bootloader that may be used with ostree. It still uses the files in `/boot/loader/entries` as metadata, but the boootloader does not read these files. Android bootloaders package their kernel+initramfs+cmdline+dtb in a signed binary blob called an [Android Boot Image](https://source.android.com/docs/core/architecture/bootloader/boot-image-header). This binary blob then is written to either partition boot_a or boot_b depending on which slot is suitable.
 
-Android bootloaders by design inject kargs into the cmdline, some patches may be required in the Android bootloader implementation to ensure that the firmware does not switch between system_a and system_b partitions by populating a `root=` karg, or that a `ro` karg that is incompatible with ostree is not inserted. Conversly leaving the `androidboot.slot_suffix=` karg injecting functionality is required but this is commonplace for any Android Bootloader that does AB updates.
+Android bootloaders by design inject kargs into the cmdline, some patches may be required in the Android bootloader implementation to ensure that the firmware does not switch between system_a and system_b partitions by populating a `root=` karg, or that a `ro` karg is not inserted (this karg is incompatible with ostree).
 
 We have two accompanying scripts that work with this type of environment:
 

--- a/docs/bootloaders.md
+++ b/docs/bootloaders.md
@@ -41,19 +41,19 @@ We have two accompanying scripts that work with this type of environment:
 [aboot-deploy](https://gitlab.com/CentOS/automotive/rpms/aboot-deploy) reads what the current slot is according to the `androidboot.slot_suffix=` karg, writes to the alternate boot_a or boot_b slot and sets a symlink either /ostree/root.a or /ostree/root.b so that it is known which userspace directory to boot into based on the `androidboot.slot_suffix=` karg, on subsequent boots.
 
 ```
-+-----------------------------+                            +---------------------------------+
-|                             |    +------------------+    |                                 |
-|  firmware appends:          |    |                  |    |                                 |
+                                                           +---------------------------------+
++-----------------------------+    +------------------+    |                                 |
+|  bootloader_a appends karg: |    |                  |    |                                 |
 |                             +--->+ boot_a partition +--->+                                 |
 |  androidboot.slot_suffix=_a |    |                  |    |                  /ostree/root.a |
-|                             |    +------------------+    |                                 |
-|  or                         |                            | system_a partition              |
-|                             |    +------------------+    |                                 |
-|  androidboot.slot_suffix=_b |    |                  |    |                  /ostree/root.b |
++-----------------------------+    +------------------+    |                                 |
+                                                           | system partition                |
++-----------------------------+    +------------------+    |                                 |
+|  bootloader_b appends karg: |    |                  |    |                  /ostree/root.b |
 |                             +--->+ boot_b partition +--->+                                 |
-|  to cmdline                 |    |                  |    |                                 |
-|                             |    +------------------+    |                                 |
-+-----------------------------+                            +---------------------------------+
+|  androidboot.slot_suffix=_b |    |                  |    |                                 |
++-----------------------------+    +------------------+    |                                 |
+                                                           +---------------------------------+
 ```
 
 ## GRUB and os-prober


### PR DESCRIPTION
The android bootloader is also split into two partitions, previously that wasn't represented in the diagram.