### PR TITLE
Sync summary times

### DIFF
--- a/tests/test-rofiles-fuse.sh
+++ b/tests/test-rofiles-fuse.sh
@@ -208,5 +208,5 @@ if fsverity enable checkout-test2/nonhardlinked 2>err.txt; then
     assert_not_streq "${orig_inode}" "${new_inode}"
     echo "ok copyup fsverity"
 else
-    skip "no fsverity support: $(cat err.txt)"
+    echo "ok copyup fsverity # SKIP no fsverity support: $(cat err.txt)"
 fi

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -51,6 +51,14 @@ ${CMD_PREFIX} ostree --repo=repo summary --update
 # Generate a signed summary file.
 ${CMD_PREFIX} ostree --repo=repo summary --update ${COMMIT_SIGN}
 
+# If the signature file was created, it should have the same
+# modification time as the summary file.
+if [ -n "${COMMIT_SIGN}" ]; then
+    stat -c '%y' repo/summary > summary-mtime
+    stat -c '%y' repo/summary.sig > summary.sig-mtime
+    assert_files_equal summary-mtime summary.sig-mtime
+fi
+
 # Try various ways of adding additional data.
 ${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata key="'value'" --add-metadata=key2=true
 ${CMD_PREFIX} ostree --repo=repo summary --update -m some-int='@t 123'
@@ -86,6 +94,14 @@ ${CMD_PREFIX} ostree --repo=repo summary --update
 
 # Generate a signed summary file.
 ${CMD_PREFIX} ostree --repo=repo summary --update ${COMMIT_SIGN}
+
+# If the signature file was created, it should have the same
+# modification time as the summary file.
+if [ -n "${COMMIT_SIGN}" ]; then
+    stat -c '%y' repo/summary > summary-mtime
+    stat -c '%y' repo/summary.sig > summary.sig-mtime
+    assert_files_equal summary-mtime summary.sig-mtime
+fi
 
 # Try various ways of adding additional data.
 ${CMD_PREFIX} ostree --repo=repo summary --update --add-metadata key="'value'" --add-metadata=key2=true


### PR DESCRIPTION
I was looking into an HTTP caching issue in a different project and it occurred to me that there's no reason the `summary` and `summary.sig` files can't have synchronized mtimes since they're now created in a temporary directory. The first commit is unrelated and I can split it out if preferred.