### PR TITLE
ostree-sysroot-deploy: check if deployments are in the same stateroot.

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -125,6 +125,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-admin-locking.sh \
 	tests/test-admin-deploy-clean.sh \
 	tests/test-admin-kargs.sh \
+        tests/test-admin-stateroot.sh \
 	tests/test-reset-nonlinear.sh \
 	tests/test-oldstyle-partial.sh \
 	tests/test-delta.sh \

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2383,6 +2383,12 @@ deployment_bootconfigs_equal (OstreeRepo *repo, OstreeDeployment *a, OstreeDeplo
   if (g_strcmp0 (a_version, b_version) != 0)
     return FALSE;
 
+  /* same stateroot? */
+  const char *a_stateroot = ostree_deployment_get_osname (a);
+  const char *b_stateroot = ostree_deployment_get_osname (b);
+  if (g_strcmp0 (a_stateroot, b_stateroot) != 0)
+    return FALSE;
+
   return TRUE;
 }
 

--- a/tests/test-admin-stateroot.sh
+++ b/tests/test-admin-stateroot.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+# Copyright (C) 2022 Huijing Hei <hhei@redhat.com>
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive" "syslinux"
+
+echo "1..2"
+
+# Initial deployment on testos stateroot
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
+${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmain/x86_64-runtime
+
+REF=$(${CMD_PREFIX} ostree admin status | grep -oE 'testos .*\.0' | sed -e 's/^testos //' -e 's/\.0$//')
+
+# Should prompt bootloader update as it does have a different stateroot
+${CMD_PREFIX} ostree admin stateroot-init testos2
+${CMD_PREFIX} ostree admin deploy ${REF} --os=testos2
+${CMD_PREFIX} ostree admin set-default 1 >out.txt
+
+assert_file_has_content out.txt 'bootconfig swap: yes'
+echo "ok stateroot new-deployment"
+
+# Should not prompt update to bootloader as stateroot/commit and kargs are all the same.
+${CMD_PREFIX} ostree admin deploy ${REF} --os=testos2
+${CMD_PREFIX} ostree admin deploy ${REF} --os=testos2
+${CMD_PREFIX} ostree admin set-default 1 >out.txt
+
+assert_file_has_content out.txt 'bootconfig swap: no'
+echo "ok stateroot equal-deployment"


### PR DESCRIPTION
Our code currently does not check for stateroot as a differentiator between deployments, however given that we allow multiple stateroots, we should see them as different deployments in the same way we check for kargs for example.