### PR TITLE
ci: Only run clang-format on ubuntu-stable GH runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,21 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Test style
         run: ./ci/ci-commitmessage-submodules.sh
+  clang-format:
+    name: "clang-format"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - run: sudo apt install clang-format
+      - name: Test style
+        run: ./ci/clang-format.sh
   build-integration:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/ci/clang-format.sh
+++ b/ci/clang-format.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tests that validate structure of the source code;
+# can be run without building it.
+set -euo pipefail
+
+clang_ver=$(clang-format --version)
+clang_min_ver=15
+version_re=" version ([0-9]+)."
+if [[ $clang_ver =~ $version_re ]]; then
+    if test "${BASH_REMATCH[1]}" -ge "${clang_min_ver}"; then
+        echo -n "checking clang-format... "
+        git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | xargs clang-format --Werror --dry-run
+        echo "ok"
+    else
+        echo "notice: clang-format ${clang_ver}" is too old
+    fi
+else
+    echo "failed to parse clang-format version ${clang_ver}" 1>&2
+    exit 1
+fi

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -15,24 +15,6 @@ done
 echo "ok"
 fi
 
-if command -v clang-format; then
-    clang_ver=$(clang-format --version)
-    clang_min_ver=15
-    version_re=" version ([0-9]+)."
-    if [[ $clang_ver =~ $version_re ]]; then
-        if test "${BASH_REMATCH[1]}" -ge "${clang_min_ver}"; then
-            echo -n "checking clang-format... "
-            git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | xargs clang-format --Werror --dry-run
-            echo "ok"
-        else
-            echo "notice: clang-format ${clang_ver}" is too old
-        fi
-    else
-        echo "failed to parse clang-format version ${clang_ver}" 1>&2
-        exit 1
-    fi
-fi
-
 echo -n 'grep-based static analysis... '
 patterns=(glnx_fd_close)
 for pat in "${patterns[@]}"; do

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -2239,9 +2239,9 @@ ostree_sysroot_deployment_unlock (OstreeSysroot *self, OstreeDeployment *deploym
         g_autofree char *devpath
             = unlocked_state == OSTREE_DEPLOYMENT_UNLOCKED_DEVELOPMENT
                   ? _ostree_sysroot_get_runstate_path (
-                      deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_DEVELOPMENT)
+                        deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_DEVELOPMENT)
                   : _ostree_sysroot_get_runstate_path (
-                      deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_TRANSIENT);
+                        deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_TRANSIENT);
         g_autofree char *devpath_parent = dirname (g_strdup (devpath));
 
         if (!glnx_shutil_mkdir_p_at (AT_FDCWD, devpath_parent, 0755, cancellable, error))


### PR DESCRIPTION
Previously we were running clang-format across multiple operating system versions and hence clang versions, and it turns out clang has changed the preferred formatting multiple times.

We could *probably* dig in and try to pin things more strongly but eh...for now let's arbitrarily just use whatever's in the default GH Action ubuntu-latest runner as that should be equally painful for everyone.