### PR TITLE
sysroot: Handle `/ostree/deploy` having epoch 0

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -85,6 +85,8 @@ struct OstreeSysroot
   OstreeDeployment *booted_deployment;
   OstreeDeployment *staged_deployment;
   GVariant *staged_deployment_data;
+  // True if loaded_ts is initialized
+  gboolean has_loaded;
   struct timespec loaded_ts;
 
   /* Only access through ostree_sysroot_[_get]repo() */

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1261,7 +1261,7 @@ ostree_sysroot_load_if_changed (OstreeSysroot *self, gboolean *out_changed,
   if (!glnx_fstatat (self->sysroot_fd, "ostree/deploy", &stbuf, 0, error))
     return FALSE;
 
-  if (self->loaded_ts.tv_sec == stbuf.st_mtim.tv_sec
+  if (self->has_loaded && self->loaded_ts.tv_sec == stbuf.st_mtim.tv_sec
       && self->loaded_ts.tv_nsec == stbuf.st_mtim.tv_nsec)
     {
       if (out_changed)
@@ -1280,6 +1280,7 @@ ostree_sysroot_load_if_changed (OstreeSysroot *self, gboolean *out_changed,
     return FALSE;
 
   self->loaded_ts = stbuf.st_mtim;
+  self->has_loaded = TRUE;
 
   if (out_changed)
     *out_changed = TRUE;

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -60,7 +60,9 @@ orig_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmain/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmain/x86_64-runtime)
 export rev
-# This initial deployment gets kicked off with some kernel arguments
+# This initial deployment gets kicked off with some kernel arguments.  We also set the initial
+# timestamp of the deploy directory to the epoch as a regression test.
+touch -d @0 sysroot/ostree/deploy
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmain/x86_64-runtime
 new_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 assert_not_streq "${orig_mtime}" "${new_mtime}"


### PR DESCRIPTION
Ironically we break if the timestamp there is zero.

Closes: https://github.com/ostreedev/ostree/issues/3022