### PR TITLE
Fix _ostree_ensure_fsverity reporting of supports in early exit

### DIFF
--- a/src/libostree/ostree-repo-verity.c
+++ b/src/libostree/ostree-repo-verity.c
@@ -229,6 +229,9 @@ _ostree_ensure_fsverity (OstreeRepo *self, gboolean allow_enoent, int dirfd, con
   struct stat buf;
   gboolean supported;
 
+  if (supported_out)
+    *supported_out = TRUE;
+
   if (fstatat (dirfd, path, &buf, AT_SYMLINK_NOFOLLOW) != 0)
     {
       if (errno == ENOENT && allow_enoent)


### PR DESCRIPTION
If supported_out is passed to _ostree_ensure_fsverity and we successfully exit early, for example because the file is a symlink, then *supported_out is not initialized.

This is problematic in the case of ostree_sysroot_update_post_copy(), because it passes in an uninitialized supported, and on successfull return of _ostree_ensure_fsverity() it assumes that it is iniialized.

In case supported happened to be initialized to non-zero it will take this branch:

      if (!supported)
        break; /* If not supported, skip rest */

Which means *all* further objects will not get fs-verity enabled.