### PR TITLE
Release 2024.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2024])
 m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2024])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION

```
Alexander Larsson (3):
      _ostree_ensure_fsverity: Properly check for errors
      prepare-root: Handle non-AB aboot properly
      Fix _ostree_ensure_fsverity reporting of supports in early exit

Colin Walters (12):
      configure: post-release version bump
      curl: Also map HTTP errors for retries
      sepolicy: Add missing `(nullable)`
      init-fs: Add --epoch
      init-fs: Add --epoch=2
      tests: Skip composefs tests without the feature
      ci: Drop `SKIP_INSTALLDEPS=1`
      Switch to external composefs
      ci: Only run clang-format on ubuntu-stable GH runner
      ci: Also skip if we detect /run/.containerenv
      sysroot: Handle `/ostree/deploy` having epoch 0
      docs: Describe offline updates with static deltas

Dan Nicholson (2):
      tests: Correctly skip single fsverity test
      repo: Make summary and signature mtime match

Eric Curtin (3):
      README & docs: Remove "RHIVOS" acronym
      docs: More accurate diagram in bootloaders documentation for aboot
      docs: Fix spelling and grammer

Jonathan Lebon (1):
      ostree-prepare-root.service: add OnFailureJobMode=isolate

Joseph Marrero (3):
      ostree-sysroot-deploy: check if deployments are in the same stateroot.
      Release 2024.6
      configure: post-release version bump
```