### PR TITLE
checkout: Add API to directly checkout composefs

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -176,7 +176,7 @@ symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
 if BUILDOPT_IS_DEVEL_BUILD
-#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
 endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -435,6 +435,7 @@ OstreeRepoCheckoutOverwriteMode
 ostree_repo_checkout_tree
 ostree_repo_checkout_tree_at
 ostree_repo_checkout_at
+ostree_repo_checkout_composefs
 ostree_repo_checkout_gc
 ostree_repo_read_commit
 OstreeRepoListObjectsFlags

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,6 +20,11 @@
    - uncomment the include in Makefile-libostree.am
 */
 
+LIBOSTREE_2024.7 {
+global:
+  ostree_repo_checkout_composefs;
+} LIBOSTREE_2023.8;
+
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION

--- a/src/libostree/ostree-repo-composefs.c
+++ b/src/libostree/ostree-repo-composefs.c
@@ -180,14 +180,6 @@ _composefs_write_cb (void *file, void *buf, size_t len)
 
 #else /* HAVE_COMPOSEFS */
 
-static gboolean
-composefs_not_supported (GError **error)
-{
-  g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
-               "composefs is not supported in this ostree build");
-  return FALSE;
-}
-
 #endif
 
 /**
@@ -520,7 +512,7 @@ ensure_lcfs_dir (struct lcfs_node_s *parent, const char *name, GError **error)
 #endif /* HAVE_COMPOSEFS */
 
 /**
- * ostree_repo_checkout_composefs:
+ * _ostree_repo_checkout_composefs:
  * @self: Repo
  * @target: A target for the checkout
  * @source: Source tree
@@ -538,8 +530,8 @@ ensure_lcfs_dir (struct lcfs_node_s *parent, const char *name, GError **error)
  * Returns: %TRUE on success, %FALSE on failure
  */
 gboolean
-ostree_repo_checkout_composefs (OstreeRepo *self, OstreeComposefsTarget *target,
-                                OstreeRepoFile *source, GCancellable *cancellable, GError **error)
+_ostree_repo_checkout_composefs (OstreeRepo *self, OstreeComposefsTarget *target,
+                                 OstreeRepoFile *source, GCancellable *cancellable, GError **error)
 {
 #ifdef HAVE_COMPOSEFS
   GLNX_AUTO_PREFIX_ERROR ("Checking out composefs", error);
@@ -601,7 +593,7 @@ ostree_repo_commit_add_composefs_metadata (OstreeRepo *self, guint format_versio
 
   g_autoptr (OstreeComposefsTarget) target = ostree_composefs_target_new ();
 
-  if (!ostree_repo_checkout_composefs (self, target, repo_root, cancellable, error))
+  if (!_ostree_repo_checkout_composefs (self, target, repo_root, cancellable, error))
     return FALSE;
 
   g_autofree guchar *fsverity_digest = NULL;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -473,9 +473,16 @@ gboolean ostree_composefs_target_write (OstreeComposefsTarget *target, int fd,
                                         guchar **out_fsverity_digest, GCancellable *cancellable,
                                         GError **error);
 
-gboolean ostree_repo_checkout_composefs (OstreeRepo *self, OstreeComposefsTarget *target,
-                                         OstreeRepoFile *source, GCancellable *cancellable,
-                                         GError **error);
+gboolean _ostree_repo_checkout_composefs (OstreeRepo *self, OstreeComposefsTarget *target,
+                                          OstreeRepoFile *source, GCancellable *cancellable,
+                                          GError **error);
+static inline gboolean
+composefs_not_supported (GError **error)
+{
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+               "composefs is not supported in this ostree build");
+  return FALSE;
+}
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeComposefsTarget, ostree_composefs_target_unref)
 

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -841,6 +841,11 @@ gboolean ostree_repo_checkout_at (OstreeRepo *self, OstreeRepoCheckoutAtOptions 
                                   const char *commit, GCancellable *cancellable, GError **error);
 
 _OSTREE_PUBLIC
+gboolean ostree_repo_checkout_composefs (OstreeRepo *self, GVariant *options, int destination_dfd,
+                                         const char *destination_path, const char *checksum,
+                                         GCancellable *cancellable, GError **error);
+
+_OSTREE_PUBLIC
 gboolean ostree_repo_checkout_gc (OstreeRepo *self, GCancellable *cancellable, GError **error);
 
 _OSTREE_PUBLIC

--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -38,4 +38,14 @@ assert_streq "${orig_composefs_digest}" "${new_composefs_digest}"
 assert_streq "${new_composefs_digest}" "be956966c70970ea23b1a8043bca58cfb0d011d490a35a7817b36d04c0210954"
 tap_ok "composefs metadata"
 
+rm test2-co -rf
+$OSTREE checkout --composefs test-composefs test2-co.cfs
+digest=$(sha256sum < test2-co.cfs | cut -f 1 -d ' ')
+# This file should be reproducible bit for bit across environments; per above
+# we're operating on predictable data (fixed uid, gid, timestamps, xattrs, permissions).
+assert_streq "${digest}" "031fab2c7f390b752a820146dc89f6880e5739cba7490f64024e0c7d11aad7c9"
+# Verify it with composefs tooling
+composefs-info dump test2-co.cfs >/dev/null
+tap_ok "checkout composefs"
+
 tap_end


### PR DESCRIPTION
We were missing the simple, obvious API and CLI to go from ostree commit -> composefs.

Internally, we had `ostree_repo_checkout_composefs` with the right "shape" mostly, except it had more code in the deploy path to turn that into a composefs.

Add a straightforward public API that does what
the deploy code did before, and then the old
API becomes an explicitly internal helper with an `_` prefix.

Goals:

- Lead towards a composefs-oriented future
- This makes the composefs logic more testable directly