### PR TITLE
otcore: add debug logging capability for ostree-prepare-root

### DIFF
--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -25,6 +25,24 @@
 // which can be used to fully verify the target filesystem tree.
 #define BINDING_KEYPATH "/etc/ostree/initramfs-root-binding.key"
 
+bool
+proc_cmdline_has_key (const char *cmdline, const char *key)
+{
+  for (const char *iter = cmdline; iter;)
+    {
+      if (g_str_equal (iter, key))
+        return true;
+
+      iter = strchr (iter, ' ');
+      if (iter == NULL)
+        return false;
+
+      iter += strspn (iter, " ");
+    }
+
+  return false;
+}
+
 static bool
 proc_cmdline_has_key_starting_with (const char *cmdline, const char *key)
 {

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -43,6 +43,7 @@ bool otcore_ed25519_init (void);
 gboolean otcore_validate_ed25519_signature (GBytes *data, GBytes *pubkey, GBytes *signature,
                                             bool *out_valid, GError **error);
 
+bool proc_cmdline_has_key (const char *cmdline, const char *key);
 char *otcore_find_proc_cmdline_key (const char *cmdline, const char *key);
 gboolean otcore_get_ostree_target (const char *cmdline, gboolean *is_aboot, char **out_target,
                                    GError **error);


### PR DESCRIPTION
This commit introduces a new function, proc_cmdline_has_key, to check for specific keys in the kernel command line. Additionally, it adds a debug logging mechanism in ostree-prepare-root.c, which is controlled by the presence of the "ostree-prepare-root.debug" key in the kernel command line.

These changes provide enhanced visibility into the mounting process, aiding in troubleshooting.