### PR TITLE
ci: Add buildroot to c9s build

### DIFF
--- a/ci/Containerfile.c9s
+++ b/ci/Containerfile.c9s
@@ -1,4 +1,5 @@
 FROM quay.io/centos/centos:stream9 as build
+COPY ci/c9s-buildroot.repo /etc/yum.repos.d
 RUN dnf -y install dnf-utils zstd && dnf config-manager --enable crb && dnf builddep -y ostree
 COPY . /build
 WORKDIR /build

--- a/ci/c9s-buildroot.repo
+++ b/ci/c9s-buildroot.repo
@@ -1,0 +1,7 @@
+[buildroot]
+name=CentOS Stream $releasever - Koji Local - BUILDROOT ONLY!
+baseurl=https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/
+cost=2000
+enabled=1
+skip_if_unavailable=False
+gpgcheck=0


### PR DESCRIPTION
Because composefs-devel isn't shipped in RHEL.