### PR TITLE
remount: ignore ENOENT error during SELinux relabeling

### DIFF
--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -25,7 +25,7 @@ After=-.mount var.mount
 After=systemd-remount-fs.service
 # But we run *before* most other core bootup services that need write access to /etc and /var
 Before=local-fs.target umount.target
-Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service
+Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service systemd-sysusers.service
 Before=systemd-tmpfiles-setup.service systemd-rfkill.service systemd-rfkill.socket
 
 [Service]


### PR DESCRIPTION
Ignore ENOENT error in selinux_restorecon to avoid failures when temporary files created by systemd-sysusers in /etc are missing during relabeling. This prevents errors such as:

  "Failed to relabel /etc/.#gshadowJzu4Rx: No such file or directory"

and allows the process to continue.