### PR TITLE
Minor cleanup related to composefs

### DIFF
--- a/docs/composefs.md
+++ b/docs/composefs.md
@@ -51,7 +51,7 @@ covering the composefs fsverity digest with a signature.
 ### Signatures
 
 If a commit is signed with an Ed25519 private key (see `ostree
---sign`), and `composefs.keyfile` is specified in `prepare-root.conf`,
+sign`), and `composefs.keyfile` is specified in `prepare-root.conf`,
 then the initrd will find the commit being booted in the system repo
 and validate its signature against the public key. It will then ensure
 that the composefs digest being booted has an fs-verity digest
@@ -63,7 +63,7 @@ to use it with transient keys. This is done like this:
  * Generate a new keypair before each build
  * Embed the public key in the initrd that is part of the commit.
  * Ensure the initrd has a `prepare-root.conf` with `[composefs] enabled=signed`, and either use `keypath` or inject `/etc/ostree/initramfs-root-binding.key`; for more see `man ostree-prepare-root`
- * After committing, run `ostree --sign` with the private key.
+ * After committing, run `ostree sign` with the private key.
  * Throw away the private key.
 
 When a transient key is used this way, that ties the initrd with the

--- a/src/libostree/ostree-repo-verity.c
+++ b/src/libostree/ostree-repo-verity.c
@@ -29,19 +29,6 @@
 #include <linux/fsverity.h>
 #endif
 
-#if defined(HAVE_OPENSSL)
-#include <openssl/bio.h>
-#include <openssl/engine.h>
-#include <openssl/err.h>
-#include <openssl/pem.h>
-#include <openssl/pkcs7.h>
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (X509, X509_free);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (EVP_PKEY, EVP_PKEY_free);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (BIO, BIO_free);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (PKCS7, PKCS7_free);
-#endif
-
 gboolean
 _ostree_repo_parse_fsverity_config (OstreeRepo *self, GError **error)
 {


### PR DESCRIPTION
This fixes `ostree sign` command line in the doc, and removes no longer used OpenSSL includes .