### PR TITLE
remount: Drop `Before=systemd-sysusers.service`

### DIFF
--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -25,7 +25,7 @@ After=-.mount var.mount
 After=systemd-remount-fs.service
 # But we run *before* most other core bootup services that need write access to /etc and /var
 Before=local-fs.target umount.target
-Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service systemd-sysusers.service
+Before=systemd-random-seed.service plymouth-read-write.service systemd-journal-flush.service
 Before=systemd-tmpfiles-setup.service systemd-rfkill.service systemd-rfkill.socket
 
 [Service]


### PR DESCRIPTION
This created an ordering cycle, and I merged over red CI for bad reasons.