### PR TITLE
ci: Bump bootc e2e to latest ubuntu, drop docker

### DIFF
--- a/.github/workflows/bootc.yaml
+++ b/.github/workflows/bootc.yaml
@@ -16,27 +16,16 @@ concurrency:
 
 jobs:
   c9s-bootc-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      # We use docker to build because it updates to the latest, whereas right now ubuntu-latest
-      # has podman and buildah from ~2021 (insane!)
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v3
-      - name: Build and export to Docker
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ci/Containerfile.c9s
-          load: true
-          tags: localhost/test:latest
-      - name: Copy to podman
-        run: sudo skopeo copy docker-daemon:localhost/test:latest containers-storage:localhost/test:latest
+      - name: build
+        run: sudo podman build -t localhost/test:latest -f ci/Containerfile.c9s .
       - name: bootc install
         run: |
           set -xeuo pipefail
           sudo podman run --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --rm -ti --privileged -v /:/target --pid=host --security-opt label=disable \
-            -v /var/lib/containers:/var/lib/containers \
+            -v /dev:/dev -v /var/lib/containers:/var/lib/containers \
             localhost/test:latest bootc install to-filesystem --skip-fetch-check \
              --replace=alongside /target
           # Verify labeling for /etc


### PR DESCRIPTION
As newer docker refuses to talk to ancient skopeo. Update this to use podman directly, also add the missing `-v /dev:/dev`.