### PR TITLE
libostree: Remove compatibility code with GLib < 2.44

### DIFF
--- a/src/libostree/ostree-autocleanups.h
+++ b/src/libostree/ostree-autocleanups.h
@@ -64,15 +64,9 @@ G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (OstreeRepoCommitTraverseIter,
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeCollectionRef, ostree_collection_ref_free)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeCollectionRefv, ostree_collection_ref_freev, NULL)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRemote, ostree_remote_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinder, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderAvahi, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderConfig, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderMount, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderOverride, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderResult, ostree_repo_finder_result_free)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeRepoFinderResultv, ostree_repo_finder_result_freev, NULL)
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSign, g_object_unref)
 #endif
 
 G_END_DECLS

--- a/src/libostree/ostree-repo-finder-avahi.h
+++ b/src/libostree/ostree-repo-finder-avahi.h
@@ -33,33 +33,9 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_REPO_FINDER_AVAHI (ostree_repo_finder_avahi_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 _OSTREE_PUBLIC
 G_DECLARE_FINAL_TYPE (OstreeRepoFinderAvahi, ostree_repo_finder_avahi, OSTREE, REPO_FINDER_AVAHI,
-GObject) */
-
-_OSTREE_PUBLIC
-GType ostree_repo_finder_avahi_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeRepoFinderAvahi OstreeRepoFinderAvahi;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeRepoFinderAvahiClass;
-
-static inline OstreeRepoFinderAvahi *
-OSTREE_REPO_FINDER_AVAHI (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_repo_finder_avahi_get_type (),
-                                     OstreeRepoFinderAvahi);
-}
-static inline gboolean
-OSTREE_IS_REPO_FINDER_AVAHI (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_repo_finder_avahi_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
+                      GObject)
 
 _OSTREE_PUBLIC
 OstreeRepoFinderAvahi *ostree_repo_finder_avahi_new (GMainContext *context);

--- a/src/libostree/ostree-repo-finder-config.h
+++ b/src/libostree/ostree-repo-finder-config.h
@@ -33,33 +33,9 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_REPO_FINDER_CONFIG (ostree_repo_finder_config_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 _OSTREE_PUBLIC
-G_DECLARE_FINAL_TYPE (OstreeRepoFinderConfig, ostree_repo_finder_config, OSTREE,
-REPO_FINDER_CONFIG, GObject) */
-
-_OSTREE_PUBLIC
-GType ostree_repo_finder_config_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeRepoFinderConfig OstreeRepoFinderConfig;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeRepoFinderConfigClass;
-
-static inline OstreeRepoFinderConfig *
-OSTREE_REPO_FINDER_CONFIG (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_repo_finder_config_get_type (),
-                                     OstreeRepoFinderConfig);
-}
-static inline gboolean
-OSTREE_IS_REPO_FINDER_CONFIG (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_repo_finder_config_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
+G_DECLARE_FINAL_TYPE (OstreeRepoFinderConfig, ostree_repo_finder_config, OSTREE, REPO_FINDER_CONFIG,
+                      GObject)
 
 _OSTREE_PUBLIC
 OstreeRepoFinderConfig *ostree_repo_finder_config_new (void);

--- a/src/libostree/ostree-repo-finder-mount.h
+++ b/src/libostree/ostree-repo-finder-mount.h
@@ -33,33 +33,9 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_REPO_FINDER_MOUNT (ostree_repo_finder_mount_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 _OSTREE_PUBLIC
 G_DECLARE_FINAL_TYPE (OstreeRepoFinderMount, ostree_repo_finder_mount, OSTREE, REPO_FINDER_MOUNT,
-GObject) */
-
-_OSTREE_PUBLIC
-GType ostree_repo_finder_mount_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeRepoFinderMount OstreeRepoFinderMount;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeRepoFinderMountClass;
-
-static inline OstreeRepoFinderMount *
-OSTREE_REPO_FINDER_MOUNT (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_repo_finder_mount_get_type (),
-                                     OstreeRepoFinderMount);
-}
-static inline gboolean
-OSTREE_IS_REPO_FINDER_MOUNT (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_repo_finder_mount_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
+                      GObject)
 
 _OSTREE_PUBLIC
 OstreeRepoFinderMount *ostree_repo_finder_mount_new (GVolumeMonitor *monitor);

--- a/src/libostree/ostree-repo-finder-override.h
+++ b/src/libostree/ostree-repo-finder-override.h
@@ -33,33 +33,9 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_REPO_FINDER_OVERRIDE (ostree_repo_finder_override_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 _OSTREE_PUBLIC
 G_DECLARE_FINAL_TYPE (OstreeRepoFinderOverride, ostree_repo_finder_override, OSTREE,
-REPO_FINDER_OVERRIDE, GObject) */
-
-_OSTREE_PUBLIC
-GType ostree_repo_finder_override_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeRepoFinderOverride OstreeRepoFinderOverride;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeRepoFinderOverrideClass;
-
-static inline OstreeRepoFinderOverride *
-OSTREE_REPO_FINDER_OVERRIDE (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_repo_finder_override_get_type (),
-                                     OstreeRepoFinderOverride);
-}
-static inline gboolean
-OSTREE_IS_REPO_FINDER_OVERRIDE (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_repo_finder_override_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
+                      REPO_FINDER_OVERRIDE, GObject)
 
 _OSTREE_PUBLIC
 OstreeRepoFinderOverride *ostree_repo_finder_override_new (void);

--- a/src/libostree/ostree-repo-finder.h
+++ b/src/libostree/ostree-repo-finder.h
@@ -34,33 +34,8 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_REPO_FINDER (ostree_repo_finder_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 _OSTREE_PUBLIC
-G_DECLARE_INTERFACE (OstreeRepoFinder, ostree_repo_finder, OSTREE, REPO_FINDER, GObject) */
-
-_OSTREE_PUBLIC
-GType ostree_repo_finder_get_type (void);
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeRepoFinder OstreeRepoFinder;
-typedef struct _OstreeRepoFinderInterface OstreeRepoFinderInterface;
-
-static inline OstreeRepoFinder *
-OSTREE_REPO_FINDER (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_repo_finder_get_type (), OstreeRepoFinder);
-}
-static inline gboolean
-OSTREE_IS_REPO_FINDER (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_repo_finder_get_type ());
-}
-static inline OstreeRepoFinderInterface *
-OSTREE_REPO_FINDER_GET_IFACE (gpointer ptr)
-{
-  return G_TYPE_INSTANCE_GET_INTERFACE (ptr, ostree_repo_finder_get_type (),
-                                        OstreeRepoFinderInterface);
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
+G_DECLARE_INTERFACE (OstreeRepoFinder, ostree_repo_finder, OSTREE, REPO_FINDER, GObject)
 
 struct _OstreeRepoFinderInterface
 {

--- a/src/libostree/ostree-sign-dummy.c
+++ b/src/libostree/ostree-sign-dummy.c
@@ -41,10 +41,6 @@ struct _OstreeSignDummy
   gchar *pk_ascii;
 };
 
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSignDummy, g_object_unref)
-#endif
-
 static void ostree_sign_dummy_iface_init (OstreeSignInterface *self);
 
 G_DEFINE_TYPE_WITH_CODE (OstreeSignDummy, _ostree_sign_dummy, G_TYPE_OBJECT,

--- a/src/libostree/ostree-sign-dummy.h
+++ b/src/libostree/ostree-sign-dummy.h
@@ -30,36 +30,8 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_SIGN_DUMMY (_ostree_sign_dummy_get_type ())
 
-GType _ostree_sign_dummy_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeSignDummy OstreeSignDummy;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeSignDummyClass;
-
-static inline OstreeSignDummy *
-OSTREE_SIGN_DUMMY (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, _ostree_sign_dummy_get_type (), OstreeSignDummy);
-}
-static inline gboolean
-OSTREE_IS_SIGN_DUMMY (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, _ostree_sign_dummy_get_type ());
-}
-
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-/* Have to use glib-2.44 for this
 _OSTREE_PUBLIC
-G_DECLARE_FINAL_TYPE (OstreeSignDummy,
-                      ostree_sign_dummy,
-                      OSTREE,
-                      SIGN_DUMMY,
-                      GObject)
-*/
+G_DECLARE_FINAL_TYPE (OstreeSignDummy, _ostree_sign_dummy, OSTREE, SIGN_DUMMY, GObject)
 
 const gchar *ostree_sign_dummy_get_name (OstreeSign *self);
 

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -53,10 +53,6 @@ struct _OstreeSignEd25519
   GList *revoked_keys; /* malloc'd buffer of length OSTREE_SIGN_ED25519_PUBKEY_SIZE */
 };
 
-#ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeSignEd25519, g_object_unref)
-#endif
-
 static void ostree_sign_ed25519_iface_init (OstreeSignInterface *self);
 
 G_DEFINE_TYPE_WITH_CODE (OstreeSignEd25519, _ostree_sign_ed25519, G_TYPE_OBJECT,

--- a/src/libostree/ostree-sign-ed25519.h
+++ b/src/libostree/ostree-sign-ed25519.h
@@ -30,36 +30,8 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_SIGN_ED25519 (_ostree_sign_ed25519_get_type ())
 
-GType _ostree_sign_ed25519_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeSignEd25519 OstreeSignEd25519;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeSignEd25519Class;
-
-static inline OstreeSignEd25519 *
-OSTREE_SIGN_ED25519 (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, _ostree_sign_ed25519_get_type (), OstreeSignEd25519);
-}
-static inline gboolean
-OSTREE_IS_SIGN_ED25519 (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, _ostree_sign_ed25519_get_type ());
-}
-
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-/* Have to use glib-2.44 for this
 _OSTREE_PUBLIC
-G_DECLARE_FINAL_TYPE (OstreeSignEd25519,
-                      ostree_sign_ed25519,
-                      OSTREE,
-                      SIGN_ED25519,
-                      GObject)
-*/
+G_DECLARE_FINAL_TYPE (OstreeSignEd25519, _ostree_sign_ed25519, OSTREE, SIGN_ED25519, GObject)
 
 gboolean ostree_sign_ed25519_data (OstreeSign *self, GBytes *data, GBytes **signature,
                                    GCancellable *cancellable, GError **error);

--- a/src/libostree/ostree-sign.h
+++ b/src/libostree/ostree-sign.h
@@ -35,30 +35,6 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_SIGN (ostree_sign_get_type ())
 
-_OSTREE_PUBLIC
-GType ostree_sign_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeSign OstreeSign;
-typedef struct _OstreeSignInterface OstreeSignInterface;
-
-static inline OstreeSign *
-OSTREE_SIGN (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_sign_get_type (), OstreeSign);
-}
-static inline gboolean
-OSTREE_IS_SIGN (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_sign_get_type ());
-}
-static inline OstreeSignInterface *
-OSTREE_SIGN_GET_IFACE (gpointer ptr)
-{
-  return G_TYPE_INSTANCE_GET_INTERFACE (ptr, ostree_sign_get_type (), OstreeSignInterface);
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
-
 /**
  * OSTREE_SIGN_NAME_ED25519:
  * The name of the default ed25519 signing type.
@@ -67,10 +43,8 @@ G_GNUC_END_IGNORE_DEPRECATIONS
  */
 #define OSTREE_SIGN_NAME_ED25519 "ed25519"
 
-/* Have to use glib-2.44 for this
 _OSTREE_PUBLIC
 G_DECLARE_INTERFACE (OstreeSign, ostree_sign, OSTREE, SIGN, GObject)
-*/
 
 struct _OstreeSignInterface
 {

--- a/tests/test-mock-gio.h
+++ b/tests/test-mock-gio.h
@@ -33,134 +33,33 @@ G_BEGIN_DECLS
 
 #define OSTREE_TYPE_MOCK_VOLUME_MONITOR (ostree_mock_volume_monitor_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 G_GNUC_INTERNAL
 G_DECLARE_FINAL_TYPE (OstreeMockVolumeMonitor, ostree_mock_volume_monitor, OSTREE,
-MOCK_VOLUME_MONITOR, GVolumeMonitor) */
-
-G_GNUC_INTERNAL
-GType ostree_mock_volume_monitor_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeMockVolumeMonitor OstreeMockVolumeMonitor;
-typedef struct
-{
-  GVolumeMonitorClass parent_class;
-} OstreeMockVolumeMonitorClass;
-
-static inline OstreeMockVolumeMonitor *
-OSTREE_MOCK_VOLUME_MONITOR (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_mock_volume_monitor_get_type (),
-                                     OstreeMockVolumeMonitor);
-}
-static inline gboolean
-OSTREE_IS_MOCK_VOLUME_MONITOR (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_mock_volume_monitor_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMockVolumeMonitor, g_object_unref)
+                      MOCK_VOLUME_MONITOR, GVolumeMonitor)
 
 G_GNUC_INTERNAL
 GVolumeMonitor *ostree_mock_volume_monitor_new (GList *mounts, GList *volumes);
 
 #define OSTREE_TYPE_MOCK_VOLUME (ostree_mock_volume_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 G_GNUC_INTERNAL
-G_DECLARE_FINAL_TYPE (OstreeMockVolume, ostree_mock_volume, OSTREE, MOCK_VOLUME, GObject) */
-
-G_GNUC_INTERNAL
-GType ostree_mock_volume_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeMockVolume OstreeMockVolume;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeMockVolumeClass;
-
-static inline OstreeMockVolume *
-OSTREE_MOCK_VOLUME (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_mock_volume_get_type (), OstreeMockVolume);
-}
-static inline gboolean
-OSTREE_IS_MOCK_VOLUME (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_mock_volume_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMockVolume, g_object_unref)
+G_DECLARE_FINAL_TYPE (OstreeMockVolume, ostree_mock_volume, OSTREE, MOCK_VOLUME, GObject)
 
 G_GNUC_INTERNAL
 OstreeMockVolume *ostree_mock_volume_new (const gchar *name, GDrive *drive, GMount *mount);
 
 #define OSTREE_TYPE_MOCK_DRIVE (ostree_mock_drive_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 G_GNUC_INTERNAL
-G_DECLARE_FINAL_TYPE (OstreeMockDrive, ostree_mock_drive, OSTREE, MOCK_DRIVE, GObject) */
-
-G_GNUC_INTERNAL
-GType ostree_mock_drive_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeMockDrive OstreeMockDrive;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeMockDriveClass;
-
-static inline OstreeMockDrive *
-OSTREE_MOCK_DRIVE (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_mock_drive_get_type (), OstreeMockDrive);
-}
-static inline gboolean
-OSTREE_IS_MOCK_DRIVE (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_mock_drive_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMockDrive, g_object_unref)
+G_DECLARE_FINAL_TYPE (OstreeMockDrive, ostree_mock_drive, OSTREE, MOCK_DRIVE, GObject)
 
 G_GNUC_INTERNAL
 OstreeMockDrive *ostree_mock_drive_new (gboolean is_removable);
 
 #define OSTREE_TYPE_MOCK_MOUNT (ostree_mock_mount_get_type ())
 
-/* Manually expanded version of the following, omitting autoptr support (for GLib < 2.44):
 G_GNUC_INTERNAL
-G_DECLARE_FINAL_TYPE (OstreeMockMount, ostree_mock_mount, OSTREE, MOCK_MOUNT, GObject) */
-
-G_GNUC_INTERNAL
-GType ostree_mock_mount_get_type (void);
-
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-typedef struct _OstreeMockMount OstreeMockMount;
-typedef struct
-{
-  GObjectClass parent_class;
-} OstreeMockMountClass;
-
-static inline OstreeMockMount *
-OSTREE_MOCK_MOUNT (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_CAST (ptr, ostree_mock_mount_get_type (), OstreeMockMount);
-}
-static inline gboolean
-OSTREE_IS_MOCK_MOUNT (gpointer ptr)
-{
-  return G_TYPE_CHECK_INSTANCE_TYPE (ptr, ostree_mock_mount_get_type ());
-}
-G_GNUC_END_IGNORE_DEPRECATIONS
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMockMount, g_object_unref)
+G_DECLARE_FINAL_TYPE (OstreeMockMount, ostree_mock_mount, OSTREE, MOCK_MOUNT, GObject)
 
 G_GNUC_INTERNAL
 OstreeMockMount *ostree_mock_mount_new (const gchar *name, GFile *root);


### PR DESCRIPTION
As the build system has required GLib 2.44 since commit eb09207e1abd7499bd92866cce1de6148d659a4a, the manual expansion of G_DECLARE_INTERFACE and G_DECLARE_FINAL_TYPE is no longer necessary.