### PR TITLE
prepare-root: Add ostree.prepare-root.composefs

### DIFF
--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -153,6 +153,18 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 commit must match the target composefs image.</para></listitem>
             </varlistentry>
         </variablelist>
+
+        <para>
+            The following kernel commandline parameters are also parsed:
+        </para>
+        <variablelist>
+            <varlistentry>
+                <term><varname>ostree.prepare-root.composefs</varname></term>
+                <listitem><para>This accepts the same values as <literal>composefs.enabled</literal> above, and overrides the config file (if present).
+                    For example, specifying <literal>ostree.prepare-root.composefs=0</literal> will disable composefs, even if it is enabled by default in the initrd config.</para></listitem>
+            </varlistentry>
+        </variablelist>
+
     </refsect1>
 
 

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -655,7 +655,7 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
   // However, we don't load the keys here, because they may not exist, such
   // as in the initial deploy
   g_autoptr (ComposefsConfig) composefs_config
-      = otcore_load_composefs_config (prepare_root_config, FALSE, error);
+      = otcore_load_composefs_config ("", prepare_root_config, FALSE, error);
   if (!composefs_config)
     return glnx_prefix_error (error, "Reading composefs config");
 

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -59,8 +59,8 @@ typedef struct
 void otcore_free_composefs_config (ComposefsConfig *config);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (ComposefsConfig, otcore_free_composefs_config)
 
-ComposefsConfig *otcore_load_composefs_config (GKeyFile *config, gboolean load_keys,
-                                               GError **error);
+ComposefsConfig *otcore_load_composefs_config (const char *cmdline, GKeyFile *config,
+                                               gboolean load_keys, GError **error);
 
 // Our directory with transient state (eventually /run/ostree-booted should be a link to
 // /run/ostree/booted)

--- a/src/libotutil/ot-keyfile-utils.h
+++ b/src/libotutil/ot-keyfile-utils.h
@@ -32,6 +32,9 @@ typedef enum
 
 G_BEGIN_DECLS
 
+gboolean _ostree_parse_boolean (const char *s, gboolean *out_val, GError **error);
+gboolean _ostree_parse_tristate (const char *s, OtTristate *out_tri, GError **error);
+
 gboolean ot_keyfile_get_boolean_with_default (GKeyFile *keyfile, const char *section,
                                               const char *value, gboolean default_value,
                                               gboolean *out_bool, GError **error);

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -290,7 +290,7 @@ main (int argc, char *argv[])
   // We always parse the composefs config, because we want to detect and error
   // out if it's enabled, but not supported at compile time.
   g_autoptr (ComposefsConfig) composefs_config
-      = otcore_load_composefs_config (config, TRUE, &error);
+      = otcore_load_composefs_config (kernel_cmdline, config, TRUE, &error);
   if (!composefs_config)
     errx (EXIT_FAILURE, "%s", error->message);
 

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -113,14 +113,11 @@ sysroot_is_configured_ro (const char *sysroot)
 }
 
 static char *
-resolve_deploy_path (const char *root_mountpoint)
+resolve_deploy_path (const char *kernel_cmdline, const char *root_mountpoint)
 {
   char destpath[PATH_MAX];
   struct stat stbuf;
   char *deploy_path;
-  g_autofree char *kernel_cmdline = read_proc_cmdline ();
-  if (!kernel_cmdline)
-    errx (EXIT_FAILURE, "Failed to read kernel cmdline");
 
   g_autoptr (GError) error = NULL;
   g_autofree char *ostree_target = NULL;
@@ -268,6 +265,10 @@ main (int argc, char *argv[])
     err (EXIT_FAILURE, "usage: ostree-prepare-root SYSROOT");
   const char *root_arg = argv[1];
 
+  g_autofree char *kernel_cmdline = read_proc_cmdline ();
+  if (!kernel_cmdline)
+    errx (EXIT_FAILURE, "Failed to read kernel cmdline");
+
   // Since several APIs want to operate in terms of file descriptors, let's
   // open the initramfs now.  Currently this is just used for the config parser.
   glnx_autofd int initramfs_rootfs_fd = -1;
@@ -308,7 +309,7 @@ main (int argc, char *argv[])
   const char *root_mountpoint = realpath (root_arg, NULL);
   if (root_mountpoint == NULL)
     err (EXIT_FAILURE, "realpath(\"%s\")", root_arg);
-  g_autofree char *deploy_path = resolve_deploy_path (root_mountpoint);
+  g_autofree char *deploy_path = resolve_deploy_path (kernel_cmdline, root_mountpoint);
   const char *deploy_directory_name = glnx_basename (deploy_path);
   // Note that realpath() should have stripped any trailing `/` which shouldn't
   // be in the karg to start with, but we assert here to be sure we have a non-empty

--- a/tests/test-keyfile-utils.c
+++ b/tests/test-keyfile-utils.c
@@ -173,6 +173,42 @@ fill_keyfile (GKeyFile *file)
   g_key_file_set_value (file, "section", "value_bar", "bar");
 }
 
+static void
+test_parse_tristate (void)
+{
+  g_autoptr (GError) error = NULL;
+
+  OtTristate t = OT_TRISTATE_NO;
+  // Verify maybe
+  (void)_ostree_parse_tristate ("maybe", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_MAYBE);
+
+  // Alternate yes and no
+  (void)_ostree_parse_tristate ("yes", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_YES);
+  (void)_ostree_parse_tristate ("no", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_NO);
+  (void)_ostree_parse_tristate ("1", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_YES);
+  (void)_ostree_parse_tristate ("0", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_NO);
+  (void)_ostree_parse_tristate ("true", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_YES);
+  (void)_ostree_parse_tristate ("false", &t, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (t, ==, OT_TRISTATE_NO);
+
+  // And an error case
+  (void)_ostree_parse_tristate ("foobar", &t, &error);
+  g_assert (error != NULL);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -186,6 +222,7 @@ main (int argc, char **argv)
   g_test_add_func ("/keyfile-utils/get-value-with-default-group-optional",
                    test_get_value_with_default_group_optional);
   g_test_add_func ("/keyfile-utils/copy-group", test_copy_group);
+  g_test_add_func ("/keyfile-utils/parse-tristate", test_parse_tristate);
 
   ret = g_test_run ();
 


### PR DESCRIPTION


We have a use case for overriding the composefs state via
the kernel commandline; see e.g.
https://gitlab.com/fedora/bootc/tracker/-/issues/27

Signed-off-by: Colin Walters <walters@verbum.org>