### PR TITLE
repo: NUL terminate readlinkat result

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -73,6 +73,7 @@ _installed_or_uninstalled_test_scripts = \
 	tests/test-remote-headers.sh \
 	tests/test-remote-refs.sh \
 	tests/test-composefs.sh \
+	tests/test-payload-link.sh \
 	tests/test-commit-sign.sh \
 	tests/test-commit-timestamp.sh \
 	tests/test-export.sh \

--- a/tests/test-payload-link.sh
+++ b/tests/test-payload-link.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.0+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+set -euox pipefail
+
+. $(dirname $0)/libtest.sh
+
+touch foo
+if ! cp --reflink=always foo bar &>/dev/null; then
+    skip "no reflinks"
+fi
+rm foo bar
+
+$CMD_PREFIX ostree --repo=repo init --mode=bare-user
+$CMD_PREFIX ostree config --repo=repo set core.payload-link-threshold 0
+
+mkdir d
+echo test > d/testcontent
+chmod 0644 d/testcontent
+$CMD_PREFIX ostree --repo=repo commit --tree=dir=d --consume -b testref
+mkdir d
+echo test > d/testcontent
+chmod 0755 d/testcontent
+$CMD_PREFIX ostree --repo=repo commit --tree=dir=d --consume -b testref
+find repo -type l -name '*.payload-link' >payload-links.txt
+assert_streq "$(wc -l < payload-links.txt)" "1"
+
+tap_ok payload-link
+
+tap_end


### PR DESCRIPTION
Coverity was correctly complaining about this.