### PR TITLE
sysroot: Make coverity happy with dirname+strdup

### DIFF
--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -2243,7 +2243,8 @@ ostree_sysroot_deployment_unlock (OstreeSysroot *self, OstreeDeployment *deploym
                         deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_DEVELOPMENT)
                   : _ostree_sysroot_get_runstate_path (
                         deployment, _OSTREE_SYSROOT_DEPLOYMENT_RUNSTATE_FLAG_TRANSIENT);
-        g_autofree char *devpath_parent = dirname (g_strdup (devpath));
+        g_autofree char *devpath_parent_owned = g_strdup (devpath);
+        const char *devpath_parent = dirname (devpath_parent_owned);
 
         if (!glnx_shutil_mkdir_p_at (AT_FDCWD, devpath_parent, 0755, cancellable, error))
           return FALSE;


### PR DESCRIPTION
Similar to d528083cae3492f9b9424f3c9830869af7b4cbd0 - I don't believe we actually had a leak here because `dirname` always returns the same start pointer, but this makes Coverity happy.