### PR TITLE
commit/payload-link: Ensure we don't overrun target_checksum size

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -820,7 +820,7 @@ _try_clone_from_payload_link (OstreeRepo *self, OstreeRepo *dest_repo, const cha
                            loose_path_buf, (unsigned long long)expected_len,
                            (unsigned long long)size);
 
-      snprintf (target_checksum, size, "%.2s%.62s", target_buf + _OSTREE_PAYLOAD_LINK_PREFIX_LEN,
+      snprintf (target_checksum, sizeof (target_checksum), "%.2s%.62s", target_buf + _OSTREE_PAYLOAD_LINK_PREFIX_LEN,
                 target_buf + _OSTREE_PAYLOAD_LINK_PREFIX_LEN + 3);
 
       _ostree_loose_path (loose_path_target_buf, target_checksum, OSTREE_OBJECT_TYPE_FILE,


### PR DESCRIPTION
This is another warning from recently changed code from Coverity:

```
1. Defect type: OVERRUN
16. libostree-2024.7/src/libostree/ostree-repo-commit.c:823:7: overrun-buffer-arg: Overrunning array "target_checksum" of 65 bytes by passing it to a function which accesses it at byte offset 258 using argument "size" (which evaluates to 259). [Note: The source code implementation of the function has been overridden by a builtin model.]
```

I think this can only happen if the repository is corrupt; the data shouldn't be that long. But fix this by passing the max length we expect; this will ignore the rest currently.