### PR TITLE
feat: Add Custom bootloader names so pretty_name can be static

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1999,7 +1999,9 @@ install_deployment_kernel (OstreeSysroot *sysroot, int new_bootversion,
 
   g_autoptr (GHashTable) osrelease_values = parse_os_release (contents, "\n");
   /* title */
-  const char *val = g_hash_table_lookup (osrelease_values, "PRETTY_NAME");
+  const char *val = g_hash_table_lookup (osrelease_values, "BOOTLOADER_NAME");
+  if (val == NULL)
+    val = g_hash_table_lookup (osrelease_values, "PRETTY_NAME");
   if (val == NULL)
     val = g_hash_table_lookup (osrelease_values, "ID");
   if (val == NULL)


### PR DESCRIPTION
In certain hardware surveys (e.g., Steam), in order for a distribution to be accounted for the PRETTY_NAME is used.

Currently, this name plays a dual role in ostree, where it is displayed on GRUB. This necessitates it changing every version, so that rollbacks are intuitive for users. If this happens, the distribution image has to either be unfairly represented in those surveys OR freeze the version that is displayed in GRUB has to be unintuitive.

Therefore, add a new variable in `/etc/os-release` called `BOOTLOADER_NAME` that will be used with priority compared to the `PRETTY_NAME` of the distribution, thereby allowing an intuitive name for both applications.

(this PR is untested; for now)