### PR TITLE
bootloader/grub2: Handle empty static configs

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -30,6 +30,7 @@
 #define BOOTUPD_CONFIG "boot/bootupd-state.json"
 // Horrible hack, to avoid including a JSON parser we just grep for this
 #define BOOTUPD_CONFIG_STATIC_JSON_FRAGMENT "\"static-configs\""
+#define BOOTUPD_CONFIG_STATIC_JSON_FRAGMENT_NULL "\"static-configs\":null"
 
 /* Maintain backwards compatibility with legacy GRUB
  * installations that might rely on the -16 suffix
@@ -90,9 +91,12 @@ _ostree_bootloader_grub2_query (OstreeBootloader *bootloader, gboolean *out_is_a
         return glnx_prefix_error (error, "Failed to read bootupd config");
       if (strstr (bootupd_config_contents, BOOTUPD_CONFIG_STATIC_JSON_FRAGMENT) != NULL)
         {
-          g_debug ("Found static bootupd config");
-          *out_is_active = FALSE;
-          return TRUE;
+          if (strstr (bootupd_config_contents, BOOTUPD_CONFIG_STATIC_JSON_FRAGMENT_NULL) == NULL)
+            {
+              g_debug ("Found static bootupd config");
+              *out_is_active = FALSE;
+              return TRUE;
+            }
         }
     }
 

--- a/tests/kolainst/destructive/bootupd-static.sh
+++ b/tests/kolainst/destructive/bootupd-static.sh
@@ -10,7 +10,7 @@ bootupd_state=/boot/bootupd-state.json
 mount -o remount,rw /boot
 if grep -qFe "\"static-configs\"" "${bootupd_state}"; then
     echo "Host is using static configs already, overriding this"
-    jq 'del(.["static-configs"])' < "${bootupd_state}" > "${bootupd_state}".new
+    jq --compact-output '.["static-configs"] = null' < "${bootupd_state}" > "${bootupd_state}".new
     mv "${bootupd_state}.new" "${bootupd_state}"
 fi
 


### PR DESCRIPTION
In #3205, we introduced a check to skip re-generating the GRUB config if we detect that static configs are in used by looking at bootupd's state.

Unfortunately this check is incomplete and does not account for present but null entries in the JSON state file.

A proper fix would be to parse the JSON but this requires a larger code change.

Fixes: https://github.com/ostreedev/ostree/issues/3295
Fixes: https://github.com/ostreedev/ostree/pull/3205