### PR TITLE
spec: %autorelease can't be resolved by COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,5 +6,6 @@ srpm:
 	curl -LO https://src.fedoraproject.org/rpms/ostree/raw/rawhide/f/ostree.spec
 	sed -ie "s,^Version:.*,Version: $$(git describe --always --tags --match 'v2???.*' | sed -e 's,-,\.,g' -e 's,^v,,')," ostree.spec
 	sed -ie 's/^Patch/# Patch/g' ostree.spec  # we don't want any downstream patches
+	sed -i 's,%autorelease,1%{?dist},g' ostree.spec # COPR does not support autorelease macro
 	rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" ostree.spec
 	mv *.src.rpm $$outdir


### PR DESCRIPTION
Fix copr build error:
`line 11: Possible unexpanded macro in: Release: %autorelease`