### PR TITLE
curl: Assert that curl_multi_assign worked

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -517,7 +517,8 @@ addsock (curl_socket_t s, CURL *easy, int action, OstreeFetcher *fetcher)
   fdp->refcount = 1;
   fdp->fetcher = fetcher;
   setsock (fdp, s, action, fetcher);
-  curl_multi_assign (fetcher->multi, s, fdp);
+  CURLMcode rc = curl_multi_assign (fetcher->multi, s, fdp);
+  g_assert_cmpint (rc, ==, CURLM_OK);
   g_hash_table_add (fetcher->sockets, fdp);
 }
 


### PR DESCRIPTION
ref https://github.com/ostreedev/ostree/issues/3299

This won't fix that issue, but *if* this assertion triggers it should give us a better idea of the possible codepaths where it is happening.