### PR TITLE
wip: support for quoting devices

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -178,6 +178,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--quote-devices</option></term>
+                <listitem><para>
+                    By default, ostree rejects block and character devices. This option instead "quotes" them
+                    as regular files. In order to be processed back into block and character devices,
+                    the corresponding <literal>--unquote-devices</literal> must be passed to <literal>ostree checkout</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--no-xattrs</option></term>
                 <listitem><para>
                     Do not import extended attributes.

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -519,6 +519,9 @@ typedef OstreeRepoCommitFilterResult (*OstreeRepoCommitFilter) (OstreeRepo *repo
  * modifier filters (non-directories only); Since: 2017.14
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SELINUX_LABEL_V1: For SELinux and other systems, label
  * /usr/etc as if it was /etc.
+ * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_QUOTE_DEVICES: Instead of erroring out on block/character
+ * devices, "quote" them as regular files that can optionally be unpacked back into native devices.
+ * Since: 2024.9
  *
  * Flags modifying commit behavior. In bare-user-only mode,
  * @OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS and
@@ -535,6 +538,7 @@ typedef enum
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME = (1 << 4),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL = (1 << 5),
   OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SELINUX_LABEL_V1 = (1 << 6),
+  OSTREE_REPO_COMMIT_MODIFIER_FLAGS_QUOTE_DEVICES = (1 << 7),
 } OstreeRepoCommitModifierFlags;
 
 /**
@@ -802,12 +806,13 @@ typedef struct
   gboolean enable_uncompressed_cache; /* Deprecated */
   gboolean enable_fsync;              /* Deprecated */
   gboolean process_whiteouts;
+  gboolean unquote_devices; /* Since: 2024.9 */
   gboolean no_copy_fallback;
   gboolean force_copy;           /* Since: 2017.6 */
   gboolean bareuseronly_dirs;    /* Since: 2017.7 */
   gboolean force_copy_zerosized; /* Since: 2018.9 */
   gboolean process_passthrough_whiteouts;
-  gboolean unused_bools[3];
+  gboolean unused_bools[2];
   /* 3 byte hole on 64 bit */
 
   const char *subpath;

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -62,6 +62,7 @@ static char *opt_base;
 static char **opt_trees;
 static gint opt_owner_uid = -1;
 static gint opt_owner_gid = -1;
+static gboolean opt_quote_devices;
 static gboolean opt_table_output;
 #ifndef OSTREE_DISABLE_GPGME
 static char **opt_gpg_key_ids;
@@ -124,6 +125,8 @@ static GOptionEntry options[] = {
   { "owner-gid", 0, 0, G_OPTION_ARG_INT, &opt_owner_gid, "Set file ownership group id", "GID" },
   { "canonical-permissions", 0, 0, G_OPTION_ARG_NONE, &opt_canonical_permissions,
     "Canonicalize permissions in the same way bare-user does for hardlinked files", NULL },
+  { "quote-devices", 0, 0, G_OPTION_ARG_NONE, &opt_quote_devices,
+    "Instead of erroring out on block/character devices, \"quote\" them as regular files", NULL },
   { "bootable", 0, 0, G_OPTION_ARG_NONE, &opt_bootable,
     "Flag this commit as a bootable OSTree (e.g. contains a Linux kernel)", NULL },
   { "mode-ro-executables", 0, 0, G_OPTION_ARG_NONE, &opt_ro_executables,
@@ -601,6 +604,8 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_SKIP_XATTRS;
   if (opt_consume)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME;
+  if (opt_quote_devices)
+    flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_QUOTE_DEVICES;
   switch (opt_selinux_labeling_epoch)
     {
     case 0:


### PR DESCRIPTION
This generalizes the whiteout support to handle block/chardev and FIFOs.

Closes: https://github.com/ostreedev/ostree/issues/2568