### PR TITLE
deploy: Don't recompute verity checksums if not enabled

### DIFF
--- a/man/ostree-checkout.xml
+++ b/man/ostree-checkout.xml
@@ -211,6 +211,24 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                     (may be /). This implies <literal>--force-copy</literal>.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--composefs</option></term>
+
+                <listitem><para>
+                    Only generate a composefs, not a directory.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--composefs-noverity</option></term>
+
+                <listitem><para>
+                    Only generate a composefs, not a directory; fsverity digests
+                    will not be included. This is best used for "opportunistic"
+                    use of composefs.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -473,9 +473,9 @@ gboolean ostree_composefs_target_write (OstreeComposefsTarget *target, int fd,
                                         guchar **out_fsverity_digest, GCancellable *cancellable,
                                         GError **error);
 
-gboolean _ostree_repo_checkout_composefs (OstreeRepo *self, OstreeComposefsTarget *target,
-                                          OstreeRepoFile *source, GCancellable *cancellable,
-                                          GError **error);
+gboolean _ostree_repo_checkout_composefs (OstreeRepo *self, OtTristate verity,
+                                          OstreeComposefsTarget *target, OstreeRepoFile *source,
+                                          GCancellable *cancellable, GError **error);
 static inline gboolean
 composefs_not_supported (GError **error)
 {

--- a/src/libotutil/ot-gio-utils.c
+++ b/src/libotutil/ot-gio-utils.c
@@ -170,3 +170,21 @@ ot_file_get_path_cached (GFile *file)
 
   return path;
 }
+
+/* Format the provided nanoseconds for human consumption;
+ * currently only suitable for tasks on the order of seconds.
+ */
+char *
+ot_format_human_duration (guint64 nanos)
+{
+  guint64 ms = nanos / 1000;
+  if (ms == 0)
+    return g_strdup_printf ("%" G_GUINT64_FORMAT "ns", nanos);
+  else if (ms < 1000)
+    return g_strdup_printf ("%" G_GUINT64_FORMAT "ms", ms);
+  else
+    {
+      double secs = ((double)ms) / 1000;
+      return g_strdup_printf ("%0.1fs", secs);
+    }
+}

--- a/src/libotutil/ot-gio-utils.h
+++ b/src/libotutil/ot-gio-utils.h
@@ -63,4 +63,6 @@ gs_file_get_path_cached (GFile *file)
   return ot_file_get_path_cached (file);
 }
 
+char *ot_format_human_duration (guint64 nanos);
+
 G_END_DECLS

--- a/tests/test-composefs.sh
+++ b/tests/test-composefs.sh
@@ -28,6 +28,7 @@ cd ${test_tmpdir}
 $OSTREE checkout test2 test2-co
 rm test2-co/whiteouts -rf  # This may or may not exist
 COMMIT_ARGS="--owner-uid=0 --owner-gid=0 --no-xattrs --canonical-permissions"
+$OSTREE commit ${COMMIT_ARGS} -b test-composefs-without-meta test2-co
 $OSTREE commit ${COMMIT_ARGS} -b test-composefs --generate-composefs-metadata test2-co
 # If the test fails we'll dump this out
 $OSTREE ls -RCX test-composefs /
@@ -36,16 +37,29 @@ $OSTREE commit ${COMMIT_ARGS} -b test-composefs2 --generate-composefs-metadata t
 new_composefs_digest=$($OSTREE show --print-hex --print-metadata-key ostree.composefs.digest.v0 test-composefs2)
 assert_streq "${orig_composefs_digest}" "${new_composefs_digest}"
 assert_streq "${new_composefs_digest}" "be956966c70970ea23b1a8043bca58cfb0d011d490a35a7817b36d04c0210954"
+rm test2-co -rf
 tap_ok "composefs metadata"
 
-rm test2-co -rf
 $OSTREE checkout --composefs test-composefs test2-co.cfs
 digest=$(sha256sum < test2-co.cfs | cut -f 1 -d ' ')
 # This file should be reproducible bit for bit across environments; per above
 # we're operating on predictable data (fixed uid, gid, timestamps, xattrs, permissions).
 assert_streq "${digest}" "031fab2c7f390b752a820146dc89f6880e5739cba7490f64024e0c7d11aad7c9"
 # Verify it with composefs tooling
-composefs-info dump test2-co.cfs >/dev/null
+composefs-info dump test2-co.cfs > dump.txt
+# Verify we have a verity digest
+assert_file_has_content_literal dump.txt '/baz/cow 4 100644 1 0 0 0 0.0 f6/a517d53831a40cff3886a965c70d57aa50797a8e5ea965b2c49cc575a6ff51.file - ebaa23af194a798df610e5fe2bd10725c9c4a3a56a6b62d4d0ee551d4fc4be27'
+rm -vf dump.txt test2-co.cfs
 tap_ok "checkout composefs"
+
+$OSTREE checkout --composefs-noverity test-composefs-without-meta test2-co-noverity.cfs
+digest=$(sha256sum < test2-co-noverity.cfs | cut -f 1 -d ' ')
+# Should be reproducible per above
+assert_streq "${digest}" "78f873a76ccfea3ad7c86312ba0e06f8e0bca54ab4912b23871b31caafe59c24"
+# Verify it with composefs tooling
+composefs-info dump test2-co-noverity.cfs > dump.txt
+# No verity digest here
+assert_file_has_content_literal dump.txt '/baz/cow 4 100644 1 0 0 0 0.0 f6/a517d53831a40cff3886a965c70d57aa50797a8e5ea965b2c49cc575a6ff51.file - -'
+tap_ok "checkout composefs noverity"
 
 tap_end

--- a/tests/test-ot-unix-utils.c
+++ b/tests/test-ot-unix-utils.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "libglnx.h"
+#include "ot-gio-utils.h"
 #include "ot-unix-utils.h"
 #include <glib.h>
 
@@ -74,11 +75,35 @@ test_ot_util_filename_validate (void)
   g_clear_error (&error);
 }
 
+static void
+test_ot_human_duration (void)
+{
+  struct tcase
+  {
+    guint64 v;
+    const char *expected;
+  };
+  const struct tcase test_cases[] = {
+    { 0, "0ns" },    { 590, "590ns" },    { 1590, "1ms" },
+    { 9001, "9ms" }, { 1597249, "1.6s" }, { 10597249, "10.6s" },
+  };
+
+  for (guint i = 0; i < G_N_ELEMENTS (test_cases); i++)
+    {
+      const struct tcase *tcase = &test_cases[i];
+      g_autofree char *buf = ot_format_human_duration (tcase->v);
+      g_assert_cmpstr (buf, ==, tcase->expected);
+    }
+
+  return;
+}
+
 int
 main (int argc, char **argv)
 {
   g_test_init (&argc, &argv, NULL);
   g_test_add_func ("/ot_util_path_split_validate", test_ot_util_path_split_validate);
   g_test_add_func ("/ot_util_filename_validate", test_ot_util_filename_validate);
+  g_test_add_func ("/ot_human_duration", test_ot_human_duration);
   return g_test_run ();
 }


### PR DESCRIPTION
This fixes a truly horrific performance bug when
composefs is enabled, but fsverity is not supported by the filesystem. We'd fall back to doing *userspace* checksumming of all files at deployment time which was absolutely not expected or required.

There's really an immense amount of technical debt here, such as the confusion between `ex-integity.composefs` vs the prepare-root config, how we handle "torn" states where some objects don't have verity enabled but some do, etc.

The ostree composefs state has two modes:

- signed: We need to enforce fsverity
- unsigned: Best effort resilience

So we fix this by making the deploy path to make verity "opportunistic" - if the ioctl gives us the data, then we add it to the composefs.

However, this code path is also invoked when we're computing the expected composefs digest to inject
as commit metadata, and *that* API must work regardless of whether the target repo has fsverity enabled as it may operate on a build server.

One lucky thing in all of this: When I went to add the "checkout composefs" API I added a stub `GVariant` for options extensibility, which we now use.