### PR TITLE
prepare-root: Fix composefs docs

### DIFF
--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -137,11 +137,11 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
             <varlistentry>
                 <term><varname>composefs.enabled</varname></term>
-                <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>. <literal>maybe</literal> or
-                <literal>signed</literal>. The default is <literal>maybe</literal>.  If set to <literal>yes</literal> or
+                <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>, <literal>maybe</literal>,
+                or <literal>signed</literal>. The default is <literal>no</literal>. If set to <literal>yes</literal> or
                 <literal>signed</literal>, then composefs is always used, and the boot fails if it is not
                 available. Additionally if set to <literal>signed</literal>, boot will fail if the image cannot be
-                validated by a public key. If set to <literal>maybe</literal>, then composefs is used if supported.
+                validated by a public key. Setting this to <literal>maybe</literal> is currently equivalent to <literal>no</literal>.
                 </para></listitem>
             </varlistentry>
             <varlistentry>


### PR DESCRIPTION
In practice in ostree-sysroot-deploy.c we only react to having `composefs = yes`; the docs mention `maybe` but that never did anything.

The value is wrong in the code too, but I'm not touching that here to avoid conflating changes - the main thing to fix is the docs because here `maybe == no`.