### PR TITLE
rofiles-fuse: when fuse execution fails, rofiles-fuse still returns exit code 0

### DIFF
--- a/src/rofiles-fuse/main.c
+++ b/src/rofiles-fuse/main.c
@@ -756,7 +756,6 @@ main (int argc, char *argv[])
       exit (EXIT_FAILURE);
     }
 
-  fuse_main (args.argc, args.argv, &callback_oper, NULL);
-
-  return 0;
+  // Refer to https://man.openbsd.org/fuse_main.3
+  return (fuse_main (args.argc, args.argv, &callback_oper, NULL));
 }


### PR DESCRIPTION
rofiles-fuse: Fixed the problem that when fuse execution fails, the command returns a status code of 0

testcase:
`$ sudo rofiles-fuse a b`
fuse: bad mount point `b': No such file or directory 

`$ echo $?`
0