### PR TITLE
libostree/deploy: enable composefs by default

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -640,9 +640,6 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
   if (!glnx_opendirat (osdeploy_dfd, checkout_target_name, TRUE, &ret_deployment_dfd, error))
     return FALSE;
 
-  guint64 composefs_start_time = 0;
-  guint64 composefs_end_time = 0;
-#ifdef HAVE_COMPOSEFS
   /* TODO: Consider changing things in the future to parse the deployment config from memory, and
    * if composefs is enabled, then we can check out in "user mode" (i.e. only have suid binaries
    * enabled in composefs, etc.)
@@ -667,6 +664,10 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
   g_debug ("composefs enabled by config: %d repo: %d", composefs_enabled, repo->composefs_wanted);
   if (repo->composefs_wanted == OT_TRISTATE_YES)
     composefs_enabled = repo->composefs_wanted;
+
+  guint64 composefs_start_time = 0;
+  guint64 composefs_end_time = 0;
+#ifdef HAVE_COMPOSEFS
   if (composefs_enabled != OT_TRISTATE_NO)
     {
       composefs_start_time = g_get_monotonic_time ();
@@ -694,6 +695,9 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
     }
   else
     g_debug ("not using composefs");
+#else
+  if (composefs_enabled == OT_TRISTATE_YES)
+    return glnx_throw (error, "composefs: enabled at runtime, but support is not compiled in");
 #endif
 
   *checkout_elapsed = (checkout_end_time - checkout_start_time);

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -667,7 +667,7 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
   g_debug ("composefs enabled by config: %d repo: %d", composefs_enabled, repo->composefs_wanted);
   if (repo->composefs_wanted == OT_TRISTATE_YES)
     composefs_enabled = repo->composefs_wanted;
-  if (composefs_enabled == OT_TRISTATE_YES)
+  if (composefs_enabled != OT_TRISTATE_NO)
     {
       composefs_start_time = g_get_monotonic_time ();
       // TODO: Clean up our mess around composefs/fsverity...we have duplication

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -71,9 +71,10 @@ assert_not_file_has_content status.txt "pending"
 assert_not_file_has_content status.txt "rollback"
 validate_bootloader
 
-# Someday probably soon we'll turn this on by default, but for now
-if test -f sysroot/ostree/deploy/testos/deploy/*.0/.ostree.cfs; then
-    fatal "found composefs unexpectedly"
+if has_ostree_feature composefs; then
+    if ! test -f sysroot/ostree/deploy/testos/deploy/*.0/.ostree.cfs; then
+        fatal "missing composefs"
+    fi
 fi
 
 # Test the bootable and linux keys


### PR DESCRIPTION
The composefs libostree integration has been supported for a while now
and is actively in use in various ostree/bootc-based systems. Let's
turn it on by default.

This has no effect if composefs support is not compiled in. Note also
that this does not change the default value of the `composefs.enabled`
tristate to `true`. The default is still `maybe`, but the deploy API
will now also create composefs images for `maybe`.

The reason for doing it this way is so that systems upgrading from
old libostree versions (which may either not have composefs support or
may have composefs-related bugs) will still be able to upgrade and not
trip `ostree-prepare-root` in the new deployment (which allows missing
composefs images for `maybe`).

We may in the future change the default value to `true`.

See also: https://github.com/ostreedev/ostree/issues/2867