### PR TITLE
prepare-root: Add composefs.enabled=verity

### DIFF
--- a/docs/composefs.md
+++ b/docs/composefs.md
@@ -47,11 +47,6 @@ before the content of a file in the mounted composefs is read,
 the integrity of its backing OSTree object in `/ostree/repo/objects` is validated by the digest stored in `.ostree.cfs`.
 This can ensure the integrity of the "backing store".
 
-The digests in `.ostree.cfs` are read from fsverity digests of OSTree objects when deploying.
-It is necessary to ensure all OSTree objects referenced have digests stored in `.ostree.cfs`.
-This can be achieved when [committing](#injecting-composefs-digests),
-or you have to set `ex-integrity.fsverity` to `true` for the OSTree repo.
-
 ### Injecting composefs digests
 
 When generating an OSTree commit, there is a CLI switch `--generate-composefs-metadata`

--- a/docs/composefs.md
+++ b/docs/composefs.md
@@ -40,6 +40,18 @@ and specify an Ed25519 public key to validate the booted commit.
 
 See the manpage for `ostree-prepare-root` for details of how to configure it.
 
+### Integrity of backing OSTree objects
+
+In `ostree/prepare-root.conf`, if `composefs.enabled` is set to `signed` or `verity`,
+before the content of a file in the mounted composefs is read,
+the integrity of its backing OSTree object in `/ostree/repo/objects` is validated by the digest stored in `.ostree.cfs`.
+This can ensure the integrity of the "backing store".
+
+The digests in `.ostree.cfs` are read from fsverity digests of OSTree objects when deploying.
+It is necessary to ensure all OSTree objects referenced have digests stored in `.ostree.cfs`.
+This can be achieved when [committing](#injecting-composefs-digests),
+or you have to set `ex-integrity.fsverity` to `true` for the OSTree repo.
+
 ### Injecting composefs digests
 
 When generating an OSTree commit, there is a CLI switch `--generate-composefs-metadata`

--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -138,10 +138,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             <varlistentry>
                 <term><varname>composefs.enabled</varname></term>
                 <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>, <literal>maybe</literal>,
-                or <literal>signed</literal>. The default is <literal>no</literal>. If set to <literal>yes</literal> or
-                <literal>signed</literal>, then composefs is always used, and the boot fails if it is not
-                available. Additionally if set to <literal>signed</literal>, boot will fail if the image cannot be
-                validated by a public key. Setting this to <literal>maybe</literal> is currently equivalent to <literal>no</literal>.
+                <literal>signed</literal>, or <literal>verity</literal>. The default is <literal>no</literal>.
+                If set to <literal>yes</literal>, <literal>signed</literal>, or <literal>verity</literal>,
+                then composefs is always used, and the boot fails if it is not available.
+                If set to <literal>signed</literal> or <literal>verity</literal>,
+                before the content of a file is read,
+                the integrity of its backing OSTree object is validated by the digest stored in the image.
+                Additionally, if set to <literal>signed</literal>, boot will fail if the image cannot be
+                validated by a public key.
+                Setting this to <literal>maybe</literal> is currently equivalent to <literal>no</literal>.
                 </para></listitem>
             </varlistentry>
             <varlistentry>

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -680,7 +680,7 @@ checkout_deployment_tree (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploy
       g_auto (GVariantBuilder) cfs_checkout_opts_builder
           = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
       guint32 composefs_requested = 1;
-      if (composefs_config->is_signed)
+      if (composefs_config->require_verity)
         composefs_requested = 2;
       g_variant_builder_add (&cfs_checkout_opts_builder, "{sv}", "verity",
                              g_variant_new_uint32 (composefs_requested));

--- a/src/libotcore/otcore-prepare-root.c
+++ b/src/libotcore/otcore-prepare-root.c
@@ -178,7 +178,14 @@ otcore_load_composefs_config (const char *cmdline, GKeyFile *config, gboolean lo
   if (g_strcmp0 (enabled, "signed") == 0)
     {
       ret->enabled = OT_TRISTATE_YES;
+      ret->require_verity = true;
       ret->is_signed = true;
+    }
+  else if (g_strcmp0 (enabled, "verity") == 0)
+    {
+      ret->enabled = OT_TRISTATE_YES;
+      ret->require_verity = true;
+      ret->is_signed = false;
     }
   else if (!ot_keyfile_get_tristate_with_default (config, OTCORE_PREPARE_ROOT_COMPOSEFS_KEY,
                                                   OTCORE_PREPARE_ROOT_ENABLED_KEY,
@@ -227,6 +234,7 @@ otcore_load_composefs_config (const char *cmdline, GKeyFile *config, gboolean lo
         {
           ret->enabled = OT_TRISTATE_YES;
           ret->is_signed = true;
+          ret->require_verity = true;
         }
       else
         {

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -52,6 +52,7 @@ GKeyFile *otcore_load_config (int rootfs, const char *filename, GError **error);
 typedef struct
 {
   OtTristate enabled;
+  gboolean require_verity;
   gboolean is_signed;
   char *signature_pubkey;
   GPtrArray *pubkeys;

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -452,9 +452,14 @@ main (int argc, char *argv[])
           expected_digest = g_malloc (OSTREE_SHA256_STRING_LEN + 1);
           ot_bin2hex (expected_digest, cfs_digest_buf, g_variant_get_size (cfs_digest_v));
 
+          g_assert (composefs_config->require_verity);
           cfs_options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
           g_print ("composefs: Verifying digest: %s\n", expected_digest);
           cfs_options.expected_fsverity_digest = expected_digest;
+        }
+      else if (composefs_config->require_verity)
+        {
+          cfs_options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
         }
 
       if (lcfs_mount_image (OSTREE_COMPOSEFS_NAME, TMP_SYSROOT, &cfs_options) == 0)


### PR DESCRIPTION
In the current implementation, a composefs deploy is either:
- signed by key and verified by fs-verity, or
- not signed and not verified.

This PR adds a new supported value `verity` to `composefs.enabled`, which:
- requires the composefs to be verified by fs-verity;
- does not require it to be signed.

The idea is that:
- If we do not specify `LCFS_MOUNT_FLAGS_REQUIRE_VERITY` (the underlying of which is `verity=require` when mounting overlayfs), overlayfs does not verify file data even if fs-verity digests are present in the image.
- It is difficult and troublesome to have the ostree commit signed in some circumstances. For example, when deploying with custom layering.
- In some cases, the integrity of the composefs image is already protected by other mechanisms, for example EVM. It is not necessary to verify the image by a key, but it is still necessary to verify file data referenced by the image using fs-verity to protect file integrity from disk corruption.