### PR TITLE
chore: Use geteuid() instead of getuid() to check privilege

### DIFF
--- a/src/libostree/ostree-bootloader-zipl.c
+++ b/src/libostree/ostree-bootloader-zipl.c
@@ -432,7 +432,7 @@ _ostree_bootloader_zipl_post_bls_sync (OstreeBootloader *bootloader, int bootver
   // This can happen in a unit testing environment; at some point what we want to do here
   // is move all of the zipl logic to a systemd unit instead that's keyed of
   // ostree-finalize-staged.service.
-  if (getuid () != 0)
+  if (!ot_util_process_privileged ())
     return TRUE;
 
   // If we're in a booted deployment, we don't need to spawn a container.

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1658,7 +1658,7 @@ ostree_repo_prepare_transaction (OstreeRepo *self, gboolean *out_transaction_res
   self->reserved_blocks = reserved_bytes / self->txn.blocksize;
 
   /* Use the appropriate free block count if we're unprivileged */
-  guint64 bfree = (getuid () != 0 ? stvfsbuf.f_bavail : stvfsbuf.f_bfree);
+  guint64 bfree = (ot_util_process_privileged () ? stvfsbuf.f_bfree : stvfsbuf.f_bavail);
   if (bfree > self->reserved_blocks)
     self->txn.max_blocks = bfree - self->reserved_blocks;
   else

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -285,7 +285,7 @@ ostree_sysroot_initialize_with_mount_namespace (OstreeSysroot *self, GCancellabl
     return FALSE;
 
   /* Do nothing if we're not privileged */
-  if (getuid () != 0)
+  if (!ot_util_process_privileged ())
     return TRUE;
 
   /* We also assume operating on non-booted roots won't have a readonly sysroot */

--- a/src/libotutil/ot-unix-utils.c
+++ b/src/libotutil/ot-unix-utils.c
@@ -32,6 +32,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/prctl.h>
+#include <linux/prctl.h>
+#include <linux/capability.h>
 #include <unistd.h>
 
 /* Ensure that a pathname component @name does not contain the special Unix
@@ -107,5 +110,12 @@ ot_util_path_split_validate (const char *path, GPtrArray **out_components, GErro
 gboolean
 ot_util_process_privileged (void)
 {
-  return geteuid() == 0;
+  if (geteuid() != 0)
+    return FALSE;
+
+  // https://github.com/containers/bootc/blob/c88fcfd6e145863408bde7d4706937dd323f64e2/lib/src/cli.rs#L621
+  if (prctl (PR_CAPBSET_READ, CAP_SYS_ADMIN) != 1)
+    return FALSE;
+
+  return TRUE;
 }

--- a/src/libotutil/ot-unix-utils.c
+++ b/src/libotutil/ot-unix-utils.c
@@ -102,3 +102,10 @@ ot_util_path_split_validate (const char *path, GPtrArray **out_components, GErro
   ot_transfer_out_value (out_components, &ret_components);
   return TRUE;
 }
+
+/* Check if current process is privileged */
+gboolean
+ot_util_process_privileged (void)
+{
+  return geteuid() == 0;
+}

--- a/src/libotutil/ot-unix-utils.h
+++ b/src/libotutil/ot-unix-utils.h
@@ -39,4 +39,6 @@ gboolean ot_util_filename_validate (const char *name, GError **error);
 
 gboolean ot_util_path_split_validate (const char *path, GPtrArray **out_components, GError **error);
 
+gboolean ot_util_process_privileged (void);
+
 G_END_DECLS

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -116,7 +116,7 @@ maybe_setup_mount_namespace (gboolean *out_ns, GError **error)
   *out_ns = FALSE;
 
   /* If we're not root, then we almost certainly can't be remounting anything */
-  if (getuid () != 0)
+  if (!ot_util_process_privileged ())
     return TRUE;
 
   /* If the system isn't booted via libostree, also nothing to do */
@@ -580,7 +580,7 @@ ostree_admin_sysroot_load (OstreeSysroot *sysroot, OstreeAdminBuiltinFlags flags
       /* Only require root if we're manipulating a booted sysroot. (Mostly
        * useful for the test suite)
        */
-      if (booted && getuid () != 0)
+      if (booted && !ot_util_process_privileged ())
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
                        "You must be root to perform this command");


### PR DESCRIPTION
I believe the correct way is to check `geteuid() == 0`, not `getuid() == 0`.