### PR TITLE
docs: update Dockerfile

### DIFF
--- a/docs/contributing-tutorial.md
+++ b/docs/contributing-tutorial.md
@@ -114,11 +114,11 @@ The example below uses Docker to manage containers. Save the contents of this **
 
 ```bash
 # this pulls the fedora 28 image
-FROM registry.fedoraproject.org/fedora:28
+FROM registry.fedoraproject.org/fedora:41
 
 # install ostree dependencies
 RUN dnf update -y && \
-    dnf -y install @buildsys-build dnf-plugins-core  && \
+    dnf -y install @buildsys-build dnf-plugins-core python3-yaml && \
     dnf -y builddep ostree  && \
     dnf clean all
 


### PR DESCRIPTION
Fix issues in Dockerfile:
1. Update Fedora image to the latest version 41, otherwise docker build fails with an error:
```
Step 1/7 : FROM registry.fedoraproject.org/fedora:28
manifest for registry.fedoraproject.org/fedora:28 not found: manifest unknown: manifest unknown
```
2. Force install python3-yaml package, as it's required for running some tests. For example, tests/test-remote-headers.sh will fail without it:

```
V=$($CMD_PREFIX ostree --version | \ python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["libostree"]["Version"])') 
Traceback (most recent call last): 
File "<string>", line 1, in <module> 
import sys, yaml; print(yaml.safe_load(sys.stdin)["libostree"]["Version"])
^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'yaml'
```
With these fixes `make check` executes successfully in a container: 
```
============================================================================ 
Testsuite summary for libostree 2024.11
============================================================================
 TOTAL: 935
 PASS:  888
 SKIP:  47
 XFAIL: 0
 FAIL:  0
 XPASS: 0
 ERROR: 0
```