### PR TITLE
Release 2025.1

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -175,9 +175,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+#if BUILDOPT_IS_DEVEL_BUILD
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
-m4_define([year_version], [2024])
-m4_define([release_version], [11])
+m4_define([year_version], [2025])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2025])
-m4_define([release_version], [1])
+m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,11 +20,6 @@
    - uncomment the include in Makefile-libostree.am
 */
 
-LIBOSTREE_2024.11 {
-global:
-  ostree_sysroot_deployment_kexec_load;
-} LIBOSTREE_2024.7;
-
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -718,6 +718,11 @@ global:
   ostree_repo_checkout_composefs;
 } LIBOSTREE_2023.8;
 
+LIBOSTREE_2025.1 {
+global:
+  ostree_sysroot_deployment_kexec_load;
+} LIBOSTREE_2024.7;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-2cbaf02fbd6d5e07cc59597dd5fc21a548bb66dde99a96c3f07fa0e46699ae57  ${released_syms}
+b242c2d7e73be550c21fee6ccf00509a5c1bea2d3c62095acf62cffc5f43bd64  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
This Release adds one new feature introduced on: https://github.com/ostreedev/ostree/pull/3362 which adds a new `--kexec` flag to `ostree admin upgrade` which will cause the deployment to be loaded into kexec after the upgrade completes.

Other than that it mostly a bugfix and small improement release with the more significant change being https://github.com/ostreedev/ostree/pull/3366 which relates to composefs and notably does:

- If composefs is enabled at build time, we always generate a composefs blob at deplyment time
- Configuring the prepare-root config now mostly only affects the runtime state.


```
Colin Walters (2):
      tree-wide: Rerun clang-format, update ci
      Always generate composefs blob, don't enable runtime by default

Joseph Marrero Corchado (1):
      Release 2025.1

Mary Strodl (1):
      bin/admin-upgrade: add kexec support

Misaki Kasumi (2):
      chore: Use geteuid() instead of getuid() to check privilege
      chore: Check CAP_SYS_ADMIN in ot_util_process_privileged
```
## New Contributors
* @Mstrodl  made their first contribution in https://github.com/ostreedev/ostree/pull/3362

**Full Changelog**: https://github.com/ostreedev/ostree/compare/v2024.10...v2025.1