### PR TITLE
Add simple service to comment / in fstab

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -42,6 +42,7 @@ systemdsystemunit_DATA = src/boot/ostree-prepare-root.service \
 	src/boot/ostree-finalize-staged.service \
 	src/boot/ostree-finalize-staged.path \
 	src/boot/ostree-finalize-staged-hold.service \
+	src/boot/ostree-edit-fstab.service \
 	src/boot/ostree-state-overlay@.service \
 	$(NULL)
 systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d

--- a/src/boot/ostree-edit-fstab.service
+++ b/src/boot/ostree-edit-fstab.service
@@ -1,0 +1,31 @@
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+[Unit]
+Description=OSTree comment / in fstab
+DefaultDependencies=no
+ConditionKernelCommandLine=ostree
+Conflicts=shutdown.target
+After=systemd-fsck-root.service
+Before=bootc-fstab-edit.service systemd-remount-fs.service local-fs-pre.target local-fs.target shutdown.target
+Wants=local-fs-pre.target
+ConditionPathIsReadWrite=/etc
+ConditionPathExists=/etc/fstab
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/sed -i 's/^\\([^#\\t ]\\+[\\t ]\\+\\/[\\t ]\\+[^\\t ]\\+[\\t ]\\+defaults[\\t ]\\+\\)/# commented by ostree-edit-fstab.service\\n#\\1/' /etc/fstab
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
ostree modes have conflictings / mount needs:
- "hardlinks" mode need / to be rw
- composefs mode need / to be ro

Some installation methods (at least Anaconda) add / to fstab,
so when systemd-remount-fs.service tries to remount
the composefs / rw, it fails because it can only be ro.

To be able to edit /etc this early during the boot it rely on
having the 'rw' kargs.

bootc has a systemd generator to edit fstab but not everyone uses bootc (yet),
and it adds 'ro' instead of commenting the whole line,
which breaks disabling composefs (downgrade).

We only comment when mount option is 'defaults'.

Fixes #3193

Notes:
This was tested with EL 9.5
The idea is to have a common fix for this step towards composefs, maybe disabled by default in the packages but ready to use by image maintainers if they know its safe