### PR TITLE
libotutil: Remove redundant import of prctl.h

### DIFF
--- a/src/libotutil/ot-unix-utils.c
+++ b/src/libotutil/ot-unix-utils.c
@@ -30,7 +30,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/capability.h>
-#include <linux/prctl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/prctl.h>


### PR DESCRIPTION
sys/prctl.h already provides prctl.h and adding both imports fails on musl libc:

	/usr/include/sys/prctl.h:88:8: error: redefinition of 'struct prctl_mm_map'
	   88 | struct prctl_mm_map {
	      |        ^~~~~~~~~~~~
	In file included from src/libotutil/ot-unix-utils.c:33:
	/usr/include/linux/prctl.h:134:8: note: originally defined here
	  134 | struct prctl_mm_map {
	      |        ^~~~~~~~~~~~