### PR TITLE
prepare-root: Log when we're mounting with verity required

### DIFF
--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -96,6 +96,8 @@ ComposefsConfig *otcore_load_composefs_config (const char *cmdline, GKeyFile *co
 #define OTCORE_RUN_BOOTED "/run/ostree-booted"
 // This key will be present if composefs was successfully used.
 #define OTCORE_RUN_BOOTED_KEY_COMPOSEFS "composefs"
+// True if fsverity was required for composefs.
+#define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_VERITY "composefs.verity"
 // This key if present contains the public key successfully used
 // to verify the signature.
 #define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_SIGNATURE "composefs.signed"

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -465,9 +465,13 @@ main (int argc, char *argv[])
       if (lcfs_mount_image (OSTREE_COMPOSEFS_NAME, TMP_SYSROOT, &cfs_options) == 0)
         {
           using_composefs = true;
+          bool using_verity = (cfs_options.flags & LCFS_MOUNT_FLAGS_REQUIRE_VERITY) > 0;
           g_variant_builder_add (&metadata_builder, "{sv}", OTCORE_RUN_BOOTED_KEY_COMPOSEFS,
                                  g_variant_new_boolean (true));
-          g_print ("composefs: mounted successfully\n");
+          g_variant_builder_add (&metadata_builder, "{sv}", OTCORE_RUN_BOOTED_KEY_COMPOSEFS_VERITY,
+                                 g_variant_new_boolean (using_verity));
+          g_print ("composefs: mounted successfully (verity=%s)\n",
+                   using_verity ? "true" : "false");
         }
       else
         {


### PR DESCRIPTION
On general principle, but specifically as I wanted to cross-check this when debugging something else.