### PR TITLE
sepolicy: Add ostree_sepolicy_set_null_log

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -175,9 +175,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-#if BUILDOPT_IS_DEVEL_BUILD
-#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-#endif
+if BUILDOPT_IS_DEVEL_BUILD
+symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -539,6 +539,7 @@ OstreeSePolicyRestoreconFlags
 ostree_sepolicy_restorecon
 ostree_sepolicy_setfscreatecon
 ostree_sepolicy_fscreatecon_cleanup
+ostree_sepolicy_set_null_log
 <SUBSECTION Standard>
 OSTREE_SEPOLICY
 OSTREE_IS_SEPOLICY

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -20,6 +20,11 @@
    - uncomment the include in Makefile-libostree.am
 */
 
+LIBOSTREE_2025.2 {
+global:
+  ostree_sepolicy_set_null_log;
+} LIBOSTREE_2025.1;
+
 /* Stub section for the stable release *after* this development one; don't
  * edit this other than to update the year.  This is just a copy/paste
  * source.  Replace $LASTSTABLE with the last stable version, and $NEWVERSION

--- a/src/libostree/ostree-sepolicy.c
+++ b/src/libostree/ostree-sepolicy.c
@@ -254,6 +254,27 @@ get_policy_checksum (char **out_csum, GCancellable *cancellable, GError **error)
 
 #endif
 
+__attribute__ ((format (printf, 2, 3))) static int
+_ostree_sepolicy_null_log (int type, const char *fmt, ...)
+{
+  return 0;
+}
+
+/**
+ * ostree_sepolicy_set_null_log:
+ * Disable SELinux's builtin logging; one rarely wants this enabled.
+ *
+ * Since: 2025.2
+ */
+void
+ostree_sepolicy_set_null_log (void)
+{
+#ifdef HAVE_SELINUX
+  selinux_set_callback (SELINUX_CB_LOG,
+                        (const union selinux_callback){ .func_log = _ostree_sepolicy_null_log });
+#endif
+}
+
 /**
  * ostree_sepolicy_new_from_commit:
  * @repo: The repo

--- a/src/libostree/ostree-sepolicy.h
+++ b/src/libostree/ostree-sepolicy.h
@@ -32,6 +32,9 @@ _OSTREE_PUBLIC
 GType ostree_sepolicy_get_type (void);
 
 _OSTREE_PUBLIC
+void ostree_sepolicy_set_null_log (void);
+
+_OSTREE_PUBLIC
 OstreeSePolicy *ostree_sepolicy_new (GFile *path, GCancellable *cancellable, GError **error);
 
 _OSTREE_PUBLIC

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -613,6 +613,9 @@ ostree_admin_option_context_parse (GOptionContext *context, const GOptionEntry *
       return TRUE;
     }
 
+  // Disable this, it's just noise
+  ostree_sepolicy_set_null_log ();
+
   g_autoptr (GFile) sysroot_path = NULL;
   if (opt_sysroot != NULL)
     sysroot_path = g_file_new_for_path (opt_sysroot);


### PR DESCRIPTION
Let's quiet the output of libselinux by default, all we get is the pointless "regex version mismatch" warnings. This is what e.g. systemd does.

This is exposed via the library; our binary opts in, then we expect higher level tools like e.g. bootc to do this too.