### PR TITLE
libostree: remove unused libmount include

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -32,9 +32,6 @@
 #include <sys/socket.h>
 #include <sys/statvfs.h>
 
-#ifdef HAVE_LIBMOUNT
-#include <libmount.h>
-#endif
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-journal.h>
 #endif


### PR DESCRIPTION
As far as I can tell, this hasn't been used since 9a526bba ("sysroot: Handle ro /boot but rw /sysroot").