### PR TITLE
commit: Clarify that syncfs is of repo/tmp

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2233,7 +2233,7 @@ ostree_repo_commit_transaction (OstreeRepo *self, OstreeRepoTransactionStats *ou
   if (!self->disable_fsync && g_getenv ("OSTREE_SUPPRESS_SYNCFS") == NULL)
     {
       if (syncfs (self->tmp_dir_fd) < 0)
-        return glnx_throw_errno_prefix (error, "syncfs");
+        return glnx_throw_errno_prefix (error, "syncfs(repo/tmp)");
     }
 
   if (!rename_pending_loose_objects (self, cancellable, error))


### PR DESCRIPTION
We saw this in an error message:
```
error: Generating commit from rootfs: syncfs: Not a directory
```

I'm pretty sure it's this function call but let's be a bit more sure by adding a bit more context.