### PR TITLE
Fix build error with --with-ed25519-libsodium and --with-openssl

### DIFF
--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -25,7 +25,9 @@
 #ifdef HAVE_LIBSODIUM
 #include <sodium.h>
 #define USE_LIBSODIUM
-#elif defined(HAVE_OPENSSL)
+#endif
+
+#if defined(HAVE_OPENSSL)
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 #define USE_OPENSSL


### PR DESCRIPTION
While libotcore can be configured with those options individually, the latter is always required for OpenSSL's EVP functions. This splits the ifdefs to accommodate that.

Fixes: #3399 