### PR TITLE
docs: removed unused argument

### DIFF
--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -86,7 +86,6 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <arg choice="req">DOMAIN</arg>
                 <arg choice="req">PATH</arg>
                 <arg choice="req">COOKIE_NAME</arg>
-                <arg choice="req">VALUE</arg>
             </cmdsynopsis>
             <cmdsynopsis>
                 <command>ostree remote list-cookies</command> <arg choice="req">NAME</arg>


### PR DESCRIPTION
Looking at the implementation [here](https://github.com/ostreedev/ostree/blob/main/src/ostree/ot-remote-builtin-delete-cookie.c#L48) we can see the $VALUE is not used. 

It would also be weird to have to supply a VALUE to a delete operation