### PR TITLE
sysroot: Detect early on when /boot is on vfat

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2216,8 +2216,9 @@ swap_bootloader (OstreeSysroot *sysroot, OstreeBootloader *bootloader, int curre
 
   if (!_ostree_sysroot_ensure_boot_fd (sysroot, error))
     return FALSE;
-
   g_assert_cmpint (sysroot->boot_fd, !=, -1);
+  // We use symlinks here.
+  g_assert (!sysroot->boot_is_vfat);
 
   /* The symlink was already written, and we used syncfs() to ensure
    * its data is in place.  Renaming now should give us atomic semantics;

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -70,6 +70,9 @@ struct OstreeSysroot
   // File descriptor for the boot partition. Should be initialized on demand internally
   // by a public API eventually invoking `_ostree_sysroot_ensure_boot_fd()`.
   int boot_fd;
+  // Set if the /boot filesystem is VFAT.
+  // Only initialized if boot_fd is set.
+  gboolean boot_is_vfat;
   // Lock for this sysroot.
   GLnxLockFile lock;
 

--- a/tests/kolainst/nondestructive/itest-alt-sysroot.sh
+++ b/tests/kolainst/nondestructive/itest-alt-sysroot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Run test-basic.sh as root.
+# https://github.com/ostreedev/ostree/pull/1199
+
+set -xeuo pipefail
+
+if test $(readlink /proc/1/ns/mnt) = $(readlink /proc/self/ns/mnt); then
+    exec unshare -m -- "$0" "$@"
+fi
+
+. ${KOLA_EXT_DATA}/libinsttest.sh
+
+# Use /var/tmp to hopefully use XFS + O_TMPFILE etc.
+prepare_tmpdir /var/tmp
+trap _tmpdir_cleanup EXIT
+
+truncate -s 512M boot.img
+mkfs.vfat boot.img
+
+mkdir sysroot
+ostree admin init-fs -E 1 sysroot
+mount -o loop boot.img sysroot/boot
+if ostree admin status --sysroot=sysroot 2>err.txt; then
+    # So cleanup works on failure too
+    umount sysroot/boot
+    fatal "computed status on vfat sysroot"
+fi
+umount sysroot/boot
+assert_file_has_content_literal err.txt "/boot cannot currently be a vfat filesystem"


### PR DESCRIPTION
We do want to support this (as part of supporing the Boot Loader Spec) but because we use symlinks in `/boot`, can't yet.

Error out very early on consistently if we detect
vfat for /boot, but also add a member variable to keep track of this in preparation for supporting it.