### PR TITLE
Revert "generator: Exit if there's no `/run/ostree`"

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -289,12 +289,6 @@ _ostree_impl_system_generator (const char *normal_dir, const char *early_dir, co
   if (unlinkat (AT_FDCWD, INITRAMFS_MOUNT_VAR, 0) == 0)
     return TRUE;
 
-  // If we're not booted via ostree, do nothing
-  if (!glnx_fstatat_allow_noent (AT_FDCWD, OTCORE_RUN_OSTREE, NULL, 0, error))
-    return FALSE;
-  if (errno == ENOENT)
-    return TRUE;
-
   g_autofree char *cmdline = read_proc_cmdline ();
   if (!cmdline)
     return glnx_throw (error, "Failed to read /proc/cmdline");


### PR DESCRIPTION
This reverts commit b9ce0e89801bbc92d50473d3620b3f41f1dbef9f.

>   The comment here said why we didn't do that before, but that's
>   for the really legacy embedded-only "ostree-prepare-root-static"
>   path, and even then I'm pretty sure it was wrong because
>   the generator here only runs in the *real* root, and we should
>   have `/run/ostree` at that point.

This is wrong assumption because in case of "ostree-prepare-root-static" path, "/run" does not exist yet, when generator runs.

According to SYSTEMD_FILE_HIERARCHY_REQUIREMENTS.md:
- `/run` must exist as an empty mount point and will automatically be mounted by systemd with a tmpfs.