### PR TITLE
sysroot: Load bootloader configs via boot_fd

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2826,6 +2826,8 @@ ostree_sysroot_write_deployments_with_options (OstreeSysroot *self, GPtrArray *n
 
   if (!_ostree_sysroot_ensure_writable (self, error))
     return FALSE;
+  if (!_ostree_sysroot_ensure_boot_fd (self, error))
+    return FALSE;
 
   const bool skip_early_prune = (self->opt_flags & OSTREE_SYSROOT_GLOBAL_OPT_NO_EARLY_PRUNE) > 0;
   if (!skip_early_prune && !opts->disable_auto_early_prune

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -64,8 +64,13 @@ struct OstreeSysroot
   GObject parent;
 
   GFile *path;
+  // File descriptor for the sysroot. Only valid after `ostree_sysroot_ensure_initialized()`
+  // has been invoked (directly by a calling program, or transitively from another public API).
   int sysroot_fd;
+  // File descriptor for the boot partition. Should be initialized on demand internally
+  // by a public API eventually invoking `_ostree_sysroot_ensure_boot_fd()`.
   int boot_fd;
+  // Lock for this sysroot.
   GLnxLockFile lock;
 
   OstreeSysrootLoadState loadstate;

--- a/src/ostree/ot-admin-builtin-finalize-staged.c
+++ b/src/ostree/ot-admin-builtin-finalize-staged.c
@@ -71,20 +71,10 @@ ot_admin_builtin_finalize_staged (int argc, char **argv, OstreeCommandInvocation
               cancellable, error))
         return FALSE;
 
-      /* In case it's an automount, open /boot so that the automount doesn't
-       * expire until before this process exits. If it did expire and got
-       * unmounted, the service would be stopped and the deployment would be
-       * finalized earlier than expected.
-       */
-      int sysroot_fd = ostree_sysroot_get_fd (sysroot);
-      glnx_autofd int boot_fd = -1;
-      g_debug ("Opening /boot directory");
-      if (!glnx_opendirat (sysroot_fd, "boot", TRUE, &boot_fd, error))
-        return FALSE;
-
-      /* We want to keep /boot open until the deployment is finalized during
+      /* By default the sysroot now holds a file descriptor for /boot open.
+       * We want that open until the deployment is finalized during
        * system shutdown, so block until we get SIGTERM which systemd will send
-       * when the unit is stopped.
+       * when the unit is stopped, then we'll exit and release it.
        */
       pause ();
     }

--- a/tests/kolainst/destructive/boot-automount.sh
+++ b/tests/kolainst/destructive/boot-automount.sh
@@ -21,6 +21,9 @@ EOF
     systemctl daemon-reload
     systemctl enable boot.automount
 
+    # Stop this as it may also be holding /boot open now
+    systemctl stop rpm-ostreed.service
+
     # Unmount /boot, start the automount unit, and ensure the units are
     # in the correct states.
     umount /boot


### PR DESCRIPTION
This was a general principle cleanup, preparation
for handling VFAT for /boot for systemd-boot/BLS
support.

However I ran into an ugly corner case in our
unit tests that pointed at a sysroot without a
boot directory. The previous logic handled
ENOENT for boot/loader but not /boot.
Continue to cope with that degenerate situation.