### PR TITLE
generator: Still create /run/ostree in static prepareroot path

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -191,6 +191,9 @@ libostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/bsdiff -I$(srcdir)/libglnx -I$(
 	$(OT_INTERNAL_GIO_UNIX_CFLAGS) $(OT_INTERNAL_GPGME_CFLAGS) $(OT_DEP_LZMA_CFLAGS) $(OT_DEP_ZLIB_CFLAGS) $(OT_DEP_CRYPTO_CFLAGS) \
 	-fvisibility=hidden '-D_OSTREE_PUBLIC=__attribute__((visibility("default"))) extern' \
 	-DPKGLIBEXECDIR=\"$(pkglibexecdir)\"
+if BUILDOPT_USE_STATIC_COMPILER
+libostree_1_la_CFLAGS += -DOSTREE_PREPARE_ROOT_STATIC=1
+endif
 libostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions $(addprefix $(wl_versionscript_arg),$(symbol_files))
 libostree_1_la_LIBADD = libotutil.la libotcore.la libglnx.la libbsdiff.la $(OT_INTERNAL_GIO_UNIX_LIBS) $(OT_INTERNAL_GPGME_LIBS) \
                         $(OT_DEP_LZMA_LIBS) $(OT_DEP_ZLIB_LIBS) $(OT_DEP_CRYPTO_LIBS)

--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -289,11 +289,18 @@ _ostree_impl_system_generator (const char *normal_dir, const char *early_dir, co
   if (unlinkat (AT_FDCWD, INITRAMFS_MOUNT_VAR, 0) == 0)
     return TRUE;
 
+#ifdef OSTREE_PREPARE_ROOT_STATIC
+  // Create /run/ostree-booted now, because other things rely on it.
+  // If the system compiled with a static prepareroot, then our generator
+  // makes a hard assumption that ostree is in use.
+  touch_run_ostree ();
+#else
   // If we're not booted via ostree, do nothing
   if (!glnx_fstatat_allow_noent (AT_FDCWD, OTCORE_RUN_OSTREE, NULL, 0, error))
     return FALSE;
   if (errno == ENOENT)
     return TRUE;
+#endif
 
   g_autofree char *cmdline = read_proc_cmdline ();
   if (!cmdline)


### PR DESCRIPTION
Ref https://github.com/ostreedev/ostree/pull/3406

There's a combination of two commits here that broke the static prepareroot path:

ec1109c7a93a2ed07503b12ffecf7048cf7cc0d0
"generator: Stop creating `/run/ostree-booted`"
and more recently
b9ce0e89801bbc92d50473d3620b3f41f1dbef9f
generator: Exit if there's no `/run/ostree`

Basically when run via a non-static prepareroot we create `/run/ostree-booted` consistently in the initramfs, using the kernel argument presence as source of truth.

But for the static prepareroot, the generator checked the kernel argument, and had a fallback of creating it.

Except that's busted in the case of running in a
container, where with many runtimes we still
default to seeing the host's commandline (which
is basically wrong...but fixing that requires a
userspace virtualizer/interceptor for `/proc`
so it's not commonly done).

This should fix the static prepareroot path
by detecting the case where we're compiled
with a static prepareroot, and if so we then
hardcode creating the `/run/ostree-booted`
file in the generator. I think basically
everyone who is compiling ostree with
a static prepareroot *and* including it
in their filesystem trees can be pretty
much guaranteed to be actually using it.