### PR TITLE
Move /run  from initramfs to real-rootfs(sysroot/run)

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -688,11 +688,12 @@ main (int argc, char *argv[])
   if (rmdir (TMP_SYSROOT) < 0)
     err (EXIT_FAILURE, "couldn't remove temporary sysroot %s", TMP_SYSROOT);
   
-  /* Moves /run mount point from initramfs(/run) to realrootfs(sysroot/run)
-  * so that systemd will not mount it again if it finds a mount point during switchroot.
-  * and all the contents of /run will be moved to realrootfs as well. It will fix the
-  * problem of mounting sysroot as read-only because during ostree-remount.service 
-  * it checks in /run/ostree-booted if we need to mount it read-only only or not
+  /* Move /run mount point from initramfs (/run) to the real root filesystem (sysroot/run).
+  * This ensures that systemd does not remount it during switchroot if it detects an existing mount point.
+  * Consequently, all contents of /run will be transferred to the real root filesystem.
+  * This adjustment resolves the issue of mounting sysroot as read-only. During the execution 
+  * of ostree-remount.service, the system checks /run/ostree-booted to determine if sysroot should be 
+  * mounted as read-only.
   */
   if (mount("/run", "run", NULL, MS_MOVE | MS_SILENT, NULL) < 0)
     err(EXIT_FAILURE, "failed to MS_MOVE '/run' to 'sysroot/run'");

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -688,8 +688,8 @@ main (int argc, char *argv[])
   if (rmdir (TMP_SYSROOT) < 0)
     err (EXIT_FAILURE, "couldn't remove temporary sysroot %s", TMP_SYSROOT);
   
-  /* Moved /run mount point from initramfs(/run) to realrootfs(sysroot/run)
-  * so that systemd will not mount it again if it finds a mount point during switchroot
+  /* Moves /run mount point from initramfs(/run) to realrootfs(sysroot/run)
+  * so that systemd will not mount it again if it finds a mount point during switchroot.
   * and all the contents of /run will be moved to realrootfs as well. It will fix the
   * problem of mounting sysroot as read-only because during ostree-remount.service 
   * it checks in /run/ostree-booted if we need to mount it read-only only or not

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -687,6 +687,15 @@ main (int argc, char *argv[])
 
   if (rmdir (TMP_SYSROOT) < 0)
     err (EXIT_FAILURE, "couldn't remove temporary sysroot %s", TMP_SYSROOT);
+  
+  /* Moved /run mount point from initramfs(/run) to realrootfs(sysroot/run)
+  * so that systemd will not mount it again if it finds a mount point during switchroot
+  * and all the contents of /run will be moved to realrootfs as well. It will fix the
+  * problem of mounting sysroot as read-only because during ostree-remount.service 
+  * it checks in /run/ostree-booted if we need to mount it read-only only or not
+  */
+  if (mount("/run", "run", NULL, MS_MOVE | MS_SILENT, NULL) < 0)
+    err(EXIT_FAILURE, "failed to MS_MOVE '/run' to 'sysroot/run'");
 
   /* Now that we've set up all the mount points, if configured we remount the physical
    * rootfs as read-only; what is visibly mutable to the OS by default is just /etc and /var.

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -688,13 +688,14 @@ main (int argc, char *argv[])
   if (rmdir (TMP_SYSROOT) < 0)
     err (EXIT_FAILURE, "couldn't remove temporary sysroot %s", TMP_SYSROOT);
   
-  /* Move /run mount point from initramfs (/run) to the real root filesystem (sysroot/run).
-  * This ensures that systemd does not remount it during switchroot if it detects an existing mount point.
-  * Consequently, all contents of /run will be transferred to the real root filesystem.
-  * This adjustment resolves the issue of mounting sysroot as read-only. During the execution 
-  * of ostree-remount.service, the system checks /run/ostree-booted to determine if sysroot should be 
-  * mounted as read-only.
-  */
+  /* Move /run mount point from initramfs (/run) to the real root filesystem
+   * (sysroot/run). This ensures that systemd does not remount it during
+   * switchroot if it detects an existing mount point. Consequently, all
+   * contents of /run will be transferred to the real root filesystem.
+   * This adjustment resolves the issue of mounting sysroot as read-only.
+   * During the execution of ostree-remount.service, the system checks
+   * /run/ostree-booted to determine if sysroot should be mounted as read-only.
+   */
   if (mount("/run", "run", NULL, MS_MOVE | MS_SILENT, NULL) < 0)
     err(EXIT_FAILURE, "failed to MS_MOVE '/run' to 'sysroot/run'");
 


### PR DESCRIPTION
  Moved /run mount point from initramfs(/run) to realrootfs(sysroot/run) so that systemd will not mount it again if it finds a mount point during switchroot and all the contents of /run will be moved to realrootfs as well. It will fix the problem of mounting sysroot as read-only because during ostree-remount.service it checks in /run/ostree-booted if we need to mount it read-only only or not