### PR TITLE
tests: remove unused import

### DIFF
--- a/tests/inst/src/test.rs
+++ b/tests/inst/src/test.rs
@@ -8,8 +8,6 @@ use std::time;
 use anyhow::{bail, Context, Result};
 use rand::Rng;
 
-pub use with_procspawn_tempdir::with_procspawn_tempdir;
-
 // HTTP Server deps
 use futures_util::future;
 use hyper::service::{make_service_fn, service_fn};


### PR DESCRIPTION
Fixes:

warning: unused import: `with_procspawn_tempdir::with_procspawn_tempdir`
  --> src/test.rs:11:9
   |
11 | pub use with_procspawn_tempdir::with_procspawn_tempdir;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
  --> src/insttestmain.rs:9:1
   |
9  | mod test;
   | ^^^^^^^^^
   = note: `#[warn(unused_imports)]` on by default