### PR TITLE
ci: Drop --fast from buildextend-live

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -68,7 +68,7 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
       coreos-assembler build
       coreos-assembler buildextend-metal
       coreos-assembler buildextend-metal4k
-      coreos-assembler buildextend-live --fast
+      coreos-assembler buildextend-live
 
     """)
   }

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -66,10 +66,7 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
       rm installed -rf
       coreos-assembler fetch
       coreos-assembler build
-      coreos-assembler buildextend-metal
-      coreos-assembler buildextend-metal4k
-      coreos-assembler buildextend-live
-
+      coreos-assembler osbuild metal metal4k live
     """)
   }
   kola(cosaDir: "${env.WORKSPACE}")


### PR DESCRIPTION
This got dropped apparently with the osbuild rewrite.