### PR TITLE
ci: Update deny to v2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,10 +86,10 @@ jobs:
       - name: Run tests
         run: cargo test --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
   cargo-deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         log-level: warn
         command: check bans sources licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,4 @@
 [licenses]
-unlicensed = "deny"
-copyleft = "allow"
 allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unlicense", "Unicode-DFS-2016", "Unicode-3.0"]
 private = { ignore = true }
 


### PR DESCRIPTION
It looks like the v1 action due to a crate bump
started hard requiring a newer rust?