### PR TITLE
A few buildsystem fixes

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -24,7 +24,7 @@ stage("Build") {
       stage("Unit tests") {
         try {
           shwrap("""
-            make check
+            make -C target/c check
           """)
         } finally {
             shwrap("cat test-suite.log || true")
@@ -32,11 +32,13 @@ stage("Build") {
         }
       }
       stage("Build installed tests") {
-        shwrap("make -C tests/kolainst")
+        shwrap("""
+           make -C tests/kolainst
+        """)
       }
       stage("Generate artifacts") {
         shwrap("""
-          make install DESTDIR=\$(pwd)/installed/rootfs
+          make -C target/c install DESTDIR=\$(pwd)/installed/rootfs
           make -C tests/kolainst install DESTDIR=\$(pwd)/installed/tests
           bash -c '. /usr/lib/os-release && echo \$VERSION_ID' >\$(pwd)/installed/buildroot-id
         """)

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+Dockerfile
+# We put most binaries under here
+target/
+# We don't have a lockfile by default
+Cargo.lock
+# Autotools generated stuff
+Makefile.in
+aclocal.m4
+apidoc/.gitignore
+apidoc/Makefile.in
+build-aux/compile
+build-aux/config.guess
+build-aux/config.sub
+build-aux/depcomp
+build-aux/install-sh
+build-aux/ltmain.sh
+build-aux/missing
+build-aux/test-driver
+buildutil/gtk-doc.m4
+buildutil/libglnx.m4
+buildutil/libtool.m4
+buildutil/ltoptions.m4
+buildutil/ltsugar.m4
+buildutil/ltversion.m4
+buildutil/lt~obsolete.m4
+config.h.in
+configure
+gtk-doc.make

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,12 @@
+# This config mainly overrides `summary: false` by default
+# as it's really noisy.
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false # turned off by default
+    code_review: true
+ignore_patterns: []

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build libostree
         run: ./ci/build.sh
       - name: Install libostree
-        run: make install
+        run: make -C target/c install
       - name: Rust build
         run: cargo test --no-run --verbose --features=${{ env['LATEST_LIBOSTREE'] }}
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build
         run: |
           env NOCONFIGURE=1 ./autogen.sh &&
-          ./configure --without-curl --without-soup --disable-gtk-doc --disable-man \
+          ./configure --without-curl --without-soup --without-soup3 --disable-gtk-doc --disable-man \
           --disable-rust --without-libarchive --without-selinux --without-smack \
           --without-openssl --without-avahi --without-libmount --disable-rofiles-fuse \
           --without-libsodium &&

--- a/apidoc/ostree-docs.xml
+++ b/apidoc/ostree-docs.xml
@@ -40,4 +40,6 @@
 			<xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
 		</index>
 	</chapter>
+
+	<xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
 </book>

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -16,6 +16,7 @@ dn=$(dirname $0)
 
 pkg_upgrade
 pkg_install_buildroot
+pkg_install ccache
 pkg_builddep ostree
 # Not yet in the spec
 pkg_install composefs-devel
@@ -27,7 +28,3 @@ if test -n "${CI_PKGS:-}"; then
 fi
 pkg_install_if_os fedora gjs gnome-desktop-testing parallel coccinelle clang \
                   python3-PyYAML
-if test "${OS_ID}" = "centos"; then
-    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    pkg_install python34{,-PyYAML}
-fi

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -6,6 +6,10 @@ OS_ID=$(. /etc/os-release; echo $ID)
 OS_ID_LIKE=$(. /etc/os-release; echo $ID ${ID_LIKE:-})
 OS_VERSION_ID=$(. /etc/os-release; echo $VERSION_ID)
 
+# Drop our content underneath target/ by default as it's already
+# ignored by rust
+BUILDDIR=target/c
+
 pkg_upgrade() {
     dnf -y distro-sync
 }
@@ -16,8 +20,9 @@ make() {
 
 build() {
     env NOCONFIGURE=1 ./autogen.sh
-    ./configure --sysconfdir=/etc --prefix=/usr --libdir=/usr/lib64 "$@"
-    make V=1
+    mkdir -p target/c
+    (cd target/c && ../../configure --sysconfdir=/etc --prefix=/usr --libdir=/usr/lib64 "$@")
+    make -C target/c V=1
 }
 
 pkg_install() {

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -40,6 +40,9 @@ pkg_install_buildroot() {
             pkg_install dnf-plugins-core @buildsys-build;;
         centos)
             # Sadly this stuff is actually hardcoded in *Python code* in mock...
+            dnf -y install dnf-utils
+            dnf config-manager --enable crb
+            dnf -y install https://dl.fedoraproject.org/pub/epel/epel{,-next}-release-latest-9.noarch.rpm
             dnf -y install make gcc;;
         *) fatal "pkg_install_buildroot(): Unhandled OS ${OS_ID}";;
     esac

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
-RUN env ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN ./ci/build.sh
+RUN make -C target/c install DESTDIR=/cosa/component-install
 RUN make -C tests/kolainst
 RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 # Uncomment this to fake a build to test the code below

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -42,6 +42,8 @@ PATH="$PATH:/usr/sbin:/sbin"
 # libtest_exit_cmds+=(expr).
 libtest_exit_cmds=()
 run_exit_cmds() {
+  # Quiet termination
+  set +x
   for expr in "${libtest_exit_cmds[@]}"; do
     eval "${expr}" || true
   done
@@ -747,8 +749,9 @@ which_gpg () {
 }
 
 libtest_cleanup_gpg () {
+    set +x
     local gpg_homedir=${1:-${test_tmpdir}/gpghome}
-    gpg-connect-agent --homedir "${gpg_homedir}" killagent /bye || true
+    gpg-connect-agent --homedir "${gpg_homedir}" killagent /bye &>/dev/null || true
 }
 libtest_exit_cmds+=(libtest_cleanup_gpg)
 


### PR DESCRIPTION
apidoc: Quiet many warnings

Should have done this long ago, this greatly reduces the spam
in the terminal logs from builds.

---

dockerignore: Add

This ensures we don't pick up things we shouldn't from the source.

---

ci: Updates for centos builds

- Do the modern way to enable the buildroot with crb and epel

---

tests/libtest: Just use python as a webserver if no libsoup

We only have a very few tests that actually need what
we have in ostree-trivial-httpd that supports things like serving
random 500 errors etc.

If we don't have libsoup, then just use a python webserver.

---
