### PR TITLE
ci: Expand bootc testing to cover c10s

### DIFF
--- a/.github/workflows/bootc.yaml
+++ b/.github/workflows/bootc.yaml
@@ -15,8 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  c9s-e2e:
+  e2e:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        stream: [stream9, stream10]
     steps:
       - uses: actions/checkout@v4
       - name: Installdeps
@@ -28,7 +32,7 @@ jobs:
           sudo apt update
           sudo apt install -y crun/testing podman/testing skopeo/testing
       - name: build
-        run: sudo just build
+        run: sudo just build --build-arg=base=quay.io/centos-bootc/centos-bootc:${{ matrix.stream }}
       - name: unitcontainer
         run: sudo just unitcontainer
       - name: unittest
@@ -46,5 +50,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-suite-log
+          name: test-suite-log-${{ matrix.stream }}
           path: target/unittest


### PR DESCRIPTION
Because it's an active development target.