### PR TITLE
repo: Add new API to write config with reload+validation

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -352,6 +352,7 @@ ostree_repo_get_remote_list_option
 ostree_repo_get_remote_option
 ostree_repo_get_parent
 ostree_repo_write_config
+ostree_repo_write_config_and_reload
 OstreeRepoTransactionStats
 ostree_repo_scan_hardlinks
 ostree_repo_prepare_transaction

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -32,6 +32,7 @@ global:
 
 LIBOSTREE_2025.3 {
 global:
+  ostree_repo_write_config_and_reload;
   ostree_deployment_is_soft_reboot_target;
   ostree_sysroot_deployment_can_soft_reboot;
   ostree_sysroot_deployment_set_soft_reboot;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -192,6 +192,9 @@ OstreeRepo *ostree_repo_get_parent (OstreeRepo *self);
 
 _OSTREE_PUBLIC
 gboolean ostree_repo_write_config (OstreeRepo *self, GKeyFile *new_config, GError **error);
+_OSTREE_PUBLIC
+gboolean ostree_repo_write_config_and_reload (OstreeRepo *self, GKeyFile *new_config,
+                                              GError **error);
 
 /**
  * OstreeRepoCommitState:

--- a/src/ostree/ot-builtin-config.c
+++ b/src/ostree/ot-builtin-config.c
@@ -116,7 +116,7 @@ ostree_builtin_config (int argc, char **argv, OstreeCommandInvocation *invocatio
       config = ostree_repo_copy_config (repo);
       g_key_file_set_string (config, section, key, value);
 
-      if (!ostree_repo_write_config (repo, config, error))
+      if (!ostree_repo_write_config_and_reload (repo, config, error))
         return FALSE;
     }
   else if (!strcmp (op, "get"))


### PR DESCRIPTION
The `ostree config set` CLI should really disallow writing invalid values. To implement that, add a new API that also *reloads* to the new config, and
rolls back on failure.

Closes: https://github.com/ostreedev/ostree/issues/1827