### PR TITLE
Release 2025.3

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -177,9 +177,9 @@ endif # USE_GPGME
 symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
-if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
-endif
+#if BUILDOPT_IS_DEVEL_BUILD
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 wl_versionscript_arg = -Wl,--version-script=

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2025])
-m4_define([release_version], [3])
+m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2025])
 m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -29,14 +29,3 @@ global:
   someostree_symbol_deleteme;
 } LIBOSTREE_$YEAR.$LASTSTABLE;
 */
-
-LIBOSTREE_2025.3 {
-global:
-  ostree_repo_write_config_and_reload;
-  ostree_deployment_is_soft_reboot_target;
-  ostree_sysroot_deployment_can_soft_reboot;
-  ostree_sysroot_deployment_set_soft_reboot;
-  ostree_sysroot_clear_soft_reboot;
-  ostree_bootconfig_parser_get_tries_left;
-  ostree_bootconfig_parser_get_tries_done;
-} LIBOSTREE_2025.2;

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -732,6 +732,17 @@ global:
   ostree_blob_reader_read_blob;
 } LIBOSTREE_2025.1;
 
+LIBOSTREE_2025.3 {
+global:
+  ostree_repo_write_config_and_reload;
+  ostree_deployment_is_soft_reboot_target;
+  ostree_sysroot_deployment_can_soft_reboot;
+  ostree_sysroot_deployment_set_soft_reboot;
+  ostree_sysroot_clear_soft_reboot;
+  ostree_bootconfig_parser_get_tries_left;
+  ostree_bootconfig_parser_get_tries_done;
+} LIBOSTREE_2025.2;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-eea94bdacf0f6a52c15ec5586372947b3e8467f42b8d08166df3576218774725  ${released_syms}
+80766c0ea2a0bc53d18f4eecc82a1710610468bdca39f23dda782365974e3baf  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
Release 2025.3

```
Christoffer N (1):
      docs: removed unused argument

Colin Walters (58):
      Post-release version bump
      tests: Add backcompat-fsck test
      rust: Add support for `locked` option for `SysrootDeployTreeOpts`
      unlock: Use deployment backing dir
      sysroot: Load bootloader configs via boot_fd
      generator: Still create /run/ostree in static prepareroot path
      prepare-root: Document that /var is unaffected by root.transient
      bin/set-origin: Don't crash if origin has no refspec
      tests: Don't mutate usr/sbin separately
      tests: Drop use of host_refspec
      tests/auto-prune: Add logging for steps
      tests/prune: Minor refactor and logging
      tests/prune: Ensure /boot is big enough for 3 bootdata
      sysroot: Detect early on when /boot is on vfat
      rust: Update to 2025.2
      ci: Drop --fast from buildextend-live
      ci: Update deny to v2
      rust: Release new minor version
      rust: Release new minor version
      rust: Drop MSRV job
      rust: Also add a feature for v2025_2
      apidoc: Quiet many warnings
      Turn off gemini summary
      dockerignore: Add
      ci: Updates for centos builds
      ci: use srcdir != builddir by default, builddir under target/
      libtest: Quiet some output
      ci: Disable soup3 in minimal
      docs: Some typo and link fixes
      tests/libtest: Just use python as a webserver if no libsoup
      ci: Rework Dockerfile, add Justfile and improved testing
      rust: Tweaks for README.md
      prepare-root: Factor out composefs handling into otcore
      prepare-root: Don't hardcode sysroot
      prepare-root: Move metadata for deployment into otcore
      prepare-root: Move metadata for root transient into lib
      prepare-root: Fix error overwrite
      prepare-root: Move /etc handling into library
      justfile: Accept args, add build-host shortcuts
      Import jsonwrt code from util-linux
      jsonwrt: Integration fixups
      status: Add --json output
      prepare-root: Use tempdir for transient etc backing
      admin: Expand column for subcommands
      Add ostree admin prepare-soft-reboot
      build-sys: Move clang-format into justfile
      status: Add `soft-reboot-target` to JSON
      status: Add more tests for json
      sysroot: Remove now-spurious assertion change from soft reboot changes
      deploy: Default quiet for forked systemctl
      sysroot: Cache deployment device/inode
      deploy: Don't create deployment object before deploying
      ci: Expand bootc testing to cover c10s
      soft-reboot: Many changes
      docs: Remove <authorgroup>
      tests: Verify soft reboot with changed kernel state
      soft-reboot: Check for kernel argument changes
      repo: Add new API to write config with reload+validation

Daiki Ueno (1):
      Fix build error with --with-ed25519-libsodium and --with-openssl

Evan Goode (1):
      man: Document `ostree admin unlock --transient`

Igor Opaniuk (1):
      sysroot: Support boot counting for boot entries

Jonathan Lebon (1):
      ci: build metal and live media in one invocation

Joseph Marrero Corchado (4):
      ostree-prepare-root: make mkdir calls idempotent
      ostree-prepare-root: add option processing for kernel arguments
      Release 2025.3
      configure: post-release version bump

Ricardo Salveti (1):
      deploy: only set aboot/abootcfg when found

Samuel Zeter (1):
      tests: remove unused import
```

## New Contributors
* @ChilloManiac  made their first contribution in https://github.com/ostreedev/ostree/pull/3403
* @evan-goode made their first contribution in https://github.com/ostreedev/ostree/pull/3423
* @samzeter made their first contribution in https://github.com/ostreedev/ostree/pull/3425

**Full Changelog**: https://github.com/ostreedev/ostree/compare/v2025.2...v2025.3