### PR TITLE
Add root.transient-ro

### DIFF
--- a/man/ostree-prepare-root.xml
+++ b/man/ostree-prepare-root.xml
@@ -133,6 +133,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><varname>root.transient-ro</varname></term>
+                <listitem><para>A boolean value; the default is <literal>false</literal>.
+                   This is like <literal>root.transient</literal>, but the overlayfs upper will be mounted
+                   read-only by default. Use this when you want specific privileged components to be able to
+                   write to the upper by temporarily mounting it writable in a new mount namespace.
+                </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><varname>composefs.enabled</varname></term>
                 <listitem><para>This can be <literal>yes</literal>, <literal>no</literal>, <literal>maybe</literal>,
                 <literal>signed</literal>, or <literal>verity</literal>. The default is <literal>no</literal>.

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -68,6 +68,7 @@ typedef struct
 {
   OtTristate composefs_enabled;
   gboolean root_transient;
+  gboolean root_transient_ro;
   gboolean require_verity;
   gboolean is_signed;
   char *signature_pubkey;
@@ -132,6 +133,7 @@ gboolean otcore_mount_etc (GKeyFile *config, GVariantBuilder *metadata_builder,
 #define OTCORE_PREPARE_ROOT_ENABLED_KEY "enabled"
 #define OTCORE_PREPARE_ROOT_KEYPATH_KEY "keypath"
 #define OTCORE_PREPARE_ROOT_TRANSIENT_KEY "transient"
+#define OTCORE_PREPARE_ROOT_TRANSIENT_RO_KEY "transient-ro"
 
 // For use with systemd soft reboots
 #define OTCORE_RUN_NEXTROOT "/run/nextroot"
@@ -152,6 +154,8 @@ gboolean otcore_mount_etc (GKeyFile *config, GVariantBuilder *metadata_builder,
 #define OTCORE_RUN_BOOTED_KEY_COMPOSEFS_SIGNATURE "composefs.signed"
 // This key will be present if the root is transient
 #define OTCORE_RUN_BOOTED_KEY_ROOT_TRANSIENT "root.transient"
+// This key will be present if the root is transient readonly
+#define OTCORE_RUN_BOOTED_KEY_ROOT_TRANSIENT_RO "root.transient-ro"
 // This key will be present if the sysroot-ro flag was found
 #define OTCORE_RUN_BOOTED_KEY_SYSROOT_RO "sysroot-ro"
 // Always holds the (device, inode) pair of the booted deployment

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -234,6 +234,11 @@ main (int argc, char *argv[])
   const bool sysroot_currently_writable = !path_is_on_readonly_fs (root_arg);
   g_print ("sysroot.readonly configuration value: %d (fs writable: %d)\n", (int)sysroot_readonly,
            (int)sysroot_currently_writable);
+  if (rootfs_config->root_transient)
+    {
+      g_print ("root.transient: %d (ro: %d)\n", (int)rootfs_config->root_transient,
+               (int)rootfs_config->root_transient_ro);
+    }
 
   /* Remount root MS_PRIVATE here to avoid errors due to the kernel-enforced
    * constraint that disallows MS_SHARED mounts to be moved.

--- a/tests/kolainst/destructive/root-transient-ro.sh
+++ b/tests/kolainst/destructive/root-transient-ro.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libinsttest.sh
+
+prepare_tmpdir
+
+echo "testing boot=${AUTOPKGTEST_REBOOT_MARK:-}"
+
+# Print this by default on each boot
+ostree admin status
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+  # xref https://github.com/coreos/coreos-assembler/pull/2814
+  systemctl mask --now zincati
+
+  test '!' -w /
+
+  cp /usr/lib/ostree/prepare-root.conf /etc/ostree/
+  cat >> /etc/ostree/prepare-root.conf <<'EOF'
+[root]
+transient-ro = true
+EOF
+
+  rpm-ostree initramfs-etc --track /etc/ostree/prepare-root.conf
+  
+  /tmp/autopkgtest-reboot "2"
+  ;;
+  "2")
+
+  test '!' -w '/'
+
+  unshare -m /bin/sh -c 'env LIBMOUNT_FORCE_MOUNT2=always mount -o remount,rw / && mkdir /new-dir-in-root'
+  test -d /new-dir-in-root
+
+  test '!' -w '/'
+
+  echo "ok root transient-ro"
+  ;;
+  *) 
+  fatal "Unexpected AUTOPKGTEST_REBOOT_MARK=${AUTOPKGTEST_REBOOT_MARK}" 
+  ;;
+esac


### PR DESCRIPTION
An example use case for this is having privileged code add dynamic new toplevel mountpoints (that don't persist across reboots/upgrades), while still keeping the rootfs readonly for processes by default.

Closes: https://github.com/ostreedev/ostree/issues/3471