### PR TITLE
ci: Adapt to cosa change

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -68,7 +68,7 @@ cosaPod(runAsUser: 0, memory: "9Gi", cpu: "4") {
       rm installed -rf
       coreos-assembler fetch
       coreos-assembler build
-      coreos-assembler osbuild metal metal4k live
+      coreos-assembler osbuild qemu metal metal4k live
     """)
   }
   kola(cosaDir: "${env.WORKSPACE}")


### PR DESCRIPTION
It seems to have stopped building qemu by default.

Closes: https://github.com/ostreedev/ostree/issues/3505