### PR TITLE
Deduplicate repo+sysroot syncfs logic

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2227,14 +2227,8 @@ ostree_repo_commit_transaction (OstreeRepo *self, OstreeRepoTransactionStats *ou
   if ((self->test_error_flags & OSTREE_REPO_TEST_ERROR_PRE_COMMIT) > 0)
     return glnx_throw (error, "OSTREE_REPO_TEST_ERROR_PRE_COMMIT specified");
 
-  /* FIXME: Added OSTREE_SUPPRESS_SYNCFS since valgrind in el7 doesn't know
-   * about `syncfs`...we should delete this later.
-   */
-  if (!self->disable_fsync && g_getenv ("OSTREE_SUPPRESS_SYNCFS") == NULL)
-    {
-      if (syncfs (self->tmp_dir_fd) < 0)
-        return glnx_throw_errno_prefix (error, "syncfs(repo/tmp)");
-    }
+  if (!_ostree_repo_syncfs (self, error))
+    return FALSE;
 
   if (!rename_pending_loose_objects (self, cancellable, error))
     return FALSE;

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -394,6 +394,7 @@ gboolean _ostree_repo_load_file_bare (OstreeRepo *self, const char *checksum, in
                                       GError **error);
 
 gboolean _ostree_repo_update_mtime (OstreeRepo *self, GError **error);
+gboolean _ostree_repo_syncfs (OstreeRepo *self, GError **error);
 
 gboolean _ostree_repo_add_remote (OstreeRepo *self, OstreeRemote *remote);
 gboolean _ostree_repo_remove_remote (OstreeRepo *self, OstreeRemote *remote);


### PR DESCRIPTION


This is a followup to https://github.com/ostreedev/ostree/pull/3504/commits/6e5a27a29d33d50a2a4380c406405435d919b6b4
which I believe is correct as is. However, we already have a file
descriptor open for the ostree repo, which *must* be on
the same filesystem as `/sysroot/ostree` (the deployment
code forces hardlinking today).

It's hence cleaner to reuse that extant fd instead of opening
a new one - we know we did writes to that fd.

But going farther here, there already is logic to use syncfs
for the repo when downloading objects (in a common case
we actually syncfs twice).

Since these are really the same operation, unify them:

- Add journaling to the repo one syncfs case
- Change the sysroot case to just call it
- Since we log consistently to the journal for all syncfs/fsfreeze
  operations now, drop the SyncStats bits which was a way
  to add info about that to a later journal message

Additionally, let's add an extra check when we're
opening the repo that it's on the same device just on general
principle.

Signed-off-by: Colin Walters <walters@verbum.org>

---
