### PR TITLE
libostree: remove OSTREE_SUPPRESS_SYNCFS

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1527,11 +1527,6 @@ _ostree_repo_syncfs (OstreeRepo *self, GError **error)
 
   if (self->disable_fsync)
     return TRUE;
-  /* FIXME: Added OSTREE_SUPPRESS_SYNCFS since valgrind in el7 doesn't know
-   * about `syncfs`...we should delete this later.
-   */
-  if (g_getenv ("OSTREE_SUPPRESS_SYNCFS") != NULL)
-    return TRUE;
 
   gboolean is_system = ostree_repo_is_system (self);
   if (is_system)

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -180,7 +180,7 @@ fi
 
 CMD_PREFIX=""
 if test -n "${OT_TESTS_VALGRIND:-}"; then
-    CMD_PREFIX="env G_SLICE=always-malloc OSTREE_SUPPRESS_SYNCFS=1 valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
+    CMD_PREFIX="env G_SLICE=always-malloc valgrind -q --error-exitcode=1 --leak-check=full --num-callers=30 --suppressions=${test_srcdir}/glib.supp --suppressions=${test_srcdir}/ostree.supp"
 fi
 
 if test -z "${OSTREE_HTTPD:-}"; then


### PR DESCRIPTION
This workaround was needed for the old valgrind version in EL 7