### PR TITLE
ostree-finalize-staged.service: RequiresMountsFor=/etc

### DIFF
--- a/src/boot/ostree-finalize-staged.service
+++ b/src/boot/ostree-finalize-staged.service
@@ -21,7 +21,7 @@ Documentation=man:ostree(1)
 ConditionPathExists=/run/ostree-booted
 DefaultDependencies=no
 
-RequiresMountsFor=/sysroot /boot
+RequiresMountsFor=/sysroot /boot /etc
 After=local-fs.target
 Before=basic.target final.target
 # We want to make sure the transaction logs are persisted to disk:


### PR DESCRIPTION
I've seen in some cases systemd try to unmount /etc quite early and then fail because it's in use.

It's confusing because I don't see this in all scenarios. But regardless, in the situations where it does occur, this fixes it.