### PR TITLE
Move dracut module from 98 ordering to the recommended 50 ordering

### DIFF
--- a/Makefile-boot.am
+++ b/Makefile-boot.am
@@ -19,7 +19,7 @@
 
 if BUILDOPT_DRACUT
 # Not using $(libdir) here is intentional, dracut modules go in prefix/lib
-dracutmoddir = $(prefix)/lib/dracut/modules.d/98ostree
+dracutmoddir = $(prefix)/lib/dracut/modules.d/50ostree
 dracutmod_SCRIPTS = src/boot/dracut/module-setup.sh
 endif
 if BUILDOPT_DRACUT_CONF


### PR DESCRIPTION
In dracut release v108 or later the recommended ordering for out out of tree modules is 50. The following is a section from dracut documentation:

> Not using the 50-59 range for out of tree dracut modules will likely
> lead to unintended errors in the initramfs generation process as your
> dracut module will either run too early or too late in the generation process.
> You have been warned.

Fixes: https://github.com/ostreedev/ostree/issues/3495