### PR TITLE
status: Include deployment index in JSON output

### DIFF
--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -203,6 +203,7 @@ deployment_write_json (OstreeSysroot *sysroot, OstreeRepo *repo, OstreeDeploymen
   ul_jsonwrt_value_s (jo, "checksum", ref);
   ul_jsonwrt_value_s (jo, "stateroot", ostree_deployment_get_osname (deployment));
   ul_jsonwrt_value_u64 (jo, "serial", ostree_deployment_get_deployserial (deployment));
+  ul_jsonwrt_value_u64 (jo, "index", ostree_deployment_get_index (deployment));
   ul_jsonwrt_value_boolean (jo, "booted", is_booted);
   ul_jsonwrt_value_boolean (jo, "pending", is_pending);
   ul_jsonwrt_value_boolean (jo, "rollback", is_rollback);


### PR DESCRIPTION
Very, very small change. Whilst you can derive the deployment index from the offset in the JSON object array, including the deployment index directly in the JSON output makes scripting just that _tiny bit_ nicer to work with. I tested it locally, and everything works fine. If this change isn't suitable, please feel free to close the merge request - cheers!


```shell
$ ./ostree admin status -J | jq -r '.[][] | "\(.booted) \(.index) \(.checksum)"'
true 0 6ecb0b27b7fc107076b8f1155ca7a3505207d244802f15dbb240483bb8d38a84
false 1 ca6b6a42071e0bdc50aed2cfab2ca94671446f255f54943e191ce4d10173a642
false 2 b3adb220dbc32851fee801645b845399aaca45fa2879602ee14aaa380bd4bf38
false 3 032383b10f1e0866e2533f40ebeb937bb50577f71de836a5fac2285b7f7f1031
false 4 b951a4ff8e863c3d41c2dbcc31c50c2080aabb38905e8272fa3b211932a791be
false 5 206b15356415400366fb94b8ccc2969a442bf0769f3319e369a492561b773ecc
false 6 2eff32e0245ed3222532e3f173e4c96a30c73887bf441994bd53e0e14acb3180
false 7 8f97670a11164680d3b73f0efc860574e3dc5e9fe5784e01bf13122a65a02b45
false 8 4fbaef23426ba974f9d8e9ec810c02f5f407a787737f059be3e0e0124a46ae2b
false 9 f8c41368a1fe0c5d99b9077169596e0a1336aa6f6ea8ba0dbfb272855066c0aa
false 10 033380f480532eb4ccef298bd9f25120ca64ebc33761e0cfa0e07c3d41c93980
false 11 5fd3b9943917eec83f85fb3256984dd1bae6dae660e05e4a39995bfaa87350ea
false 12 891a7e06d65e38e7976c6c150173686f989cdb93d80bd2ea909aa55a5b401f90
false 13 eafa97d059cdb7e511e971993441972120a023b264225f4d59861348918201a4
$ ./ostree admin status -J | jq -r '.[][0]'
{
  "checksum": "6ecb0b27b7fc107076b8f1155ca7a3505207d244802f15dbb240483bb8d38a84",
  "index": 0,
  "stateroot": "yorha",
  "serial": 0,
  "booted": true,
  "pending": false,
  "rollback": false,
  "finalization-locked": false,
  "soft-reboot-target": false,
  "staged": false,
  "pinned": false,
  "unlocked": "none"
}
```