### PR TITLE
grub2: source /etc/default/grub.d/*.cfg after /etc/default/grub

### DIFF
--- a/src/boot/grub2/grub2-15_ostree
+++ b/src/boot/grub2/grub2-15_ostree
@@ -35,6 +35,11 @@ fi
 # Since there is no need to create menu entries for that case.
 # See: https://src.fedoraproject.org/rpms/grub2/c/7c2bab5e98d
 . /etc/default/grub
+
+for f in /etc/default/grub.d/*.cfg; do
+    [ -f "$f" ] && . "$f"
+done
+
 if test -f /boot/grub2/.grub2-blscfg-supported && \
    test "${GRUB_ENABLE_BLSCFG}" = "true"; then
    exit 0


### PR DESCRIPTION
Previously only /etc/default/grub was sourced, ignoring fragments in /etc/default/grub.d. This patch sources all *.cfg files after the main grub file, allowing configuration fragments to override defaults.