### PR TITLE
ci,Justfile: fix building with the right stream

### DIFF
--- a/.github/workflows/bootc.yaml
+++ b/.github/workflows/bootc.yaml
@@ -32,11 +32,11 @@ jobs:
           sudo apt update
           sudo apt install -y crun/testing podman/testing skopeo/testing
       - name: build
-        run: sudo just build --build-arg=base=quay.io/centos-bootc/centos-bootc:${{ matrix.stream }}
+        run: sudo STREAM=${{ matrix.stream }} just build
       - name: unitcontainer
-        run: sudo just unitcontainer
+        run: sudo STREAM=${{ matrix.stream }} just unitcontainer
       - name: unittest
-        run: sudo just unittest
+        run: sudo STREAM=${{ matrix.stream }} just unittest
       - name: bootc install
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
Part of the `e2e (stream10)` was running stream9.

As `just` doesn't support named parameters yet (https://github.com/casey/just/issues/476),
use `STREAM` env var to select between stream9 and stream10

see https://github.com/ostreedev/ostree/actions/runs/18376803524/job/52481290836?pr=3532#step:6:6, part of the e2e stream10 was using stream9