### PR TITLE
aboot: Add missing stdint.h include

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,26 @@ jobs:
         with:
           name: inst.tar.zst
           path: inst.tar.zst
+  build-musl:
+    name: "Build (Alpine)"
+    runs-on: ubuntu-latest
+    container: docker.io/alpine:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apk update
+          apk add autoconf automake bison build-base curl-dev e2fsprogs-dev \
+            fuse-dev git glib-dev gpgme-dev libsoup-dev libtool pkgconfig xz-dev
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build
+        run: |
+          env NOCONFIGURE=1 ./autogen.sh &&
+          ./configure --with-curl --with-selinux --with-dracut=yesbutnoconf --without-selinux &&
+          make -j 4 && make install DESTDIR=$(pwd)/install && tar -c -C install --zstd -f inst.tar.zst .
   tests:
     # Distro configuration matrix
     #

--- a/src/libostree/ostree-bootloader-aboot.c
+++ b/src/libostree/ostree-bootloader-aboot.c
@@ -24,6 +24,7 @@
 #include "otutil.h"
 #include <sys/mount.h>
 
+#include <stdint.h>
 #include <string.h>
 
 /* This is specific to aboot and zipl today, but in the future we could also


### PR DESCRIPTION
Without this include, builds on musl systems end up with the following
error:

```
src/libostree/ostree-bootloader-aboot.c:136:18: error: 'uintptr_t'
    undeclared (first use in this function)
  136 |   int fd = (int)(uintptr_t)data;
      |                  ~~~~~~~~
```