### PR TITLE
tests: account for different locales in remote-gpg-list-keys test

### DIFF
--- a/tests/test-remote-gpg-list-keys.sh
+++ b/tests/test-remote-gpg-list-keys.sh
@@ -61,14 +61,19 @@ echo "ok remote with global keyring"
 # Import a key and check that it's listed
 ${OSTREE} remote gpg-import --keyring ${TEST_GPG_KEYHOME}/key1.asc R1
 ${OSTREE} remote gpg-list-keys R1 > result
-cat > expected <<"EOF"
+
+# In different locales the date is returned differently
+# Convert the known Creation date to the current locale.
+EXPECTED_DATE=$(date -d "Tue Sep 10 02:29:42 2013" "+%c")
+
+cat > expected <<EOF
 Key: 5E65DE75AB1C501862D476347FCA23D8472CDAFA
-  Created: Tue Sep 10 02:29:42 2013
+  Created: $EXPECTED_DATE
   UID: Ostree Tester <test@test.com>
   Advanced update URL: https://openpgpkey.test.com/.well-known/openpgpkey/test.com/hu/iffe93qcsgp4c8ncbb378rxjo6cn9q6u?l=test
   Direct update URL: https://test.com/.well-known/openpgpkey/hu/iffe93qcsgp4c8ncbb378rxjo6cn9q6u?l=test
   Subkey: CC47B2DFB520AEF231180725DF20F58B408DEA49
-    Created: Tue Sep 10 02:29:42 2013
+    Created: $EXPECTED_DATE
 EOF
 assert_files_equal result expected
 
@@ -85,28 +90,35 @@ echo "ok global no keyring"
 OSTREE_GPG_HOME=${trusteddir}
 ${OSTREE} remote gpg-list-keys > result
 OSTREE_GPG_HOME=${emptydir}
-cat > expected <<"EOF"
+
+# In different locales the date is returned differently
+# Convert the known Creation date to the current locale.
+EXPECTED_DATE=$(date -d "Tue Sep 10 02:29:42 2013" "+%c")
+EXPECTED_DATE2=$(date -d "Tue Mar 17 14:00:32 2015" "+%c")
+EXPECTED_DATE3=$(date -d "Tue Mar 17 14:01:05 2015" "+%c")
+
+cat > expected <<EOF
 Key: 5E65DE75AB1C501862D476347FCA23D8472CDAFA
-  Created: Tue Sep 10 02:29:42 2013
+  Created: $EXPECTED_DATE
   UID: Ostree Tester <test@test.com>
   Advanced update URL: https://openpgpkey.test.com/.well-known/openpgpkey/test.com/hu/iffe93qcsgp4c8ncbb378rxjo6cn9q6u?l=test
   Direct update URL: https://test.com/.well-known/openpgpkey/hu/iffe93qcsgp4c8ncbb378rxjo6cn9q6u?l=test
   Subkey: CC47B2DFB520AEF231180725DF20F58B408DEA49
-    Created: Tue Sep 10 02:29:42 2013
+    Created: $EXPECTED_DATE
 Key: 7B3B1020D74479687FDB2273D8228CFECA950D41
-  Created: Tue Mar 17 14:00:32 2015
+  Created: $EXPECTED_DATE2
   UID: Ostree Tester II <test2@test.com>
   Advanced update URL: https://openpgpkey.test.com/.well-known/openpgpkey/test.com/hu/nnxwsxno46ap6hw7fgphp68j76egpfa9?l=test2
   Direct update URL: https://test.com/.well-known/openpgpkey/hu/nnxwsxno46ap6hw7fgphp68j76egpfa9?l=test2
   Subkey: 1EFA95C06EB1EB91754575E004B69C2560D53993
-    Created: Tue Mar 17 14:00:32 2015
+    Created: $EXPECTED_DATE2
 Key: 7D29CF060B8269CDF63BFBDD0D15FAE7DF444D67
-  Created: Tue Mar 17 14:01:05 2015
+  Created: $EXPECTED_DATE3
   UID: Ostree Tester III <test3@test.com>
   Advanced update URL: https://openpgpkey.test.com/.well-known/openpgpkey/test.com/hu/8494gyqhmrcs6gn38tn6kgjexet117cj?l=test3
   Direct update URL: https://test.com/.well-known/openpgpkey/hu/8494gyqhmrcs6gn38tn6kgjexet117cj?l=test3
   Subkey: 0E45E48CBF7B360C0E04443E0C601A7402416340
-    Created: Tue Mar 17 14:01:05 2015
+    Created: $EXPECTED_DATE3
 EOF
 assert_files_equal result expected
 


### PR DESCRIPTION
During test preparation in libtest-core.sh either C or en_US locale is set for the test execution.

The remote-gpg-list-keys compares outputs that contain locale-dependent dates, but the current test case expects the result to be in C locale.

However in case C.utf-8 locale is not available, but en_US.utf-8 locale is available, then the latter will be used, and the testcase will fail, because it expects dates to be in this format:

`Tue 17 Mar 2015 02:00:32 PM UTC`

However with US locale it receives the date like this:

`Tue Mar 17 2015 02:00:32 PM UTC`

This change converts these dates to the current locale before comparing the expected gpg key content with the received one.