### PR TITLE
Add missing `:` to the gtk-doc in a few places

### DIFF
--- a/src/libostree/ostree-blob-reader.c
+++ b/src/libostree/ostree-blob-reader.c
@@ -30,7 +30,7 @@ ostree_blob_reader_default_init (OstreeBlobReaderInterface *iface)
 }
 
 /**
- * ostree_blob_reader_read_blob
+ * ostree_blob_reader_read_blob:
  * @self: A OstreeBlobReader
  * @cancellable: a #GCancellable
  * @error: a #GError

--- a/src/libostree/ostree-kernel-args.c
+++ b/src/libostree/ostree-kernel-args.c
@@ -363,7 +363,7 @@ ostree_kernel_args_new_replace (OstreeKernelArgs *kargs, const char *arg, GError
 }
 
 /**
- * ostree_kernel_args_delete_key_entry
+ * ostree_kernel_args_delete_key_entry:
  * @kargs: an OstreeKernelArgs instance
  * @key: the key to remove
  * @error: an GError instance

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -4948,7 +4948,7 @@ ostree_repo_pull_one_dir (OstreeRepo *self, const char *remote_name, const char 
 }
 
 /**
- * _formatted_time_remaining_from_seconds
+ * _formatted_time_remaining_from_seconds:
  * @seconds_remaining: Estimated number of seconds remaining.
  *
  * Returns a strings showing the number of days, hours, minutes

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -4508,7 +4508,7 @@ ostree_sysroot_clear_soft_reboot (OstreeSysroot *self, GCancellable *cancellable
 }
 
 /**
- * ostree_sysroot_deployment_kexec_load
+ * ostree_sysroot_deployment_kexec_load:
  * @self: Sysroot
  * @deployment: Deployment to prepare a kexec for
  * @cancellable: Cancellable


### PR DESCRIPTION
This is SUCH a giant trap. I am not totally sure why it's working for me in a fedora-42 build env, but it seems like it may have broken in a different build environment in https://github.com/ostreedev/ostree/pull/3548#discussion_r2500278890

I used Sonnet to audit for similar instances beyond `read_blob` and it found some, fix those too.