### PR TITLE
static-delta: Avoid copying bspatch output

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -30,6 +30,7 @@
 #include <glib/gprintf.h>
 #include <stdbool.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/statvfs.h>
 #include <sys/xattr.h>
 
@@ -488,6 +489,9 @@ typedef struct
   OtChecksum checksum;
   guint64 content_len;
   guint64 bytes_written;
+  gpointer mapped;
+  gsize mapped_len;
+  gboolean mapped_active;
   guint uid;
   guint gid;
   guint mode;
@@ -509,7 +513,7 @@ _ostree_repo_bare_content_open (OstreeRepo *self, const char *expected_checksum,
   g_assert (!real->initialized);
   real->initialized = TRUE;
   g_assert (S_ISREG (mode));
-  if (!glnx_open_tmpfile_linkable_at (commit_tmp_dfd (self), ".", O_WRONLY | O_CLOEXEC, &real->tmpf,
+  if (!glnx_open_tmpfile_linkable_at (commit_tmp_dfd (self), ".", O_RDWR | O_CLOEXEC, &real->tmpf,
                                       error))
     return FALSE;
   ot_checksum_init (&real->checksum);
@@ -536,9 +540,81 @@ _ostree_repo_bare_content_write (OstreeRepo *repo, OstreeRepoBareContent *barewr
 {
   OstreeRealRepoBareContent *real = (OstreeRealRepoBareContent *)barewrite;
   g_assert (real->initialized);
+  g_assert (!real->mapped_active);
   ot_checksum_update (&real->checksum, buf, len);
   if (glnx_loop_write (real->tmpf.fd, buf, len) < 0)
     return glnx_throw_errno_prefix (error, "write");
+  real->bytes_written += len;
+  return TRUE;
+}
+
+gboolean
+_ostree_repo_bare_content_map (OstreeRepoBareContent *barewrite, guint8 **out_buf, GError **error)
+{
+  OstreeRealRepoBareContent *real = (OstreeRealRepoBareContent *)barewrite;
+  g_assert (real->initialized);
+  g_assert (!real->mapped_active);
+
+  if (G_UNLIKELY (real->bytes_written != 0))
+    return glnx_throw (error, "Cannot map bare content after writing");
+
+  if (G_UNLIKELY (real->content_len > G_MAXSIZE))
+    return glnx_throw (error, "Content size is too large to map");
+
+  if (!glnx_try_fallocate (real->tmpf.fd, 0, real->content_len, error))
+    return FALSE;
+  if (ftruncate (real->tmpf.fd, real->content_len) < 0)
+    return glnx_throw_errno_prefix (error, "ftruncate");
+
+  real->mapped_len = (gsize)real->content_len;
+  if (real->mapped_len > 0)
+    {
+      real->mapped
+          = mmap (NULL, real->mapped_len, PROT_READ | PROT_WRITE, MAP_SHARED, real->tmpf.fd, 0);
+      if (real->mapped == MAP_FAILED)
+        {
+          real->mapped = NULL;
+          real->mapped_len = 0;
+          return glnx_throw_errno_prefix (error, "mmap");
+        }
+      *out_buf = real->mapped;
+    }
+  else
+    {
+      static guint8 zero_size_dummy;
+      *out_buf = &zero_size_dummy;
+    }
+
+  real->mapped_active = TRUE;
+  return TRUE;
+}
+
+gboolean
+_ostree_repo_bare_content_finish_mapped (OstreeRepoBareContent *barewrite,
+                                         GCancellable *cancellable, GError **error)
+{
+  OstreeRealRepoBareContent *real = (OstreeRealRepoBareContent *)barewrite;
+  g_assert (real->initialized);
+  g_assert (real->mapped_active);
+
+  if (real->mapped_len > 0)
+    {
+      for (gsize offset = 0; offset < real->mapped_len;)
+        {
+          if (g_cancellable_set_error_if_cancelled (cancellable, error))
+            return FALSE;
+          const gsize len = MIN (real->mapped_len - offset, 1024 * 1024);
+          ot_checksum_update (&real->checksum, (guint8 *)real->mapped + offset, len);
+          offset += len;
+        }
+      if (munmap (real->mapped, real->mapped_len) < 0)
+        return glnx_throw_errno_prefix (error, "munmap");
+    }
+
+  real->mapped = NULL;
+  real->mapped_len = 0;
+  real->mapped_active = FALSE;
+  real->bytes_written = real->content_len;
   return TRUE;
 }
 
@@ -549,6 +625,7 @@ _ostree_repo_bare_content_commit (OstreeRepo *self, OstreeRepoBareContent *barew
 {
   OstreeRealRepoBareContent *real = (OstreeRealRepoBareContent *)barewrite;
   g_assert (real->initialized);
+  g_assert (!real->mapped_active);
 
   fsblkcnt_t object_blocks_reserved = 0;
   if ((self->min_free_space_percent > 0 || self->min_free_space_mb > 0) && self->in_transaction)
@@ -604,6 +681,11 @@ _ostree_repo_bare_content_cleanup (OstreeRepoBareContent *regwrite)
   OstreeRealRepoBareContent *real = (OstreeRealRepoBareContent *)regwrite;
   if (!real->initialized)
     return;
+  if (real->mapped_active && real->mapped_len > 0)
+    (void)munmap (real->mapped, real->mapped_len);
+  real->mapped = NULL;
+  real->mapped_len = 0;
+  real->mapped_active = FALSE;
   glnx_tmpfile_clear (&real->tmpf);
   ot_checksum_clear (&real->checksum);
   g_clear_pointer (&real->expected_checksum, g_free);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -366,8 +366,9 @@ gboolean _ostree_repo_commit_tmpf_final (OstreeRepo *self, const char *checksum,
 typedef struct
 {
   gboolean initialized;
-  gpointer opaque0[10];
+  gpointer opaque0[12];
   guint opaque1[10];
+  guint64 opaque2;
 } OstreeRepoBareContent;
 void _ostree_repo_bare_content_cleanup (OstreeRepoBareContent *regwrite);
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (OstreeRepoBareContent, _ostree_repo_bare_content_cleanup)
@@ -380,6 +381,12 @@ gboolean _ostree_repo_bare_content_open (OstreeRepo *self, const char *checksum,
 gboolean _ostree_repo_bare_content_write (OstreeRepo *repo, OstreeRepoBareContent *barewrite,
                                           const guint8 *buf, size_t len, GCancellable *cancellable,
                                           GError **error);
+
+gboolean _ostree_repo_bare_content_map (OstreeRepoBareContent *barewrite, guint8 **out_buf,
+                                        GError **error);
+
+gboolean _ostree_repo_bare_content_finish_mapped (OstreeRepoBareContent *barewrite,
+                                                  GCancellable *cancellable, GError **error);
 
 gboolean _ostree_repo_bare_content_commit (OstreeRepo *self, OstreeRepoBareContent *barewrite,
                                            char *checksum_buf, size_t buflen,

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -414,7 +414,25 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
       if (!input_mfile)
         return FALSE;
 
-      g_autofree guchar *buf = g_malloc0 (state->content_size);
+      /* Instead of allocating the entire content_size in memory, use a tmpfile
+       * that can be paged to disk by the OS if needed. This prevents OOM on
+       * systems with limited RAM when processing large files.
+       * See: https://github.com/flatpak/flatpak/issues/6255
+       */
+      g_auto (GLnxTmpfile) tmpf = {
+        0,
+      };
+      if (!glnx_open_anonymous_tmpfile (O_RDWR | O_CLOEXEC, &tmpf, error))
+        return FALSE;
+
+      /* Resize tmpfile to content_size */
+      if (ftruncate (tmpf.fd, state->content_size) < 0)
+        return glnx_throw_errno_prefix (error, "ftruncate");
+
+      /* Memory-map the tmpfile for bspatch to write to */
+      void *buf = mmap (NULL, state->content_size, PROT_READ | PROT_WRITE, MAP_SHARED, tmpf.fd, 0);
+      if (buf == MAP_FAILED)
+        return glnx_throw_errno_prefix (error, "mmap");
 
       struct bzpatch_opaque_s opaque;
       opaque.state = state;
@@ -423,14 +441,45 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
       struct bspatch_stream stream;
       stream.read = bspatch_read;
       stream.opaque = &opaque;
-      if (bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
-                   g_mapped_file_get_length (input_mfile), buf, state->content_size, &stream)
-          < 0)
+
+      int bspatch_result = bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
+                                    g_mapped_file_get_length (input_mfile), buf,
+                                    state->content_size, &stream);
+
+      /* Unmap before checking result */
+      if (munmap (buf, state->content_size) < 0)
+        return glnx_throw_errno_prefix (error, "munmap");
+
+      if (bspatch_result < 0)
         return glnx_throw (error, "bsdiff patch failed");
 
-      if (!_ostree_repo_bare_content_write (repo, &state->content_out, buf, state->content_size,
-                                            cancellable, error))
-        return FALSE;
+      /* Now read from tmpfile and write to repository */
+      if (lseek (tmpf.fd, 0, SEEK_SET) < 0)
+        return glnx_throw_errno_prefix (error, "lseek");
+
+      /* Read and write in chunks to avoid loading entire file into memory */
+      guint64 bytes_remaining = state->content_size;
+      while (bytes_remaining > 0)
+        {
+          guchar chunk_buf[8192];
+          gsize chunk_size = MIN (sizeof (chunk_buf), bytes_remaining);
+          gssize bytes_read;
+
+          do
+            bytes_read = read (tmpf.fd, chunk_buf, chunk_size);
+          while (G_UNLIKELY (bytes_read == -1 && errno == EINTR));
+
+          if (bytes_read < 0)
+            return glnx_throw_errno_prefix (error, "read");
+          if (bytes_read == 0)
+            return glnx_throw (error, "Unexpected EOF reading from tmpfile");
+
+          if (!_ostree_repo_bare_content_write (repo, &state->content_out, chunk_buf, bytes_read,
+                                                cancellable, error))
+            return FALSE;
+
+          bytes_remaining -= bytes_read;
+        }
     }
 
   return TRUE;

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <string.h>
+#include <sys/mman.h>
 
 #include <gio/gfiledescriptorbased.h>
 #include <gio/gunixinputstream.h>

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -457,9 +457,9 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
       stream.read = bspatch_read;
       stream.opaque = &opaque;
 
-      int bspatch_result = bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
-                                    g_mapped_file_get_length (input_mfile), buf,
-                                    state->content_size, &stream);
+      int bspatch_result
+          = bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
+                     g_mapped_file_get_length (input_mfile), buf, state->content_size, &stream);
 
       /* Unmap before checking result - only if we actually created a mapping */
       if (state->content_size > 0 && munmap (buf, state->content_size) < 0)

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -398,6 +398,7 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
                   GError **error)
 {
   guint64 offset, length;
+  (void)repo;
 
   if (!read_varuint64 (state, &offset, error))
     return FALSE;
@@ -414,11 +415,9 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
       if (!input_mfile)
         return FALSE;
 
-      /* Guard against integer truncation on 32-bit systems: g_malloc0() takes
-       * gsize which is 32-bit on those platforms, but bspatch() uses the full
-       * int64_t newsize.  Without this check a crafted content_size > G_MAXSIZE
-       * would allocate a truncated (small) buffer while bspatch() writes using
-       * the full 64-bit value, causing a heap buffer overflow.
+      /* Guard against integer truncation on 32-bit systems: mmap() takes gsize
+       * while bspatch() uses int64_t. Without this check the mapped region and
+       * the size used by bspatch() could differ.
        * (CVE / RHEL-189207, CWE-680, CWE-122)
        */
       if (G_UNLIKELY (state->content_size > G_MAXSIZE || state->content_size > (guint64)G_MAXINT64))
@@ -430,10 +429,11 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
           return FALSE;
         }
 
-      const gsize alloc_size = (gsize)state->content_size;
       const int64_t newsize = (int64_t)state->content_size;
 
-      g_autofree guchar *buf = g_malloc0 (alloc_size);
+      guint8 *buf;
+      if (!_ostree_repo_bare_content_map (&state->content_out, &buf, error))
+        return FALSE;
 
       struct bzpatch_opaque_s opaque;
       opaque.state = state;
@@ -442,13 +442,13 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
       struct bspatch_stream stream;
       stream.read = bspatch_read;
       stream.opaque = &opaque;
-      if (bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
-                   g_mapped_file_get_length (input_mfile), buf, newsize, &stream)
-          < 0)
+      int bspatch_result = bspatch ((const guint8 *)g_mapped_file_get_contents (input_mfile),
+                                    g_mapped_file_get_length (input_mfile), buf, newsize, &stream);
+
+      if (bspatch_result < 0)
         return glnx_throw (error, "bsdiff patch failed");
 
-      if (!_ostree_repo_bare_content_write (repo, &state->content_out, buf, state->content_size,
-                                            cancellable, error))
+      if (!_ostree_repo_bare_content_finish_mapped (&state->content_out, cancellable, error))
         return FALSE;
     }
 


### PR DESCRIPTION
Hey,

my C is very bad, so this was found and done with AI. After looking at the reports an https://github.com/flatpak/flatpak/issues/6255

I would expect this, to be slightly less performant, but work more reliably on systems with less RAM. Most of the things we do here, also seem to have been done in other code files here and there, so it doesn't seem to be unprecedented to go this route.

I haven't been able to runtime test this and I'm unsure how - especially validating, that it still works in the wild (e.g. doesn't break deltas)