### PR TITLE
trivial-httpd: Fix const-correctness of slash pointer

### DIFF
--- a/src/ostree/ostree-trivial-httpd.c
+++ b/src/ostree/ostree-trivial-httpd.c
@@ -281,7 +281,7 @@ do_get (OtTrivialHttpd *self, SoupServer *server, SoupServerMessage *msg, const 
 do_get (OtTrivialHttpd *self, SoupServer *server, SoupServerMessage *msg, const char *path)
 #endif
 {
-  char *slash;
+  const char *slash;
   int ret;
   struct stat stbuf;
 


### PR DESCRIPTION
strrchr() returns a 'const char *' when passed a 'const char *' argument. Declare the local 'slash' variable as 'const char *' to match, fixing a build failure with clang when
-Werror,-Wincompatible-pointer-types-discards-qualifiers is active.