### PR TITLE
Release 2026.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
-m4_define([year_version], [2025])
-m4_define([release_version], [8])
+m4_define([year_version], [2026])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2026])
-m4_define([release_version], [1])
+m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
```
Colin Walters (2):
      libarchive: Handle UTF-8 filenames without locale dependency
      ci: Revamp bootc integration test suite with bcvk VM support

Dusty Mabe (2):
      ci: drop running COSA as UID 0
      ci: drop cosa fetch

Fabio Erculiani (1):
      status: Include deployment origin refspec as refspec in JSON output

Igor Opaniuk (1):
      tests: Respect TEST_TMPDIR for temporary directories

Joseph Marrero Corchado (7):
      configure: post-release version bump
      state-overlay: Fix ENODATA handling for GLib < 2.74
      ci: Sync bootc-ubuntu-setup action from bootc-dev/infra
      bootconfig: Preserve extension BLS keys across staged deployments
      generator: Fix soft-reboot for var, sysroot, and boot
      Release 2026.1
      configure: post-release version bump

Pavel Valena (1):
      boot/dracut: use systemdsystemunitdir instead of systemdsystemconfdir

Xiaofeng Wang (12):
      ci: Add Packit CI with RPM builds and TMT integration tests
      tests: Remove bcvk VM dispatch from Rust integration tests
      ci: Replace test-tmt shell script with Rust xtask
      ci: Fix cargo build failure on Fedora 43/44 in Containerfile.packit
      ci: Extend cargo fmt check to cover all Rust crates
      ci: Sync Rust linting checks from bootc-dev/bootc
      tests/xtask: Fix cargo fmt formatting
      tests/inst: Remove unused Kill9Stats and RebootStats structs
      ci: Add Rust validate targets to Justfile for local development
      ci: Use Justfile targets in GitHub workflow and add missing v2024_7 feature
      ci: Install ca-certificates in Debian Testing pre-checkout setup
      ci: Make fuse and libfuse-dev conditional for Debian Testing
```