### PR TITLE
Parallel compression and bsdiff

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -1654,6 +1654,7 @@ _ostree_static_delta_generate() {
         --max-chunk-size
         --min-fallback-size
         --swap-endianness
+        --threads -j
     "
 
     local options_with_args="

--- a/man/ostree-static-delta.xml
+++ b/man/ostree-static-delta.xml
@@ -107,6 +107,25 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>-j</option>, <option>--threads</option>[=<replaceable>VALUE</replaceable>]</term>
+
+                <listitem><para>
+                    Compress delta parts in parallel. <replaceable>VALUE</replaceable> is
+                    an integer in <arg choice="plain">0</arg>..<arg choice="plain">256</arg>
+                    (values <arg choice="plain">&gt; 1</arg> enable parallel compression with
+                    that many workers; <arg choice="plain">0</arg> and <arg choice="plain">1</arg>
+                    are serial) or one of <arg choice="plain">true</arg>,
+                    <arg choice="plain">yes</arg>, <arg choice="plain">on</arg>,
+                    <arg choice="plain">auto</arg> (use all CPUs) or
+                    <arg choice="plain">false</arg>, <arg choice="plain">no</arg>,
+                    <arg choice="plain">off</arg> (serial). Bare <option>--threads</option>
+                    with no value is equivalent to <arg choice="plain">auto</arg>.
+                    Defaults to serial; the <envar>OSTREE_DELTA_COMPRESS_THREADS</envar>
+                    environment variable is consulted when this option is not set.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--sign-type</option>=ENGINE</term>
 
                 <listitem><para>

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -58,7 +58,27 @@ typedef struct
   GPtrArray *xattrs;
   GLnxTmpfile part_tmpf;
   GVariant *header;
+  guint number; /* zero-based index into builder->parts; captured at allocate time */
 } OstreeStaticDeltaPartBuilder;
+
+/* Parallel-work state shared by the compress and bsdiff pools. Lives on the
+ * stack of ostree_repo_static_delta_generate(); a pointer is stashed in
+ * OstreeStaticDeltaBuilder so the per-task helpers can reach it. pool == NULL
+ * means serial mode (legacy behavior). */
+typedef struct
+{
+  GThreadPool *pool;
+  GMutex mutex;
+  GCond cond;
+  guint inflight;
+  guint max_inflight;
+  /* Protected by mutex. Owned by the pool for its whole lifetime: set once by
+   * the first failing worker, read as the "pool has failed" flag by other
+   * workers (to short-circuit) and by submitters, propagated to callers as a
+   * copy, and freed exactly once in worker_pool_clear(). It is deliberately
+   * not stolen on propagation so the flag stays set for in-flight workers. */
+  GError *first_error;
+} OstreeDeltaWorkerPool;
 
 typedef struct
 {
@@ -75,7 +95,66 @@ typedef struct
   gboolean swap_endian;
   int parts_dfd;
   DeltaOpts delta_opts;
+  OstreeDeltaWorkerPool *compress_pool; /* nullable; NULL = serial */
+  OstreeDeltaWorkerPool *bsdiff_pool;   /* nullable; NULL = serial */
 } OstreeStaticDeltaBuilder;
+
+/* Set up @pool with @n_workers threads running @threadfn. Publishes @pool to
+ * *@publish_to BEFORE g_thread_pool_new() so worker reads happen-after via
+ * pthread_create's release semantics. On failure clears *@publish_to. */
+static gboolean
+worker_pool_init (OstreeDeltaWorkerPool *pool, OstreeDeltaWorkerPool **publish_to, GFunc threadfn,
+                  gpointer user_data, gint n_workers, GError **error)
+{
+  g_mutex_init (&pool->mutex);
+  g_cond_init (&pool->cond);
+  /* +1 lets the producer prepare the next task while workers finish */
+  pool->max_inflight = n_workers + 1;
+  *publish_to = pool;
+  GError *pool_error = NULL;
+  pool->pool
+      = g_thread_pool_new (threadfn, user_data, n_workers, TRUE /* exclusive */, &pool_error);
+  if (pool->pool == NULL)
+    {
+      *publish_to = NULL;
+      g_mutex_clear (&pool->mutex);
+      g_cond_clear (&pool->cond);
+      g_propagate_error (error, pool_error);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+/* Tear down @pool. No-op if it was never initialized. @immediate=TRUE drops
+ * any tasks still queued (used on error paths); workers in progress always
+ * run to completion via wait=TRUE in g_thread_pool_free(). */
+static void
+worker_pool_clear (OstreeDeltaWorkerPool *pool, OstreeDeltaWorkerPool **publish_to,
+                   gboolean immediate)
+{
+  if (pool->pool == NULL)
+    return;
+  g_thread_pool_free (pool->pool, immediate, TRUE /* wait */);
+  pool->pool = NULL;
+  g_mutex_clear (&pool->mutex);
+  g_cond_clear (&pool->cond);
+  g_clear_error (&pool->first_error);
+  *publish_to = NULL;
+}
+
+/* Wait until @pool has no in-flight tasks. Does not propagate first_error;
+ * callers that care should read it under the mutex themselves. No-op if
+ * @pool is NULL or was never initialized. */
+static void
+worker_pool_drain (OstreeDeltaWorkerPool *pool)
+{
+  if (pool == NULL || pool->pool == NULL)
+    return;
+  g_mutex_lock (&pool->mutex);
+  while (pool->inflight > 0)
+    g_cond_wait (&pool->cond, &pool->mutex);
+  g_mutex_unlock (&pool->mutex);
+}
 
 /* Get an input stream for a GVariant */
 static GInputStream *
@@ -209,10 +288,15 @@ xattr_chunk_equals (const void *one, const void *two)
   return memcmp (g_variant_get_data (v1), g_variant_get_data (v2), l1) == 0;
 }
 
+/* Compress one part's payload, write it to a tmpfile, and populate its header.
+ * Safe to call from worker threads: it only mutates fields of @part_builder
+ * (which the caller guarantees no other thread is touching) plus opens an
+ * O_TMPFILE under builder->parts_dfd (kernel-side thread-safe).
+ */
 static gboolean
-finish_part (OstreeStaticDeltaBuilder *builder, GError **error)
+finish_part_compress (OstreeStaticDeltaBuilder *builder, OstreeStaticDeltaPartBuilder *part_builder,
+                      GError **error)
 {
-  OstreeStaticDeltaPartBuilder *part_builder = builder->parts->pdata[builder->parts->len - 1];
   g_autofree guchar *part_checksum = NULL;
   g_autoptr (GBytes) objtype_checksum_array = NULL;
   g_autoptr (GBytes) checksum_bytes = NULL;
@@ -302,10 +386,148 @@ finish_part (OstreeStaticDeltaBuilder *builder, GError **error)
     {
       g_printerr ("part %u n:%u compressed:%" G_GUINT64_FORMAT " uncompressed:%" G_GUINT64_FORMAT
                   "\n",
-                  builder->parts->len, part_builder->objects->len, part_builder->compressed_size,
+                  part_builder->number, part_builder->objects->len, part_builder->compressed_size,
                   part_builder->uncompressed_size);
     }
 
+  return TRUE;
+}
+
+/* Worker entry point for the compression thread pool. Errors are stashed in
+ * builder->compress_pool->first_error and bubble up via drain_compress_pool().
+ */
+static void
+finish_part_threadfn (gpointer data, gpointer user_data)
+{
+  OstreeStaticDeltaPartBuilder *part_builder = data;
+  OstreeStaticDeltaBuilder *builder = user_data;
+  OstreeDeltaWorkerPool *cp = builder->compress_pool;
+
+  g_mutex_lock (&cp->mutex);
+  gboolean already_failed = (cp->first_error != NULL);
+  g_mutex_unlock (&cp->mutex);
+
+  if (!already_failed)
+    {
+      g_autoptr (GError) local_error = NULL;
+      if (!finish_part_compress (builder, part_builder, &local_error))
+        {
+          g_mutex_lock (&cp->mutex);
+          if (cp->first_error == NULL)
+            cp->first_error = g_steal_pointer (&local_error);
+          g_mutex_unlock (&cp->mutex);
+        }
+    }
+
+  g_mutex_lock (&cp->mutex);
+  g_assert (cp->inflight > 0);
+  cp->inflight--;
+  /* At most one waiter exists at any time (producer in submit_finish_part or
+   * in drain_compress_pool, never both), so signal is enough. */
+  g_cond_signal (&cp->cond);
+  g_mutex_unlock (&cp->mutex);
+}
+
+/* Hand a part off to be compressed. In serial mode (no pool) this runs
+ * inline; in parallel mode it blocks until queue room exists, then enqueues.
+ */
+static gboolean
+submit_finish_part (OstreeStaticDeltaBuilder *builder, OstreeStaticDeltaPartBuilder *part_builder,
+                    GError **error)
+{
+  OstreeDeltaWorkerPool *cp = builder->compress_pool;
+
+  if (cp == NULL)
+    return finish_part_compress (builder, part_builder, error);
+
+  g_mutex_lock (&cp->mutex);
+  while (cp->inflight >= cp->max_inflight && cp->first_error == NULL)
+    g_cond_wait (&cp->cond, &cp->mutex);
+  /* Propagate a copy and leave first_error set (the pool owns it; see the
+   * struct comment). This keeps the short-circuit flag valid for still-queued
+   * workers. It cannot double-report: every caller returns FALSE on the first
+   * failure, so drain_compress_pool() is never reached on this path. */
+  if (cp->first_error != NULL)
+    {
+      g_propagate_error (error, g_error_copy (cp->first_error));
+      g_mutex_unlock (&cp->mutex);
+      return FALSE;
+    }
+  cp->inflight++;
+  g_mutex_unlock (&cp->mutex);
+
+  GError *push_error = NULL;
+  if (!g_thread_pool_push (cp->pool, part_builder, &push_error))
+    {
+      g_mutex_lock (&cp->mutex);
+      g_assert (cp->inflight > 0);
+      cp->inflight--;
+      g_cond_signal (&cp->cond);
+      g_mutex_unlock (&cp->mutex);
+      g_propagate_error (error, push_error);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+/* Wait until every in-flight part has been compressed, then surface the first
+ * worker error (if any). first_error stays owned by the pool (propagated as a
+ * copy, freed in worker_pool_clear()); this is the single point that reports a
+ * late worker failure not already seen by submit_finish_part(). Safe to call
+ * when no pool was ever set up. */
+static gboolean
+drain_compress_pool (OstreeStaticDeltaBuilder *builder, GError **error)
+{
+  OstreeDeltaWorkerPool *cp = builder->compress_pool;
+  worker_pool_drain (cp);
+  if (cp == NULL)
+    return TRUE;
+  g_mutex_lock (&cp->mutex);
+  gboolean ok = (cp->first_error == NULL);
+  if (!ok)
+    g_propagate_error (error, g_error_copy (cp->first_error));
+  g_mutex_unlock (&cp->mutex);
+  return ok;
+}
+
+/* Parse the compress-threads option (CLI / GVariant param / env var).
+ * Returns the worker count via @out_threads: 0 means serial (the default),
+ * 1 also runs serially (no worker thread is spawned for a single part), and
+ * values >1 enable parallel compression with that many workers.
+ *
+ * Accepts: NULL → 0; empty / "true" / "yes" / "on" / "auto" → all CPUs;
+ * "false" / "no" / "off" → 0; integer in [0, 256] → that integer.
+ * Anything else is an error.
+ */
+static gboolean
+parse_compress_threads (const char *value, gint *out_threads, GError **error)
+{
+  if (value == NULL)
+    {
+      *out_threads = 0;
+      return TRUE;
+    }
+  if (*value == '\0' || g_ascii_strcasecmp (value, "true") == 0
+      || g_ascii_strcasecmp (value, "yes") == 0 || g_ascii_strcasecmp (value, "on") == 0
+      || g_ascii_strcasecmp (value, "auto") == 0)
+    {
+      *out_threads = (gint)g_get_num_processors ();
+      return TRUE;
+    }
+  if (g_ascii_strcasecmp (value, "false") == 0 || g_ascii_strcasecmp (value, "no") == 0
+      || g_ascii_strcasecmp (value, "off") == 0)
+    {
+      *out_threads = 0;
+      return TRUE;
+    }
+  gchar *endptr = NULL;
+  gint64 v = g_ascii_strtoll (value, &endptr, 10);
+  if (endptr == value || *endptr != '\0' || v < 0 || v > 256)
+    return glnx_throw (error,
+                       "Invalid compress-threads value '%s' "
+                       "(expected integer 0..256, or true/false/yes/no/on/off/auto)",
+                       value);
+  *out_threads = (gint)v;
   return TRUE;
 }
 
@@ -314,7 +536,8 @@ allocate_part (OstreeStaticDeltaBuilder *builder, GError **error)
 {
   if (builder->parts->len > 0)
     {
-      if (!finish_part (builder, error))
+      OstreeStaticDeltaPartBuilder *prev = builder->parts->pdata[builder->parts->len - 1];
+      if (!submit_finish_part (builder, prev, error))
         return NULL;
     }
 
@@ -329,6 +552,7 @@ allocate_part (OstreeStaticDeltaBuilder *builder, GError **error)
   part->xattr_set = g_hash_table_new_full (xattr_chunk_hash, xattr_chunk_equals,
                                            (GDestroyNotify)g_variant_unref, NULL);
   part->xattrs = g_ptr_array_new ();
+  part->number = builder->parts->len;
   g_ptr_array_add (builder->parts, part);
   return part;
 }
@@ -761,10 +985,95 @@ process_one_rollsum (OstreeRepo *repo, OstreeStaticDeltaBuilder *builder,
   return TRUE;
 }
 
+/* One unit of bsdiff work. Inputs (repo, to_checksum, bsdiff_content,
+ * cancellable) are borrowed and must outlive the task. Outputs are filled by
+ * compute_bsdiff_for_task() and freed via bsdiff_task_free(). The producer
+ * fills the inputs, hands the task to a worker (or runs the compute inline),
+ * and later calls pack_bsdiff_task() to splice the results into a part.
+ */
+typedef struct
+{
+  /* Inputs (borrowed) */
+  OstreeRepo *repo;
+  const char *to_checksum;
+  ContentBsdiff *bsdiff_content;
+  GCancellable *cancellable;
+
+  /* Outputs (filled by worker) */
+  GFileInfo *content_finfo;
+  GVariant *content_xattrs;
+  GBytes *patch;
+
+  /* Coordination (touched only under bsdiff_pool->mutex) */
+  gboolean done;
+  GError *error;
+} BsdiffTask;
+
+static void
+bsdiff_task_free (BsdiffTask *task)
+{
+  g_clear_object (&task->content_finfo);
+  g_clear_pointer (&task->content_xattrs, g_variant_unref);
+  g_clear_pointer (&task->patch, g_bytes_unref);
+  g_clear_error (&task->error);
+  g_free (task);
+}
+
+/* Pure-compute portion of the old process_one_bsdiff: loads source/target
+ * content, fetches file info+xattrs, and runs bsdiff() into a memory buffer.
+ * Safe to call from a worker thread. tmp_from/tmp_to are scope-local and
+ * released as soon as the patch is produced; only the (much smaller) patch
+ * survives in the task.
+ */
 static gboolean
-process_one_bsdiff (OstreeRepo *repo, OstreeStaticDeltaBuilder *builder,
-                    OstreeStaticDeltaPartBuilder **current_part_val, const char *to_checksum,
-                    ContentBsdiff *bsdiff_content, GCancellable *cancellable, GError **error)
+compute_bsdiff_for_task (BsdiffTask *task, GError **error)
+{
+  g_autoptr (GBytes) tmp_from = NULL;
+  if (!get_unpacked_unlinked_content (task->repo, task->bsdiff_content->from_checksum, &tmp_from,
+                                      task->cancellable, error))
+    return FALSE;
+  g_autoptr (GBytes) tmp_to = NULL;
+  if (!get_unpacked_unlinked_content (task->repo, task->to_checksum, &tmp_to, task->cancellable,
+                                      error))
+    return FALSE;
+
+  if (!ostree_repo_load_file (task->repo, task->to_checksum, NULL, &task->content_finfo,
+                              &task->content_xattrs, task->cancellable, error))
+    return FALSE;
+
+  gsize tmp_from_len;
+  const guint8 *tmp_from_buf = g_bytes_get_data (tmp_from, &tmp_from_len);
+  gsize tmp_to_len;
+  const guint8 *tmp_to_buf = g_bytes_get_data (tmp_to, &tmp_to_len);
+  g_assert_cmpint (tmp_to_len, ==, g_file_info_get_size (task->content_finfo));
+
+  struct bsdiff_stream stream;
+  struct bzdiff_opaque_s op;
+  g_autoptr (GOutputStream) out = g_memory_output_stream_new_resizable ();
+  stream.malloc = malloc;
+  stream.free = free;
+  stream.write = bzdiff_write;
+  op.out = out;
+  op.cancellable = task->cancellable;
+  op.error = error;
+  stream.opaque = &op;
+  if (bsdiff (tmp_from_buf, tmp_from_len, tmp_to_buf, tmp_to_len, &stream) < 0)
+    return glnx_throw (error, "bsdiff generation failed");
+
+  /* steal_as_bytes requires the stream to be closed first, otherwise the
+   * returned GBytes may include unwritten capacity beyond the actual data. */
+  if (!g_output_stream_close (out, task->cancellable, error))
+    return FALSE;
+  task->patch = g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (out));
+  return TRUE;
+}
+
+/* Splice a completed BsdiffTask into the current part. Mutates part-builder
+ * state and may roll over to a new part, so must run on the producer thread.
+ */
+static gboolean
+pack_bsdiff_task (OstreeRepo *repo, OstreeStaticDeltaBuilder *builder,
+                  OstreeStaticDeltaPartBuilder **current_part_val, BsdiffTask *task, GError **error)
 {
   OstreeStaticDeltaPartBuilder *current_part = *current_part_val;
 
@@ -777,96 +1086,218 @@ process_one_bsdiff (OstreeRepo *repo, OstreeStaticDeltaBuilder *builder,
       *current_part_val = current_part;
     }
 
-  g_autoptr (GBytes) tmp_from = NULL;
-  if (!get_unpacked_unlinked_content (repo, bsdiff_content->from_checksum, &tmp_from, cancellable,
-                                      error))
-    return FALSE;
-  g_autoptr (GBytes) tmp_to = NULL;
-  if (!get_unpacked_unlinked_content (repo, to_checksum, &tmp_to, cancellable, error))
-    return FALSE;
-
-  gsize tmp_to_len;
-  const guint8 *tmp_to_buf = g_bytes_get_data (tmp_to, &tmp_to_len);
-  gsize tmp_from_len;
-  const guint8 *tmp_from_buf = g_bytes_get_data (tmp_from, &tmp_from_len);
-
-  g_autoptr (GFileInfo) content_finfo = NULL;
-  g_autoptr (GVariant) content_xattrs = NULL;
-  if (!ostree_repo_load_file (repo, to_checksum, NULL, &content_finfo, &content_xattrs, cancellable,
-                              error))
-    return FALSE;
-  const guint64 content_size = g_file_info_get_size (content_finfo);
-  g_assert_cmpint (tmp_to_len, ==, content_size);
-
+  const guint64 content_size = g_file_info_get_size (task->content_finfo);
   current_part->uncompressed_size += content_size;
 
   g_ptr_array_add (current_part->objects,
-                   ostree_object_name_serialize (to_checksum, OSTREE_OBJECT_TYPE_FILE));
+                   ostree_object_name_serialize (task->to_checksum, OSTREE_OBJECT_TYPE_FILE));
 
-  {
-    gsize mode_offset, xattr_offset;
-    guchar source_csum[OSTREE_SHA256_DIGEST_LEN];
+  gsize mode_offset, xattr_offset;
+  guchar source_csum[OSTREE_SHA256_DIGEST_LEN];
 
-    write_content_mode_xattrs (repo, current_part, content_finfo, content_xattrs, &mode_offset,
-                               &xattr_offset);
+  write_content_mode_xattrs (repo, current_part, task->content_finfo, task->content_xattrs,
+                             &mode_offset, &xattr_offset);
 
-    /* Write the origin checksum */
-    ostree_checksum_inplace_to_bytes (bsdiff_content->from_checksum, source_csum);
+  /* Write the origin checksum */
+  ostree_checksum_inplace_to_bytes (task->bsdiff_content->from_checksum, source_csum);
 
-    g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_SET_READ_SOURCE);
-    _ostree_write_varuint64 (current_part->operations, current_part->payload->len);
-    g_string_append_len (current_part->payload, (char *)source_csum, sizeof (source_csum));
+  g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_SET_READ_SOURCE);
+  _ostree_write_varuint64 (current_part->operations, current_part->payload->len);
+  g_string_append_len (current_part->payload, (char *)source_csum, sizeof (source_csum));
 
-    g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_OPEN);
-    _ostree_write_varuint64 (current_part->operations, mode_offset);
-    _ostree_write_varuint64 (current_part->operations, xattr_offset);
-    _ostree_write_varuint64 (current_part->operations, content_size);
+  g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_OPEN);
+  _ostree_write_varuint64 (current_part->operations, mode_offset);
+  _ostree_write_varuint64 (current_part->operations, xattr_offset);
+  _ostree_write_varuint64 (current_part->operations, content_size);
 
-    {
-      struct bsdiff_stream stream;
-      struct bzdiff_opaque_s op;
-      const gchar *payload;
-      gssize payload_size;
-      g_autoptr (GOutputStream) out = g_memory_output_stream_new_resizable ();
-      stream.malloc = malloc;
-      stream.free = free;
-      stream.write = bzdiff_write;
-      op.out = out;
-      op.cancellable = cancellable;
-      op.error = error;
-      stream.opaque = &op;
-      if (bsdiff (tmp_from_buf, tmp_from_len, tmp_to_buf, tmp_to_len, &stream) < 0)
-        return glnx_throw (error, "bsdiff generation failed");
+  gsize patch_size;
+  const guint8 *patch_buf = g_bytes_get_data (task->patch, &patch_size);
 
-      payload = g_memory_output_stream_get_data (G_MEMORY_OUTPUT_STREAM (out));
-      payload_size = g_memory_output_stream_get_data_size (G_MEMORY_OUTPUT_STREAM (out));
+  g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_BSPATCH);
+  _ostree_write_varuint64 (current_part->operations, current_part->payload->len);
+  _ostree_write_varuint64 (current_part->operations, patch_size);
 
-      g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_BSPATCH);
-      _ostree_write_varuint64 (current_part->operations, current_part->payload->len);
-      _ostree_write_varuint64 (current_part->operations, payload_size);
+  g_string_append_len (current_part->payload, (const char *)patch_buf, patch_size);
 
-      /* A bit too verbose to print by default...but leaving this #if 0'd out to
-       * use later. One approach I've been thinking about is to optionally
-       * output e.g. a JSON file as we build the deltas. Alternatively, we could
-       * try to reverse engineer things more in the "show" path, but that gets
-       * hard/messy as it's quite optimized for execution now.
-       */
-#if 0
-      g_printerr ("bspatch %s [%llu] → %s [%llu] bsdiff:%llu (%f)\n",
-                  bsdiff_content->from_checksum, (unsigned long long)tmp_from_len,
-                  to_checksum, (unsigned long long)tmp_to_len,
-                  (unsigned long long)payload_size,
-                  ((double)payload_size)/tmp_to_len);
-#endif
-
-      g_string_append_len (current_part->payload, payload, payload_size);
-    }
-    g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_CLOSE);
-  }
-
+  g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_CLOSE);
   g_string_append_c (current_part->operations, (gchar)OSTREE_STATIC_DELTA_OP_UNSET_READ_SOURCE);
 
   return TRUE;
+}
+
+/* Worker entry point for the bsdiff pool. Computes the patch into @task and
+ * signals the producer; the first worker error is also stashed on the pool
+ * so subsequent submissions short-circuit.
+ */
+static void
+bsdiff_task_threadfn (gpointer data, gpointer user_data)
+{
+  BsdiffTask *task = data;
+  OstreeStaticDeltaBuilder *builder = user_data;
+  OstreeDeltaWorkerPool *bp = builder->bsdiff_pool;
+
+  g_mutex_lock (&bp->mutex);
+  gboolean already_failed = (bp->first_error != NULL);
+  g_mutex_unlock (&bp->mutex);
+
+  GError *local_error = NULL;
+  if (!already_failed)
+    {
+      if (!compute_bsdiff_for_task (task, &local_error))
+        g_assert (local_error != NULL);
+    }
+  else
+    {
+      local_error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_CANCELLED,
+                                         "bsdiff skipped after earlier error");
+    }
+
+  g_mutex_lock (&bp->mutex);
+  task->error = local_error; /* transfer ownership; may be NULL on success */
+  task->done = TRUE;
+  if (local_error != NULL && bp->first_error == NULL)
+    bp->first_error = g_error_copy (local_error);
+  g_assert (bp->inflight > 0);
+  bp->inflight--;
+  /* At most one waiter exists at any time (the producer in
+   * wait_for_bsdiff_task), so signal is enough. */
+  g_cond_signal (&bp->cond);
+  g_mutex_unlock (&bp->mutex);
+}
+
+/* Enqueue a task for parallel compute. In serial mode (no pool) compute
+ * synchronously so wait_for_bsdiff_task() is a no-op. */
+static gboolean
+submit_bsdiff_task (OstreeStaticDeltaBuilder *builder, BsdiffTask *task, GError **error)
+{
+  OstreeDeltaWorkerPool *bp = builder->bsdiff_pool;
+  if (bp == NULL)
+    {
+      task->done = TRUE;
+      if (!compute_bsdiff_for_task (task, error))
+        return FALSE;
+      return TRUE;
+    }
+
+  g_mutex_lock (&bp->mutex);
+  /* Fail-fast: stop enqueueing once any worker has failed, mirroring
+   * submit_finish_part(). Workers already short-circuit, but this also
+   * stops the producer from queuing further no-op tasks. */
+  if (bp->first_error != NULL)
+    {
+      g_propagate_error (error, g_error_copy (bp->first_error));
+      g_mutex_unlock (&bp->mutex);
+      return FALSE;
+    }
+  bp->inflight++;
+  g_mutex_unlock (&bp->mutex);
+
+  GError *push_error = NULL;
+  if (!g_thread_pool_push (bp->pool, task, &push_error))
+    {
+      g_mutex_lock (&bp->mutex);
+      g_assert (bp->inflight > 0);
+      bp->inflight--;
+      g_cond_signal (&bp->cond);
+      g_mutex_unlock (&bp->mutex);
+      g_propagate_error (error, push_error);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+/* Block until @task->done is set by a worker, then propagate any error.
+ * In serial mode submit_bsdiff_task() has already done the compute. */
+static gboolean
+wait_for_bsdiff_task (OstreeStaticDeltaBuilder *builder, BsdiffTask *task, GError **error)
+{
+  OstreeDeltaWorkerPool *bp = builder->bsdiff_pool;
+  if (bp == NULL)
+    return TRUE;
+
+  g_mutex_lock (&bp->mutex);
+  while (!task->done)
+    g_cond_wait (&bp->cond, &bp->mutex);
+  gboolean ok = (task->error == NULL);
+  if (!ok)
+    g_propagate_error (error, g_steal_pointer (&task->error));
+  g_mutex_unlock (&bp->mutex);
+  return ok;
+}
+
+/* Wait for every in-flight bsdiff task to finish so workers don't outlive
+ * the BsdiffTask array. Must be called before that array is freed on any
+ * exit path from process_bsdiff_tasks(). No-op when no pool was set up. */
+static void
+drain_bsdiff_pool (OstreeStaticDeltaBuilder *builder)
+{
+  worker_pool_drain (builder->bsdiff_pool);
+}
+
+/* Drive the bsdiff queue: prefetch up to max_inflight tasks, then for each
+ * task in submission order wait for its completion, pack it, free its
+ * outputs, and replenish the queue. Preserves byte-identical output to the
+ * serial path because packing is sequential and in the same order. On any
+ * failure path the in-flight pool is drained before returning so workers
+ * don't continue writing to BsdiffTasks the caller is about to free.
+ */
+static gboolean
+process_bsdiff_tasks (OstreeRepo *repo, OstreeStaticDeltaBuilder *builder,
+                      OstreeStaticDeltaPartBuilder **current_part_val, GPtrArray *bsdiff_tasks,
+                      DeltaOpts opts, GError **error)
+{
+  const guint n_tasks = bsdiff_tasks->len;
+  if (n_tasks == 0)
+    return TRUE;
+
+  OstreeDeltaWorkerPool *bp = builder->bsdiff_pool;
+  const guint prefetch = (bp != NULL) ? bp->max_inflight : 1;
+  const guint mod = n_tasks / 10;
+
+  gboolean ret = FALSE;
+  guint next_submit = 0;
+
+  while (next_submit < n_tasks && next_submit < prefetch)
+    {
+      if (!submit_bsdiff_task (builder, bsdiff_tasks->pdata[next_submit], error))
+        goto out;
+      next_submit++;
+    }
+
+  for (guint i = 0; i < n_tasks; i++)
+    {
+      BsdiffTask *t = bsdiff_tasks->pdata[i];
+
+      if (opts & DELTAOPT_FLAG_VERBOSE && (mod == 0 || i % mod == 0))
+        g_printerr ("processing bsdiff: [%u/%u]\n", i, n_tasks);
+
+      if (!wait_for_bsdiff_task (builder, t, error))
+        goto out;
+      if (!pack_bsdiff_task (repo, builder, current_part_val, t, error))
+        goto out;
+
+      /* Free the patch + content_finfo/xattrs now to bound memory; the task
+       * struct itself is freed by the GPtrArray's free_func at scope exit. */
+      g_clear_pointer (&t->patch, g_bytes_unref);
+      g_clear_object (&t->content_finfo);
+      g_clear_pointer (&t->content_xattrs, g_variant_unref);
+
+      builder->n_bsdiff++;
+
+      if (next_submit < n_tasks)
+        {
+          if (!submit_bsdiff_task (builder, bsdiff_tasks->pdata[next_submit], error))
+            goto out;
+          next_submit++;
+        }
+    }
+
+  ret = TRUE;
+out:
+  /* Ensure no worker is still writing into any BsdiffTask we are about to
+   * hand back to the caller's autoptr cleanup. */
+  drain_bsdiff_pool (builder);
+  return ret;
 }
 
 static gboolean
@@ -1076,27 +1507,26 @@ generate_delta_lowlatency (OstreeRepo *repo, const char *from, const char *to, D
       builder->n_rollsum++;
     }
 
-  /* Now do bsdiff'ed objects */
-
-  const guint n_bsdiff = g_hash_table_size (bsdiff_optimized_content_objects);
-  if (n_bsdiff > 0)
+  /* Now do bsdiff'ed objects. Collect tasks in hash-table iteration order
+   * (deterministic for identical input), then run compute in parallel while
+   * the producer packs results into parts in that same order. */
+  if (g_hash_table_size (bsdiff_optimized_content_objects) > 0)
     {
-      const guint mod = n_bsdiff / 10;
+      g_autoptr (GPtrArray) bsdiff_tasks
+          = g_ptr_array_new_with_free_func ((GDestroyNotify)bsdiff_task_free);
       g_hash_table_iter_init (&hashiter, bsdiff_optimized_content_objects);
       while (g_hash_table_iter_next (&hashiter, &key, &value))
         {
-          const char *checksum = key;
-          ContentBsdiff *bsdiff = value;
-
-          if (opts & DELTAOPT_FLAG_VERBOSE && (mod == 0 || builder->n_bsdiff % mod == 0))
-            g_printerr ("processing bsdiff: [%u/%u]\n", builder->n_bsdiff, n_bsdiff);
-
-          if (!process_one_bsdiff (repo, builder, &current_part, checksum, bsdiff, cancellable,
-                                   error))
-            return FALSE;
-
-          builder->n_bsdiff++;
+          BsdiffTask *t = g_new0 (BsdiffTask, 1);
+          t->repo = repo;
+          t->to_checksum = key;
+          t->bsdiff_content = value;
+          t->cancellable = cancellable;
+          g_ptr_array_add (bsdiff_tasks, t);
         }
+
+      if (!process_bsdiff_tasks (repo, builder, &current_part, bsdiff_tasks, opts, error))
+        return FALSE;
     }
 
   /* Scan for large objects, so we can fall back to plain HTTP-based
@@ -1162,7 +1592,17 @@ generate_delta_lowlatency (OstreeRepo *repo, const char *from, const char *to, D
         return FALSE;
     }
 
-  if (!finish_part (builder, error))
+  /* Submit the last part. In serial mode this compresses inline; in parallel
+   * mode the drain below guarantees all parts (including this one) are done
+   * before we return — every part_builder->header is then safe to read. */
+  if (builder->parts->len > 0)
+    {
+      OstreeStaticDeltaPartBuilder *last = builder->parts->pdata[builder->parts->len - 1];
+      if (!submit_finish_part (builder, last, error))
+        return FALSE;
+    }
+
+  if (!drain_compress_pool (builder, error))
     return FALSE;
 
   return TRUE;
@@ -1250,6 +1690,11 @@ get_fallback_headers (OstreeRepo *self, OstreeStaticDeltaBuilder *builder, GVari
  * directory.  Default saves to repository.
  *   - sign-name: ^ay: Signature type to use (bytestring).
  *   - sign-key-ids: ^as: NULL-terminated array of keys used to sign delta superblock.
+ *   - compress-threads: s: Parallelism for bsdiff and LZMA part compression.
+ *     Integer in 0..256 (values > 1 enable parallel processing with that many
+ *     workers per stage; 0 and 1 are serial) or a keyword: true/yes/on/auto =
+ *     all CPUs; false/no/off = serial. If unset, the
+ *     OSTREE_DELTA_COMPRESS_THREADS env var is consulted.
  */
 gboolean
 ostree_repo_static_delta_generate (OstreeRepo *self, OstreeStaticDeltaGenerateOpt opt,
@@ -1367,8 +1812,54 @@ ostree_repo_static_delta_generate (OstreeRepo *self, OstreeStaticDeltaGenerateOp
     }
   builder.parts_dfd = descriptor_dfd;
 
+  /* Optional parallelism. Selected by (in precedence order) the
+   * "compress-threads" GVariant param or the OSTREE_DELTA_COMPRESS_THREADS
+   * env var. A value > 1 enables parallel bsdiff and parallel LZMA part
+   * compression; 0 or 1 keeps the serial code path. See
+   * parse_compress_threads() for the full grammar. Memory cost in parallel
+   * mode is dominated by the LZMA-8 encoder state (~94 MiB per worker) plus
+   * a few in-flight part payloads (up to max-chunk-size each) and a few
+   * in-flight bsdiff source/target buffers (up to max-bsdiff-size each).
+   */
+  OstreeDeltaWorkerPool compress_pool = {
+    0,
+  };
+  OstreeDeltaWorkerPool bsdiff_pool = {
+    0,
+  };
+  const char *thread_str = NULL;
+  if (!g_variant_lookup (params, "compress-threads", "&s", &thread_str))
+    thread_str = g_getenv ("OSTREE_DELTA_COMPRESS_THREADS");
+  gint compress_threads = 0;
+  if (!parse_compress_threads (thread_str, &compress_threads, error))
+    return FALSE;
+  if (compress_threads > 1)
+    {
+      if (!worker_pool_init (&compress_pool, &builder.compress_pool, finish_part_threadfn, &builder,
+                             compress_threads, error))
+        return FALSE;
+      if (!worker_pool_init (&bsdiff_pool, &builder.bsdiff_pool, bsdiff_task_threadfn, &builder,
+                             compress_threads, error))
+        {
+          worker_pool_clear (&compress_pool, &builder.compress_pool, TRUE /* immediate */);
+          return FALSE;
+        }
+      if (delta_opts & DELTAOPT_FLAG_VERBOSE)
+        g_printerr ("parallel bsdiff + compression: %d threads each\n", compress_threads);
+    }
+
   /* Ignore optimization flags */
-  if (!generate_delta_lowlatency (self, from, to, delta_opts, &builder, cancellable, error))
+  gboolean lowlatency_ok
+      = generate_delta_lowlatency (self, from, to, delta_opts, &builder, cancellable, error);
+
+  /* Tear down both pools unconditionally so any in-flight work is reaped.
+   * On success, the in-loop drains inside generate_delta_lowlatency() have
+   * already surfaced worker errors; here we just release resources.
+   * immediate=TRUE on the error path discards any tasks still queued. */
+  worker_pool_clear (&bsdiff_pool, &builder.bsdiff_pool, !lowlatency_ok);
+  worker_pool_clear (&compress_pool, &builder.compress_pool, !lowlatency_ok);
+
+  if (!lowlatency_ok)
     return FALSE;
 
   if (!glnx_open_tmpfile_linkable_at (descriptor_dfd, ".", O_RDWR | O_CLOEXEC, &descriptor_tmpf,

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -40,6 +40,20 @@ static char **opt_key_ids;
 static char *opt_sign_name;
 static char *opt_keysfilename;
 static char *opt_keysdir;
+static char *opt_threads;
+static gboolean opt_threads_set;
+
+/* Callback for --threads[=VALUE]. Without an argument, treat as "yes" so the
+ * library picks all CPUs. Empty/yes/true/auto/N/false are all accepted by the
+ * library-side parser; we just pass the string through. */
+static gboolean
+opt_threads_cb (const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  opt_threads_set = TRUE;
+  g_free (opt_threads);
+  opt_threads = g_strdup (value != NULL ? value : "");
+  return TRUE;
+}
 
 #define BUILTINPROTO(name) \
   static gboolean ot_static_delta_builtin_##name (int argc, char **argv, \
@@ -107,6 +121,11 @@ static GOptionEntry generate_options[] = {
 #if defined(HAVE_ED25519)
   { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_keysfilename, "Read key(s) from file", "NAME" },
 #endif
+  { "threads", 'j', G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK, opt_threads_cb,
+    "Compress parts in parallel. Accepts an integer in 0..256 (>1 enables "
+    "parallel compression with that many workers; 0 and 1 are serial) or "
+    "true/false/yes/no/auto. Defaults to off; bare --threads means auto.",
+    "[VALUE]" },
   { NULL }
 };
 
@@ -416,6 +435,9 @@ ot_static_delta_builtin_generate (int argc, char **argv, OstreeCommandInvocation
       if (opt_endianness || opt_swap_endianness)
         g_variant_builder_add (parambuilder, "{sv}", "endianness",
                                g_variant_new_uint32 (endianness));
+      if (opt_threads_set)
+        g_variant_builder_add (parambuilder, "{sv}", "compress-threads",
+                               g_variant_new_string (opt_threads));
 
       if (opt_key_ids || opt_keysfilename)
         {

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -26,7 +26,7 @@ skip_without_user_xattrs
 bindatafiles="bash true ostree"
 morebindatafiles="false ls"
 
-echo '1..14'
+echo '1..20'
 
 mkdir repo
 ostree_repo_init repo --mode=archive
@@ -324,3 +324,105 @@ fi
 assert_file_has_content err.txt "Invalid rev GARBAGE"
 
 echo 'ok handle bad delta name'
+
+# Parallel-compression tests.
+#
+# Force several parts with --max-chunk-size=1 so the threading code is
+# actually exercised, then prove that serial and --threads=N produce
+# byte-identical part files. The superblock varies run-to-run because of
+# its timestamp, so we exclude it from the comparison. apply-offline
+# expects a directory containing a file literally named "superblock".
+mkdir delta-serial delta-par
+${CMD_PREFIX} ostree --repo=repo static-delta generate --empty --to=${newrev} \
+    --max-chunk-size=1 --filename=delta-serial/superblock
+${CMD_PREFIX} ostree --repo=repo static-delta generate --empty --to=${newrev} \
+    --max-chunk-size=1 --threads=4 --filename=delta-par/superblock
+
+# Sanity: both produced the same set of part files (0, 1, ...).
+ls delta-serial | grep -E '^[0-9]+$' | sort > delta-serial-parts.txt
+ls delta-par    | grep -E '^[0-9]+$' | sort > delta-par-parts.txt
+assert_streq "$(cat delta-serial-parts.txt)" "$(cat delta-par-parts.txt)"
+# At least 2 parts so we know chunking actually fired.
+n_parts=$(wc -l < delta-serial-parts.txt)
+if test "${n_parts}" -lt 2; then
+    assert_not_reached "expected >=2 parts with --max-chunk-size=1, got ${n_parts}"
+fi
+
+# Every part file must be byte-identical between serial and parallel.
+for p in $(cat delta-serial-parts.txt); do
+    cmp delta-serial/$p delta-par/$p || \
+        assert_not_reached "part $p differs between serial and parallel runs"
+done
+
+echo 'ok parallel compression byte-identical parts'
+
+# Apply-offline using the parallel-generated delta into a fresh repo and
+# verify the result matches the original commit.
+ostree_repo_init repo-par-apply --mode=bare-user
+${CMD_PREFIX} ostree --repo=repo-par-apply static-delta apply-offline delta-par
+${CMD_PREFIX} ostree --repo=repo-par-apply fsck
+${CMD_PREFIX} ostree --repo=repo-par-apply ls ${newrev} >/dev/null
+rm -rf repo-par-apply
+
+echo 'ok parallel compression apply-offline'
+
+# Env var path should work the same as --threads.
+mkdir delta-env
+OSTREE_DELTA_COMPRESS_THREADS=4 ${CMD_PREFIX} ostree --repo=repo \
+    static-delta generate --empty --to=${newrev} --max-chunk-size=1 \
+    --filename=delta-env/superblock
+for p in $(cat delta-serial-parts.txt); do
+    cmp delta-serial/$p delta-env/$p || \
+        assert_not_reached "part $p differs when threads enabled via env var"
+done
+
+echo 'ok parallel compression via env var'
+
+# Value parser: keyword and numeric forms must all be accepted; invalid
+# input must be rejected. --filename needs an existing parent directory,
+# so we make/clean it for each iteration.
+for v in 0 1 2 yes no true false on off auto; do
+    mkdir delta-val
+    ${CMD_PREFIX} ostree --repo=repo static-delta generate --empty --to=${newrev} \
+        --threads=$v --filename=delta-val/superblock >/dev/null
+    rm -rf delta-val
+done
+mkdir delta-val
+if ${CMD_PREFIX} ostree --repo=repo static-delta generate --empty --to=${newrev} \
+       --threads=garbage --filename=delta-val/superblock 2>err.txt; then
+    assert_not_reached "--threads=garbage unexpectedly succeeded"
+fi
+assert_file_has_content err.txt "compress-threads"
+rm -rf delta-val
+
+echo 'ok parallel compression value parsing'
+
+# Parallel-bsdiff: between the two committed trees there are modified files,
+# so --from=origrev --to=newrev exercises the bsdiff path. Compare serial vs
+# --threads=4 output and round-trip the parallel one through apply-offline.
+mkdir bsdiff-serial bsdiff-par
+${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} \
+    --max-chunk-size=1 --filename=bsdiff-serial/superblock
+${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} \
+    --max-chunk-size=1 --threads=4 --filename=bsdiff-par/superblock
+
+# Every part file must be byte-identical between serial and parallel bsdiff.
+ls bsdiff-serial | grep -E '^[0-9]+$' | sort > bsdiff-serial-parts.txt
+ls bsdiff-par    | grep -E '^[0-9]+$' | sort > bsdiff-par-parts.txt
+assert_streq "$(cat bsdiff-serial-parts.txt)" "$(cat bsdiff-par-parts.txt)"
+for p in $(cat bsdiff-serial-parts.txt); do
+    cmp bsdiff-serial/$p bsdiff-par/$p || \
+        assert_not_reached "bsdiff part $p differs between serial and parallel runs"
+done
+
+echo 'ok parallel bsdiff byte-identical parts'
+
+# Apply the parallel-generated from-A-to-B delta on top of A, expect B.
+ostree_repo_init repo-bsdiff-apply --mode=bare-user
+${CMD_PREFIX} ostree --repo=repo-bsdiff-apply pull-local repo ${origrev}
+${CMD_PREFIX} ostree --repo=repo-bsdiff-apply static-delta apply-offline bsdiff-par
+${CMD_PREFIX} ostree --repo=repo-bsdiff-apply fsck
+${CMD_PREFIX} ostree --repo=repo-bsdiff-apply ls ${newrev} >/dev/null
+rm -rf repo-bsdiff-apply
+
+echo 'ok parallel bsdiff apply-offline'


### PR DESCRIPTION
I have a similar performance desire as in issue #2845, except for the compression part.

This change adds a way that bsdiff and lzma compression for static-delta can be run on multiple cores.
Verification was done with sanitisers, and the thread sanitiser; the output should be byte identical.

Looking for input on this feature, since I uses claude and before I invest significant time for further clean up of any code.