### PR TITLE
Ignore typedef-redefinition warnings with Clang and Fix enum type mismatch in copy flags 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,12 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
   -Wstrict-aliasing=2 \
   -Werror=unused-result \
 ])])
+
+AS_CASE([$CC], [*clang*], [
+  CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS],
+                        [-Wno-typedef-redefinition])
+])
+
 AC_SUBST(WARN_CFLAGS)
 
 AC_ARG_ENABLE(sanitizers,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -399,8 +399,9 @@ again:
   if (!glnx_opendirat (new_etc_fd, path, TRUE, &target_dfd, error))
     return FALSE;
 
-  if (!dirfd_copy_attributes_and_xattrs (modified_etc_fd, path, src_dfd, target_dfd, flags,
-                                         cancellable, error))
+  if (!dirfd_copy_attributes_and_xattrs (modified_etc_fd, path, src_dfd, target_dfd,
+                                         sysroot_flags_to_copy_flags (0, flags), cancellable,
+                                         error))
     return FALSE;
 
   if (out_dfd)


### PR DESCRIPTION
Fixes: #3590
Fixes: #3591