### PR TITLE
checkout: Fix GVariant leak when scanning for opaque whiteouts

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -1031,15 +1031,19 @@ checkout_tree_at_recurse (OstreeRepo *self, OstreeRepoCheckoutAtOptions *options
       g_autoptr (GVariant) dir_file_contents = g_variant_get_child_value (dirtree, 0);
       GVariantIter viter;
       const char *fname;
-      g_autoptr (GVariant) contents_csum_v = NULL;
       g_variant_iter_init (&viter, dir_file_contents);
-      while (g_variant_iter_loop (&viter, "(&s@ay)", &fname, &contents_csum_v))
+      /* We only need the name; pass NULL to skip extracting the checksum.
+       * Note that breaking out of a g_variant_iter_loop() without freeing
+       * extracted values would leak them - and a leaked child variant pins
+       * the whole (possibly mmap'd) dirtree object in memory, which kept
+       * the filesystem busy across the final unmount in `bootc install`.
+       */
+      while (g_variant_iter_loop (&viter, "(&s@ay)", &fname, NULL))
         {
           is_opaque_whiteout = (g_str_equal (fname, OPAQUE_WHITEOUT_NAME));
           if (is_opaque_whiteout)
             break;
         }
-      contents_csum_v = NULL; /* iter_loop freed it */
     }
 
   /* First, make the directory.  Push a new scope in case we end up using


### PR DESCRIPTION
Breaking out of `g_variant_iter_loop()` leaves ownership of the current element with the caller. The opaque-whiteout scan in `checkout_tree_at_recurse()` breaks out of the loop when it finds `.wh..wh..opq`, and then cleared the local pointer (defeating the `g_autoptr`), leaking one reference to the extracted checksum variant for every directory that contains an opaque whiteout entry.

A leaked child variant keeps the whole backing dirtree object alive — including its `GMappedFile` when the object is large enough to be mmap'd rather than read into the heap. In a process that unmounts the target filesystem afterwards — notably `bootc install to-disk`, which checks out container layers with `process_whiteouts` enabled (once for the merged tree, once for layer relabeling) and then unmounts the physical root — the stale mappings make the final `umount -R` fail with `EBUSY`, aborting the installation. See bootc-dev/bootc#2246 for the full investigation.

Since the scan only needs the entry name, pass `NULL` to skip extracting the checksum entirely, so nothing needs freeing on the early exit (same pattern as in `ostree-repo-finder-avahi.c`).

### Verification

- Reproduced the leak deterministically with a container image whose dnf layer carries opaque whiteouts in two large directories (`/usr/include/linux`, `/usr/lib/.build-id`, dirtrees >16kB so they take the mmap path): after import, `/proc/self/maps` shows the two `.dirtree` objects still mapped (twice each — merge + relabel checkout). With this patch: zero residual mappings at every phase of the import.
- A previously 100%-reproducible `bootc install to-disk` failure (`umount: /run/bootc/mounts/rootfs: target is busy`) completes successfully with the patched library and no other change.

Fixes the root cause of bootc-dev/bootc#2246.
