### PR TITLE
README: update Torizon's aktualizr link to Toradex's fork of aktualizr

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ their distribution using ostree.
 [Torizon OS](https://developer.toradex.com/torizon/torizoncore/torizoncore-technical-overview/)
 is a Linux distribution for embedded systems that updates via OSTree images
 delivered via [Uptane](https://uptane.github.io/) and
-[aktualizr](https://github.com/uptane/aktualizr/).
+[aktualizr](https://gitlab.com/toradex/rd/torizon-core/aktualizr).
 
 ## Distribution build tools
 


### PR DESCRIPTION
The README references the upstream uptane/aktualizr repository for Torizon OS, but Torizon actually uses Toradex's own fork of aktualizr hosted on GitLab. This corrects the link to point to the actual implementation used by Torizon OS.