### PR TITLE
ci/prow: Make jobs no-op in preparation for removal

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,45 +1,6 @@
-FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
-WORKDIR /src
-COPY . .
-RUN ./ci/build.sh
-RUN make -C tests/kolainst
-RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
-
-# Build RPMs inside the cosa base image so they link against its libraries.
-# The buildroot (Fedora N+1) and cosa (Fedora N) may ship different sonames.
-FROM quay.io/coreos-assembler/coreos-assembler:latest as rpmbuild
-USER root
-COPY --from=builder /src /src
-WORKDIR /src
-RUN dnf -y install /usr/bin/rpmbuild gcc
-RUN <<EORUN
-set -xeuo pipefail
-git config --global --add safe.directory '*'
-git submodule update --init
-ci/make-git-snapshot.sh
-ci/packit-fix-spec.sh ostree.spec
-rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" \
-    --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" \
-    --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" ostree.spec
-dnf builddep -y *.src.rpm
-ci/rpmbuild-cwd --rebuild *.src.rpm
-mkdir -p /rpms
-find . -name '*.rpm' -not -name '*.src.rpm' -exec mv {} /rpms/ \;
-EORUN
-
-FROM quay.io/coreos-assembler/coreos-assembler:latest
-WORKDIR /srv
-USER root
-# Install RPMs built against this image's libraries
-COPY --from=rpmbuild /rpms/*.rpm /tmp/rpms/
-RUN dnf -y install --allowerasing $(ls /tmp/rpms/ostree-*.rpm | grep -v -e devel -e debug) && \
-    rm -rf /tmp/rpms
-# Stage RPMs for cosa overrides (used by fcos-e2e.sh)
-COPY --from=rpmbuild /rpms /cosa/rpms
-# Copy test binaries that aren't packaged as RPMs
-COPY --from=builder /cosa/component-tests /cosa/component-tests
-RUN rsync -rlv /cosa/component-tests/ /
-# Grab all of our ci scripts
-COPY --from=builder /src/ci/ /ci/
-RUN ln -sr /ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e
-USER builder
+# Prow CI is being dropped in favor of GHA and Konflux.
+# This is a no-op placeholder until the job is removed from openshift/release.
+# See: https://github.com/ostreedev/ostree/pull/3599#issuecomment-4792307868
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e
+RUN chmod +x /usr/bin/fcos-e2e

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
-set -xeuo pipefail
-
-# Prow jobs don't support adding emptydir today
-export COSA_SKIP_OVERLAY=1
-ostree --version
-cd $(mktemp -d)
-cosa init https://github.com/coreos/fedora-coreos-config/
-# Use RPM overrides so cosa/rpm-ostree resolves dependencies properly
-cp /cosa/rpms/ostree-*.rpm overrides/rpm/
-# Remove -devel and -debug RPMs that aren't needed in the compose
-rm -f overrides/rpm/ostree-devel-* overrides/rpm/ostree-debug*
-cosa fetch
-# For composefs
-echo 'rootfs: "ext4verity"' >> src/config/image.yaml
-cosa build
-# For now, Prow just runs the composefs tests, since Jenkins covers the others
-#cosa kola run 'ext.ostree.destructive-rs.composefs*'
+# Prow CI is being dropped in favor of GHA and Konflux.
+# This is a no-op placeholder until the job is removed from openshift/release.
+# See: https://github.com/ostreedev/ostree/pull/3599#issuecomment-4792307868
+echo "Prow CI is deprecated for ostree; skipping."


### PR DESCRIPTION
Prow CI is being dropped in favor of GHA and Konflux. Replace the Dockerfile and e2e script with no-op placeholders until the jobs are removed from openshift/release.

Ref: https://github.com/ostreedev/ostree/pull/3599#issuecomment-4792307868
Ref: https://github.com/openshift/release/pull/81042