### PR TITLE
tests/kolainst: Fix failures on container-native FCOS

### DIFF
--- a/tests/kolainst/destructive/finalization.sh
+++ b/tests/kolainst/destructive/finalization.sh
@@ -8,8 +8,13 @@ prepare_tmpdir
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-  # Need to disable gpg verification for test builds
-  sed -i -e 's,gpg-verify=true,gpg-verify=false,' /etc/ostree/remotes.d/*.conf
+  # Need to disable gpg verification for test builds.
+  # On container-native FCOS there may be no remotes.d conf files.
+  for conf in /etc/ostree/remotes.d/*.conf; do
+    if test -f "$conf"; then
+      sed -i -e 's,gpg-verify=true,gpg-verify=false,' "$conf"
+    fi
+  done
   # xref https://github.com/coreos/coreos-assembler/pull/2814
   systemctl mask --now zincati
 

--- a/tests/kolainst/destructive/staged-deploy.sh
+++ b/tests/kolainst/destructive/staged-deploy.sh
@@ -8,8 +8,13 @@ prepare_tmpdir
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-  # Need to disable gpg verification for test builds
-  sed -i -e 's,gpg-verify=true,gpg-verify=false,' /etc/ostree/remotes.d/*.conf
+  # Need to disable gpg verification for test builds.
+  # On container-native FCOS there may be no remotes.d conf files.
+  for conf in /etc/ostree/remotes.d/*.conf; do
+    if test -f "$conf"; then
+      sed -i -e 's,gpg-verify=true,gpg-verify=false,' "$conf"
+    fi
+  done
 
   # Test our generator
   test -f /run/systemd/generator/local-fs.target.requires/ostree-remount.service

--- a/tests/kolainst/nondestructive/itest-remotes.sh
+++ b/tests/kolainst/nondestructive/itest-remotes.sh
@@ -12,6 +12,12 @@ trap _tmpdir_cleanup EXIT
 
 ostree remote list > remotes.txt
 if ! test -s remotes.txt; then
+    # On container-native FCOS, there are no ostree remotes — that's expected.
+    # On traditional ostree systems, missing remotes is a real regression.
+    if [ "$(rpmostree_query_json '.deployments[0]."container-image-reference" // empty')" != "" ]; then
+        echo "No ostree remotes found; skipping test on container-native system"
+        exit 0
+    fi
     assert_not_reached "no ostree remotes"
 fi
 date


### PR DESCRIPTION
On container-native FCOS (F44+), /etc/ostree/remotes.d/ may have no .conf files since the system uses container-based updates rather than traditional ostree remotes. This caused test failures:

- staged-deploy.sh and finalization.sh: sed on the unexpanded glob '/etc/ostree/remotes.d/*.conf' fails under set -euo pipefail when no files match. Fix by iterating with a for loop and guarding with test -f.

- itest-remotes.sh: 'ostree remote list' returns empty, hitting assert_not_reached. Fix by skipping the test gracefully on systems with no remotes configured.

Assisted-by: OpenCode (Claude Opus 4.6)