### PR TITLE
Release 2026.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2026])
-m4_define([release_version], [2])
+m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2026])
 m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This release is mostly bug fixes, test fixes and CI updates.

```
Eric Curtin (1):
      static-delta: remove unused total_usize variable

Jonas Svatos (1):
      checkout: Fix GVariant leak when scanning for opaque whiteouts

Joseph Marrero Corchado (12):
      configure: post-release version bump
      ci: Use dnf instead of rpm to install built RPMs in container
      ci/prow: Use RPMs with dnf instead of raw file overlay
      ci/prow: Make jobs no-op in preparation for removal
      sysroot: Merge bootconfig-extra from previously staged deployment
      tests/kolainst: Fix failures on container-native FCOS
      kargs: Fix crash on quoted values in /proc/cmdline
      tests: Run clang-format on test-validate-utf8.c
      tests: Fix "remote:branch" test to use ostree_parse_refspec
      ci: Remove Prow and coreos-ci Jenkins infrastructure
      Release 2026.2
      configure: post-release version bump

Khem Raj (1):
      trivial-httpd: Fix const-correctness of slash pointer

Nikita Dubrovskii (1):
      zipl: Switch from genprotimg to pvimg for SE boot image generation

wangzhaohui (2):
      pull: Fix GLib assertion crash on invalid UTF-8 ref names
      repo: Fix validation for min-free-space-percent config option

```