### PR TITLE
ci: revert removing coreos-ci Jenkins CI job

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,77 @@
+// Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
+
+properties([
+  // abort previous runs when a PR is updated to save resources
+  disableConcurrentBuilds(abortPrevious: true)
+])
+
+stage("Build") {
+  def n = 5
+  buildPod(memory: "2Gi", cpu: "${n}") {
+      checkout scm
+      stage("Static analysis") {
+          shwrap("./ci/codestyle.sh")
+      }
+      stage("Core build") {
+        shwrap("""
+          # fetch tags so `git describe` gives a nice NEVRA when building the RPM
+          git fetch origin --tags
+          git submodule update --init
+
+          env MAKE_JOBS=${n} ./ci/build.sh
+        """)
+      }
+      stage("Unit tests") {
+        try {
+          shwrap("""
+            make -C target/c check
+          """)
+        } finally {
+            shwrap("cat test-suite.log || true")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'test-suite.log'
+        }
+      }
+      stage("Build installed tests") {
+        shwrap("""
+           make -C tests/kolainst
+        """)
+      }
+      stage("Generate artifacts") {
+        shwrap("""
+          make -C target/c install DESTDIR=\$(pwd)/installed/rootfs
+          make -C tests/kolainst install DESTDIR=\$(pwd)/installed/tests
+          bash -c '. /usr/lib/os-release && echo \$VERSION_ID' >\$(pwd)/installed/buildroot-id
+        """)
+      }
+      stash includes: "installed/", name: 'build'
+  }
+}
+
+// Build FCOS and run kola tests.
+// There's some parallelization in testiso up to 8G, add 1G for overhead
+cosaPod(memory: "9Gi", cpu: "4") {
+  stage("Build FCOS") {
+    checkout scm
+    unstash 'build'
+    shwrap("""
+      # Make sure none of the files in the unstashed build are setgid
+      chmod -c -R g-s installed/
+      # Move the bits into the cosa pod (but only if major versions match)
+      buildroot_id=\$(cat installed/buildroot-id)
+      osver=\$(. /usr/lib/os-release && echo \$VERSION_ID)
+      if test \$osver = \$buildroot_id; then
+        rsync -rlv installed/rootfs/ /
+      fi
+      rsync -rlv installed/tests/ /
+      coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+      mkdir -p overrides/rootfs
+      # And override the on-host bits
+      mv installed/rootfs/* overrides/rootfs/
+      rm installed -rf
+      coreos-assembler build
+      coreos-assembler osbuild qemu metal metal4k live
+    """)
+  }
+  kola(cosaDir: "${env.WORKSPACE}")
+  kolaTestIso(cosaDir: "${env.WORKSPACE}", extraArgs: "--denylist-test *.4k.* --denylist-test *.mpath.*")
+}

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -58,9 +58,8 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, OstreeCommandInvocat
   context = g_option_context_new ("ARGS");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER
-                                              | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
-                                          invocation, &sysroot, cancellable, error))
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER, invocation, &sysroot,
+                                          cancellable, error))
     goto out;
 
   deployments = ostree_sysroot_get_deployments (sysroot);


### PR DESCRIPTION
This partially reverts commit 3a4ced5c97bee5196f33feea6c685e191e129acf.

Restore .cci.jenkinsfile — the coreos-ci Jenkins pipeline is still in use and should not have been removed. The Prow removal (ci/prow/) and the installdeps.sh comment cleanup remain as intended.