### PR TITLE
ostree-sign-ed25519: Fix overwriting already-set GErrors

### DIFF
--- a/man/ostree-sign.xml
+++ b/man/ostree-sign.xml
@@ -123,13 +123,13 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
            <varlistentry>
                 <term><option>--keys-file</option></term>
                 <listitem><para>
-                    Read key(s) from file <filename>filename</filename>.
+                    Read keys from file <filename>filename</filename>.
                 </para></listitem>
 
                 <listitem><para>
                     Valid for <literal>ed25519</literal> and <literal>spki</literal> signature types.
-                    This file must contain <literal>base64</literal>-encoded
-                    secret key(s) (for signing) or public key(s) (for verifying) per line.
+                    This file must contain one <literal>base64</literal>-encoded key per line.
+                    Each key may be a secret key (for signing) or a public key (for verifying).
                 </para></listitem>
             </varlistentry>
             <varlistentry>

--- a/src/libostree/ostree-blob-reader-base64.c
+++ b/src/libostree/ostree-blob-reader-base64.c
@@ -71,9 +71,16 @@ ostree_blob_reader_base64_read_blob (OstreeBlobReader *self, GCancellable *cance
 
   if (line == NULL)
     return NULL;
+  else if (len == 0)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                           "Invalid base64 blob format");
+      return NULL;
+    }
 
   gsize n_elements;
   g_base64_decode_inplace (line, &n_elements);
+  g_assert (n_elements <= len);
   explicit_bzero (line + n_elements, len - n_elements);
 
   return g_bytes_new_take (g_steal_pointer (&line), n_elements);

--- a/src/libostree/ostree-sign-ed25519.c
+++ b/src/libostree/ostree-sign-ed25519.c
@@ -492,6 +492,8 @@ static gboolean
 _load_pk_from_stream (OstreeSign *self, GInputStream *key_stream_in, gboolean trusted,
                       GError **error)
 {
+  g_autoptr (GError) first_error = NULL;
+
   if (key_stream_in == NULL)
     return glnx_throw (error, "ed25519: unable to read from NULL key-data input stream");
 
@@ -514,16 +516,17 @@ _load_pk_from_stream (OstreeSign *self, GInputStream *key_stream_in, gboolean tr
           return FALSE;
         }
 
+      /* No more blobs? */
       if (blob == NULL)
-        return ret;
+        break;
 
       /* Read the key itself */
       pk = g_variant_new_from_bytes (G_VARIANT_TYPE_BYTESTRING, blob, FALSE);
 
       if (trusted)
-        added = ostree_sign_ed25519_add_pk (self, pk, error);
+        added = ostree_sign_ed25519_add_pk (self, pk, (first_error == NULL) ? &first_error : NULL);
       else
-        added = _ed25519_add_revoked (self, pk, error);
+        added = _ed25519_add_revoked (self, pk, (first_error == NULL) ? &first_error : NULL);
 
       g_autofree gchar *pk_printable = g_variant_print (pk, FALSE);
       g_debug ("%s %s key: %s", added ? "Added" : "Invalid", trusted ? "public" : "revoked",
@@ -533,6 +536,10 @@ _load_pk_from_stream (OstreeSign *self, GInputStream *key_stream_in, gboolean tr
       if (added)
         ret = TRUE;
     }
+
+  if (!ret)
+    g_propagate_prefixed_error (error, g_steal_pointer (&first_error),
+                                "ed25519: unable to read from NULL key-data input stream: ");
 
   return ret;
 }

--- a/src/ostree/ot-builtin-sign.c
+++ b/src/ostree/ot-builtin-sign.c
@@ -48,7 +48,7 @@ static GOptionEntry options[]
         { "sign-type", 's', 0, G_OPTION_ARG_STRING, &opt_sign_name,
           "Signature type to use (defaults to 'ed25519')", "NAME" },
 #if defined(HAVE_ED25519)
-        { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_filename, "Read key(s) from file", "NAME" },
+        { "keys-file", 0, 0, G_OPTION_ARG_STRING, &opt_filename, "Read keys from file", "NAME" },
         { "keys-dir", 0, 0, G_OPTION_ARG_STRING, &opt_keysdir,
           "Redefine system-wide directories with public and revoked keys for verification",
           "NAME" },


### PR DESCRIPTION
There were a couple of issues here, related to passing a `GError**` into
a sub-function inside a loop:
 - If multiple calls inside the loop failed (e.g. if multiple keys
   inside the file were invalid, because it was a malformed file), the
   `GError` would be overwritten and cause a critical warning from GLib.
 - If an early iteration failed, but then subsequent ones succeeded, the
   `_load_pk_from_stream()` function would return `TRUE` but would also
   set its `GError`, which is a very non-standard (basically prohibited)
   thing to do with a `GError` argument.

Fix that by using a `first_error` variable internally and only
propagating it to the caller on failure.

This can be reproduced by trying to verify a signature using a key file
which isn’t actually a key file:
```
ostree sign --verify --repo ./my-repo $commit_id \
  --keys-file ./test.published.gpg
```

The keys file is expected to be in a custom format, with one ed25519 key
per line. An ASCII-armoured GPG keyring is not that format, and causes
it to go big boom.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>