### PR TITLE
commit: Support comments in --statoverride files

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -232,7 +232,9 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <listitem><para>
                     File containing list of modifications to make permissions (file mode in
                     decimal, followed by space, followed by file path).  The specified mode
-                    is ORed with the file's original mode unless preceded by "=".
+                    is ORed with the file's original mode unless preceded by "=" in which
+                    case it replaces the mode. Lines starting with "#" are treated as
+                    comments and ignored.
                 </para></listitem>
             </varlistentry>
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -191,6 +191,11 @@ static gboolean
 handle_statoverride_line (const char *line, void *data, GError **error)
 {
   struct CommitFilterData *cf = data;
+  /* Skip comments and blank lines (blank lines are already skipped by
+   * ot_parse_file_by_line, but be defensive). */
+  if (*line == '#' || *line == '\0')
+    return TRUE;
+
   const char *spc = strchr (line, ' ');
   if (spc == NULL)
     return glnx_throw (error, "Malformed statoverride file (no space found)");

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -565,8 +565,11 @@ echo "ok commit combined ref trees"
 # NB: The + is optional, but we need to make sure we support it
 cd ${test_tmpdir}
 cat > test-statoverride.txt <<EOF
+# This is a comment
 +1048 /a/nested/2
 2048 /a/nested/3
+
+# blank line above is fine too
 =384 /a/readable-only
 EOF
 cd ${test_tmpdir}/checkout-test2-4


### PR DESCRIPTION
## Summary

Add support for comments in `--statoverride` files.  Lines starting
with `#` are now skipped, making it easier to annotate and organize
permission overrides.

## Changes

- `handle_statoverride_line` in `ot-builtin-commit.c` skips lines
  starting with `#` (and empty lines defensively).
- Updated the `ostree-commit` man page to document comment support.
- Extended the existing statoverride test in `basic-test.sh` to include
  comment and blank lines.

Fixes #2399
