### PR TITLE
commit: Support octal mode notation in --statoverride files

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -230,9 +230,12 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><option>--statoverride</option>="PATH"</term>
 
                 <listitem><para>
-                    File containing list of modifications to make permissions (file mode in
-                    decimal, followed by space, followed by file path).  The specified mode
-                    is ORed with the file's original mode unless preceded by "=".
+                    File containing list of modifications to make permissions (file mode
+                    followed by space, followed by file path).  The mode may be specified
+                    in decimal, or in octal by using a leading <literal>0</literal> (e.g.
+                    <literal>0700</literal>), or in hexadecimal with a leading
+                    <literal>0x</literal>.  The specified mode is ORed with the file's
+                    original mode unless preceded by "=".
                 </para></listitem>
             </varlistentry>
 

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -198,13 +198,13 @@ handle_statoverride_line (const char *line, void *data, GError **error)
 
   if (g_str_has_prefix (line, "="))
     {
-      guint mode_override = (guint32)(gint32)g_ascii_strtod (line + 1, NULL);
+      guint mode_override = (guint32)(gint32)g_ascii_strtoull (line + 1, NULL, 0);
       g_hash_table_insert (cf->mode_overrides, g_strdup (fn),
                            GUINT_TO_POINTER ((gint32)mode_override));
     }
   else
     {
-      guint mode_add = (guint32)(gint32)g_ascii_strtod (line, NULL);
+      guint mode_add = (guint32)(gint32)g_ascii_strtoull (line, NULL, 0);
       g_hash_table_insert (cf->mode_adds, g_strdup (fn), GUINT_TO_POINTER ((gint32)mode_add));
     }
   return TRUE;

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..$((91 + ${extra_basic_tests:-0}))"
+echo "1..$((92 + ${extra_basic_tests:-0}))"
 
 CHECKOUT_U_ARG=""
 CHECKOUT_H_ARGS="-H"
@@ -584,6 +584,19 @@ else
 fi
 assert_file_has_mode checkout-test2-override/a/readable-only 600
 echo "ok commit statoverride"
+
+# Test octal mode notation in statoverride files
+cd ${test_tmpdir}
+cat > test-statoverride-octal.txt <<EOF
+=0600 /a/readable-only
+EOF
+cd ${test_tmpdir}/checkout-test2-4
+chmod 664 a/readable-only
+$OSTREE commit ${COMMIT_ARGS} -b test2-override-octal -s "octal statoverride" --statoverride=../test-statoverride-octal.txt
+cd ${test_tmpdir}
+$OSTREE checkout test2-override-octal checkout-test2-override-octal
+assert_file_has_mode checkout-test2-override-octal/a/readable-only 600
+echo "ok commit statoverride octal"
 
 cd ${test_tmpdir}
 rm test2-checkout -rf


### PR DESCRIPTION
## Summary

- Use `g_ascii_strtoull` with base 0 instead of `g_ascii_strtod` for
  parsing mode values in `--statoverride` files.  This allows modes to
  be written in octal (e.g. `0700`) or hexadecimal (e.g. `0x1ff`) in
  addition to decimal, matching the familiar `chmod` syntax and making
  permission specifications less error-prone.

## Changes

- `handle_statoverride_line` in `ot-builtin-commit.c`: replaced
  `g_ascii_strtod` with `g_ascii_strtoull(..., 0)` for both the `=`
  (override) and add branches.
- Updated `ostree-commit.xml` man page to document octal/hex mode
  support.
- Added a test in `basic-test.sh` using octal notation (`=0600`).

Fixes #2400
