### PR TITLE
ot-builtin-summary: Verify signature when viewing a summary file

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -178,7 +178,7 @@ symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
 #if BUILDOPT_IS_DEVEL_BUILD
-#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
 #endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -490,6 +490,7 @@ ostree_repo_verify_commit
 ostree_repo_verify_commit_ext
 ostree_repo_verify_commit_for_remote
 ostree_repo_verify_summary
+ostree_repo_verify_local_summary
 ostree_repo_regenerate_metadata
 ostree_repo_regenerate_summary
 <SUBSECTION Standard>

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -29,3 +29,8 @@ global:
   someostree_symbol_deleteme;
 } LIBOSTREE_$YEAR.$LASTSTABLE;
 */
+
+LIBOSTREE_2026.3 {
+global:
+  ostree_repo_verify_local_summary;
+} LIBOSTREE_2025.2;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2417,7 +2417,7 @@ out:
 
   return ret;
 #else  /* OSTREE_DISABLE_GPGME */
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -2535,7 +2535,7 @@ ostree_repo_remote_get_gpg_keys (OstreeRepo *self, const char *name, const char 
 
   return TRUE;
 #else  /* OSTREE_DISABLE_GPGME */
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5158,7 +5158,7 @@ ostree_repo_append_gpg_signature (OstreeRepo *self, const gchar *commit_checksum
 
   return TRUE;
 #else
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5295,7 +5295,7 @@ ostree_repo_sign_commit (OstreeRepo *self, const gchar *commit_checksum, const g
   return TRUE;
 #else
   /* FIXME: Return false until refactoring */
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5365,7 +5365,7 @@ _ostree_repo_add_gpg_signature_summary_at (OstreeRepo *self, int dir_fd, const g
 
   return TRUE;
 #else
-  return glnx_throw (error, "GPG feature is disabled at build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5387,7 +5387,7 @@ ostree_repo_add_gpg_signature_summary (OstreeRepo *self, const gchar **key_id, c
   return _ostree_repo_add_gpg_signature_summary_at (self, self->repo_dir_fd, key_id, homedir,
                                                     cancellable, error);
 #else
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5440,7 +5440,7 @@ ostree_repo_gpg_sign_data (OstreeRepo *self, GBytes *data, GBytes *old_signature
   *out_signatures = g_variant_get_data_as_bytes (res);
   return TRUE;
 #else
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5684,7 +5684,7 @@ ostree_repo_verify_commit (OstreeRepo *self, const gchar *commit_checksum, GFile
   return TRUE;
 #else
   /* FIXME: Return false until refactoring */
-  return glnx_throw (error, "GPG feature is disabled in a build time");
+  return glnx_throw (error, "GPG has been disabled at build time");
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
@@ -5710,7 +5710,7 @@ ostree_repo_verify_commit_ext (OstreeRepo *self, const gchar *commit_checksum, G
   return _ostree_repo_verify_commit_internal (self, commit_checksum, NULL, keyringdir,
                                               extra_keyring, cancellable, error);
 #else
-  glnx_throw (error, "GPG feature is disabled in a build time");
+  glnx_throw (error, "GPG has been disabled at build time");
   return NULL;
 #endif /* OSTREE_DISABLE_GPGME */
 }
@@ -5740,7 +5740,7 @@ ostree_repo_verify_commit_for_remote (OstreeRepo *self, const gchar *commit_chec
   return _ostree_repo_verify_commit_internal (self, commit_checksum, remote_name, NULL, NULL,
                                               cancellable, error);
 #else
-  glnx_throw (error, "GPG feature is disabled in a build time");
+  glnx_throw (error, "GPG has been disabled at build time");
   return NULL;
 #endif /* OSTREE_DISABLE_GPGME */
 }
@@ -5780,7 +5780,7 @@ ostree_repo_gpg_verify_data (OstreeRepo *self, const gchar *remote_name, GBytes 
       self, (remote_name != NULL) ? remote_name : OSTREE_ALL_REMOTES, data, signatures, keyringdir,
       extra_keyring, cancellable, error);
 #else
-  glnx_throw (error, "GPG feature is disabled in a build time");
+  glnx_throw (error, "GPG has been disabled at build time");
   return NULL;
 #endif /* OSTREE_DISABLE_GPGME */
 }
@@ -5817,7 +5817,7 @@ ostree_repo_verify_summary (OstreeRepo *self, const char *remote_name, GBytes *s
   return _ostree_repo_gpg_verify_with_metadata (self, summary, signatures_variant, remote_name,
                                                 NULL, NULL, cancellable, error);
 #else
-  glnx_throw (error, "GPG feature is disabled in a build time");
+  glnx_throw (error, "GPG has been disabled at build time");
   return NULL;
 #endif /* OSTREE_DISABLE_GPGME */
 }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5822,6 +5822,52 @@ ostree_repo_verify_summary (OstreeRepo *self, const char *remote_name, GBytes *s
 #endif /* OSTREE_DISABLE_GPGME */
 }
 
+/**
+ * ostree_repo_verify_local_summary:
+ * @self: Repo
+ * @summary: Summary data as a #GBytes
+ * @signatures: Summary signatures as a #GBytes
+ * @keyringdir: (nullable): Path to directory GPG keyrings; overrides built-in default if given
+ * @extra_keyring: (nullable): Path to additional keyring file (not a directory)
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Verify @signatures for @summary data using GPG keys in the given keyring (GPG
+ * homedir), and return an #OstreeGpgVerifyResult.
+ *
+ * This is intended to be used on a server repository, for verifying the
+ * signatures on the summary file it exports. Use ostree_repo_verify_summary()
+ * to verify the summary file from a configured remote in a repository.
+ *
+ * Returns: (transfer full): an #OstreeGpgVerifyResult, or %NULL on error
+ */
+OstreeGpgVerifyResult *
+ostree_repo_verify_local_summary (OstreeRepo *self, GBytes *summary, GBytes *signatures,
+                                  GFile *keyringdir, GFile *extra_keyring,
+                                  GCancellable *cancellable, GError **error)
+{
+  g_autoptr (GVariant) signatures_variant = NULL;
+
+  g_return_val_if_fail (OSTREE_IS_REPO (self), NULL);
+  g_return_val_if_fail (summary != NULL, NULL);
+  g_return_val_if_fail (signatures != NULL, NULL);
+  g_return_val_if_fail (keyringdir == NULL || G_IS_FILE (keyringdir), NULL);
+  g_return_val_if_fail (extra_keyring == NULL || G_IS_FILE (extra_keyring), NULL);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+  signatures_variant
+      = g_variant_new_from_bytes (OSTREE_SUMMARY_SIG_GVARIANT_FORMAT, signatures, FALSE);
+
+#ifndef OSTREE_DISABLE_GPGME
+  return _ostree_repo_gpg_verify_with_metadata (self, summary, signatures_variant, NULL, keyringdir,
+                                                extra_keyring, cancellable, error);
+#else
+  glnx_throw (error, "GPG has been disabled at build time");
+  return NULL;
+#endif /* OSTREE_DISABLE_GPGME */
+}
+
 /* Add an entry for a @ref ↦ @checksum mapping to an `a(s(t@ay@a{sv}))`
  * @refs_builder to go into a `summary` file. This includes building the
  * standard additional metadata keys for the ref. */

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1279,6 +1279,12 @@ OstreeGpgVerifyResult *ostree_repo_verify_summary (OstreeRepo *self, const char 
                                                    GBytes *summary, GBytes *signatures,
                                                    GCancellable *cancellable, GError **error);
 
+_OSTREE_PUBLIC
+OstreeGpgVerifyResult *ostree_repo_verify_local_summary (OstreeRepo *self, GBytes *summary,
+                                                         GBytes *signatures, GFile *keyfiledir,
+                                                         GFile *extra_keyring,
+                                                         GCancellable *cancellable, GError **error);
+
 /**
  * OstreeRepoVerifyFlags:
  * @OSTREE_REPO_VERIFY_FLAGS_NONE: No flags

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -93,10 +93,14 @@ build_additional_metadata (const char *const *args, GError **error)
   return g_variant_ref_sink (g_variant_builder_end (builder));
 }
 
+/* @out_summary_data is guaranteed to return non-NULL, but @out_summary_sig_data
+ * may return NULL (with no error) if the summary is unsigned. */
 static gboolean
-get_summary_data (OstreeRepo *repo, GBytes **out_summary_data, GError **error)
+get_summary_data (OstreeRepo *repo, GBytes **out_summary_data, GBytes **out_summary_sig_data,
+                  GError **error)
 {
   g_assert (out_summary_data != NULL);
+  g_assert (out_summary_sig_data != NULL);
 
   g_autoptr (GBytes) summary_data = NULL;
   glnx_autofd int fd = -1;
@@ -106,7 +110,19 @@ get_summary_data (OstreeRepo *repo, GBytes **out_summary_data, GError **error)
   if (!summary_data)
     return FALSE;
 
+  g_autoptr (GBytes) summary_sig_data = NULL;
+  glnx_autofd int sig_fd = -1;
+  if (!ot_openat_ignore_enoent (repo->repo_dir_fd, "summary.sig", &sig_fd, error))
+    return FALSE;
+  if (sig_fd >= 0)
+    {
+      summary_sig_data = ot_fd_readall_or_mmap (sig_fd, 0, error);
+      if (!summary_sig_data)
+        return FALSE;
+    }
+
   *out_summary_data = g_steal_pointer (&summary_data);
+  *out_summary_sig_data = g_steal_pointer (&summary_sig_data);
 
   return TRUE;
 }
@@ -119,6 +135,9 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
   g_autoptr (OstreeRepo) repo = NULL;
   g_autoptr (OstreeSign) sign = NULL;
   OstreeDumpFlags flags = OSTREE_DUMP_NONE;
+  g_autoptr (GBytes) summary_data = NULL;
+  g_autoptr (GBytes) summary_sig_data = NULL;
+  gboolean show_signatures = FALSE;
 
   context = g_option_context_new ("");
 
@@ -188,34 +207,32 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
     }
   else if (opt_view || opt_raw)
     {
-      g_autoptr (GBytes) summary_data = NULL;
-
       if (opt_raw)
         flags |= OSTREE_DUMP_RAW;
 
-      if (!get_summary_data (repo, &summary_data, error))
+      if (!get_summary_data (repo, &summary_data, &summary_sig_data, error))
         return FALSE;
 
       ot_dump_summary_bytes (summary_data, flags);
+      show_signatures = !opt_raw;
     }
   else if (opt_list_metadata_keys)
     {
-      g_autoptr (GBytes) summary_data = NULL;
-
-      if (!get_summary_data (repo, &summary_data, error))
+      if (!get_summary_data (repo, &summary_data, &summary_sig_data, error))
         return FALSE;
 
       ot_dump_summary_metadata_keys (summary_data);
+      show_signatures = FALSE;
     }
   else if (opt_print_metadata_key)
     {
-      g_autoptr (GBytes) summary_data = NULL;
-
-      if (!get_summary_data (repo, &summary_data, error))
+      if (!get_summary_data (repo, &summary_data, &summary_sig_data, error))
         return FALSE;
 
       if (!ot_dump_summary_metadata_key (summary_data, opt_print_metadata_key, error))
         return FALSE;
+
+      show_signatures = FALSE;
     }
   else
     {
@@ -223,6 +240,50 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
                    "No option specified; use -u to update summary");
       return FALSE;
     }
+
+#ifndef OSTREE_DISABLE_GPGME
+  if (show_signatures && summary_sig_data == NULL)
+    {
+      g_print ("Summary is unsigned\n");
+    }
+  else if (show_signatures)
+    {
+      g_autoptr (OstreeGpgVerifyResult) result = NULL;
+      g_autoptr (GFile) gpg_homedir
+          = opt_gpg_homedir ? g_file_new_for_path (opt_gpg_homedir) : NULL;
+      g_autoptr (GError) local_error = NULL;
+
+      g_assert (summary_data != NULL && summary_sig_data != NULL);
+
+      result = ostree_repo_verify_local_summary (repo, summary_data, summary_sig_data, gpg_homedir,
+                                                 NULL, cancellable, &local_error);
+
+      if (g_error_matches (local_error, OSTREE_GPG_ERROR, OSTREE_GPG_ERROR_NO_SIGNATURE))
+        {
+          /* Ignore */
+        }
+      else if (local_error != NULL)
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+      else
+        {
+          unsigned int n_sigs = ostree_gpg_verify_result_count_all (result);
+          g_print ("\nFound %u signature%s on the summary:\n", n_sigs, n_sigs == 1 ? "" : "s");
+
+          g_autoptr (GString) buffer = g_string_sized_new (256);
+          for (unsigned int ii = 0; ii < n_sigs; ii++)
+            {
+              g_string_append_c (buffer, '\n');
+              ostree_gpg_verify_result_describe (result, ii, buffer, "  ",
+                                                 OSTREE_GPG_SIGNATURE_FORMAT_DEFAULT);
+            }
+
+          g_print ("%s", buffer->str);
+        }
+    }
+#endif /* OSTREE_DISABLE_GPGME */
 
   return TRUE;
 }

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -27,8 +27,10 @@ set -euo pipefail
 echo "1..2"
 
 COMMIT_SIGN=""
+SUMMARY_HOMEDIR=""
 if has_ostree_feature gpgme; then
     COMMIT_SIGN="--gpg-homedir=${TEST_GPG_KEYHOME} --gpg-sign=${TEST_GPG_KEYID_1}"
+    SUMMARY_HOMEDIR="--gpg-homedir=${TEST_GPG_KEYHOME}"
 fi
 
 setup_fake_remote_repo1 "archive" "${COMMIT_SIGN}"
@@ -40,7 +42,7 @@ echo 'hello world some object' > hello-world
 ${CMD_PREFIX} ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit ${COMMIT_SIGN} -b other -s "A commit" -m "Example commit body"
 
 # Generate the summary file.
-${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
 # Check out the repository.
 prev_dir=`pwd`
@@ -51,17 +53,22 @@ ${CMD_PREFIX} ostree --repo=repo pull --mirror origin
 
 # Check the summary file exists in the checkout, and can be viewed.
 assert_has_file repo/summary
-${OSTREE} summary --view > summary.txt
+${OSTREE} summary ${SUMMARY_HOMEDIR} --view > summary.txt
 assert_file_has_content_literal summary.txt "* main"
 assert_file_has_content_literal summary.txt "* other"
 assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
 assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp): "
 assert_file_has_content_literal summary.txt "Version (ostree.commit.version): 3.2"
+if has_ostree_feature gpgme; then
+    assert_file_has_content_literal summary.txt "Good signature from"
+fi
 echo "ok view summary"
 
-# Check the summary can be viewed raw too.
-${OSTREE} summary --raw > raw-summary.txt
+# Check the summary can be viewed raw too, but that it doesn’t include signature information.
+${OSTREE} summary ${SUMMARY_HOMEDIR} --raw > raw-summary.txt
 assert_file_has_content_literal raw-summary.txt "('main', ("
 assert_file_has_content_literal raw-summary.txt "('other', ("
 assert_file_has_content_literal raw-summary.txt "'ostree.summary.last-modified': <uint64"
+assert_not_file_has_content raw-summary.txt "Found [0-9]+ signature"
+assert_not_file_has_content raw-summary.txt "Summary is unsigned"
 echo "ok view summary raw"

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..2"
+echo "1..4"
 
 COMMIT_SIGN=""
 SUMMARY_HOMEDIR=""
@@ -72,3 +72,18 @@ assert_file_has_content_literal raw-summary.txt "'ostree.summary.last-modified':
 assert_not_file_has_content raw-summary.txt "Found [0-9]+ signature"
 assert_not_file_has_content raw-summary.txt "Summary is unsigned"
 echo "ok view summary raw"
+
+# Listing keys.
+${OSTREE} summary ${SUMMARY_HOMEDIR} --list-metadata-keys > keys-summary.txt
+assert_file_has_content_literal keys-summary.txt "ostree.summary.mode"
+assert_file_has_content_literal keys-summary.txt "ostree.summary.indexed-deltas"
+assert_not_file_has_content keys-summary.txt "Found [0-9]+ signature"
+assert_not_file_has_content keys-summary.txt "Summary is unsigned"
+echo "ok list summary keys"
+
+# Printing a particular key.
+${OSTREE} summary ${SUMMARY_HOMEDIR} --print-metadata-key ostree.summary.mode > key-summary.txt
+assert_file_has_content_literal key-summary.txt "'archive-z2'"
+assert_not_file_has_content key-summary.txt "Found [0-9]+ signature"
+assert_not_file_has_content key-summary.txt "Summary is unsigned"
+echo "ok print a summary key"


### PR DESCRIPTION
So now we can run `ostree summary --repo . --view --gpg-homedir
/path/to/servers/gpg-homedir` and it’ll verify the GPG signatures.
That’s not so useful for verification per-se, since if you’re running
this on a server you’d expect the signatures you’ve generated to verify
correctly. It’s more useful to see how many signatures are on the
`summary` and which subkeys were used to generate them, when messing
around with multiple signing keys.

Aside from this, there is no way (that I know of) to inspect the
signatures on a summary file without checking out a copy of the
repository and hoping that the client has got a full copy of the keyring
containing all relevant subkeys.

The verification output is very similar to that of `ostree show`.

Note that signatures are not verified if running with `--raw`,
`--list-metadata-keys` or `--print-metadata-key`, since clients may be
parsing the output of those commands.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>