### PR TITLE
man: Document how to select subkeys with --gpg-sign

### DIFF
--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -265,6 +265,10 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
                 <listitem><para>
                     GPG Key ID with which to sign the commit (if built with GPGME - GNU Privacy Guard Made Easy).
+                </para>
+
+                <para>
+                    To use a specific subkey, pass the subkey’s fingerprint followed by <literal>!</literal>.
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree-commit.xml
+++ b/man/ostree-commit.xml
@@ -264,7 +264,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><option>--gpg-sign</option>="KEY-ID"</term>
 
                 <listitem><para>
-                    GPG Key ID with which to sign the commit (if have GPGME - GNU Privacy Guard Made Easy).
+                    GPG Key ID with which to sign the commit (if built with GPGME - GNU Privacy Guard Made Easy).
                 </para></listitem>
             </varlistentry>
 
@@ -272,7 +272,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><option>--gpg-homedir</option>="HOMEDIR"</term>
 
                 <listitem><para>
-                    GPG home directory to use when looking for keyrings (if have GPGME - GNU Privacy Guard Made Easy).
+                    GPG home directory to use when looking for keyrings (if built with GPGME - GNU Privacy Guard Made Easy).
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree-show.xml
+++ b/man/ostree-show.xml
@@ -128,7 +128,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                 <term><option>--gpg-homedir</option>="HOMEDIR"</term>
 
                 <listitem><para>
-                    GPG home directory to use when looking for keyrings (if have GPGME - GNU Privacy Guard Made Easy).
+                    GPG home directory to use when looking for keyrings (if built with GPGME - GNU Privacy Guard Made Easy).
                 </para></listitem>
             </varlistentry>
         </variablelist>

--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -41,7 +41,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
     <refsynopsisdiv>
             <cmdsynopsis>
-                <command>ostree summary</command> <arg choice="opt">--gpg-sign=KEYID</arg> <arg choice="opt">--gpg-homedir=HOMEDIR</arg> <arg choice="opt">--sign=KEYID</arg> <arg choice="opt">--sign-type=ENGINE</arg> <arg choice="req">--update</arg> <arg choice="opt" rep="repeat">--add-metadata=<replaceable>KEY</replaceable>=<replaceable>VALUE</replaceable></arg>
+                <command>ostree summary</command> <arg choice="opt">--gpg-sign=KEY-ID</arg> <arg choice="opt">--gpg-homedir=HOMEDIR</arg> <arg choice="opt">--sign=KEYID</arg> <arg choice="opt">--sign-type=ENGINE</arg> <arg choice="req">--update</arg> <arg choice="opt" rep="repeat">--add-metadata=<replaceable>KEY</replaceable>=<replaceable>VALUE</replaceable></arg>
             </cmdsynopsis>
 
             <cmdsynopsis>
@@ -114,7 +114,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
-                <term><option>--gpg-sign</option>=KEYID</term>
+                <term><option>--gpg-sign</option>=KEY-ID</term>
 
                 <listitem><para>
                     GPG Key ID to sign the summary with.

--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -118,6 +118,10 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
                 <listitem><para>
                     GPG Key ID to sign the summary with.
+                </para>
+
+                <para>
+                    To use a specific subkey, pass the subkey’s fingerprint followed by <literal>!</literal>.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
See the ‘HOW TO SPECIFY A USER ID’ section of `man 1 gpg`; or
https://stackoverflow.com/a/48240076/2931197.

This will be important when rotating signing subkeys for an OSTree
repository.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>