### PR TITLE
build: Remove G_GNUC_CONST from *_get_type declarations

### DIFF
--- a/src/libostree/ostree-async-progress.h
+++ b/src/libostree/ostree-async-progress.h
@@ -45,7 +45,7 @@ struct OstreeAsyncProgressClass
 };
 
 _OSTREE_PUBLIC
-GType ostree_async_progress_get_type (void) G_GNUC_CONST;
+GType ostree_async_progress_get_type (void);
 
 _OSTREE_PUBLIC
 OstreeAsyncProgress *ostree_async_progress_new (void);

--- a/src/libostree/ostree-bootconfig-parser.h
+++ b/src/libostree/ostree-bootconfig-parser.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 typedef struct _OstreeBootconfigParser OstreeBootconfigParser;
 
 _OSTREE_PUBLIC
-GType ostree_bootconfig_parser_get_type (void) G_GNUC_CONST;
+GType ostree_bootconfig_parser_get_type (void);
 
 _OSTREE_PUBLIC
 OstreeBootconfigParser *ostree_bootconfig_parser_new (void);

--- a/src/libostree/ostree-bootloader-aboot.h
+++ b/src/libostree/ostree-bootloader-aboot.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeBootloaderAboot OstreeBootloaderAboot;
 
-GType _ostree_bootloader_aboot_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_aboot_get_type (void);
 
 OstreeBootloaderAboot *_ostree_bootloader_aboot_new (OstreeSysroot *sysroot);
 G_END_DECLS

--- a/src/libostree/ostree-bootloader-grub2.h
+++ b/src/libostree/ostree-bootloader-grub2.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeBootloaderGrub2 OstreeBootloaderGrub2;
 
-GType _ostree_bootloader_grub2_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_grub2_get_type (void);
 
 OstreeBootloaderGrub2 *_ostree_bootloader_grub2_new (OstreeSysroot *sysroot);
 

--- a/src/libostree/ostree-bootloader-syslinux.h
+++ b/src/libostree/ostree-bootloader-syslinux.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeBootloaderSyslinux OstreeBootloaderSyslinux;
 
-GType _ostree_bootloader_syslinux_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_syslinux_get_type (void);
 
 OstreeBootloaderSyslinux *_ostree_bootloader_syslinux_new (OstreeSysroot *sysroot);
 

--- a/src/libostree/ostree-bootloader-uboot.h
+++ b/src/libostree/ostree-bootloader-uboot.h
@@ -33,7 +33,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeBootloaderUboot OstreeBootloaderUboot;
 
-GType _ostree_bootloader_uboot_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_uboot_get_type (void);
 
 OstreeBootloaderUboot *_ostree_bootloader_uboot_new (OstreeSysroot *sysroot);
 

--- a/src/libostree/ostree-bootloader-zipl.h
+++ b/src/libostree/ostree-bootloader-zipl.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeBootloaderZipl OstreeBootloaderZipl;
 
-GType _ostree_bootloader_zipl_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_zipl_get_type (void);
 
 OstreeBootloaderZipl *_ostree_bootloader_zipl_new (OstreeSysroot *sysroot);
 G_END_DECLS

--- a/src/libostree/ostree-bootloader.h
+++ b/src/libostree/ostree-bootloader.h
@@ -49,7 +49,7 @@ struct _OstreeBootloaderInterface
 };
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeBootloader, g_object_unref)
 
-GType _ostree_bootloader_get_type (void) G_GNUC_CONST;
+GType _ostree_bootloader_get_type (void);
 
 gboolean _ostree_bootloader_query (OstreeBootloader *bootloader, gboolean *out_is_active,
                                    GCancellable *cancellable, GError **error);

--- a/src/libostree/ostree-chain-input-stream.h
+++ b/src/libostree/ostree-chain-input-stream.h
@@ -64,7 +64,7 @@ struct _OstreeChainInputStreamClass
 };
 
 _OSTREE_PUBLIC
-GType ostree_chain_input_stream_get_type (void) G_GNUC_CONST;
+GType ostree_chain_input_stream_get_type (void);
 
 _OSTREE_PUBLIC
 OstreeChainInputStream *ostree_chain_input_stream_new (GPtrArray *streams);

--- a/src/libostree/ostree-checksum-input-stream.h
+++ b/src/libostree/ostree-checksum-input-stream.h
@@ -63,7 +63,7 @@ struct _OstreeChecksumInputStreamClass
 };
 
 _OSTREE_PUBLIC
-GType ostree_checksum_input_stream_get_type (void) G_GNUC_CONST;
+GType ostree_checksum_input_stream_get_type (void);
 
 _OSTREE_PUBLIC
 OstreeChecksumInputStream *ostree_checksum_input_stream_new (GInputStream *stream,

--- a/src/libostree/ostree-deployment.h
+++ b/src/libostree/ostree-deployment.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 typedef struct _OstreeDeployment OstreeDeployment;
 
 _OSTREE_PUBLIC
-GType ostree_deployment_get_type (void) G_GNUC_CONST;
+GType ostree_deployment_get_type (void);
 
 _OSTREE_PUBLIC
 guint ostree_deployment_hash (gconstpointer v);

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -83,7 +83,7 @@ char *_ostree_fetcher_uri_to_string (OstreeFetcherURI *uri);
 
 gboolean _ostree_fetcher_uri_validate (OstreeFetcherURI *uri, GError **error);
 
-GType _ostree_fetcher_get_type (void) G_GNUC_CONST;
+GType _ostree_fetcher_get_type (void);
 
 OstreeFetcher *_ostree_fetcher_new (int tmpdir_dfd, const char *remote_name,
                                     OstreeFetcherConfigFlags flags);

--- a/src/libostree/ostree-libarchive-input-stream.h
+++ b/src/libostree/ostree-libarchive-input-stream.h
@@ -66,7 +66,7 @@ struct _OstreeLibarchiveInputStreamClass
   void (*_g_reserved5) (void);
 };
 
-GType _ostree_libarchive_input_stream_get_type (void) G_GNUC_CONST;
+GType _ostree_libarchive_input_stream_get_type (void);
 
 GInputStream *_ostree_libarchive_input_stream_new (struct archive *a);
 

--- a/src/libostree/ostree-lzma-compressor.h
+++ b/src/libostree/ostree-lzma-compressor.h
@@ -42,7 +42,7 @@ struct _OstreeLzmaCompressorClass
   GObjectClass parent_class;
 };
 
-GType _ostree_lzma_compressor_get_type (void) G_GNUC_CONST;
+GType _ostree_lzma_compressor_get_type (void);
 
 OstreeLzmaCompressor *_ostree_lzma_compressor_new (GVariant *params);
 

--- a/src/libostree/ostree-lzma-decompressor.h
+++ b/src/libostree/ostree-lzma-decompressor.h
@@ -44,7 +44,7 @@ struct _OstreeLzmaDecompressorClass
 };
 
 GLIB_AVAILABLE_IN_ALL
-GType _ostree_lzma_decompressor_get_type (void) G_GNUC_CONST;
+GType _ostree_lzma_decompressor_get_type (void);
 
 GLIB_AVAILABLE_IN_ALL
 OstreeLzmaDecompressor *_ostree_lzma_decompressor_new (void);

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -43,7 +43,7 @@ struct OstreeMetalinkClass
 };
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMetalink, g_object_unref)
 
-GType _ostree_metalink_get_type (void) G_GNUC_CONST;
+GType _ostree_metalink_get_type (void);
 
 OstreeMetalink *_ostree_metalink_new (OstreeFetcher *fetcher, const char *requested_file,
                                       guint64 max_size, OstreeFetcherURI *uri,

--- a/src/libostree/ostree-mutable-tree.h
+++ b/src/libostree/ostree-mutable-tree.h
@@ -49,7 +49,7 @@ struct OstreeMutableTreeClass
 };
 
 _OSTREE_PUBLIC
-GType ostree_mutable_tree_get_type (void) G_GNUC_CONST;
+GType ostree_mutable_tree_get_type (void);
 
 _OSTREE_PUBLIC
 OstreeMutableTree *ostree_mutable_tree_new (void);

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  */
 
 _OSTREE_PUBLIC
-GType ostree_remote_get_type (void) G_GNUC_CONST;
+GType ostree_remote_get_type (void);
 _OSTREE_PUBLIC
 OstreeRemote *ostree_remote_ref (OstreeRemote *remote);
 _OSTREE_PUBLIC

--- a/src/libostree/ostree-repo-file-enumerator.h
+++ b/src/libostree/ostree-repo-file-enumerator.h
@@ -46,7 +46,7 @@ struct _OstreeRepoFileEnumeratorClass
 };
 
 G_GNUC_INTERNAL
-GType _ostree_repo_file_enumerator_get_type (void) G_GNUC_CONST;
+GType _ostree_repo_file_enumerator_get_type (void);
 
 G_GNUC_INTERNAL
 GFileEnumerator *_ostree_repo_file_enumerator_new (OstreeRepoFile *dir, const char *attributes,

--- a/src/libostree/ostree-repo-file.h
+++ b/src/libostree/ostree-repo-file.h
@@ -43,7 +43,7 @@ struct _OstreeRepoFileClass
 };
 
 _OSTREE_PUBLIC
-GType ostree_repo_file_get_type (void) G_GNUC_CONST;
+GType ostree_repo_file_get_type (void);
 
 _OSTREE_PUBLIC
 gboolean ostree_repo_file_ensure_resolved (OstreeRepoFile *self, GError **error);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -468,7 +468,7 @@ OstreeRepoAutoTransaction *_ostree_repo_auto_transaction_new (OstreeRepo *repo);
 
 typedef struct OstreeComposefsTarget OstreeComposefsTarget;
 
-GType ostree_composefs_target_get_type (void) G_GNUC_CONST;
+GType ostree_composefs_target_get_type (void);
 OstreeComposefsTarget *ostree_composefs_target_new (void);
 OstreeComposefsTarget *ostree_composefs_target_ref (OstreeComposefsTarget *target);
 void ostree_composefs_target_unref (OstreeComposefsTarget *target);

--- a/src/libostree/ostree-tls-cert-interaction-private.h
+++ b/src/libostree/ostree-tls-cert-interaction-private.h
@@ -40,7 +40,7 @@ typedef struct _OstreeTlsCertInteraction OstreeTlsCertInteraction;
 typedef struct _OstreeTlsCertInteractionClass OstreeTlsCertInteractionClass;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeTlsCertInteraction, g_object_unref)
 
-GType _ostree_tls_cert_interaction_get_type (void) G_GNUC_CONST;
+GType _ostree_tls_cert_interaction_get_type (void);
 
 OstreeTlsCertInteraction *_ostree_tls_cert_interaction_new (const char *cert_path,
                                                             const char *key_path);

--- a/src/libotutil/ot-checksum-instream.h
+++ b/src/libotutil/ot-checksum-instream.h
@@ -52,7 +52,7 @@ struct _OtChecksumInstreamClass
   GFilterInputStreamClass parent_class;
 };
 
-GType ot_checksum_instream_get_type (void) G_GNUC_CONST;
+GType ot_checksum_instream_get_type (void);
 
 OtChecksumInstream *ot_checksum_instream_new (GInputStream *stream, GChecksumType checksum);
 OtChecksumInstream *ot_checksum_instream_new_with_start (GInputStream *stream,


### PR DESCRIPTION
## Summary

Remove `G_GNUC_CONST` attribute from all `*_get_type()` function declarations, following the same change made in GLib itself.

## Context

GLib recently removed `G_GNUC_CONST` from its `*_get_type` declarations ([GLib MR 5223](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223)) because the attribute causes miscompilations with GCC trunk. See also [this blog post](https://blogs.gnome.org/mcatanzaro/2026/06/29/your-_get_type-function-is-not-g_gnuc_const/) for background.

The `const` attribute tells the compiler the function has no side effects and its result depends only on its arguments. This is **not true** for GType registration functions — they initialize the type system on first call. GCC trunk may incorrectly eliminate calls to these functions when they appear unused, leading to missing type registrations.

## Changes

Removed ` G_GNUC_CONST` from 23 `*_get_type()` declarations across `src/libostree/` and `src/libotutil/`. No functional behavior change; this is purely a correctness fix for modern GCC.

Closes #3612
