### PR TITLE
find-remotes: Don't require write access unless pulling

### DIFF
--- a/src/ostree/ot-builtin-find-remotes.c
+++ b/src/ostree/ot-builtin-find-remotes.c
@@ -190,9 +190,6 @@ ostree_builtin_find_remotes (int argc, char **argv, OstreeCommandInvocation *inv
                                     error))
     return FALSE;
 
-  if (!ostree_ensure_repo_writable (repo, error))
-    return FALSE;
-
   if (argc < 3)
     {
       ot_util_usage_error (context, "At least one COLLECTION-ID REF pair must be specified", error);
@@ -362,6 +359,10 @@ ostree_builtin_find_remotes (int argc, char **argv, OstreeCommandInvocation *inv
   /* Does the user want us to pull the updates? */
   if (!opt_pull)
     return TRUE;
+
+  /* Pulling requires write access to the repository. */
+  if (!ostree_ensure_repo_writable (repo, error))
+    return FALSE;
 
   {
     GVariantBuilder builder;


### PR DESCRIPTION
## Summary

`ostree find-remotes` is a read-only operation that searches for remotes
which have a given collection-ref. However, it currently fails with
"Cannot write to repository: Permission denied" when run against a
read-only repository, even without `--pull`.

This moves the `ostree_ensure_repo_writable()` check from before argument
validation to just before the pull phase, so that `find-remotes` without
`--pull` works on read-only repositories.

Closes #3585
