### PR TITLE
Release 2026.3

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -178,7 +178,7 @@ symbol_files = $(top_srcdir)/src/libostree/libostree-released.sym
 
 # Uncomment this include when adding new development symbols.
 #if BUILDOPT_IS_DEVEL_BUILD
-symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
+#symbol_files += $(top_srcdir)/src/libostree/libostree-devel.sym
 #endif
 
 # http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ([2.63])
 dnl To perform a release, follow the instructions in `docs/CONTRIBUTING.md`.
 m4_define([year_version], [2026])
-m4_define([release_version], [3])
+m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=yes
+is_release_build=no
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([year_version], [2026])
 m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/libostree/libostree-devel.sym
+++ b/src/libostree/libostree-devel.sym
@@ -30,7 +30,4 @@ global:
 } LIBOSTREE_$YEAR.$LASTSTABLE;
 */
 
-LIBOSTREE_2026.3 {
-global:
-  ostree_repo_verify_local_summary;
-} LIBOSTREE_2025.2;
+/* No new symbols yet for next development version */

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -743,6 +743,11 @@ global:
   ostree_bootconfig_parser_get_tries_done;
 } LIBOSTREE_2025.2;
 
+LIBOSTREE_2026.3 {
+global:
+  ostree_repo_verify_local_summary;
+} LIBOSTREE_2025.3;
+
 /* NOTE: Only add more content here in release commits!  See the
  * comments at the top of this file.
  */

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-80766c0ea2a0bc53d18f4eecc82a1710610468bdca39f23dda782365974e3baf  ${released_syms}
+c5e236d6349550082b0aaf6bd6410358dad52b4024a9ec3bf94e9cc9c844015b  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
## Release 2026.3

This PR contains two commits:
1. **Release 2026.3** -- sets `is_release_build=yes`
2. **Post-release version bump** -- bumps to 2026.4 and sets `is_release_build=no`

The tarball `libostree-2026.3.tar.xz` was generated from the release commit via `./autogen.sh && make dist`.

### Changes since 2026.2

**Security:**
- static-delta: Add resource limits for LZMA decompression (CVE / RHEL-189208)
- static-delta: Reject oversized parts at generation time
- static-delta: Validate decompressed size against declared usize
- static-delta: guard bspatch against integer truncation on 32-bit
- static-delta: Account for the full part payload consistently

**Bug fixes:**
- repo-commit: preserve existing object inode when staging to objects/
- lib/commit: Fix min-free-space accounting for duplicate content objects
- lib/commit: Fix min-free-space accounting for reflinked content objects
- deploy: Fix enum type mismatch in copy flags
- prepare-root: Properly check return value of snprintf()
- ostree-sign-ed25519: Fix overwriting already-set GErrors
- ostree-blob-reader: Add error handling for invalid base64 blobs
- find-remotes: Don't require write access to repo unless pulling
- build: Remove G_GNUC_CONST from *_get_type declarations
- configure: Ignore typedef-redefinition warnings with Clang
- Revert "sysroot: Merge bootconfig-extra from previously staged deployment"

**Features & improvements:**
- lib/commit: Report whether committed object already existed
- prepare-root: create /run/systemd/volatile-root for composefs
- man: Document how to select subkeys with --gpg-sign
- man: Tweak formatting for ostree-summary.xml options

**CI / style:**
- style: Fix clang-format violations
- ci: revert removing coreos-ci Jenkins CI job

```
Colin Walters (21):
      Merge pull request #3606 from jmarrero/release-20262
      Revert "sysroot: Merge bootconfig-extra from previously staged deployment"
      Merge pull request #3610 from cgwalters/revert-staged-bootconfig-extra-merge
      Merge pull request #3603 from electricface/fix-consume-inode-stability
      Merge pull request #3614 from jlebon/pr/double-accounting
      Merge pull request #3615 from jlebon/pr/reflink-accounting
      Merge commit from fork
      Merge commit from fork
      Merge pull request #3607 from jmarrero/re-add-jenkins
      Merge pull request #3592 from bbhtt/bbhtt/fix-werrors
      Merge pull request #3589 from miabbott/vserver
      Merge pull request #3617 from cgwalters/ukleinek-snprintf-rebase
      Merge pull request #3566 from jeckersb/readme-atomic-desktops
      Merge pull request #3608 from ricardosalveti/volatile-root-composefs
      static-delta: Account for the full part payload consistently
      Merge pull request #3618 from cgwalters/static-delta-overhead
      Merge pull request #3620 from pwithnall/sign-verify-error-handling
      Merge pull request #3625 from pwithnall/gpg-sign-bang
      Merge pull request #3629 from jmarrero/ci-fixes-aug26
      Merge pull request #3627 from lzwind/fix-find-remotes-writable
      Merge pull request #3626 from lzwind/remove-g-gnuc-const

John Eckersberg (1):
      README.md: Link to top-level Atomic Desktops page

Jonathan Lebon (4):
      lib/commit: Report whether committed object already existed
      lib/commit: Fix min-free-space accounting for duplicate content objects
      tree: Go back to git.mk-generated .gitignore
      lib/commit: Fix min-free-space accounting for reflinked content objects

Joseph Marrero Corchado (11):
      configure: post-release version bump
      ci: revert removing coreos-ci Jenkins CI job
      admin: Drop UNLOCKED flag from instutil set-kargs
      static-delta: guard bspatch against integer truncation on 32-bit
      tests/bsdiff: add content_size guard boundary test
      static-delta: Add resource limits for LZMA decompression
      static-delta: Reject oversized parts at generation time
      static-delta: Validate decompressed size against declared usize
      style: Fix clang-format violation in ostree-repo-finder-mount.c
      style: Fix clang-format violation in tests/test-bsdiff.c
      Release 2026.3

Micah Abbott (1):
      docs: update link to VServer reference

Philip Withnall (6):
      ostree-blob-reader: Add error handling for invalid base64 blobs
      ostree-sign-ed25519: Fix overwriting already-set GErrors
      ostree-sign: Slightly clarify docs around --key-file
      man: Fix some grammar problems with --gpg-sign documentation
      man: Document how to select subkeys with --gpg-sign
      man: Tweak formatting for ostree-summary.xml options

Ricardo Salveti (1):
      prepare-root: create /run/systemd/volatile-root for composefs

Uwe Kleine-König (1):
      prepare-root: Properly check return value of snprintf()

bbhtt (2):
      configure: Ignore typedef-redefinition warnings with Clang
      deploy: Fix enum type mismatch in copy flags

electricface (1):
      repo-commit: preserve existing object inode when staging to objects/

lzwind (2):
      find-remotes: Don't require write access to repo unless pulling
      build: Remove G_GNUC_CONST from *_get_type declarations
```

Closes #3628