### PR TITLE
ostree-repo: Change argument name in header to match implementation

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1281,7 +1281,7 @@ OstreeGpgVerifyResult *ostree_repo_verify_summary (OstreeRepo *self, const char 
 
 _OSTREE_PUBLIC
 OstreeGpgVerifyResult *ostree_repo_verify_local_summary (OstreeRepo *self, GBytes *summary,
-                                                         GBytes *signatures, GFile *keyfiledir,
+                                                         GBytes *signatures, GFile *keyringdir,
                                                          GFile *extra_keyring,
                                                          GCancellable *cancellable, GError **error);
 


### PR DESCRIPTION
A minor cleanup spotted in
https://github.com/ostreedev/ostree/pull/3624#discussion_r3721121910 but unfortunately only after the PR was merged.