### PR TITLE
ostree-gpg-verify-result: Strictly match subkeys if suffixed with `!`

### DIFF
--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -278,10 +278,10 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result, const gchar *key
       if ((match_only_subkey &&
            /* compare without the trailing `!`: */
            strlen (signature->fpr) == key_id_len - 1
-           && strncmp (key_id, signature->fpr, key_id_len - 1) == 0)
+           && g_ascii_strncasecmp (key_id, signature->fpr, key_id_len - 1) == 0)
           || (!match_only_subkey &&
               /* the first subkey in the list is the primary key: */
-              !g_strcmp0 (lookup_key->subkeys->fpr, signature_key->subkeys->fpr)))
+              g_ascii_strcasecmp (lookup_key->subkeys->fpr, signature_key->subkeys->fpr) == 0))
         {
 
           if (out_signature_index != NULL)

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -242,7 +242,7 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result, const gchar *key
   gboolean match_only_subkey;
 
   g_return_val_if_fail (OSTREE_IS_GPG_VERIFY_RESULT (result), FALSE);
-  g_return_val_if_fail (key_id != NULL, FALSE);
+  g_return_val_if_fail (key_id != NULL && ot_validate_gpg_key_id (key_id, NULL), FALSE);
 
   key_id_len = strlen (key_id);
   match_only_subkey = (key_id[key_id_len - 1] == '!');

--- a/src/libostree/ostree-gpg-verify-result.c
+++ b/src/libostree/ostree-gpg-verify-result.c
@@ -221,6 +221,11 @@ ostree_gpg_verify_result_count_valid (OstreeGpgVerifyResult *result)
  * Searches @result for a signature signed by @key_id.  If a match is found,
  * the function returns %TRUE and sets @out_signature_index so that further
  * signature details can be obtained through ostree_gpg_verify_result_get().
+ *
+ * If @key_id is a subkey fingerprint suffixed with `!`, the search will look
+ * for a signature from exactly that subkey. Otherwise, the search will look for
+ * a signature from any subkey in the primary key for @key_id.
+ *
  * If no match is found, the function returns %FALSE and leaves
  * @out_signature_index unchanged.
  *
@@ -233,17 +238,25 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result, const gchar *key
   g_auto (gpgme_key_t) lookup_key = NULL;
   gpgme_signature_t signature;
   guint signature_index;
+  size_t key_id_len;
+  gboolean match_only_subkey;
 
   g_return_val_if_fail (OSTREE_IS_GPG_VERIFY_RESULT (result), FALSE);
   g_return_val_if_fail (key_id != NULL, FALSE);
 
-  /* fetch requested key_id from keyring to canonicalise ID */
-  (void)gpgme_get_key (result->context, key_id, &lookup_key, 0);
+  key_id_len = strlen (key_id);
+  match_only_subkey = (key_id[key_id_len - 1] == '!');
 
-  if (lookup_key == NULL)
+  if (!match_only_subkey)
     {
-      g_debug ("Could not find key ID %s to lookup signature.", key_id);
-      return FALSE;
+      /* fetch requested key_id from keyring to canonicalise ID */
+      (void)gpgme_get_key (result->context, key_id, &lookup_key, 0);
+
+      if (lookup_key == NULL)
+        {
+          g_debug ("Could not find key ID %s to lookup signature.", key_id);
+          return FALSE;
+        }
     }
 
   for (signature = result->details->signatures, signature_index = 0; signature != NULL;
@@ -251,17 +264,26 @@ ostree_gpg_verify_result_lookup (OstreeGpgVerifyResult *result, const gchar *key
     {
       g_auto (gpgme_key_t) signature_key = NULL;
 
-      (void)gpgme_get_key (result->context, signature->fpr, &signature_key, 0);
-
-      if (signature_key == NULL)
+      if (!match_only_subkey)
         {
-          g_debug ("Could not find key when looking up signature from %s.", signature->fpr);
-          continue;
+          (void)gpgme_get_key (result->context, signature->fpr, &signature_key, 0);
+
+          if (signature_key == NULL)
+            {
+              g_debug ("Could not find key when looking up signature from %s.", signature->fpr);
+              continue;
+            }
         }
 
-      /* the first subkey in the list is the primary key */
-      if (!g_strcmp0 (lookup_key->subkeys->fpr, signature_key->subkeys->fpr))
+      if ((match_only_subkey &&
+           /* compare without the trailing `!`: */
+           strlen (signature->fpr) == key_id_len - 1
+           && strncmp (key_id, signature->fpr, key_id_len - 1) == 0)
+          || (!match_only_subkey &&
+              /* the first subkey in the list is the primary key: */
+              !g_strcmp0 (lookup_key->subkeys->fpr, signature_key->subkeys->fpr)))
         {
+
           if (out_signature_index != NULL)
             *out_signature_index = signature_index;
           /* Note early return */

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5242,6 +5242,8 @@ ostree_repo_sign_commit (OstreeRepo *self, const gchar *commit_checksum, const g
   g_autoptr (GBytes) commit_data = NULL;
   g_autoptr (GBytes) signature = NULL;
 
+  g_return_val_if_fail (key_id != NULL && ot_validate_gpg_key_id (key_id, NULL), FALSE);
+
   g_autoptr (GVariant) commit_variant = NULL;
   if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT, commit_checksum, &commit_variant,
                                  error))
@@ -5953,6 +5955,14 @@ regenerate_metadata (OstreeRepo *self, gboolean do_metadata_commit, GVariant *ad
           if (sign == NULL)
             return FALSE;
         }
+
+#ifndef OSTREE_DISABLE_GPGME
+      for (size_t i = 0; gpg_key_ids != NULL && gpg_key_ids[i] != NULL; i++)
+        {
+          if (!ot_validate_gpg_key_id (gpg_key_ids[i], NULL))
+            return glnx_throw (error, "Invalid key ID in gpg-key-ids");
+        }
+#endif
     }
 
   const gchar *main_collection_id = ostree_repo_get_collection_id (self);

--- a/src/libotutil/ot-gpg-utils.c
+++ b/src/libotutil/ot-gpg-utils.c
@@ -577,3 +577,16 @@ ot_gpg_wkd_urls (const char *email, char **out_advanced_url, char **out_direct_u
 
   return TRUE;
 }
+
+/* For now, we just check the key ID is non-empty. Stricter validation could
+ * be implemented in future. */
+gboolean
+ot_validate_gpg_key_id (const char *key_id, GError **error)
+{
+  g_return_val_if_fail (key_id != NULL, FALSE);
+
+  if (*key_id == '\0')
+    return glnx_throw (error, "Invalid empty GPG key ID");
+
+  return TRUE;
+}

--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -46,4 +46,6 @@ void ot_gpgme_kill_agent (const char *homedir);
 gboolean ot_gpg_wkd_urls (const char *email, char **out_advanced_url, char **out_direct_url,
                           GError **error);
 
+gboolean ot_validate_gpg_key_id (const char *key_id, GError **error);
+
 G_END_DECLS

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -595,6 +595,17 @@ ostree_builtin_commit (int argc, char **argv, OstreeCommandInvocation *invocatio
       goto out;
     }
 
+#ifndef OSTREE_DISABLE_GPGME
+  for (size_t i = 0; opt_gpg_key_ids != NULL && opt_gpg_key_ids[i] != NULL; i++)
+    {
+      if (!ot_validate_gpg_key_id (opt_gpg_key_ids[i], NULL))
+        {
+          glnx_throw (error, "Invalid key ID passed to --gpg-sign");
+          goto out;
+        }
+    }
+#endif
+
   if (opt_canonical_permissions || repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)
     flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS;
   if (opt_no_xattrs || repo->mode == OSTREE_REPO_MODE_BARE_USER_ONLY)

--- a/src/ostree/ot-builtin-gpg-sign.c
+++ b/src/ostree/ot-builtin-gpg-sign.c
@@ -211,6 +211,15 @@ ostree_builtin_gpg_sign (int argc, char **argv, OstreeCommandInvocation *invocat
   char **key_ids = argv + 2;
   int n_key_ids = argc - 2;
 
+  for (int i = 0; i < n_key_ids; i++)
+    {
+      if (!ot_validate_gpg_key_id (key_ids[i], NULL))
+        {
+          usage_error (context, "Key IDs must be valid", error);
+          return FALSE;
+        }
+    }
+
   g_autofree char *resolved_commit = NULL;
   if (!ostree_repo_resolve_rev (repo, commit, FALSE, &resolved_commit, error))
     return FALSE;

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -145,6 +145,17 @@ ostree_builtin_summary (int argc, char **argv, OstreeCommandInvocation *invocati
                                     error))
     return FALSE;
 
+#ifndef OSTREE_DISABLE_GPGME
+  for (size_t i = 0; opt_gpg_key_ids != NULL && opt_gpg_key_ids[i] != NULL; i++)
+    {
+      if (!ot_validate_gpg_key_id (opt_gpg_key_ids[i], error))
+        {
+          glnx_throw (error, "Invalid key ID passed to --gpg-sign");
+          return FALSE;
+        }
+    }
+#endif
+
   /* Initialize crypto system */
   if (opt_key_ids)
     {

--- a/tests/test-admin-gpg.sh
+++ b/tests/test-admin-gpg.sh
@@ -34,7 +34,7 @@ setup_os_repository_signed () {
     bootdir=${1:-usr/lib/modules/3.6.0}
 
     oldpwd=`pwd`
-    keyid="7FCA23D8472CDAFA"
+    keyid="${TEST_GPG_KEYID_1}"
 
     cd ${test_tmpdir}
     mkdir testos-repo

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -28,7 +28,7 @@ if test -z "${OSTREE_HTTPD}"; then
     exit 0
 fi
 
-echo "1..9"
+echo "1..11"
 
 keyid="7FCA23D8472CDAFA"
 oldpwd=`pwd`
@@ -148,6 +148,33 @@ ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo show main >show.txt
 assert_not_file_has_content show.txt 'Found.*signature'
 echo "ok pull sig deleted"
+
+rm -rf repo gnomerepo-files
+
+cd ${test_tmpdir}/ostree-srv/gnomerepo-files
+echo secret > signme
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo commit -b main -s "Don't forget to sign me!"
+cd ${test_tmpdir}
+mkdir repo
+ostree_repo_init repo
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
+${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo show main > show.txt
+assert_not_file_has_content show.txt 'Found.*signature'
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome main "${TEST_GPG_KEYFPR_1}!"
+${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo show main > show.txt
+assert_file_has_content_literal show.txt 'Found 1 signature'
+assert_file_has_content_literal show.txt "key ID ${TEST_GPG_KEYID_1}"
+echo "ok pull unsigned, then sign with explicit subkey"
+
+# Delete the signature from the commit so the detached metadata is empty,
+# then pull and verify the signature is also deleted on the client side.
+${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome --delete main "${TEST_GPG_KEYFPR_1}!"
+${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo show main >show.txt
+assert_not_file_has_content show.txt 'Found.*signature'
+echo "ok pull sig deleted with explicit subkey"
 
 # Try committing with an invalid key ID
 if ${CMD_PREFIX} ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit -b main -s "A remote commit with invalid --gpg-sign" -m "Some Commit body" --gpg-sign="" --gpg-homedir=${test_tmpdir}/gpghome 2>commit.txt; then

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -28,7 +28,7 @@ if test -z "${OSTREE_HTTPD}"; then
     exit 0
 fi
 
-echo "1..7"
+echo "1..9"
 
 keyid="7FCA23D8472CDAFA"
 oldpwd=`pwd`
@@ -148,5 +148,19 @@ ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo show main >show.txt
 assert_not_file_has_content show.txt 'Found.*signature'
 echo "ok pull sig deleted"
+
+# Try committing with an invalid key ID
+if ${CMD_PREFIX} ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit -b main -s "A remote commit with invalid --gpg-sign" -m "Some Commit body" --gpg-sign="" --gpg-homedir=${test_tmpdir}/gpghome 2>commit.txt; then
+    assert_not_reached "commit with invalid --gpg-sign unexpectedly succeeded!"
+fi
+assert_file_has_content commit.txt 'Invalid key ID'
+echo "ok commit --gpg-sign validation"
+
+# Try signing with an invalid key ID
+if ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo gpg-sign --gpg-homedir=${test_tmpdir}/gpghome main "" 2>gpg-sign.txt; then
+    assert_not_reached "gpg-sign with invalid key ID unexpectedly succeeded!"
+fi
+assert_file_has_content gpg-sign.txt 'Key IDs must be valid'
+echo "ok gpg-sign key ID validation"
 
 rm -rf repo gnomerepo-files

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -30,7 +30,7 @@ fi
 
 echo "1..11"
 
-keyid="7FCA23D8472CDAFA"
+keyid="${TEST_GPG_KEYID_1}"
 oldpwd=`pwd`
 mkdir ostree-srv
 cd ostree-srv

--- a/tests/test-gpg-verify-result.c
+++ b/tests/test-gpg-verify-result.c
@@ -167,14 +167,20 @@ test_signature_lookup (TestFixture *fixture, gconstpointer user_data)
   /* Checking the signature with the revoked key for this case. */
   guint expected_signature_index = 2;
 
-  /* Lowercase letters to ensure OstreeGpgVerifyResult handles it. */
-  const char *fingerprint = "68dcc2db4bec5811c2573590bd9d2a44b7f541a6";
-
   guint signature_index;
   gboolean signature_found;
 
   /* Lookup full fingerprint. */
   signature_index = 999999;
+  const char *fingerprint = "68dcc2db4bec5811c2573590bd9d2a44b7f541a6";
+  signature_found
+      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
+  g_assert_true (signature_found);
+  g_assert_cmpint (signature_index, ==, expected_signature_index);
+
+  /* Lookup full fingerprint but using mixed-case hex. */
+  signature_index = 999999;
+  fingerprint = "68dCC2db4bEc5811C2573590bd9d2A44B7f541a6";
   signature_found
       = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
   g_assert_true (signature_found);
@@ -182,8 +188,9 @@ test_signature_lookup (TestFixture *fixture, gconstpointer user_data)
 
   /* Lookup abbreviated key ID. */
   signature_index = 999999;
+  fingerprint = "bd9d2a44b7f541a6";
   signature_found
-      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint + 24, &signature_index);
+      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
   g_assert_true (signature_found);
   g_assert_cmpint (signature_index, ==, expected_signature_index);
 
@@ -199,6 +206,14 @@ test_signature_lookup (TestFixture *fixture, gconstpointer user_data)
   expected_signature_index = 2;
   signature_index = 999999;
   fingerprint = "68dcc2db4bec5811c2573590bd9d2a44b7f541a6!";
+  signature_found
+      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
+  g_assert_true (signature_found);
+  g_assert_cmpint (signature_index, ==, expected_signature_index);
+
+  /* Lookup full fingerprint by subkey, case-insensitively. */
+  signature_index = 999999;
+  fingerprint = "68Dcc2DB4bec5811c2573590bd9d2a44b7f541A6!";
   signature_found
       = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
   g_assert_true (signature_found);

--- a/tests/test-gpg-verify-result.c
+++ b/tests/test-gpg-verify-result.c
@@ -194,6 +194,23 @@ test_signature_lookup (TestFixture *fixture, gconstpointer user_data)
       = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
   g_assert_false (signature_found);
   g_assert_cmpint (signature_index, ==, expected_signature_index);
+
+  /* Lookup full fingerprint by subkey. */
+  expected_signature_index = 2;
+  signature_index = 999999;
+  fingerprint = "68dcc2db4bec5811c2573590bd9d2a44b7f541a6!";
+  signature_found
+      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
+  g_assert_true (signature_found);
+  g_assert_cmpint (signature_index, ==, expected_signature_index);
+
+  /* Can’t abbreviate key IDs when asking for a subkey match. */
+  signature_index = expected_signature_index = 999999;
+  fingerprint = "bd9d2a44b7f541a6!";
+  signature_found
+      = ostree_gpg_verify_result_lookup (fixture->result, fingerprint, &signature_index);
+  g_assert_false (signature_found);
+  g_assert_cmpint (signature_index, ==, expected_signature_index);
 }
 
 static void

--- a/tests/test-summary-update.sh
+++ b/tests/test-summary-update.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..2"
+echo "1..3"
 
 COMMIT_SIGN=""
 if has_ostree_feature gpgme; then
@@ -132,3 +132,14 @@ cat files | wc -l > files-count
 assert_file_has_content files-count "^1$"
 
 echo "ok 2 update summary with collections"
+
+# Try updating the summary with an invalid key ID
+if has_ostree_feature gpgme; then
+    if ${CMD_PREFIX} ostree --repo=repo summary --update --gpg-sign="" 2>summary.txt; then
+        assert_not_reached "summary update with invalid --gpg-sign unexpectedly succeeded!"
+    fi
+    assert_file_has_content summary.txt 'Invalid key ID'
+    echo "ok --gpg-sign validation"
+else
+    echo "ok # SKIP --gpg-sign validation as GPGME is disabled"
+fi


### PR DESCRIPTION
flatpak calls `ostree_gpg_verify_result_lookup()` when building an app commit to check whether it’s adding duplicate GPG signatures, for example to catch if the user accidentally specifies the same GPG key ID in `--gpg-sign` twice.

The code in `ostree_gpg_verify_result_lookup()` canonicalises its input and the fingerprint for each existing signature on a commit to the corresponding primary subkey fingerprint, and compares those.

This means that if `--gpg-sign` is passed twice to `flatpak build-export`, with the fingerprints of two *different* signing subkeys of the same primary key, the second will be rejected as a duplicate of the first, even if specified with `!` as a suffix. That suffix is accepted by `gpg` to force it to sign with a specific subkey rather than choosing the best subkey from the primary.

OSTree should follow `gpg`’s behaviour here, because it’s important for supporting subkey rotation. If we’re rotating subkeys, the primary key will have multiple valid signing subkeys at once, and we might want to legitimately sign a commit with all of them, in case some clients don’t have copies of all subkeys yet (e.g. they only have the old subkeys).

When doing a subkey rotation, it’s preferable to use an out-of-band mechanism to distribute the new subkey to all clients before they start trying to verify OSTree commits. Such a mechanism would be https://github.com/flatpak/flatpak/issues/6517 (for flatpak). Then we only have to sign commits with the new subkey. However, the approach allowed by this commit is also valid, and can be a useful fallback in case the out-of-band mechanism doesn’t work for some reason and we need a transition period for the rotation instead.

The existing behaviour of `ostree_gpg_verify_result_lookup()` is kept if the key ID does _not_ have a `!` suffix.