### PR TITLE
build: Remove `G_GNUC_CONST` from `ostree-enumtypes.h.template`

### DIFF
--- a/src/libostree/ostree-enumtypes.h.template
+++ b/src/libostree/ostree-enumtypes.h.template
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 
 /*** BEGIN enumeration-production ***/
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (_@enum_name@_get_type ())
-GType _@enum_name@_get_type (void) G_GNUC_CONST;
+GType _@enum_name@_get_type (void);
 
 /*** END enumeration-production ***/
 


### PR DESCRIPTION
get_type functions have global side effects, which makes them ineligible for the `G_GNUC_CONST` attribute.

See https://gitlab.gnome.org/GNOME/glib/-/commit/01682955 for further details.

Completes: e87513c5

---

Testing:
- I am unable to test the change locally