### PR TITLE
core: don't skip entries in _ostree_validate_structureof_xattrs

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -2351,7 +2351,6 @@ _ostree_validate_structureof_xattrs (GVariant *xattrs, GError **error)
                                previous, name, i);
         }
       previous = name;
-      i++;
     }
   return TRUE;
 }

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -593,6 +593,19 @@ test_dirmeta_xattrs (void)
                                                 g_variant_builder_end (xattr_builder));
   g_assert (!ostree_validate_structureof_dirmeta (dirmeta, error));
   g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_FAILED);
+  g_clear_error (&local_error);
+
+  /* Every entry must be checked, including those at odd indices; a duplicate
+   * name in the second slot must still be rejected. */
+  g_autoptr (GVariantBuilder) dup_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(ayay)"));
+  g_variant_builder_add (dup_builder, "(@ay@ay)", g_variant_new_bytestring ("user.a"),
+                         g_variant_new_bytestring (data));
+  g_variant_builder_add (dup_builder, "(@ay@ay)", g_variant_new_bytestring ("user.a"),
+                         g_variant_new_bytestring (data));
+  g_autoptr (GVariant) dup_dirmeta = g_variant_new ("(uuu@a(ayay))", uidgid, uidgid, mode,
+                                                    g_variant_builder_end (dup_builder));
+  g_assert (!ostree_validate_structureof_dirmeta (dup_dirmeta, error));
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_FAILED);
 }
 
 int


### PR DESCRIPTION
_ostree_validate_structureof_xattrs walks the xattr array with a for loop that already increments i, but the body increments it a second time, so only even-indexed entries are ever examined. the empty-name, duplicate-name and sort-order checks it exists to enforce quietly skip half the array, so a crafted dirmeta pulled from a remote can hide an unsorted or duplicate xattr in an odd slot and still pass ostree_validate_structureof_dirmeta on the write-metadata path. dropping the extra increment makes every entry get checked. the /dirmeta-xattrs test is extended with a duplicate name in the second slot, which is accepted before the change and rejected after.