### PR TITLE
min-free-space: Use min(3%, 1GB) as default

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -135,13 +135,15 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
           <para>
             Integer percentage value (0-99) that specifies a minimum percentage
             of total space (in blocks) in the underlying filesystem to keep
-            free. The default value is 3, which is enforced when neither this
-            option nor <varname>min-free-space-size</varname> are set.
+            free. The default value is 3, which is used when neither this
+            option nor <varname>min-free-space-size</varname> are set (together
+            with a default <varname>min-free-space-size</varname> of
+            <literal>1GB</literal>; the smaller of the two is enforced).
           </para>
           <para>
             If <varname>min-free-space-size</varname> is set to a non-zero
-            value, <varname>min-free-space-percent</varname> is ignored. Note
-            that, <varname>min-free-space-percent</varname> is not enforced on
+            value, the smaller of the two limits is used. Note that,
+            <varname>min-free-space-percent</varname> is not enforced on
             metadata objects. It is assumed that metadata objects are relatively
             small in size compared to content objects and thus kept outside the
             scope of this option.
@@ -161,10 +163,12 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
           </para>
           <para>
             If this option is set to a non-zero value, and
-            <varname>min-free-space-percent</varname> is also set, this option
-            takes priority. Note that, <varname>min-free-space-size</varname> is
-            not enforced on metadata objects. It is assumed that metadata objects
-            are relatively small in size compared to content objects and thus kept
+            <varname>min-free-space-percent</varname> is also set, the smaller
+            of the two limits is used. When neither option is set, the default
+            is <literal>1GB</literal> (capped at 3% of total filesystem size).
+            Note that, <varname>min-free-space-size</varname> is not enforced on
+            metadata objects. It is assumed that metadata objects are relatively
+            small in size compared to content objects and thus kept
             outside the scope of this option.
           </para>
         </listitem>

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -472,7 +472,7 @@ throw_min_free_space_error (OstreeRepo *self, guint64 bytes_required, GError **e
     err_msg = "would be exceeded";
   (void)err_msg_owned; // Conditional ownership
 
-  if (self->min_free_space_mb > 0)
+  if (!self->min_free_space_use_percent)
     return glnx_throw (error, "min-free-space-size %" G_GUINT64_FORMAT "MB %s",
                        self->min_free_space_mb, err_msg);
   else

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -222,9 +222,10 @@ struct OstreeRepo
   /* Cache the repo's device/inode to use for comparisons elsewhere */
   dev_t device;
   ino_t inode;
-  uid_t owner_uid;              /* Cache of repo's owner uid */
-  guint min_free_space_percent; /* See the min-free-space-percent config option */
-  guint64 min_free_space_mb;    /* See the min-free-space-size config option */
+  uid_t owner_uid;                     /* Cache of repo's owner uid */
+  guint min_free_space_percent;        /* See the min-free-space-percent config option */
+  guint64 min_free_space_mb;           /* See the min-free-space-size config option */
+  gboolean min_free_space_use_percent; /* See the min-free-space-percent config option */
   guint64 reserved_blocks;
   gboolean cleanup_stagedir;
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2967,6 +2967,9 @@ min_free_space_calculate_reserved_bytes (OstreeRepo *self, guint64 *bytes, GErro
   if (TEMP_FAILURE_RETRY (fstatvfs (self->repo_dir_fd, &stvfsbuf)) < 0)
     return glnx_throw_errno_prefix (error, "fstatvfs");
 
+  guint64 reserved_from_mb = 0;
+  guint64 reserved_from_pct = 0;
+
   if (self->min_free_space_mb > 0)
     {
       if (self->min_free_space_mb > (G_MAXUINT64 >> 20))
@@ -2976,9 +2979,10 @@ min_free_space_calculate_reserved_bytes (OstreeRepo *self, guint64 *bytes, GErro
             " bytes",
             (G_MAXUINT64 >> 20));
 
-      reserved_bytes = self->min_free_space_mb << 20;
+      reserved_from_mb = self->min_free_space_mb << 20;
     }
-  else if (self->min_free_space_percent > 0)
+
+  if (self->min_free_space_percent > 0)
     {
       if (stvfsbuf.f_frsize > (G_MAXUINT64 / stvfsbuf.f_blocks))
         return glnx_throw (
@@ -2988,7 +2992,34 @@ min_free_space_calculate_reserved_bytes (OstreeRepo *self, guint64 *bytes, GErro
             (G_MAXUINT64 / stvfsbuf.f_blocks));
 
       guint64 total_bytes = (stvfsbuf.f_frsize * stvfsbuf.f_blocks);
-      reserved_bytes = ((double)total_bytes) * (self->min_free_space_percent / 100.0);
+      reserved_from_pct = ((double)total_bytes) * (self->min_free_space_percent / 100.0);
+    }
+
+  /* When both percentage and absolute limits are set, use the smaller of the two,
+   * and keep track of which one supplied the limit so that the error path can
+   * report the limit that was actually enforced. */
+  if (reserved_from_mb > 0 && reserved_from_pct > 0)
+    {
+      if (reserved_from_mb <= reserved_from_pct)
+        {
+          reserved_bytes = reserved_from_mb;
+          self->min_free_space_use_percent = FALSE;
+        }
+      else
+        {
+          reserved_bytes = reserved_from_pct;
+          self->min_free_space_use_percent = TRUE;
+        }
+    }
+  else if (reserved_from_mb > 0)
+    {
+      reserved_bytes = reserved_from_mb;
+      self->min_free_space_use_percent = FALSE;
+    }
+  else
+    {
+      reserved_bytes = reserved_from_pct;
+      self->min_free_space_use_percent = TRUE;
     }
 
   *bytes = reserved_bytes;
@@ -3150,10 +3181,14 @@ reload_core_config (OstreeRepo *self, GCancellable *cancellable, GError **error)
   }
 
   {
-    /* Try to parse both min-free-space-* config options first. If both are absent, fallback on 3%
-     * free space. If both are present and are non-zero, use min-free-space-size unconditionally
-     * and display a warning.
+    /* Parse both min-free-space-* config options. Reset the cached values first so
+     * that a config reload doesn't retain stale limits from a previous load. If both
+     * options are absent, fall back to min(3%, 1GB). When both are set and non-zero,
+     * the smaller of the two limits is enforced (see
+     * min_free_space_calculate_reserved_bytes()).
      */
+    self->min_free_space_percent = 0;
+    self->min_free_space_mb = 0;
     if (g_key_file_has_key (self->config, "core", "min-free-space-size", NULL))
       {
         g_autofree char *min_free_space_size_str = NULL;
@@ -3191,17 +3226,17 @@ reload_core_config (OstreeRepo *self, GCancellable *cancellable, GError **error)
       }
     else if (!g_key_file_has_key (self->config, "core", "min-free-space-size", NULL))
       {
-        /* Default fallback of 3% free space. If changing this, be sure to change the man page too
+        /* Default fallback of min(3%, 1GB) free space.
+         * If changing this, be sure to change the man page too.
          */
         self->min_free_space_percent = 3;
-        self->min_free_space_mb = 0;
+        self->min_free_space_mb = 1024;
       }
 
     if (self->min_free_space_percent != 0 && self->min_free_space_mb != 0)
       {
-        self->min_free_space_percent = 0;
-        g_debug ("Both min-free-space-percent and -size are mentioned in config. Enforcing "
-                 "min-free-space-size check only.");
+        g_debug ("Both min-free-space-percent and -size are mentioned in config. "
+                 "Using the minimum of the two for free space checks.");
       }
   }
 

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -602,8 +602,8 @@ test_dirmeta_xattrs (void)
                          g_variant_new_bytestring (data));
   g_variant_builder_add (dup_builder, "(@ay@ay)", g_variant_new_bytestring ("user.a"),
                          g_variant_new_bytestring (data));
-  g_autoptr (GVariant) dup_dirmeta = g_variant_new ("(uuu@a(ayay))", uidgid, uidgid, mode,
-                                                    g_variant_builder_end (dup_builder));
+  g_autoptr (GVariant) dup_dirmeta
+      = g_variant_new ("(uuu@a(ayay))", uidgid, uidgid, mode, g_variant_builder_end (dup_builder));
   g_assert (!ostree_validate_structureof_dirmeta (dup_dirmeta, error));
   g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_FAILED);
 }

--- a/tests/test-repo.c
+++ b/tests/test-repo.c
@@ -548,6 +548,95 @@ test_repo_lock_multi_thread (Fixture *fixture, gconstpointer test_data)
 /* Test that writing duplicate content objects within a single transaction does
  * not spuriously trigger the min-free-space check.
  */
+static guint64
+expected_min_free_space_bytes (OstreeRepo *repo)
+{
+  struct statvfs stvfsbuf;
+  if (TEMP_FAILURE_RETRY (fstatvfs (repo->repo_dir_fd, &stvfsbuf)) < 0)
+    g_assert_not_reached ();
+
+  /* Mirrors min_free_space_calculate_reserved_bytes(): the smaller of the two
+   * configured limits is enforced. */
+  guint64 total_bytes = (guint64)stvfsbuf.f_frsize * stvfsbuf.f_blocks;
+  guint64 from_mb = repo->min_free_space_mb > 0 ? (guint64)repo->min_free_space_mb << 20 : 0;
+  guint64 from_pct = repo->min_free_space_percent > 0
+                         ? (guint64)((double)total_bytes * (repo->min_free_space_percent / 100.0))
+                         : 0;
+
+  if (from_mb > 0 && from_pct > 0)
+    return MIN (from_mb, from_pct);
+  else if (from_mb > 0)
+    return from_mb;
+  else
+    return from_pct;
+}
+
+static void
+reload_config_with (OstreeRepo *repo, GKeyFile *config, const char *size, const char *percent)
+{
+  g_autoptr (GError) error = NULL;
+  g_key_file_remove_key (config, "core", "min-free-space-size", NULL);
+  g_key_file_remove_key (config, "core", "min-free-space-percent", NULL);
+  if (size != NULL)
+    g_key_file_set_string (config, "core", "min-free-space-size", size);
+  if (percent != NULL)
+    g_key_file_set_string (config, "core", "min-free-space-percent", percent);
+  g_assert_true (ostree_repo_write_config_and_reload (repo, config, &error));
+  g_assert_no_error (error);
+}
+
+static void
+test_repo_get_min_free_space_limits (Fixture *fixture, gconstpointer test_data)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (OstreeRepo) repo = ostree_repo_create_at (
+      fixture->tmpdir.fd, ".", OSTREE_REPO_MODE_ARCHIVE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_autoptr (GKeyFile) config = ostree_repo_copy_config (repo);
+  guint64 bytes = 0;
+
+  /* Only min-free-space-size is set; the reserved bytes are exact. */
+  reload_config_with (repo, config, "500MB", NULL);
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 0);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 500);
+  g_assert_true (ostree_repo_get_min_free_space_bytes (repo, &bytes, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (bytes, ==, (guint64)500 << 20);
+
+  /* Only min-free-space-percent is set; match the percentage. */
+  reload_config_with (repo, config, NULL, "97");
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 97);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 0);
+  g_assert_true (ostree_repo_get_min_free_space_bytes (repo, &bytes, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (bytes, ==, expected_min_free_space_bytes (repo));
+
+  /* Both are set; the smaller of the two limits is enforced. */
+  reload_config_with (repo, config, "500MB", "97");
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 97);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 500);
+  g_assert_true (ostree_repo_get_min_free_space_bytes (repo, &bytes, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (bytes, ==, expected_min_free_space_bytes (repo));
+
+  /* Neither is set; the default of min(3%, 1GB) applies. */
+  reload_config_with (repo, config, NULL, NULL);
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 3);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 1024);
+  g_assert_true (ostree_repo_get_min_free_space_bytes (repo, &bytes, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (bytes, ==, expected_min_free_space_bytes (repo));
+
+  /* Reloading only a size after the default must clear the stale percent value,
+   * and setting the size to zero disables the check entirely. */
+  reload_config_with (repo, config, "1MB", NULL);
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 0);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 1);
+  reload_config_with (repo, config, "0MB", NULL);
+  g_assert_cmpuint (repo->min_free_space_percent, ==, 0);
+  g_assert_cmpuint (repo->min_free_space_mb, ==, 0);
+}
+
 static void
 test_min_free_space_dup_content (Fixture *fixture, gconstpointer test_data)
 {
@@ -738,6 +827,8 @@ main (int argc, char **argv)
   g_test_add ("/repo/equal", Fixture, NULL, setup, test_repo_equal, teardown);
   g_test_add ("/repo/get_min_free_space", Fixture, NULL, setup, test_repo_get_min_free_space,
               teardown);
+  g_test_add ("/repo/get_min_free_space_limits", Fixture, NULL, setup,
+              test_repo_get_min_free_space_limits, teardown);
   g_test_add ("/repo/write_regfile_api", Fixture, NULL, setup, test_write_regfile_api, teardown);
   g_test_add ("/repo/min_free_space_dup_content", Fixture, NULL, setup,
               test_min_free_space_dup_content, teardown);


### PR DESCRIPTION
The default minimum free space check uses 3%% of total filesystem space. On large disks (e.g., 1TB), this reserves 30GB which is excessive for typical operations.

Change the default to the lower of 3%% or 1GB, so the check is reasonable on both small and large filesystems.

Changes:
- Default fallback now sets both `min-free-space-percent = 3` and `min-free-space-mb = 1024`
- When both values are set, the minimum of the two is used (instead of size overriding percent)
- Updated man page documentation accordingly

Closes #3616