### PR TITLE
static-delta: Add safety margin for decompression limit

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -661,6 +661,15 @@ _ostree_static_delta_compute_part_margin (guint64 expected_usize, guint32 expect
   if (!g_uint64_checked_add (&margin, margin, rollsum_overhead))
     return G_MAXUINT64;
 
+  /* Add a multiplier-based safety margin for deltas generated before the
+   * usize overhead accounting fix (PR #3618).  This accounts for metadata
+   * overhead (mode/xattr tables, operations bytecode, bsdiff patches) that
+   * was not included in the declared usize by older delta generators.
+   */
+  const guint64 mult_margin = expected_usize * OSTREE_STATIC_DELTA_PART_USIZE_MULTIPLIER;
+  if (!g_uint64_checked_add (&margin, margin, mult_margin))
+    return G_MAXUINT64;
+
   return margin;
 }
 

--- a/src/libostree/ostree-repo-static-delta-private.h
+++ b/src/libostree/ostree-repo-static-delta-private.h
@@ -99,6 +99,25 @@ G_BEGIN_DECLS
  */
 #define OSTREE_STATIC_DELTA_PART_ROLLSUM_OVERHEAD_DIVISOR 32ULL
 
+/* Multiplier-based safety margin applied on top of the other margin terms.
+ * This accounts for the gap between the declared usize and the actual
+ * decompressed payload size for deltas generated before the overhead
+ * accounting fix (PR #3618).  Older delta generators didn't include
+ * mode/xattr tables or operations bytecode in the usize declaration, so
+ * the difference can exceed the formulaic per-object estimates in
+ * OSTREE_STATIC_DELTA_PART_OP_OVERHEAD_PER_OBJECT_BYTES and
+ * OSTREE_STATIC_DELTA_PART_XATTR_ALLOWANCE_PER_OBJECT_BYTES.
+ *
+ * The effective decompression limit is at least
+ * expected_usize * OSTREE_STATIC_DELTA_PART_USIZE_MULTIPLIER plus
+ * the other margin terms, still bounded by
+ * OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES (512 MiB). A multiplier of 1
+ * doubles the effective limit (expected_usize + expected_usize = 2x), which
+ * is sufficient for all known legitimate deltas while remaining well
+ * below the hard cap.
+ */
+#define OSTREE_STATIC_DELTA_PART_USIZE_MULTIPLIER 1ULL
+
 /* 1 byte for object type, 32 bytes for checksum */
 #define OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN 33
 


### PR DESCRIPTION
The per-part size limit computed from declared usize can reject legitimate delta parts whose metadata overhead exceeds the formulaic per-object estimates. This particularly affects deltas generated before PR #3618, where the usize didn't account for mode/xattr table overhead, operations bytecode, or bsdiff patch data.

Add expected_usize as an additional margin term, so the effective decompression limit is expected_usize * 2 plus the per-object and rollsum overhead terms, bounded by the 512 MiB hard cap. This keeps the maximum ratio between expected and allowed size at 2:1, limiting decompression-bomb amplification to 2x.

Closes #3635