### PR TITLE
main: Don't pass subcommand verb to external CLI extensions

### DIFF
--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -87,6 +87,19 @@ main (int argc, char **argv)
   g_autofree gchar *ext_command = ostree_command_lookup_external (argc, argv, commands);
   if (ext_command != NULL)
     {
+      /* Strip the subcommand verb from argv so it is not passed to the
+       * external command as an unexpected argument (matching Git's
+       * behavior). The verb is the first non-option argument after argv[0]. */
+      for (guint i = 1; i < (guint)argc; i++)
+        {
+          if (argv[i] != NULL && !g_str_has_prefix (argv[i], "-")
+              && g_strcmp0 (argv[i], "") != 0)
+            {
+              for (guint j = i; j < (guint)argc; j++)
+                argv[j] = argv[j + 1];
+              break;
+            }
+        }
       argv[0] = ext_command;
       return ostree_command_exec_external (argv);
     }

--- a/tests/test-cli-extensions.sh
+++ b/tests/test-cli-extensions.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo '1..2'
+echo '1..3'
 
 # Test CLI extensions via $PATH.  If you change this, you may
 # also want to change the corresponding destructive version in
@@ -26,6 +26,23 @@ export -n A_CUSTOM_TEST_FLAG
 rm -rf -- localbin
 
 echo 'ok CLI extension localbin ostree-env'
+
+# Test that the subcommand verb is not passed to the external command.
+mkdir -p ./localbin
+ORIG_PATH="${PATH}"
+export PATH="./localbin/:${PATH}"
+echo '#!/bin/sh' >> ./localbin/ostree-echoargs
+echo 'echo "argc=$#" ; for a in "$@"; do echo "arg=$a"; done' >> ./localbin/ostree-echoargs
+chmod +x ./localbin/ostree-echoargs
+${CMD_PREFIX} ostree echoargs foo bar >out.txt
+assert_file_has_content out.txt "^argc=2"
+assert_file_has_content out.txt "^arg=foo"
+assert_file_has_content out.txt "^arg=bar"
+assert_not_file_has_content out.txt "arg=echoargs"
+PATH="${ORIG_PATH}"
+rm -rf -- localbin
+
+echo 'ok CLI extension does not pass verb to external command'
 
 if ${CMD_PREFIX} ostree nosuchcommand 2>err.txt; then
     assert_not_reached "missing CLI extension ostree-nosuchcommand succeeded"


### PR DESCRIPTION
When `ostree` dispatches to an external CLI extension binary (e.g. `ostree-ext-cli`), it replaces `argv[0]` with the extension path but leaves the subcommand verb (e.g. `ext-cli`) in `argv`, causing the external program to receive the verb as an unexpected argument:

```
$ ostree ext-cli
error: Found argument 'ext-cli' which wasn't expected, or isn't valid in this context
```

This strips the subcommand verb from `argv` before calling `execvp`, matching Git's behavior with external commands. The verb is identified as the first non-option argument after `argv[0]` (the same logic used by `ostree_command_lookup_external()`).

A test case in `tests/test-cli-extensions.sh` verifies the verb is not passed through.

Closes #3321
