### PR TITLE
boot/mkinitcpio: Add help text to ostree hook

### DIFF
--- a/src/boot/mkinitcpio/ostree
+++ b/src/boot/mkinitcpio/ostree
@@ -8,3 +8,10 @@ build() {
     add_symlink /usr/lib/systemd/system/initrd-root-fs.target.wants/ostree-prepare-root.service \
         /usr/lib/systemd/system/ostree-prepare-root.service
 }
+
+help() {
+    cat <<HELPEOF
+Sets up the ostree prepare-root and remount services in the initramfs
+so the system can boot from an ostree deployment.
+HELPEOF
+}


### PR DESCRIPTION
The mkinitcpio ostree hook shipped at `src/boot/mkinitcpio/ostree` had no `help()` function, so `mkinitcpio -H ostree` reported:

```
==> ERROR: No help for hook ostree
```

This adds a `help()` function with a brief description of what the hook does, following the convention used by other mkinitcpio hooks (e.g. `base`).

Closes #3536
