### PR TITLE
static-delta: validate bspatch payload offset and length

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -403,6 +403,8 @@ dispatch_bspatch (OstreeRepo *repo, StaticDeltaExecutionState *state, GCancellab
     return FALSE;
   if (!read_varuint64 (state, &length, error))
     return FALSE;
+  if (!validate_ofs (state, offset, length, error))
+    return FALSE;
 
   if (state->stats_only)
     return TRUE; /* Early return */


### PR DESCRIPTION
dispatch_bspatch reads the bspatch payload offset and length as varints from the delta opcode stream but never runs them through validate_ofs, unlike the other opcodes that index payload_data (open-splice-and-close, write, set-read-source). the only guard is the two asserts in bspatch_read, and opaque->offset + length overflows the second one for a 64-bit offset near UINT64_MAX, so a crafted offset passes the check and the memcpy reads before the mapped payload. add the same validate_ofs call the sibling opcodes use, right after the varints are read, which also returns a clean GError instead of aborting on an out-of-range window.