### PR TITLE
static-delta: validate on-disk checksum names when listing deltas

### DIFF
--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -30,6 +30,84 @@
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
 
+#define SHA256_B64_LEN 43
+#define STATIC_DELTA_FANOUT_LEN 2
+#define STATIC_DELTA_BASENAME_LEN (SHA256_B64_LEN - STATIC_DELTA_FANOUT_LEN)
+
+/* Decode an on-disk SHA-256 checksum encoded as RFC 4648 Base64, with '/'
+ * replaced by '_' and trailing '=' padding omitted. Do not alter @buf unless
+ * every check succeeds. */
+static gboolean
+decode_modified_base64_sha256 (const char *checksum, guint8 *buf)
+{
+  char base64[SHA256_B64_LEN + 2];
+  char canonical[SHA256_B64_LEN + 1];
+  guchar *decoded;
+  gsize decoded_len;
+
+  if (strlen (checksum) != SHA256_B64_LEN)
+    return FALSE;
+
+  for (guint i = 0; i < SHA256_B64_LEN; i++)
+    {
+      const char c = checksum[i];
+
+      if (!(g_ascii_isalnum (c) || c == '+' || c == '_'))
+        return FALSE;
+      base64[i] = c == '_' ? '/' : c;
+    }
+  base64[SHA256_B64_LEN] = '=';
+  base64[SHA256_B64_LEN + 1] = '\0';
+
+  decoded = g_base64_decode_inplace (base64, &decoded_len);
+  g_assert (decoded == (guchar *)base64);
+  if (decoded_len != OSTREE_SHA256_DIGEST_LEN)
+    return FALSE;
+
+  ostree_checksum_b64_inplace_from_bytes (decoded, canonical);
+  /* Reject alternate encodings with nonzero unused Base64 bits. */
+  if (memcmp (checksum, canonical, SHA256_B64_LEN) != 0)
+    return FALSE;
+
+  memcpy (buf, decoded, OSTREE_SHA256_DIGEST_LEN);
+  return TRUE;
+}
+
+/* Parse a static delta directory split at the two-character fanout. */
+static gboolean
+parse_static_delta_basename (const char *fanout, const char *basename, guint8 *out_from,
+                             guint8 *out_to)
+{
+  g_autoptr (GString) checksum = g_string_new (fanout);
+  const char *separator;
+
+  if (strlen (fanout) != STATIC_DELTA_FANOUT_LEN)
+    return FALSE;
+
+  separator = strchr (basename, '-');
+  if (separator != NULL)
+    {
+      if (out_from == NULL)
+        return FALSE;
+
+      g_string_append_len (checksum, basename, separator - basename);
+      if (!decode_modified_base64_sha256 (checksum->str, out_from))
+        return FALSE;
+
+      g_string_assign (checksum, separator + 1);
+      if (!decode_modified_base64_sha256 (checksum->str, out_to))
+        return FALSE;
+    }
+  else
+    {
+      g_string_append (checksum, basename);
+      if (!decode_modified_base64_sha256 (checksum->str, out_to))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
 gboolean
 _ostree_static_delta_parse_checksum_array (GVariant *array, guint8 **out_checksums_array,
                                            guint *out_n_checksums, GError **error)
@@ -137,22 +215,23 @@ ostree_repo_list_static_delta_names (OstreeRepo *self, GPtrArray **out_deltas,
           if (errno == ENOENT)
             continue;
 
-          g_autofree char *buf = g_strconcat (name1, name2, NULL);
-          GString *out = g_string_new ("");
           char checksum[OSTREE_SHA256_STRING_LEN + 1];
-          guchar csum[OSTREE_SHA256_DIGEST_LEN];
-          const char *dash = strchr (buf, '-');
+          guchar csum_from[OSTREE_SHA256_DIGEST_LEN];
+          guchar csum_to[OSTREE_SHA256_DIGEST_LEN];
+          const gboolean has_from = strchr (name2, '-') != NULL;
 
-          ostree_checksum_b64_inplace_to_bytes (buf, csum);
-          ostree_checksum_inplace_from_bytes (csum, checksum);
-          g_string_append (out, checksum);
-          if (dash)
+          if (!parse_static_delta_basename (name1, name2, has_from ? csum_from : NULL, csum_to))
+            continue;
+
+          GString *out = g_string_new ("");
+          if (has_from)
             {
-              g_string_append_c (out, '-');
-              ostree_checksum_b64_inplace_to_bytes (dash + 1, csum);
-              ostree_checksum_inplace_from_bytes (csum, checksum);
+              ostree_checksum_inplace_from_bytes (csum_from, checksum);
               g_string_append (out, checksum);
+              g_string_append_c (out, '-');
             }
+          ostree_checksum_inplace_from_bytes (csum_to, checksum);
+          g_string_append (out, checksum);
 
           g_ptr_array_add (ret_deltas, g_string_free (out, FALSE));
         }
@@ -207,7 +286,7 @@ ostree_repo_list_static_delta_indexes (OstreeRepo *self, GPtrArray **out_indexes
         break;
       if (dent->d_type != DT_DIR)
         continue;
-      if (strlen (dent->d_name) != 2)
+      if (strlen (dent->d_name) != STATIC_DELTA_FANOUT_LEN)
         continue;
 
       if (!glnx_dirfd_iterator_init_at (dfd_iter.fd, dent->d_name, FALSE, &sub_dfd_iter, error))
@@ -228,17 +307,17 @@ ostree_repo_list_static_delta_indexes (OstreeRepo *self, GPtrArray **out_indexes
           const char *name1 = dent->d_name;
           const char *name2 = sub_dent->d_name;
 
-          /* base64 len is 43, but 2 chars are in the parent dir name */
-          if (strlen (name2) != 41 + strlen (".index") || !g_str_has_suffix (name2, ".index"))
+          if (strlen (name2) != STATIC_DELTA_BASENAME_LEN + strlen (".index")
+              || !g_str_has_suffix (name2, ".index"))
             continue;
-
-          g_autoptr (GString) out = g_string_new (name1);
-          g_string_append_len (out, name2, 41);
 
           char checksum[OSTREE_SHA256_STRING_LEN + 1];
           guchar csum[OSTREE_SHA256_DIGEST_LEN];
 
-          ostree_checksum_b64_inplace_to_bytes (out->str, csum);
+          g_autofree char *basename = g_strndup (name2, STATIC_DELTA_BASENAME_LEN);
+          if (!parse_static_delta_basename (name1, basename, NULL, csum))
+            continue;
+
           ostree_checksum_inplace_from_bytes (csum, checksum);
 
           g_ptr_array_add (ret_indexes, g_strdup (checksum));

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <err.h>
+#include <fcntl.h>
 #include <gio/gio.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -608,6 +609,146 @@ test_dirmeta_xattrs (void)
   g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_FAILED);
 }
 
+static void
+create_static_delta_file (int dfd, const char *path)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree char *dir = g_path_get_dirname (path);
+  glnx_autofd int fd = -1;
+
+  g_assert (glnx_shutil_mkdir_p_at (dfd, dir, 0755, NULL, &error));
+  g_assert_no_error (error);
+  fd = openat (dfd, path, O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
+  g_assert_cmpint (fd, !=, -1);
+}
+
+static gboolean
+strv_contains (GPtrArray *strv, const char *value)
+{
+  for (guint i = 0; i < strv->len; i++)
+    if (g_str_equal (strv->pdata[i], value))
+      return TRUE;
+
+  return FALSE;
+}
+
+static void
+test_list_static_delta_entries (void)
+{
+  static const char from_checksum[]
+      = "30d13b73cfe1e6988ffc345eac905f82a18def8ef1f0666fc392019e9eac388d";
+  static const char to_checksum[]
+      = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03";
+  guint8 from_bytes[OSTREE_SHA256_DIGEST_LEN];
+  guint8 to_bytes[OSTREE_SHA256_DIGEST_LEN];
+  char from_b64[44];
+  char to_b64[44];
+  char from_fanout[3];
+  char to_fanout[3];
+  static const char modified_base64_alphabet[]
+      = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+_";
+  g_autofree char *invalid_to_b64 = NULL;
+  g_autofree char *noncanonical_to_b64 = NULL;
+  g_autofree char *invalid_second_b64 = NULL;
+  g_autofree char *from_to_b64 = NULL;
+  g_autofree char *invalid_second_delta_b64 = NULL;
+  g_autofree char *missing_second_b64 = NULL;
+  g_autofree char *double_separator_b64 = NULL;
+  g_autofree char *early_separator_b64 = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GPtrArray) names = NULL;
+  g_autoptr (GPtrArray) indexes = NULL;
+  g_autoptr (GFile) repo_path = NULL;
+  g_autoptr (OstreeRepo) repo = NULL;
+  gboolean ret;
+
+  ret = ot_test_run_libtest ("setup_test_repository archive", &error);
+  g_assert_no_error (error);
+  g_assert (ret);
+  repo_path = g_file_new_for_path ("repo");
+  repo = ostree_repo_new (repo_path);
+  ret = ostree_repo_open (repo, NULL, &error);
+  g_assert_no_error (error);
+  g_assert (ret);
+  const int dfd = ostree_repo_get_dfd (repo);
+
+  ostree_checksum_inplace_to_bytes (from_checksum, from_bytes);
+  ostree_checksum_inplace_to_bytes (to_checksum, to_bytes);
+  ostree_checksum_b64_inplace_from_bytes (from_bytes, from_b64);
+  ostree_checksum_b64_inplace_from_bytes (to_bytes, to_b64);
+  memcpy (from_fanout, from_b64, 2);
+  from_fanout[2] = '\0';
+  memcpy (to_fanout, to_b64, 2);
+  to_fanout[2] = '\0';
+  invalid_to_b64 = g_strdup (to_b64);
+  invalid_to_b64[10] = '!';
+  noncanonical_to_b64 = g_strdup (to_b64);
+  const char *last_char = strchr (modified_base64_alphabet, to_b64[42]);
+  g_assert_nonnull (last_char);
+  noncanonical_to_b64[42] = modified_base64_alphabet[(last_char - modified_base64_alphabet) | 1];
+  invalid_second_b64 = g_strdup (to_b64);
+  invalid_second_b64[10] = '!';
+  from_to_b64 = g_strdup_printf ("%s-%s", from_b64 + 2, to_b64);
+  invalid_second_delta_b64 = g_strdup_printf ("%s-%s", from_b64 + 2, invalid_second_b64);
+  missing_second_b64 = g_strdup_printf ("%s-", from_b64 + 2);
+  double_separator_b64 = g_strdup_printf ("%s--%s", from_b64 + 2, to_b64);
+  early_separator_b64 = g_strdup_printf ("-%s", to_b64);
+
+  const struct
+  {
+    const char *fanout;
+    const char *basename;
+  } name_cases[] = {
+    { from_fanout, from_b64 + 2 },
+    { from_fanout, from_to_b64 },
+    { from_fanout, invalid_second_delta_b64 },
+    { from_fanout, missing_second_b64 },
+    { from_fanout, double_separator_b64 },
+    { from_fanout, early_separator_b64 },
+    { from_fanout, invalid_to_b64 + 2 },
+    { to_fanout, noncanonical_to_b64 + 2 },
+    { "xxx", to_b64 + 2 },
+  };
+
+  for (guint i = 0; i < G_N_ELEMENTS (name_cases); i++)
+    {
+      g_autofree char *path = g_strdup_printf ("deltas/%s/%s/superblock", name_cases[i].fanout,
+                                               name_cases[i].basename);
+      create_static_delta_file (dfd, path);
+    }
+
+  const struct
+  {
+    const char *fanout;
+    const char *basename;
+  } index_cases[] = {
+    { to_fanout, to_b64 + 2 },
+    { to_fanout, invalid_to_b64 + 2 },
+    { to_fanout, noncanonical_to_b64 + 2 },
+    { "xxx", to_b64 + 2 },
+    { to_fanout, "too-short" },
+  };
+
+  for (guint i = 0; i < G_N_ELEMENTS (index_cases); i++)
+    {
+      g_autofree char *path = g_strdup_printf ("delta-indexes/%s/%s.index", index_cases[i].fanout,
+                                               index_cases[i].basename);
+      create_static_delta_file (dfd, path);
+    }
+
+  g_assert (ostree_repo_list_static_delta_names (repo, &names, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (names->len, ==, 2);
+  g_assert (strv_contains (names, from_checksum));
+  g_autofree char *from_to = g_strconcat (from_checksum, "-", to_checksum, NULL);
+  g_assert (strv_contains (names, from_to));
+
+  g_assert (ostree_repo_list_static_delta_indexes (repo, &indexes, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_cmpuint (indexes->len, ==, 1);
+  g_assert_cmpstr (indexes->pdata[0], ==, to_checksum);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -629,6 +770,7 @@ main (int argc, char **argv)
   g_test_add_func ("/big-metadata", test_big_metadata);
   g_test_add_func ("/read-xattrs", test_read_xattrs);
   g_test_add_func ("/dirmeta-xattrs", test_dirmeta_xattrs);
+  g_test_add_func ("/list-static-delta-entries", test_list_static_delta_entries);
 
   return g_test_run ();
 out:


### PR DESCRIPTION
ostree_repo_list_static_delta_names concatenates the two deltas/ directory levels and hands the result straight to ostree_checksum_b64_inplace_to_bytes, which reads a fixed 43 bytes with no length check, and then does the same for the tail after '-'. A deltas/<a>/<b>/superblock tree whose directory names are shorter than a checksum therefore reads past the heap string.

Length checks alone aren't enough either: g_base64_decode_step skips characters outside the base64 alphabet, so a 43 byte name containing one decodes to fewer than 32 bytes and leaves the rest of the digest buffer uninitialized.

This adds a strict decoder for the on-disk modified base64 form (length, alphabet, decoded length, and canonical re-encoding) and uses it from both ostree_repo_list_static_delta_names and ostree_repo_list_static_delta_indexes; entries that don't parse are skipped as before. The regression test covers valid from-scratch and from-to names plus malformed, non-canonical and misplaced-separator entries for both listers, and trips a heap-buffer-overflow under -fsanitize=address without the code change.

The implementation is the one @cgwalters proposed in review; it replaces the earlier length-only check.
