### PR TITLE
man: Document signed-delta and sign-verify behaviour

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -994,6 +994,7 @@ _ostree_remote_add() {
         --if-not-exists
         --force
         --no-gpg-verify
+        --no-sign-verify
     "
 
     local options_with_args="
@@ -1002,6 +1003,7 @@ _ostree_remote_add() {
         --gpg-import
         --repo
         --set
+        --sign-verify
         --sysroot
     "
 

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -149,6 +149,35 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             </varlistentry>
 
             <varlistentry>
+                <term><option>--sign-verify</option>=KEYTYPE=[inline|file]:PUBKEY</term>
+
+                <listitem><para>
+                    Require commits to be signed by the given public key.
+                    KEYTYPE names a signature engine, currently
+                    <literal>ed25519</literal>. The key is given either
+                    literally, as <literal>inline:PUBKEY</literal>, or as a
+                    path to a file of keys, as
+                    <literal>file:/path/to/keys</literal>. May be repeated.
+                </para><para>
+                    This writes the <varname>sign-verify</varname> option and
+                    the matching <varname>verification-KEYTYPE-key</varname> or
+                    <varname>verification-KEYTYPE-file</varname> companion; see
+                    <citerefentry><refentrytitle>ostree.repo-config</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+                    It does not disable GPG verification, which is enabled by
+                    default.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-sign-verify</option></term>
+
+                <listitem><para>
+                    Disable signature verification. This disables GPG
+                    verification as well.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--gpg-import</option>=FILE</term>
 
                 <listitem><para>

--- a/man/ostree-remote.xml
+++ b/man/ostree-remote.xml
@@ -157,7 +157,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                     <literal>ed25519</literal>. The key is given either
                     literally, as <literal>inline:PUBKEY</literal>, or as a
                     path to a file of keys, as
-                    <literal>file:/path/to/keys</literal>. May be repeated.
+                    <literal>file:/path/to/keys</literal>.
                 </para><para>
                     This writes the <varname>sign-verify</varname> option and
                     the matching <varname>verification-KEYTYPE-key</varname> or

--- a/man/ostree-static-delta.xml
+++ b/man/ostree-static-delta.xml
@@ -71,13 +71,18 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
             A delta generated with a signature (see <option>--sign-type</option>
             and <option>--sign</option> under 'Generate' Options) is written in a
             different on-disk format, in which the superblock is wrapped in a
-            signed envelope. Only <command>ostree static-delta apply-offline</command>
-            understands that envelope. <command>ostree pull</command> parses a
-            fetched superblock directly and cannot consume a signed delta; it
-            fails with <literal>Invalid checksum of length 0 expected 32</literal>.
-            Signed static deltas are therefore for offline application only, such
-            as from removable media. A delta that will be served to
-            <command>ostree pull</command> clients must be generated unsigned.
+            signed envelope. The <command>show</command> and
+            <command>verify</command> subcommands read that envelope, but
+            <command>ostree static-delta apply-offline</command> is the only
+            command that can apply a delta wrapped in one. <command>ostree
+            pull</command> parses a fetched superblock directly, so a pull that
+            reaches for a signed delta fails with <literal>Invalid checksum of
+            length 0 expected 32</literal>. A pull into an archive-mode
+            repository does not reach that point, because such a pull does not
+            use static deltas at all. Signed static deltas are therefore for
+            offline application only, such as from removable media. A delta that
+            will be served to <command>ostree pull</command> clients must be
+            generated unsigned.
         </para>
     </refsect1>
 

--- a/man/ostree-static-delta.xml
+++ b/man/ostree-static-delta.xml
@@ -66,6 +66,19 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <para>
             List and manipulate static delta files.
         </para>
+
+        <para>
+            A delta generated with a signature (see <option>--sign-type</option>
+            and <option>--sign</option> under 'Generate' Options) is written in a
+            different on-disk format, in which the superblock is wrapped in a
+            signed envelope. Only <command>ostree static-delta apply-offline</command>
+            understands that envelope. <command>ostree pull</command> parses a
+            fetched superblock directly and cannot consume a signed delta; it
+            fails with <literal>Invalid checksum of length 0 expected 32</literal>.
+            Signed static deltas are therefore for offline application only, such
+            as from removable media. A delta that will be served to
+            <command>ostree pull</command> clients must be generated unsigned.
+        </para>
     </refsect1>
 
     <refsect1>
@@ -115,6 +128,11 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
                     signature types.
 
                     The default is <arg choice="plain">ed25519</arg>.
+                </para>
+                <para>
+                    Signing a delta makes it applicable only by
+                    <command>ostree static-delta apply-offline</command>; see the
+                    Description above.
                 </para></listitem>
             </varlistentry>
 

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -271,9 +271,8 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <para>This option cannot require a delta to be signed. It is consulted
         only after a delta has been found to carry a signature, so an unsigned
         delta is applied whatever this is set to. It also has no effect on
-        <command>ostree pull</command>, which cannot consume signed deltas at
-        all; see
-        <citerefentry><refentrytitle>ostree-static-delta</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        <command>ostree pull</command>, which cannot consume signed deltas at all;
+        see <citerefentry><refentrytitle>ostree-static-delta</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
         </para></listitem>
       </varlistentry>
     </variablelist>

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -336,15 +336,17 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         <term><varname>sign-verify</varname></term>
         <listitem><para>Controls whether OSTree will require commits to be
         signed by a known key using one of the non-GPG signature engines
-        (currently <literal>ed25519</literal>). If unset or empty, no such
-        verification is performed.</para>
+        (currently <literal>ed25519</literal>). If unset, empty, or set to a
+        boolean-false value (<literal>false</literal> or
+        <literal>0</literal>), no such verification is performed.</para>
         <para>A boolean-true value enables every compiled-in signature engine.
         Keys are optional in this case: an engine with no
         <varname>verification-&lt;engine&gt;</varname> option set for the
         remote is still enabled, and falls back to the system-wide key
-        storage. Any other value is read as a list of engine names; a commit
-        must then carry a valid signature from each named engine, and keys for
-        those engines become mandatory rather than optional.</para>
+        storage. Any other value is read as a semicolon-delimited list of
+        engine names. Keys for each named engine then become mandatory rather
+        than optional, and a commit is accepted if any one of the named
+        engines finds a valid signature for it.</para>
         <para>Public keys are supplied by the companion options
         <varname>verification-&lt;engine&gt;-key</varname>, holding an inline
         key, and <varname>verification-&lt;engine&gt;-file</varname>, holding a

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -338,11 +338,13 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         signed by a known key using one of the non-GPG signature engines
         (currently <literal>ed25519</literal>). If unset or empty, no such
         verification is performed.</para>
-        <para>A boolean-true value enables every compiled-in signature engine
-        for which keys happen to be configured. Any other value is read as a
-        list of engine names; a commit must then carry a valid signature from
-        each named engine, and keys for those engines become mandatory rather
-        than optional.</para>
+        <para>A boolean-true value enables every compiled-in signature engine.
+        Keys are optional in this case: an engine with no
+        <varname>verification-&lt;engine&gt;</varname> option set for the
+        remote is still enabled, and falls back to the system-wide key
+        storage. Any other value is read as a list of engine names; a commit
+        must then carry a valid signature from each named engine, and keys for
+        those engines become mandatory rather than optional.</para>
         <para>Public keys are supplied by the companion options
         <varname>verification-&lt;engine&gt;-key</varname>, holding an inline
         key, and <varname>verification-&lt;engine&gt;-file</varname>, holding a

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -260,6 +260,22 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         save network bandwidth.
         </para></listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><varname>sign-verify-deltas</varname></term>
+        <listitem><para>A boolean value, defaults to false. When true, applying
+        a <emphasis>signed</emphasis> static delta with <command>ostree
+        static-delta apply-offline</command> requires a key to be supplied, and
+        fails with <literal>Key is mandatory to check delta signature</literal>
+        when none is.</para>
+        <para>This option cannot require a delta to be signed. It is consulted
+        only after a delta has been found to carry a signature, so an unsigned
+        delta is applied whatever this is set to. It also has no effect on
+        <command>ostree pull</command>, which cannot consume signed deltas at
+        all; see
+        <citerefentry><refentrytitle>ostree-static-delta</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        </para></listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
@@ -314,6 +330,40 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
         is signed by a known GPG key.
         For more information, see the <citerefentry><refentrytitle>ostree</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         manual under GPG.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>sign-verify</varname></term>
+        <listitem><para>Controls whether OSTree will require commits to be
+        signed by a known key using one of the non-GPG signature engines
+        (currently <literal>ed25519</literal>). If unset or empty, no such
+        verification is performed.</para>
+        <para>A boolean-true value enables every compiled-in signature engine
+        for which keys happen to be configured. Any other value is read as a
+        list of engine names; a commit must then carry a valid signature from
+        each named engine, and keys for those engines become mandatory rather
+        than optional.</para>
+        <para>Public keys are supplied by the companion options
+        <varname>verification-&lt;engine&gt;-key</varname>, holding an inline
+        key, and <varname>verification-&lt;engine&gt;-file</varname>, holding a
+        path to a file of keys, for example
+        <varname>verification-ed25519-file</varname>.
+        <command>ostree remote add --sign-verify=ed25519=file:/path/to/key</command>
+        writes this option and the matching companion together.</para>
+        <para>This setting is independent of <varname>gpg-verify</varname>,
+        which defaults to true. Enabling only <varname>sign-verify</varname>
+        therefore leaves GPG verification enabled as well, and a pull against a
+        remote with no GPG signatures fails with <literal>GPG verification
+        enabled, but no signatures found</literal> until
+        <varname>gpg-verify</varname> is also set to false.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><varname>sign-verify-summary</varname></term>
+        <listitem><para>As <varname>sign-verify</varname>, but controls whether
+        the summary must carry a valid signature. If unset or empty the summary
+        is not verified.</para></listitem>
       </varlistentry>
 
       <varlistentry>


### PR DESCRIPTION
 Documentation only, no behaviour change. Covers the three gaps in #3651: signed static deltas being applicable offline only, core.sign-verify-deltas not being able to require a signature, and the ed25519 verify options being absent from the man pages while their gpg-verify counterparts are documented.

The last commit also adds --sign-verify/--no-sign-verify to man/ostree-remote.xml and bash/ostree, which `ot-remote-builtin-add.c` asks to be kept in step with its option list.

Please reshape the wording however you like, or tell me to drop it if you'd rather write it yourselves.

Two things I deliberately left out, noted in the issue as yours to decide: making pull recognise the OSTSGNDT magic and say so instead of Invalid checksum of length 0 expected 32, and having static-delta show print Signed: yes (offline apply only). Happy to write either.