### PR TITLE
docs: drop parameters that are no longer in the signatures

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1639,9 +1639,7 @@ _ostree_loose_path (char *buf, const char *checksum, OstreeObjectType objtype, O
 
 /**
  * _ostree_stbuf_to_gfileinfo:
- * @mode: File mode
- * @uid: File uid
- * @gid: File gid
+ * @stbuf: File stat buffer
  *
  * OSTree only stores a subset of file attributes; for example,
  * timestamps are intentionally not stored.  This function creates a

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -687,8 +687,6 @@ ostree_repo_auto_lock_cleanup (OstreeRepoAutoLock *auto_lock)
 /**
  * _ostree_repo_auto_transaction_new:
  * @repo: (not nullable): an #OsreeRepo object
- * @cancellable: Cancellable
- * @error: a #GError
  *
  * Return a guard for a transaction in @repo.
  *

--- a/src/libotcore/otcore.h
+++ b/src/libotcore/otcore.h
@@ -84,7 +84,6 @@ RootConfig *otcore_load_rootfs_config (const char *cmdline, GKeyFile *config, gb
  * otcore_mount_rootfs:
  * @rootfs_config: Configuration for root
  * @metadata_builder: (transfer none): GVariantBuilder to add metadata to.
- * @root_transient: Whether the root filesystem is transient.
  * @root_mountpoint: The mount point of the physical root filesystem.
  * @deploy_path: The path to the deployment.
  * @mount_target: The target path to mount the composefs image.


### PR DESCRIPTION
The `otcore_mount_rootfs` one is the interesting case: `root_transient` is now a field of `RootConfig`, which is declared a few lines above the block in the same header, so the parameter did not disappear, it moved. The other two describe signatures that predate the current ones, and the return text in `_ostree_stbuf_to_gfileinfo` already refers to `@stbuf`.
