### PR TITLE
generator: Skip boot.mount if /etc/fstab has a /boot entry

### DIFF
--- a/src/libostree/ostree-impl-system-generator.c
+++ b/src/libostree/ostree-impl-system-generator.c
@@ -89,6 +89,49 @@ path_kill_slashes (char *path)
 
 #endif
 
+/* Look for a mount entry for @where (e.g. "/var") in /etc/fstab. */
+static gboolean
+fstab_has_mount_entry (const char *where, gboolean *out_found, GError **error)
+{
+#ifdef HAVE_LIBMOUNT
+  static const char fstab_path[] = "/etc/fstab";
+
+  *out_found = FALSE;
+
+  g_autoptr (OtLibMountFile) fstab = setmntent (fstab_path, "re");
+  if (!fstab)
+    {
+      if (errno == ENOENT)
+        return TRUE;
+      return glnx_throw_errno_prefix (error, "Reading %s", fstab_path);
+    }
+
+  struct mntent *me;
+  while ((me = getmntent (fstab)))
+    {
+      g_autofree char *mnt_dir = g_strdup (me->mnt_dir);
+      if (is_path (mnt_dir))
+        path_kill_slashes (mnt_dir);
+
+      if (strcmp (mnt_dir, where) == 0)
+        {
+          *out_found = TRUE;
+          break;
+        }
+    }
+
+  return TRUE;
+#else
+  /* Without libmount we can't parse /etc/fstab; just report "no entry". The
+   * generator as a whole is not functional in this configuration anyway, since
+   * fstab_generator() below throws "Not implemented". */
+  (void)where;
+  (void)error;
+  *out_found = FALSE;
+  return TRUE;
+#endif
+}
+
 /* Forcibly enable our internal units, since we detected ostree= on the kernel cmdline */
 static gboolean
 require_internal_units (const char *normal_dir, const char *early_dir, const char *late_dir,
@@ -269,6 +312,22 @@ boot_mount_generator (const char *normal_dir, GError **error)
   if (!(lstat ("/boot", &stbuf) == 0 && S_ISDIR (stbuf.st_mode)))
     return TRUE;
 
+  /* If /etc/fstab has an entry for /boot, then systemd-fstab-generator owns
+   * boot.mount and we must not generate our own.
+   *
+   * An fstab entry for /boot is the documented way to opt out of Fedora CoreOS'
+   * coreos-boot-mount-generator on systems that have no separate partition
+   * labelled "boot" (for example the layout produced by "bootc install
+   * to-disk"). Without this check we unconditionally created our own unit and
+   * aborted the whole generator with EEXIST, which meant fstab_generator()
+   * below never ran and /var was never mounted at all.
+   */
+  gboolean fstab_has_boot = FALSE;
+  if (!fstab_has_mount_entry (boot_path, &fstab_has_boot, error))
+    return FALSE;
+  if (fstab_has_boot)
+    return TRUE;
+
   glnx_autofd int normal_dir_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, normal_dir, TRUE, &normal_dir_dfd, error))
     return FALSE;
@@ -307,6 +366,7 @@ boot_mount_generator (const char *normal_dir, GError **error)
   g_clear_object (&outstream);
   if (!glnx_fchmod (tmpf.fd, 0644, error))
     return FALSE;
+  /* Error out if somehow it already exists, that'll help us debug conflicts */
   if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_NOREPLACE, normal_dir_dfd, "boot.mount",
                              error))
     return FALSE;
@@ -330,7 +390,6 @@ fstab_generator (const char *ostree_target, const bool is_aboot, const char *nor
   /* Not currently cancellable, but define a var in case we care later */
   GCancellable *cancellable = NULL;
   /* Some path constants to avoid typos */
-  static const char fstab_path[] = "/etc/fstab";
   static const char var_path[] = "/var";
 
   /* Written by ostree-sysroot-deploy.c. We parse out the stateroot here since we
@@ -348,31 +407,9 @@ fstab_generator (const char *ostree_target, const bool is_aboot, const char *nor
     return glnx_prefix_error (error, "Parsing stateroot");
 
   /* Load /etc/fstab if it exists, and look for a /var mount */
-  g_autoptr (OtLibMountFile) fstab = setmntent (fstab_path, "re");
   gboolean found_var_mnt = FALSE;
-  if (!fstab)
-    {
-      if (errno != ENOENT)
-        return glnx_throw_errno_prefix (error, "Reading %s", fstab_path);
-    }
-  else
-    {
-      /* Parse it */
-      struct mntent *me;
-      while ((me = getmntent (fstab)))
-        {
-          g_autofree char *where = g_strdup (me->mnt_dir);
-          if (is_path (where))
-            path_kill_slashes (where);
-
-          /* We're only looking for /var here */
-          if (strcmp (where, var_path) != 0)
-            continue;
-
-          found_var_mnt = TRUE;
-          break;
-        }
-    }
+  if (!fstab_has_mount_entry (var_path, &found_var_mnt, error))
+    return FALSE;
 
   /* If we found /var, we're done */
   if (found_var_mnt)

--- a/tests-unit-container/test-system-generator.sh
+++ b/tests-unit-container/test-system-generator.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Tests ostree-system-generator's boot.mount handling. It expects to run in
+# a podman container. See the `unitcontainer` target in the Justfile.
+#
+# The interesting case is an /etc/fstab entry for /boot: systemd-fstab-generator
+# owns boot.mount then, so we must not generate our own and must still generate
+# var.mount.
+
+set -xeuo pipefail
+
+# Ensure this isn't run accidentally
+test "${TEST_CONTAINER}" = 1
+
+generator=/usr/lib/systemd/system-generators/ostree-system-generator
+
+workdir=$(mktemp -d)
+cmdline=${workdir}/cmdline
+
+cleanup() {
+	if mountpoint /proc/cmdline &>/dev/null; then
+		umount -l /proc/cmdline
+	fi
+	if test -f /etc/fstab.test-orig; then
+		mv /etc/fstab.test-orig /etc/fstab
+	else
+		rm -f /etc/fstab
+	fi
+	rm -rf /run/ostree /sysroot/boot "${workdir}"
+}
+trap cleanup EXIT
+
+# The generator no-ops unless it thinks we booted via ostree
+mkdir -p /run/ostree
+rm -f /run/ostree/initramfs-mount-var
+
+# Fake a kernel commandline with a valid ostree= bootlink
+echo "root=UUID=cafebabe ostree=/ostree/boot.1/default/cafecafe/0" >"${cmdline}"
+mount --bind "${cmdline}" /proc/cmdline
+
+# No /var entry in fstab, otherwise var.mount is skipped
+if test -f /etc/fstab; then
+	mv /etc/fstab /etc/fstab.test-orig
+fi
+: >/etc/fstab
+
+# /boot on the same partition as /sysroot is detected via this symlink
+mkdir -p /boot /sysroot/boot/loader.0
+ln -sf loader.0 /sysroot/boot/loader
+
+#
+# Case 1: no /boot entry in fstab, we generate boot.mount
+#
+dest=${workdir}/case1
+mkdir -p "${dest}"
+${generator} "${dest}" "${dest}" "${dest}"
+
+test -f "${dest}/boot.mount"
+grep -q '^What=/sysroot/boot$' "${dest}/boot.mount"
+grep -q '^Where=/boot$' "${dest}/boot.mount"
+test -L "${dest}/local-fs.target.requires/boot.mount"
+test -f "${dest}/var.mount"
+
+echo "ok generated boot.mount"
+
+#
+# Case 2: /etc/fstab has an entry for /boot, so systemd-fstab-generator owns
+# boot.mount. We must skip it and crucially still generate var.mount.
+# Previously we wrote our own unit and aborted with EEXIST, so /var was never
+# mounted.
+#
+echo '/dev/disk/by-uuid/deadbeef /boot ext4 defaults 1 2' >/etc/fstab
+
+dest=${workdir}/case2
+mkdir -p "${dest}"
+${generator} "${dest}" "${dest}" "${dest}"
+
+test '!' -e "${dest}/boot.mount"
+test '!' -e "${dest}/local-fs.target.requires/boot.mount"
+test -f "${dest}/var.mount"
+grep -q '^What=/sysroot/ostree/deploy/default/var$' "${dest}/var.mount"
+test -L "${dest}/local-fs.target.requires/var.mount"
+
+echo "ok fstab /boot entry wins"
+
+# Trailing slashes and duplicate separators must still match
+printf '/dev/disk/by-uuid/deadbeef //boot/ ext4 defaults 1 2\n' >/etc/fstab
+
+dest=${workdir}/case2b
+mkdir -p "${dest}"
+${generator} "${dest}" "${dest}" "${dest}"
+
+test '!' -e "${dest}/boot.mount"
+test -f "${dest}/var.mount"
+
+echo "ok fstab /boot entry is path-normalized"
+
+#
+# Case 3: no /etc/fstab at all; nothing owns /boot or /var, so we generate both
+#
+rm -f /etc/fstab
+
+dest=${workdir}/case3
+mkdir -p "${dest}"
+${generator} "${dest}" "${dest}" "${dest}"
+
+test -f "${dest}/boot.mount"
+test -L "${dest}/local-fs.target.requires/boot.mount"
+test -f "${dest}/var.mount"
+
+echo "ok missing /etc/fstab is tolerated"
+
+: >/etc/fstab
+
+#
+# Case 4: /boot is a separate partition (no /sysroot/boot/loader symlink),
+# systemd handles it, so we generate no boot.mount at all.
+#
+rm -f /sysroot/boot/loader
+dest=${workdir}/case4
+mkdir -p "${dest}"
+${generator} "${dest}" "${dest}" "${dest}"
+
+test '!' -e "${dest}/boot.mount"
+test '!' -e "${dest}/local-fs.target.requires/boot.mount"
+test -f "${dest}/var.mount"
+
+echo "ok no boot.mount for separate /boot partition"


### PR DESCRIPTION
## Problem

`boot_mount_generator()` links its unit with `GLNX_LINK_TMPFILE_NOREPLACE` and treats `EEXIST` as fatal. Because it runs *before* `fstab_generator()` in `_ostree_impl_system_generator()`:

```c
  if (!require_internal_units (normal_dir, early_dir, late_dir, error)) return FALSE;
  if (!sysroot_mount_generator (normal_dir, error))                     return FALSE;
  if (!boot_mount_generator (normal_dir, error))                        return FALSE;  /* aborts here */
  if (!fstab_generator (ostree_target, is_aboot, ...))                  return FALSE;  /* var.mount, never reached */
```

a `boot.mount` already written by `systemd-fstab-generator` aborts the whole generator, `var.mount` is never written, and `/var` is left unmounted. The system boots severely degraded: `local-fs.target` breaks and everything writing under `/var/lib` fails.

## Why this is reachable on a supported configuration

On systems where `/boot` lives on the root filesystem, an `/etc/fstab` entry for `/boot` is the *documented* way to opt out of Fedora CoreOS' `coreos-boot-mount-generator`:

```bash
# If there's already an /etc/fstab entries for /boot, then this is is a non-FCOS
# system, likely RHCOS pre-4.3 (which still used Anaconda).  In that case, we
# don't want to overwrite what the systemd-fstab-generator will do.
if findmnt --fstab /boot &>/dev/null; then
    exit 0
fi
```

That opt-out is required because `bootc install to-disk` does **not** create a partition labelled `boot` (its layout is BIOS-BOOT / EFI-SYSTEM / root, with `/boot` on the root fs). Without the fstab entry, the CoreOS generator emits a `boot.mount` that blocks forever on `/dev/disk/by-label/boot`:

```
[ *** ] Job dev-disk-by\x2dlabel-boot.device/start running (47s / 1min 30s)
```

But *with* the fstab entry, `systemd-fstab-generator` writes `boot.mount` first and this generator aborts. So on a CoreOS-derived image installed via `bootc install to-disk`, both paths fail, for different reasons.

## Reproducer

No special hardware needed; any ostree system with `/boot` on the root filesystem:

```console
$ mkdir -p /tmp/g /tmp/ge /tmp/gl
$ touch /tmp/g/boot.mount    # stand in for systemd-fstab-generator's unit
$ /usr/lib/systemd/system-generators/ostree-system-generator /tmp/g /tmp/ge /tmp/gl
ostree-system-generator: linkat: File exists
$ echo $?
1
$ ls /tmp/g
boot.mount  local-fs.target.requires  multi-user.target.wants  sysroot.mount.d
```

Note the absent `var.mount`. With an empty target directory the same invocation exits 0 and produces both units.

## Fix

Per review feedback: instead of probing the output directory for an existing `boot.mount` (which depends on generator ordering and is nondeterministic), check `/etc/fstab` directly. If it carries an entry for `/boot`, `systemd-fstab-generator` owns that unit, so we skip generating ours and continue to `var.mount`. The `GLNX_LINK_TMPFILE_NOREPLACE` behaviour is otherwise unchanged, so a genuinely unexpected conflict is still an error.

The fstab parsing already used to look for `/var` is factored out into `fstab_has_mount_entry()` and reused, so path normalization (`//boot/` -> `/boot`) and the missing-fstab handling are shared.

## Regression range

This looks like a regression from the soft-reboot work in #3487 / #3571. ostree 2025.7 did not generate `boot.mount` in the generator; the failure first appears in 2026.1 and is still present in `main`. Observed in the wild on ostree 2026.2 (Fedora 44 / uCore).

## Testing

Added `tests-unit-container/test-system-generator.sh`, picked up automatically by
`tests-unit-container/run.sh` (`just unitcontainer`). It fakes the generator's
environment (`/run/ostree`, a bind-mounted `/proc/cmdline` with a valid `ostree=`
bootlink, an `/etc/fstab`, and the `/sysroot/boot/loader` symlink) and covers:

1. No `/boot` entry in fstab: `boot.mount` (with `What=/sysroot/boot`), its
   `local-fs.target.requires` symlink, and `var.mount` are all generated.
2. `/etc/fstab` has a `/boot` entry: no `boot.mount` is generated, and
   `var.mount` still is. This is the regression. Also covered with a
   non-normalized `//boot/` path.
3. No `/etc/fstab` at all: both units are generated (ENOENT is not an error).
4. No `/sysroot/boot/loader` (separate `/boot` partition): no `boot.mount`,
   `var.mount` still generated.

The reproducer above was also verified on ostree 2026.2, before and after.

Note the same `GLNX_LINK_TMPFILE_NOREPLACE` pattern is used for `var.mount` and the soft-reboot drop-in. I left those alone since they're much less likely to collide, but say the word if you'd prefer consistency.

## Disclosure

```
Assisted-by: AI
```

Per `AGENTS.md` conventions: this was investigated and drafted with AI assistance after hitting the bug on a production host.
