### PR TITLE
static-delta: bound mode and xattr dict offsets

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -361,6 +361,13 @@ do_content_open_generic (OstreeRepo *repo, StaticDeltaExecutionState *state,
   if (!read_varuint64 (state, &xattr_offset, error))
     return FALSE;
 
+  if (mode_offset >= g_variant_n_children (state->mode_dict))
+    return glnx_throw (error, "Static delta mode offset %" G_GUINT64_FORMAT " out of range",
+                       mode_offset);
+  if (xattr_offset >= g_variant_n_children (state->xattr_dict))
+    return glnx_throw (error, "Static delta xattr offset %" G_GUINT64_FORMAT " out of range",
+                       xattr_offset);
+
   g_autoptr (GVariant) modev = g_variant_get_child_value (state->mode_dict, mode_offset);
   guint32 uid, gid, mode;
   g_variant_get (modev, "(uuu)", &uid, &gid, &mode);


### PR DESCRIPTION
do_content_open_generic reads mode_offset and xattr_offset as varints straight from the attacker-controlled delta opcode stream and passes them to g_variant_get_child_value on mode_dict/xattr_dict without checking them against the dictionary sizes, unlike the payload byte offsets which all go through validate_ofs. an out-of-range mode_offset makes g_variant_get_child_value return NULL, so the following g_variant_get is a no-op and uid/gid/mode are left uninitialized before being used as the written file's owner and mode; under G_DISABLE_CHECKS the same index is an out-of-bounds read of the offset table. this bounds both offsets before the lookups. valid deltas are unaffected since write_unique_variant_chunk only ever hands out offsets into chunks it has appended.